### PR TITLE
Update2 : Quick Recipie changes

### DIFF
--- a/Database/Patches/AtlanIsparian/4 CraftTable/00793 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00793 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 793;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00795 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00795 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 795;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00796 Superb Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00796 Superb Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 796;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00797 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00797 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 797;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00799 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00799 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 799;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00801 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00801 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 801;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00802 Superb Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00802 Superb Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 802;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00803 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00803 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 803;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00804 Superb Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00804 Superb Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 804;

--- a/Database/Patches/AtlanIsparian/4 CraftTable/00805 Quality Infused Pyreal Ingot - Retired.sql
+++ b/Database/Patches/AtlanIsparian/4 CraftTable/00805 Quality Infused Pyreal Ingot - Retired.sql
@@ -1,0 +1,1 @@
+DELETE FROM recipe WHERE id = 805;

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06200 Academy Handwraps.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06200 Academy Handwraps.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6305;
+DELETE FROM recipe WHERE id = 6200;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6305, 0, 0, 0, 0, 45532 /* Academy Hand Axe */, 1, 'As you pour the Oil of Rendering onto the Training Hand Axe, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Hand Axe.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6200, 0, 0, 0, 0, 45555 /* Academy Handwraps */, 1, 'As you pour the Oil of Rendering onto the Training Handwraps, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Handwraps.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6305, 12711 /* Oil of Rendering */, 45534 /* Training Hand Axe */);
+VALUES (6200, 12711 /* Oil of Rendering */, 45557 /* Training Handwraps */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06201 Academy Short Sword.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06201 Academy Short Sword.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6306;
+DELETE FROM recipe WHERE id = 6201;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6306, 0, 0, 0, 0, 41514 /* Academy Spadone */, 1, 'As you pour the Oil of Rendering onto the Training Spadone, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Spadone.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6201, 0, 0, 0, 0, 45551 /* Academy Short Sword */, 1, 'As you pour the Oil of Rendering onto the Training Short Sword, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Short Sword.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6306, 12711 /* Oil of Rendering */, 41512 /* Training Spadone */);
+VALUES (6201, 12711 /* Oil of Rendering */, 45553 /* Training Short Sword */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06202 Academy Bastone.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06202 Academy Bastone.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6287;
+DELETE FROM recipe WHERE id = 6202;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6287, 0, 0, 0, 0, 45547 /* Academy Bastone */, 1, 'As you pour the Oil of Rendering onto the Training Bastone, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Bastone.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6202, 0, 0, 0, 0, 45547 /* Academy Bastone */, 1, 'As you pour the Oil of Rendering onto the Training Bastone, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Bastone.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6287, 12711 /* Oil of Rendering */, 45549 /* Training Bastone */);
+VALUES (6202, 12711 /* Oil of Rendering */, 45549 /* Training Bastone */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06203 Academy Budiaq.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06203 Academy Budiaq.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6300;
+DELETE FROM recipe WHERE id = 6203;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6300, 0, 0, 0, 0, 45552 /* Academy Broad Sword */, 1, 'As you pour the Oil of Rendering onto the Training Broad Sword, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Broad Sword.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6203, 0, 0, 0, 0, 45543 /* Academy Budiaq */, 1, 'As you pour the Oil of Rendering onto the Training Budiaq, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Budiaq.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6300, 12711 /* Oil of Rendering */, 45554 /* Training Broad Sword */);
+VALUES (6203, 12711 /* Oil of Rendering */, 45545 /* Training Budiaq */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06204 Academy Dabus.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06204 Academy Dabus.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6289;
+DELETE FROM recipe WHERE id = 6204;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6289, 0, 0, 0, 0, 45539 /* Academy Dabus */, 1, 'As you pour the Oil of Rendering onto the Training Dabus, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Dabus.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6204, 0, 0, 0, 0, 45539 /* Academy Dabus */, 1, 'As you pour the Oil of Rendering onto the Training Dabus, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Dabus.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6289, 12711 /* Oil of Rendering */, 45541 /* Training Dabus */);
+VALUES (6204, 12711 /* Oil of Rendering */, 45541 /* Training Dabus */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06205 Academy Knife.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06205 Academy Knife.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6301;
+DELETE FROM recipe WHERE id = 6205;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6301, 0, 0, 0, 0, 45548 /* Academy Staff */, 1, 'As you pour the Oil of Rendering onto the Training Staff, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Staff.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6205, 0, 0, 0, 0, 45535 /* Academy Knife */, 1, 'As you pour the Oil of Rendering onto the Training Knife, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Knife.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6301, 12711 /* Oil of Rendering */, 45550 /* Training Staff */);
+VALUES (6205, 12711 /* Oil of Rendering */, 45537 /* Training Knife */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06206 Academy Tungi.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06206 Academy Tungi.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6299;
+DELETE FROM recipe WHERE id = 6206;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6299, 0, 0, 0, 0, 45556 /* Academy Knuckles */, 1, 'As you pour the Oil of Rendering onto the Training Knuckles, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Knuckles.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6206, 0, 0, 0, 0, 45531 /* Academy Tungi */, 1, 'As you pour the Oil of Rendering onto the Training Tungi, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Tungi.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6299, 12711 /* Oil of Rendering */, 45558 /* Training Knuckles */);
+VALUES (6206, 12711 /* Oil of Rendering */, 45533 /* Training Tungi */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06214 Academy Knuckles.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06214 Academy Knuckles.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6302;
+DELETE FROM recipe WHERE id = 6214;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6302, 0, 0, 0, 0, 45544 /* Academy Spear */, 1, 'As you pour the Oil of Rendering onto the Training Spear, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Spear.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6214, 0, 0, 0, 0, 45556 /* Academy Knuckles */, 1, 'As you pour the Oil of Rendering onto the Training Knuckles, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Knuckles.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6302, 12711 /* Oil of Rendering */, 45546 /* Training Spear */);
+VALUES (6214, 12711 /* Oil of Rendering */, 45558 /* Training Knuckles */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06215 Academy Broad Sword.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06215 Academy Broad Sword.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6290;
+DELETE FROM recipe WHERE id = 6215;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6290, 0, 0, 0, 0, 45535 /* Academy Knife */, 1, 'As you pour the Oil of Rendering onto the Training Knife, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Knife.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6215, 0, 0, 0, 0, 45552 /* Academy Broad Sword */, 1, 'As you pour the Oil of Rendering onto the Training Broad Sword, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Broad Sword.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6290, 12711 /* Oil of Rendering */, 45537 /* Training Knife */);
+VALUES (6215, 12711 /* Oil of Rendering */, 45554 /* Training Broad Sword */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06216 Academy Staff.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06216 Academy Staff.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6285;
+DELETE FROM recipe WHERE id = 6216;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6285, 0, 0, 0, 0, 45555 /* Academy Handwraps */, 1, 'As you pour the Oil of Rendering onto the Training Handwraps, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Handwraps.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6216, 0, 0, 0, 0, 45548 /* Academy Staff */, 1, 'As you pour the Oil of Rendering onto the Training Staff, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Staff.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6285, 12711 /* Oil of Rendering */, 45557 /* Training Handwraps */);
+VALUES (6216, 12711 /* Oil of Rendering */, 45550 /* Training Staff */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06217 Academy Spear.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06217 Academy Spear.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6291;
+DELETE FROM recipe WHERE id = 6217;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6291, 0, 0, 0, 0, 45531 /* Academy Tungi */, 1, 'As you pour the Oil of Rendering onto the Training Tungi, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Tungi.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6217, 0, 0, 0, 0, 45544 /* Academy Spear */, 1, 'As you pour the Oil of Rendering onto the Training Spear, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Spear.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6291, 12711 /* Oil of Rendering */, 45533 /* Training Tungi */);
+VALUES (6217, 12711 /* Oil of Rendering */, 45546 /* Training Spear */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06218 Academy Club.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06218 Academy Club.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6286;
+DELETE FROM recipe WHERE id = 6218;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6286, 0, 0, 0, 0, 45551 /* Academy Short Sword */, 1, 'As you pour the Oil of Rendering onto the Training Short Sword, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Short Sword.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6218, 0, 0, 0, 0, 45540 /* Academy Club */, 1, 'As you pour the Oil of Rendering onto the Training Club, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Club.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6286, 12711 /* Oil of Rendering */, 45553 /* Training Short Sword */);
+VALUES (6218, 12711 /* Oil of Rendering */, 45542 /* Training Club */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06219 Academy Dagger.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06219 Academy Dagger.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6288;
+DELETE FROM recipe WHERE id = 6219;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6288, 0, 0, 0, 0, 45543 /* Academy Budiaq */, 1, 'As you pour the Oil of Rendering onto the Training Budiaq, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Budiaq.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6219, 0, 0, 0, 0, 45536 /* Academy Dagger */, 1, 'As you pour the Oil of Rendering onto the Training Dagger, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Dagger.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6288, 12711 /* Oil of Rendering */, 45545 /* Training Budiaq */);
+VALUES (6219, 12711 /* Oil of Rendering */, 45538 /* Training Dagger */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06220 Academy Hand Axe.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06220 Academy Hand Axe.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6303;
+DELETE FROM recipe WHERE id = 6220;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6303, 0, 0, 0, 0, 45540 /* Academy Club */, 1, 'As you pour the Oil of Rendering onto the Training Club, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Club.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6220, 0, 0, 0, 0, 45532 /* Academy Hand Axe */, 1, 'As you pour the Oil of Rendering onto the Training Hand Axe, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Hand Axe.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6303, 12711 /* Oil of Rendering */, 45542 /* Training Club */);
+VALUES (6220, 12711 /* Oil of Rendering */, 45534 /* Training Hand Axe */);

--- a/Database/Patches/TrainingAcademy/4 CraftTable/06221 Academy Spadone.sql
+++ b/Database/Patches/TrainingAcademy/4 CraftTable/06221 Academy Spadone.sql
@@ -1,7 +1,7 @@
-DELETE FROM recipe WHERE id = 6304;
+DELETE FROM recipe WHERE id = 6221;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`)
-VALUES (6304, 0, 0, 0, 0, 45536 /* Academy Dagger */, 1, 'As you pour the Oil of Rendering onto the Training Dagger, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Dagger.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
+VALUES (6221, 0, 0, 0, 0, 41514 /* Academy Spadone */, 1, 'As you pour the Oil of Rendering onto the Training Spadone, it slowly deepens to a lustrous red.', 0, 0, 'You were unable pour the Oil of Rendering onto the Training Spadone.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0);
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`)
-VALUES (6304, 12711 /* Oil of Rendering */, 45538 /* Training Dagger */);
+VALUES (6221, 12711 /* Oil of Rendering */, 41512 /* Training Spadone */);


### PR DESCRIPTION
- Add retirement recipe changes for old Atlan weapons that don't exist post 16PY
- Update Academy Weapon recipe IDs to match the Lifestoned data team's work