### PR TITLE
Fix Elena NPC and update NoCorpse to TreasureCorpse

### DIFF
--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14513 Caustic.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14513 Caustic.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 14513;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (14513, 'acidelementalcaustic-nofall', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14513 Caustic.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14513 Caustic.sql
@@ -1,0 +1,127 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (14513, 'acidelementalcaustic-nofall', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (14513,   1,         16) /* ItemType - Creature */
+     , (14513,   2,         60) /* CreatureType - AcidElemental */
+     , (14513,   6,         -1) /* ItemsCapacity */
+     , (14513,   7,         -1) /* ContainersCapacity */
+     , (14513,  16,          1) /* ItemUseable - No */
+     , (14513,  25,         95) /* Level */
+     , (14513,  27,          0) /* ArmorType - None */
+     , (14513,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (14513,  93,    4197384) /* PhysicsState - ReportCollisions, Gravity, LightingOn, EdgeSlide */
+     , (14513, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (14513, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (14513, 140,          1) /* AiOptions - CanOpenDoors */
+     , (14513, 146,      26677) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (14513,   1, True ) /* Stuck */
+     , (14513,   6, True ) /* AiUsesMana */
+     , (14513,  11, False) /* IgnoreCollisions */
+     , (14513,  12, True ) /* ReportCollisions */
+     , (14513,  13, False) /* Ethereal */
+     , (14513,  15, True ) /* LightsStatus */
+     , (14513, 120, True ) /* TreasureCorpse */
+     , (14513,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (14513,   1,       5) /* HeartbeatInterval */
+     , (14513,   2,       0) /* HeartbeatTimestamp */
+     , (14513,   3,     0.9) /* HealthRate */
+     , (14513,   4,     0.5) /* StaminaRate */
+     , (14513,   5,       2) /* ManaRate */
+     , (14513,  13,       1) /* ArmorModVsSlash */
+     , (14513,  14,       1) /* ArmorModVsPierce */
+     , (14513,  15,       1) /* ArmorModVsBludgeon */
+     , (14513,  16,       1) /* ArmorModVsCold */
+     , (14513,  17,       1) /* ArmorModVsFire */
+     , (14513,  18,       1) /* ArmorModVsAcid */
+     , (14513,  19,     1.1) /* ArmorModVsElectric */
+     , (14513,  31,      20) /* VisualAwarenessRange */
+     , (14513,  39,     1.5) /* DefaultScale */
+     , (14513,  64,     0.2) /* ResistSlash */
+     , (14513,  65,     0.2) /* ResistPierce */
+     , (14513,  66,     0.2) /* ResistBludgeon */
+     , (14513,  67,     0.2) /* ResistFire */
+     , (14513,  68,     0.2) /* ResistCold */
+     , (14513,  69,       0) /* ResistAcid */
+     , (14513,  70,    0.35) /* ResistElectric */
+     , (14513,  71,       1) /* ResistHealthBoost */
+     , (14513,  72,       1) /* ResistStaminaDrain */
+     , (14513,  73,       1) /* ResistStaminaBoost */
+     , (14513,  74,       1) /* ResistManaDrain */
+     , (14513,  75,       1) /* ResistManaBoost */
+     , (14513,  80,       3) /* AiUseMagicDelay */
+     , (14513, 104,      10) /* ObviousRadarRange */
+     , (14513, 122,       2) /* AiAcquireHealth */
+     , (14513, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (14513,   1, 'Caustic') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (14513,   1,   33557486) /* Setup */
+     , (14513,   2,  150995087) /* MotionTable */
+     , (14513,   3,  536871002) /* SoundTable */
+     , (14513,   4,  805306368) /* CombatTable */
+     , (14513,   8,  100672513) /* Icon */
+     , (14513,  22,  872415349) /* PhysicsEffectTable */
+     , (14513,  35,        460) /* DeathTreasureType - Loot Tier: 4 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (14513,   1, 270, 0, 0) /* Strength */
+     , (14513,   2, 240, 0, 0) /* Endurance */
+     , (14513,   3, 230, 0, 0) /* Quickness */
+     , (14513,   4, 230, 0, 0) /* Coordination */
+     , (14513,   5, 220, 0, 0) /* Focus */
+     , (14513,   6, 220, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (14513,   1,   130, 0, 0, 250) /* MaxHealth */
+     , (14513,   3,   200, 0, 0, 440) /* MaxStamina */
+     , (14513,   5,   300, 0, 0, 520) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (14513,  6, 0, 3, 0, 260, 0, 891.650339655286) /* MeleeDefense        Specialized */
+     , (14513,  7, 0, 3, 0, 348, 0, 891.650339655286) /* MissileDefense      Specialized */
+     , (14513, 12, 0, 3, 0, 140, 0, 891.650339655286) /* ThrownWeapon        Specialized */
+     , (14513, 13, 0, 3, 0, 230, 0, 891.650339655286) /* UnarmedCombat       Specialized */
+     , (14513, 14, 0, 3, 0, 170, 0, 891.650339655286) /* ArcaneLore          Specialized */
+     , (14513, 15, 0, 3, 0, 213, 0, 891.650339655286) /* MagicDefense        Specialized */
+     , (14513, 20, 0, 3, 0, 150, 0, 891.650339655286) /* Deception           Specialized */
+     , (14513, 24, 0, 3, 0, 100, 0, 891.650339655286) /* Run                 Specialized */
+     , (14513, 31, 0, 3, 0, 130, 0, 891.650339655286) /* CreatureEnchantment Specialized */
+     , (14513, 33, 0, 3, 0, 130, 0, 891.650339655286) /* LifeMagic           Specialized */
+     , (14513, 34, 0, 3, 0, 130, 0, 891.650339655286) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (14513,  0, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (14513,  1, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (14513,  2, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (14513,  3, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (14513,  4, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (14513,  5, 32, 50, 0.75,  120,  120,  120,  120,  120,  120,  120,  132,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (14513,  6, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (14513,  7, 32,  0,    0,  120,  120,  120,  120,  120,  120,  120,  132,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (14513,  8, 32, 50, 0.75,  120,  120,  120,  120,  120,  120,  120,  132,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (14513,    62,  2.014)  /* Acid Stream V */
+     , (14513,   233,  2.017)  /* Vulnerability Other V */
+     , (14513,   266,  2.017)  /* Defenselessness Other V */
+     , (14513,   525,  2.017)  /* Acid Vulnerability Other V */
+     , (14513,  1160,  2.013)  /* Heal Self V */
+     , (14513,  1237,  2.008)  /* Drain Health Other I */
+     , (14513,  1326,  2.017)  /* Imperil Other V */
+     , (14513,  1783,  2.014)  /* Searing Disc */
+     , (14513,  1794,  2.002)  /* Acid Streak V */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (14513,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (14513, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (14513, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */
+     , (14513, 9,  6876,  0, 0, 0.01, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14514 Miasma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14514 Miasma.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14514;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14514, 'acidelementalmiasma', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14514, 'acidelementalmiasma', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14514,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (14514,   1, True ) /* Stuck */
      , (14514,  14, True ) /* GravityStatus */
      , (14514,  15, True ) /* LightsStatus */
      , (14514,  19, True ) /* Attackable */
-     , (14514,  29, True ) /* NoCorpse */
+     , (14514, 120, True ) /* TreasureCorpse */
      , (14514,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14515 Miasma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14515 Miasma.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 14515;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (14515, 'acidelementalmiasma-nofall', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14515 Miasma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14515 Miasma.sql
@@ -1,0 +1,129 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (14515, 'acidelementalmiasma-nofall', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (14515,   1,         16) /* ItemType - Creature */
+     , (14515,   2,         60) /* CreatureType - AcidElemental */
+     , (14515,   6,         -1) /* ItemsCapacity */
+     , (14515,   7,         -1) /* ContainersCapacity */
+     , (14515,  16,          1) /* ItemUseable - No */
+     , (14515,  25,        115) /* Level */
+     , (14515,  27,          0) /* ArmorType - None */
+     , (14515,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (14515,  93,    4197384) /* PhysicsState - ReportCollisions, Gravity, LightingOn, EdgeSlide */
+     , (14515, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (14515, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (14515, 140,          1) /* AiOptions - CanOpenDoors */
+     , (14515, 146,      55728) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (14515,   1, True ) /* Stuck */
+     , (14515,   6, True ) /* AiUsesMana */
+     , (14515,  11, False) /* IgnoreCollisions */
+     , (14515,  12, True ) /* ReportCollisions */
+     , (14515,  13, False) /* Ethereal */
+     , (14515,  15, True ) /* LightsStatus */
+     , (14515, 120, True ) /* TreasureCorpse */
+     , (14515,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (14515,   1,       5) /* HeartbeatInterval */
+     , (14515,   2,       0) /* HeartbeatTimestamp */
+     , (14515,   3,     0.9) /* HealthRate */
+     , (14515,   4,     0.5) /* StaminaRate */
+     , (14515,   5,       2) /* ManaRate */
+     , (14515,  13,       1) /* ArmorModVsSlash */
+     , (14515,  14,       1) /* ArmorModVsPierce */
+     , (14515,  15,       1) /* ArmorModVsBludgeon */
+     , (14515,  16,       1) /* ArmorModVsCold */
+     , (14515,  17,       1) /* ArmorModVsFire */
+     , (14515,  18,       1) /* ArmorModVsAcid */
+     , (14515,  19,     1.1) /* ArmorModVsElectric */
+     , (14515,  31,      20) /* VisualAwarenessRange */
+     , (14515,  39,     1.7) /* DefaultScale */
+     , (14515,  64,     0.2) /* ResistSlash */
+     , (14515,  65,     0.2) /* ResistPierce */
+     , (14515,  66,     0.2) /* ResistBludgeon */
+     , (14515,  67,     0.2) /* ResistFire */
+     , (14515,  68,     0.2) /* ResistCold */
+     , (14515,  69,       0) /* ResistAcid */
+     , (14515,  70,     0.3) /* ResistElectric */
+     , (14515,  71,       1) /* ResistHealthBoost */
+     , (14515,  72,       1) /* ResistStaminaDrain */
+     , (14515,  73,       1) /* ResistStaminaBoost */
+     , (14515,  74,       1) /* ResistManaDrain */
+     , (14515,  75,       1) /* ResistManaBoost */
+     , (14515,  80,       3) /* AiUseMagicDelay */
+     , (14515, 104,      10) /* ObviousRadarRange */
+     , (14515, 122,       2) /* AiAcquireHealth */
+     , (14515, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (14515,   1, 'Miasma') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (14515,   1,   33557486) /* Setup */
+     , (14515,   2,  150995087) /* MotionTable */
+     , (14515,   3,  536871002) /* SoundTable */
+     , (14515,   4,  805306368) /* CombatTable */
+     , (14515,   8,  100672513) /* Icon */
+     , (14515,  22,  872415349) /* PhysicsEffectTable */
+     , (14515,  35,        464) /* DeathTreasureType - Loot Tier: 5 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (14515,   1, 270, 0, 0) /* Strength */
+     , (14515,   2, 240, 0, 0) /* Endurance */
+     , (14515,   3, 240, 0, 0) /* Quickness */
+     , (14515,   4, 240, 0, 0) /* Coordination */
+     , (14515,   5, 220, 0, 0) /* Focus */
+     , (14515,   6, 220, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (14515,   1,   280, 0, 0, 400) /* MaxHealth */
+     , (14515,   3,   200, 0, 0, 440) /* MaxStamina */
+     , (14515,   5,   300, 0, 0, 520) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (14515,  6, 0, 3, 0, 335, 0, 891.874108633974) /* MeleeDefense        Specialized */
+     , (14515,  7, 0, 3, 0, 416, 0, 891.874108633974) /* MissileDefense      Specialized */
+     , (14515, 12, 0, 3, 0, 180, 0, 891.874108633974) /* ThrownWeapon        Specialized */
+     , (14515, 13, 0, 3, 0, 280, 0, 891.874108633974) /* UnarmedCombat       Specialized */
+     , (14515, 14, 0, 3, 0, 170, 0, 891.874108633974) /* ArcaneLore          Specialized */
+     , (14515, 15, 0, 3, 0, 257, 0, 891.874108633974) /* MagicDefense        Specialized */
+     , (14515, 20, 0, 3, 0, 150, 0, 891.874108633974) /* Deception           Specialized */
+     , (14515, 24, 0, 3, 0, 100, 0, 891.874108633974) /* Run                 Specialized */
+     , (14515, 31, 0, 3, 0, 178, 0, 891.874108633974) /* CreatureEnchantment Specialized */
+     , (14515, 33, 0, 3, 0, 178, 0, 891.874108633974) /* LifeMagic           Specialized */
+     , (14515, 34, 0, 3, 0, 178, 0, 891.874108633974) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (14515,  0, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (14515,  1, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (14515,  2, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (14515,  3, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (14515,  4, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (14515,  5, 32, 55, 0.75,  220,  220,  220,  220,  220,  220,  220,  242,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (14515,  6, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (14515,  7, 32,  0,    0,  220,  220,  220,  220,  220,  220,  220,  242,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (14515,  8, 32, 55, 0.75,  220,  220,  220,  220,  220,  220,  220,  242,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (14515,    63,  2.004)  /* Acid Stream VI */
+     , (14515,   175,  2.017)  /* Fester Other V */
+     , (14515,   232,  2.017)  /* Vulnerability Other IV */
+     , (14515,   276,  2.008)  /* Magic Resistance Self III */
+     , (14515,   525,  2.017)  /* Acid Vulnerability Other V */
+     , (14515,  1071,  2.008)  /* Lightning Protection Self VI */
+     , (14515,  1160,  2.013)  /* Heal Self V */
+     , (14515,  1237,  2.008)  /* Drain Health Other I */
+     , (14515,  1326,  2.017)  /* Imperil Other V */
+     , (14515,  1783,  2.004)  /* Searing Disc */
+     , (14515,  1795,  2.004)  /* Acid Streak VI */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (14515,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (14515, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (14515, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (14515, 9,  6876,  0, 0, 0.02, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14516 Caustic.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/14516 Caustic.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14516;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14516, 'acidelementalcaustic', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14516, 'acidelementalcaustic', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14516,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (14516,   1, True ) /* Stuck */
      , (14516,  14, True ) /* GravityStatus */
      , (14516,  15, True ) /* LightsStatus */
      , (14516,  19, True ) /* Attackable */
-     , (14516,  29, True ) /* NoCorpse */
+     , (14516, 120, True ) /* TreasureCorpse */
      , (14516,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20186 Apozim.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20186 Apozim.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 20186;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (20186, 'acidelementalapozim', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (20186, 'acidelementalapozim', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (20186,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (20186,   1, True ) /* Stuck */
      , (20186,  14, True ) /* GravityStatus */
      , (20186,  15, True ) /* LightsStatus */
      , (20186,  19, True ) /* Attackable */
-     , (20186,  29, True ) /* NoCorpse */
+     , (20186, 120, True ) /* TreasureCorpse */
      , (20186,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20187 Buillic.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20187 Buillic.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 20187;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (20187, 'acidelementalbuillic', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (20187, 'acidelementalbuillic', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (20187,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (20187,   1, True ) /* Stuck */
      , (20187,  14, True ) /* GravityStatus */
      , (20187,  15, True ) /* LightsStatus */
      , (20187,  19, True ) /* Attackable */
-     , (20187,  29, True ) /* NoCorpse */
+     , (20187, 120, True ) /* TreasureCorpse */
      , (20187,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20188 Mox.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20188 Mox.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 20188;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (20188, 'acidelementalmox', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (20188, 'acidelementalmox', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (20188,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (20188,   1, True ) /* Stuck */
      , (20188,  14, True ) /* GravityStatus */
      , (20188,  15, True ) /* LightsStatus */
      , (20188,  19, True ) /* Attackable */
-     , (20188,  29, True ) /* NoCorpse */
+     , (20188, 120, True ) /* TreasureCorpse */
      , (20188,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20864 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20864 Corrosion.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20864, 'somaticelementalcorrosion', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20864,   1,         16) /* ItemType - Creature */
+     , (20864,   2,         60) /* CreatureType - AcidElemental */
+     , (20864,   6,         -1) /* ItemsCapacity */
+     , (20864,   7,         -1) /* ContainersCapacity */
+     , (20864,  16,          1) /* ItemUseable - No */
+     , (20864,  25,        161) /* Level */
+     , (20864,  27,          0) /* ArmorType - None */
+     , (20864,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20864,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20864, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20864, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20864, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20864, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20864,   1, True ) /* Stuck */
+     , (20864,   6, True ) /* AiUsesMana */
+     , (20864,  11, False) /* IgnoreCollisions */
+     , (20864,  12, True ) /* ReportCollisions */
+     , (20864,  13, False) /* Ethereal */
+     , (20864,  15, True ) /* LightsStatus */
+     , (20864, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20864,   1,       5) /* HeartbeatInterval */
+     , (20864,   2,       0) /* HeartbeatTimestamp */
+     , (20864,   3,     0.9) /* HealthRate */
+     , (20864,   4,     0.5) /* StaminaRate */
+     , (20864,   5,       2) /* ManaRate */
+     , (20864,  13,       1) /* ArmorModVsSlash */
+     , (20864,  14,       1) /* ArmorModVsPierce */
+     , (20864,  15,       1) /* ArmorModVsBludgeon */
+     , (20864,  16,       1) /* ArmorModVsCold */
+     , (20864,  17,       1) /* ArmorModVsFire */
+     , (20864,  18,     1.1) /* ArmorModVsAcid */
+     , (20864,  19,     1.1) /* ArmorModVsElectric */
+     , (20864,  31,      40) /* VisualAwarenessRange */
+     , (20864,  39,     1.4) /* DefaultScale */
+     , (20864,  64,     0.2) /* ResistSlash */
+     , (20864,  65,     0.2) /* ResistPierce */
+     , (20864,  66,     0.2) /* ResistBludgeon */
+     , (20864,  67,       0) /* ResistFire */
+     , (20864,  68,     0.4) /* ResistCold */
+     , (20864,  69,       0) /* ResistAcid */
+     , (20864,  70,     0.4) /* ResistElectric */
+     , (20864,  71,       1) /* ResistHealthBoost */
+     , (20864,  72,       1) /* ResistStaminaDrain */
+     , (20864,  73,       1) /* ResistStaminaBoost */
+     , (20864,  74,       1) /* ResistManaDrain */
+     , (20864,  75,       1) /* ResistManaBoost */
+     , (20864,  80,       3) /* AiUseMagicDelay */
+     , (20864, 104,      10) /* ObviousRadarRange */
+     , (20864, 122,       2) /* AiAcquireHealth */
+     , (20864, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20864,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20864,   1,   33557678) /* Setup */
+     , (20864,   2,  150995087) /* MotionTable */
+     , (20864,   3,  536870998) /* SoundTable */
+     , (20864,   4,  805306368) /* CombatTable */
+     , (20864,   8,  100672513) /* Icon */
+     , (20864,  22,  872415349) /* PhysicsEffectTable */
+     , (20864,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20864,   1, 400, 0, 0) /* Strength */
+     , (20864,   2, 600, 0, 0) /* Endurance */
+     , (20864,   3, 400, 0, 0) /* Quickness */
+     , (20864,   4, 400, 0, 0) /* Coordination */
+     , (20864,   5, 350, 0, 0) /* Focus */
+     , (20864,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20864,   1,  4400, 0, 0, 4700) /* MaxHealth */
+     , (20864,   3, 22700, 0, 0, 23300) /* MaxStamina */
+     , (20864,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20864,  6, 0, 3, 0,  15, 0, 1263.06841726355) /* MeleeDefense        Specialized */
+     , (20864,  7, 0, 3, 0, 190, 0, 1263.06841726355) /* MissileDefense      Specialized */
+     , (20864, 12, 0, 3, 0,  70, 0, 1263.06841726355) /* ThrownWeapon        Specialized */
+     , (20864, 13, 0, 3, 0,  50, 0, 1263.06841726355) /* UnarmedCombat       Specialized */
+     , (20864, 14, 0, 3, 0, 170, 0, 1263.06841726355) /* ArcaneLore          Specialized */
+     , (20864, 15, 0, 3, 0, 159, 0, 1263.06841726355) /* MagicDefense        Specialized */
+     , (20864, 20, 0, 3, 0, 150, 0, 1263.06841726355) /* Deception           Specialized */
+     , (20864, 24, 0, 3, 0, 100, 0, 1263.06841726355) /* Run                 Specialized */
+     , (20864, 31, 0, 3, 0, 228, 0, 1263.06841726355) /* CreatureEnchantment Specialized */
+     , (20864, 33, 0, 3, 0, 228, 0, 1263.06841726355) /* LifeMagic           Specialized */
+     , (20864, 34, 0, 3, 0, 228, 0, 1263.06841726355) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20864,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20864,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20864,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20864,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20864,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20864,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20864,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20864,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20864,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20864,   276,  2.008)  /* Magic Resistance Self III */
+     , (20864,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20864,  1237,  2.008)  /* Drain Health Other I */
+     , (20864,  1783,  2.004)  /* Searing Disc */
+     , (20864,  2068,  2.017)  /* Brittle Bones */
+     , (20864,  2073,  2.013)  /* Adja's Intervention */
+     , (20864,  2074,  2.017)  /* Gossamer Flesh */
+     , (20864,  2122,  2.004)  /* Disintegration */
+     , (20864,  2162,  2.017)  /* Olthoi's Gift */
+     , (20864,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20864,  2228,  2.017)  /* Broadside of a Barn */
+     , (20864,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20864,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20864, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20864 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20864 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20864;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20864, 'somaticelementalcorrosion', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20865 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20865 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20865;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20865, 'somaticelementalcorrosion1', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20865 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20865 Corrosion.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20865, 'somaticelementalcorrosion1', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20865,   1,         16) /* ItemType - Creature */
+     , (20865,   2,         60) /* CreatureType - AcidElemental */
+     , (20865,   3,          8) /* PaletteTemplate - Green */
+     , (20865,   6,         -1) /* ItemsCapacity */
+     , (20865,   7,         -1) /* ContainersCapacity */
+     , (20865,  16,          1) /* ItemUseable - No */
+     , (20865,  25,        999) /* Level */
+     , (20865,  27,          0) /* ArmorType - None */
+     , (20865,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20865,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20865, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20865, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20865, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20865, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20865,   1, True ) /* Stuck */
+     , (20865,   6, True ) /* AiUsesMana */
+     , (20865,  11, False) /* IgnoreCollisions */
+     , (20865,  12, True ) /* ReportCollisions */
+     , (20865,  13, False) /* Ethereal */
+     , (20865,  15, True ) /* LightsStatus */
+     , (20865, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20865,   1,       5) /* HeartbeatInterval */
+     , (20865,   2,       0) /* HeartbeatTimestamp */
+     , (20865,   3,     0.9) /* HealthRate */
+     , (20865,   4,     0.5) /* StaminaRate */
+     , (20865,   5,       2) /* ManaRate */
+     , (20865,  13,       1) /* ArmorModVsSlash */
+     , (20865,  14,       1) /* ArmorModVsPierce */
+     , (20865,  15,       1) /* ArmorModVsBludgeon */
+     , (20865,  16,       1) /* ArmorModVsCold */
+     , (20865,  17,       1) /* ArmorModVsFire */
+     , (20865,  18,     1.1) /* ArmorModVsAcid */
+     , (20865,  19,     1.1) /* ArmorModVsElectric */
+     , (20865,  31,      40) /* VisualAwarenessRange */
+     , (20865,  39,     1.4) /* DefaultScale */
+     , (20865,  64,     0.2) /* ResistSlash */
+     , (20865,  65,     0.2) /* ResistPierce */
+     , (20865,  66,     0.2) /* ResistBludgeon */
+     , (20865,  67,       0) /* ResistFire */
+     , (20865,  68,     0.4) /* ResistCold */
+     , (20865,  69,       0) /* ResistAcid */
+     , (20865,  70,     0.4) /* ResistElectric */
+     , (20865,  71,       1) /* ResistHealthBoost */
+     , (20865,  72,       1) /* ResistStaminaDrain */
+     , (20865,  73,       1) /* ResistStaminaBoost */
+     , (20865,  74,       1) /* ResistManaDrain */
+     , (20865,  75,       1) /* ResistManaBoost */
+     , (20865,  80,       3) /* AiUseMagicDelay */
+     , (20865, 104,      10) /* ObviousRadarRange */
+     , (20865, 122,       2) /* AiAcquireHealth */
+     , (20865, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20865,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20865,   1,   33557853) /* Setup */
+     , (20865,   2,  150995087) /* MotionTable */
+     , (20865,   3,  536871002) /* SoundTable */
+     , (20865,   4,  805306368) /* CombatTable */
+     , (20865,   6,   67108990) /* PaletteBase */
+     , (20865,   7,  268436431) /* ClothingBase */
+     , (20865,   8,  100672513) /* Icon */
+     , (20865,  22,  872415349) /* PhysicsEffectTable */
+     , (20865,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20865,   1, 400, 0, 0) /* Strength */
+     , (20865,   2, 600, 0, 0) /* Endurance */
+     , (20865,   3, 400, 0, 0) /* Quickness */
+     , (20865,   4, 400, 0, 0) /* Coordination */
+     , (20865,   5, 350, 0, 0) /* Focus */
+     , (20865,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20865,   1, 22700, 0, 0, 23000) /* MaxHealth */
+     , (20865,   3,  4400, 0, 0, 5000) /* MaxStamina */
+     , (20865,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20865,  6, 0, 3, 0,  15, 0, 1263.17270617215) /* MeleeDefense        Specialized */
+     , (20865,  7, 0, 3, 0, 190, 0, 1263.17270617215) /* MissileDefense      Specialized */
+     , (20865, 12, 0, 3, 0,  70, 0, 1263.17270617215) /* ThrownWeapon        Specialized */
+     , (20865, 13, 0, 3, 0,  50, 0, 1263.17270617215) /* UnarmedCombat       Specialized */
+     , (20865, 14, 0, 3, 0, 170, 0, 1263.17270617215) /* ArcaneLore          Specialized */
+     , (20865, 15, 0, 3, 0, 159, 0, 1263.17270617215) /* MagicDefense        Specialized */
+     , (20865, 20, 0, 3, 0, 150, 0, 1263.17270617215) /* Deception           Specialized */
+     , (20865, 24, 0, 3, 0, 100, 0, 1263.17270617215) /* Run                 Specialized */
+     , (20865, 31, 0, 3, 0, 228, 0, 1263.17270617215) /* CreatureEnchantment Specialized */
+     , (20865, 33, 0, 3, 0, 228, 0, 1263.17270617215) /* LifeMagic           Specialized */
+     , (20865, 34, 0, 3, 0, 228, 0, 1263.17270617215) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20865,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20865,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20865,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20865,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20865,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20865,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20865,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20865,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20865,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20865,   276,  2.008)  /* Magic Resistance Self III */
+     , (20865,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20865,  1783,  2.004)  /* Searing Disc */
+     , (20865,  2068,  2.017)  /* Brittle Bones */
+     , (20865,  2073,  2.013)  /* Adja's Intervention */
+     , (20865,  2074,  2.017)  /* Gossamer Flesh */
+     , (20865,  2122,  2.004)  /* Disintegration */
+     , (20865,  2162,  2.017)  /* Olthoi's Gift */
+     , (20865,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20865,  2228,  2.017)  /* Broadside of a Barn */
+     , (20865,  2318,  2.017)  /* Gravity Well */
+     , (20865,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20865,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20865, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20865,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Your persistence in striking against us has begun to unnerve us. You cannot hope to survive what is coming there is no stopping nature. Not even time can dwindle our power and what we are.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Corrosion, the Essence of Verdancy, repelling Gaerlan''s forces back from the cities of the west...for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20865,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'In my new gained sentience I did not understand destruction. But now I see that even I can be dispersed. But my death like yours is not permanent. I shall return sooner than you think.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Tempest, the Essence of Storms. Its form is driven from the world and Gaerlan''s forces are routed at Fort Tethana, Ayan Baqur, Wai Jhou, and Danby''s Outpost.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20865, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Your flesh dissolved from bones, I triumph again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20865, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Tempt not, what your magic is made of. There will only be a reckoning.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20866 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20866 Corrosion.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20866, 'somaticelementalcorrosion2', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20866,   1,         16) /* ItemType - Creature */
+     , (20866,   2,         60) /* CreatureType - AcidElemental */
+     , (20866,   3,          8) /* PaletteTemplate - Green */
+     , (20866,   6,         -1) /* ItemsCapacity */
+     , (20866,   7,         -1) /* ContainersCapacity */
+     , (20866,  16,          1) /* ItemUseable - No */
+     , (20866,  25,        161) /* Level */
+     , (20866,  27,          0) /* ArmorType - None */
+     , (20866,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20866,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20866, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20866, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20866, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20866, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20866,   1, True ) /* Stuck */
+     , (20866,   6, True ) /* AiUsesMana */
+     , (20866,  11, False) /* IgnoreCollisions */
+     , (20866,  12, True ) /* ReportCollisions */
+     , (20866,  13, False) /* Ethereal */
+     , (20866,  15, True ) /* LightsStatus */
+     , (20866, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20866,   1,       5) /* HeartbeatInterval */
+     , (20866,   2,       0) /* HeartbeatTimestamp */
+     , (20866,   3,     0.9) /* HealthRate */
+     , (20866,   4,     0.5) /* StaminaRate */
+     , (20866,   5,       2) /* ManaRate */
+     , (20866,  13,       1) /* ArmorModVsSlash */
+     , (20866,  14,       1) /* ArmorModVsPierce */
+     , (20866,  15,       1) /* ArmorModVsBludgeon */
+     , (20866,  16,       1) /* ArmorModVsCold */
+     , (20866,  17,       1) /* ArmorModVsFire */
+     , (20866,  18,     1.1) /* ArmorModVsAcid */
+     , (20866,  19,     1.1) /* ArmorModVsElectric */
+     , (20866,  31,      40) /* VisualAwarenessRange */
+     , (20866,  39,     1.4) /* DefaultScale */
+     , (20866,  64,     0.2) /* ResistSlash */
+     , (20866,  65,     0.2) /* ResistPierce */
+     , (20866,  66,     0.2) /* ResistBludgeon */
+     , (20866,  67,       0) /* ResistFire */
+     , (20866,  68,     0.4) /* ResistCold */
+     , (20866,  69,       0) /* ResistAcid */
+     , (20866,  70,     0.4) /* ResistElectric */
+     , (20866,  71,       1) /* ResistHealthBoost */
+     , (20866,  72,       1) /* ResistStaminaDrain */
+     , (20866,  73,       1) /* ResistStaminaBoost */
+     , (20866,  74,       1) /* ResistManaDrain */
+     , (20866,  75,       1) /* ResistManaBoost */
+     , (20866,  80,       3) /* AiUseMagicDelay */
+     , (20866, 104,      10) /* ObviousRadarRange */
+     , (20866, 122,       2) /* AiAcquireHealth */
+     , (20866, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20866,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20866,   1,   33557853) /* Setup */
+     , (20866,   2,  150995087) /* MotionTable */
+     , (20866,   3,  536870998) /* SoundTable */
+     , (20866,   4,  805306368) /* CombatTable */
+     , (20866,   6,   67108990) /* PaletteBase */
+     , (20866,   7,  268436431) /* ClothingBase */
+     , (20866,   8,  100672513) /* Icon */
+     , (20866,  22,  872415349) /* PhysicsEffectTable */
+     , (20866,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20866,   1, 400, 0, 0) /* Strength */
+     , (20866,   2, 600, 0, 0) /* Endurance */
+     , (20866,   3, 400, 0, 0) /* Quickness */
+     , (20866,   4, 400, 0, 0) /* Coordination */
+     , (20866,   5, 350, 0, 0) /* Focus */
+     , (20866,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20866,   1, 22700, 0, 0, 23000) /* MaxHealth */
+     , (20866,   3,  4400, 0, 0, 5000) /* MaxStamina */
+     , (20866,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20866,  6, 0, 3, 0,  15, 0, 1263.33663599774) /* MeleeDefense        Specialized */
+     , (20866,  7, 0, 3, 0, 190, 0, 1263.33663599774) /* MissileDefense      Specialized */
+     , (20866, 12, 0, 3, 0,  70, 0, 1263.33663599774) /* ThrownWeapon        Specialized */
+     , (20866, 13, 0, 3, 0,  50, 0, 1263.33663599774) /* UnarmedCombat       Specialized */
+     , (20866, 14, 0, 3, 0, 170, 0, 1263.33663599774) /* ArcaneLore          Specialized */
+     , (20866, 15, 0, 3, 0, 159, 0, 1263.33663599774) /* MagicDefense        Specialized */
+     , (20866, 20, 0, 3, 0, 150, 0, 1263.33663599774) /* Deception           Specialized */
+     , (20866, 24, 0, 3, 0, 100, 0, 1263.33663599774) /* Run                 Specialized */
+     , (20866, 31, 0, 3, 0, 228, 0, 1263.33663599774) /* CreatureEnchantment Specialized */
+     , (20866, 33, 0, 3, 0, 228, 0, 1263.33663599774) /* LifeMagic           Specialized */
+     , (20866, 34, 0, 3, 0, 228, 0, 1263.33663599774) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20866,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20866,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20866,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20866,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20866,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20866,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20866,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20866,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20866,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20866,   276,  2.008)  /* Magic Resistance Self III */
+     , (20866,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20866,  1783,  2.004)  /* Searing Disc */
+     , (20866,  2068,  2.017)  /* Brittle Bones */
+     , (20866,  2073,  2.013)  /* Adja's Intervention */
+     , (20866,  2074,  2.017)  /* Gossamer Flesh */
+     , (20866,  2122,  2.004)  /* Disintegration */
+     , (20866,  2162,  2.017)  /* Olthoi's Gift */
+     , (20866,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20866,  2228,  2.017)  /* Broadside of a Barn */
+     , (20866,  2318,  2.017)  /* Gravity Well */
+     , (20866,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20866,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20866, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20866,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Your persistence in striking against us has begun to unnerve us. You cannot hope to survive what is coming there is no stopping nature. Not even time can dwindle our power and what we are.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Corrosion, the Essence of Verdancy.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20866,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'In my new gained sentience I did not understand destruction. But now I see that even I can be dispersed. But my death like yours is not permanent. I shall return sooner than you think.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Corrosion, the Essence of Verdancy.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20866, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Your flesh dissolved from bones, I triumph again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20866, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Tempt not, what your magic is made of. There will only be a reckoning.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20866 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20866 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20866;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20866, 'somaticelementalcorrosion2', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20867 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20867 Corrosion.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20867, 'somaticelementalcorrosion3', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20867,   1,         16) /* ItemType - Creature */
+     , (20867,   2,         60) /* CreatureType - AcidElemental */
+     , (20867,   6,         -1) /* ItemsCapacity */
+     , (20867,   7,         -1) /* ContainersCapacity */
+     , (20867,  16,          1) /* ItemUseable - No */
+     , (20867,  25,        161) /* Level */
+     , (20867,  27,          0) /* ArmorType - None */
+     , (20867,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20867,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20867, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20867, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20867, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20867, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20867,   1, True ) /* Stuck */
+     , (20867,   6, True ) /* AiUsesMana */
+     , (20867,  11, False) /* IgnoreCollisions */
+     , (20867,  12, True ) /* ReportCollisions */
+     , (20867,  13, False) /* Ethereal */
+     , (20867,  15, True ) /* LightsStatus */
+     , (20867, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20867,   1,       5) /* HeartbeatInterval */
+     , (20867,   2,       0) /* HeartbeatTimestamp */
+     , (20867,   3,     0.9) /* HealthRate */
+     , (20867,   4,     0.5) /* StaminaRate */
+     , (20867,   5,       2) /* ManaRate */
+     , (20867,  13,       1) /* ArmorModVsSlash */
+     , (20867,  14,       1) /* ArmorModVsPierce */
+     , (20867,  15,       1) /* ArmorModVsBludgeon */
+     , (20867,  16,       1) /* ArmorModVsCold */
+     , (20867,  17,       1) /* ArmorModVsFire */
+     , (20867,  18,     1.1) /* ArmorModVsAcid */
+     , (20867,  19,     1.1) /* ArmorModVsElectric */
+     , (20867,  31,      40) /* VisualAwarenessRange */
+     , (20867,  39,     1.4) /* DefaultScale */
+     , (20867,  64,     0.2) /* ResistSlash */
+     , (20867,  65,     0.2) /* ResistPierce */
+     , (20867,  66,     0.2) /* ResistBludgeon */
+     , (20867,  67,       0) /* ResistFire */
+     , (20867,  68,     0.4) /* ResistCold */
+     , (20867,  69,       0) /* ResistAcid */
+     , (20867,  70,     0.4) /* ResistElectric */
+     , (20867,  71,       1) /* ResistHealthBoost */
+     , (20867,  72,       1) /* ResistStaminaDrain */
+     , (20867,  73,       1) /* ResistStaminaBoost */
+     , (20867,  74,       1) /* ResistManaDrain */
+     , (20867,  75,       1) /* ResistManaBoost */
+     , (20867,  80,       3) /* AiUseMagicDelay */
+     , (20867, 104,      10) /* ObviousRadarRange */
+     , (20867, 122,       2) /* AiAcquireHealth */
+     , (20867, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20867,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20867,   1,   33557678) /* Setup */
+     , (20867,   2,  150995087) /* MotionTable */
+     , (20867,   3,  536870998) /* SoundTable */
+     , (20867,   4,  805306368) /* CombatTable */
+     , (20867,   8,  100672513) /* Icon */
+     , (20867,  22,  872415349) /* PhysicsEffectTable */
+     , (20867,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20867,   1, 400, 0, 0) /* Strength */
+     , (20867,   2, 600, 0, 0) /* Endurance */
+     , (20867,   3, 400, 0, 0) /* Quickness */
+     , (20867,   4, 400, 0, 0) /* Coordination */
+     , (20867,   5, 350, 0, 0) /* Focus */
+     , (20867,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20867,   1,  4400, 0, 0, 4700) /* MaxHealth */
+     , (20867,   3, 22700, 0, 0, 23300) /* MaxStamina */
+     , (20867,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20867,  6, 0, 3, 0,  15, 0, 1263.44328467849) /* MeleeDefense        Specialized */
+     , (20867,  7, 0, 3, 0, 190, 0, 1263.44328467849) /* MissileDefense      Specialized */
+     , (20867, 12, 0, 3, 0,  70, 0, 1263.44328467849) /* ThrownWeapon        Specialized */
+     , (20867, 13, 0, 3, 0,  50, 0, 1263.44328467849) /* UnarmedCombat       Specialized */
+     , (20867, 14, 0, 3, 0, 170, 0, 1263.44328467849) /* ArcaneLore          Specialized */
+     , (20867, 15, 0, 3, 0, 159, 0, 1263.44328467849) /* MagicDefense        Specialized */
+     , (20867, 20, 0, 3, 0, 150, 0, 1263.44328467849) /* Deception           Specialized */
+     , (20867, 24, 0, 3, 0, 100, 0, 1263.44328467849) /* Run                 Specialized */
+     , (20867, 31, 0, 3, 0, 228, 0, 1263.44328467849) /* CreatureEnchantment Specialized */
+     , (20867, 33, 0, 3, 0, 228, 0, 1263.44328467849) /* LifeMagic           Specialized */
+     , (20867, 34, 0, 3, 0, 228, 0, 1263.44328467849) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20867,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20867,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20867,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20867,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20867,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20867,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20867,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20867,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20867,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20867,   276,  2.008)  /* Magic Resistance Self III */
+     , (20867,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20867,  1237,  2.008)  /* Drain Health Other I */
+     , (20867,  1783,  2.004)  /* Searing Disc */
+     , (20867,  2068,  2.017)  /* Brittle Bones */
+     , (20867,  2073,  2.013)  /* Adja's Intervention */
+     , (20867,  2074,  2.017)  /* Gossamer Flesh */
+     , (20867,  2122,  2.004)  /* Disintegration */
+     , (20867,  2162,  2.017)  /* Olthoi's Gift */
+     , (20867,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20867,  2228,  2.017)  /* Broadside of a Barn */
+     , (20867,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20867,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20867, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20867 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20867 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20867;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20867, 'somaticelementalcorrosion3', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20868 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20868 Corrosion.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20868, 'somaticelementalcorrosion4', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20868,   1,         16) /* ItemType - Creature */
+     , (20868,   2,         60) /* CreatureType - AcidElemental */
+     , (20868,   6,         -1) /* ItemsCapacity */
+     , (20868,   7,         -1) /* ContainersCapacity */
+     , (20868,  16,          1) /* ItemUseable - No */
+     , (20868,  25,        161) /* Level */
+     , (20868,  27,          0) /* ArmorType - None */
+     , (20868,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20868,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20868, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20868, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20868, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20868, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20868,   1, True ) /* Stuck */
+     , (20868,   6, True ) /* AiUsesMana */
+     , (20868,  11, False) /* IgnoreCollisions */
+     , (20868,  12, True ) /* ReportCollisions */
+     , (20868,  13, False) /* Ethereal */
+     , (20868,  15, True ) /* LightsStatus */
+     , (20868, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20868,   1,       5) /* HeartbeatInterval */
+     , (20868,   2,       0) /* HeartbeatTimestamp */
+     , (20868,   3,     0.9) /* HealthRate */
+     , (20868,   4,     0.5) /* StaminaRate */
+     , (20868,   5,       2) /* ManaRate */
+     , (20868,  13,       1) /* ArmorModVsSlash */
+     , (20868,  14,       1) /* ArmorModVsPierce */
+     , (20868,  15,       1) /* ArmorModVsBludgeon */
+     , (20868,  16,       1) /* ArmorModVsCold */
+     , (20868,  17,       1) /* ArmorModVsFire */
+     , (20868,  18,     1.1) /* ArmorModVsAcid */
+     , (20868,  19,     1.1) /* ArmorModVsElectric */
+     , (20868,  31,      40) /* VisualAwarenessRange */
+     , (20868,  39,     1.4) /* DefaultScale */
+     , (20868,  64,     0.2) /* ResistSlash */
+     , (20868,  65,     0.2) /* ResistPierce */
+     , (20868,  66,     0.2) /* ResistBludgeon */
+     , (20868,  67,       0) /* ResistFire */
+     , (20868,  68,     0.4) /* ResistCold */
+     , (20868,  69,       0) /* ResistAcid */
+     , (20868,  70,     0.4) /* ResistElectric */
+     , (20868,  71,       1) /* ResistHealthBoost */
+     , (20868,  72,       1) /* ResistStaminaDrain */
+     , (20868,  73,       1) /* ResistStaminaBoost */
+     , (20868,  74,       1) /* ResistManaDrain */
+     , (20868,  75,       1) /* ResistManaBoost */
+     , (20868,  80,       3) /* AiUseMagicDelay */
+     , (20868, 104,      10) /* ObviousRadarRange */
+     , (20868, 122,       2) /* AiAcquireHealth */
+     , (20868, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20868,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20868,   1,   33557678) /* Setup */
+     , (20868,   2,  150995087) /* MotionTable */
+     , (20868,   3,  536870998) /* SoundTable */
+     , (20868,   4,  805306368) /* CombatTable */
+     , (20868,   8,  100672513) /* Icon */
+     , (20868,  22,  872415349) /* PhysicsEffectTable */
+     , (20868,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20868,   1, 400, 0, 0) /* Strength */
+     , (20868,   2, 600, 0, 0) /* Endurance */
+     , (20868,   3, 400, 0, 0) /* Quickness */
+     , (20868,   4, 400, 0, 0) /* Coordination */
+     , (20868,   5, 350, 0, 0) /* Focus */
+     , (20868,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20868,   1,  4400, 0, 0, 4700) /* MaxHealth */
+     , (20868,   3, 22700, 0, 0, 23300) /* MaxStamina */
+     , (20868,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20868,  6, 0, 3, 0,  15, 0, 1263.54812342837) /* MeleeDefense        Specialized */
+     , (20868,  7, 0, 3, 0, 190, 0, 1263.54812342837) /* MissileDefense      Specialized */
+     , (20868, 12, 0, 3, 0,  70, 0, 1263.54812342837) /* ThrownWeapon        Specialized */
+     , (20868, 13, 0, 3, 0,  50, 0, 1263.54812342837) /* UnarmedCombat       Specialized */
+     , (20868, 14, 0, 3, 0, 170, 0, 1263.54812342837) /* ArcaneLore          Specialized */
+     , (20868, 15, 0, 3, 0, 159, 0, 1263.54812342837) /* MagicDefense        Specialized */
+     , (20868, 20, 0, 3, 0, 150, 0, 1263.54812342837) /* Deception           Specialized */
+     , (20868, 24, 0, 3, 0, 100, 0, 1263.54812342837) /* Run                 Specialized */
+     , (20868, 31, 0, 3, 0, 228, 0, 1263.54812342837) /* CreatureEnchantment Specialized */
+     , (20868, 33, 0, 3, 0, 228, 0, 1263.54812342837) /* LifeMagic           Specialized */
+     , (20868, 34, 0, 3, 0, 228, 0, 1263.54812342837) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20868,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20868,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20868,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20868,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20868,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20868,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20868,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20868,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20868,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20868,   276,  2.008)  /* Magic Resistance Self III */
+     , (20868,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20868,  1237,  2.008)  /* Drain Health Other I */
+     , (20868,  1783,  2.004)  /* Searing Disc */
+     , (20868,  2068,  2.017)  /* Brittle Bones */
+     , (20868,  2073,  2.013)  /* Adja's Intervention */
+     , (20868,  2074,  2.017)  /* Gossamer Flesh */
+     , (20868,  2122,  2.004)  /* Disintegration */
+     , (20868,  2162,  2.017)  /* Olthoi's Gift */
+     , (20868,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20868,  2228,  2.017)  /* Broadside of a Barn */
+     , (20868,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20868,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20868, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20868 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20868 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20868;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20868, 'somaticelementalcorrosion4', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20869 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20869 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20869;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20869, 'somaticelementalcorrosion5', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20869 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20869 Corrosion.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20869, 'somaticelementalcorrosion5', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20869,   1,         16) /* ItemType - Creature */
+     , (20869,   2,         60) /* CreatureType - AcidElemental */
+     , (20869,   6,         -1) /* ItemsCapacity */
+     , (20869,   7,         -1) /* ContainersCapacity */
+     , (20869,  16,          1) /* ItemUseable - No */
+     , (20869,  25,        161) /* Level */
+     , (20869,  27,          0) /* ArmorType - None */
+     , (20869,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20869,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20869, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20869, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20869, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20869, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20869,   1, True ) /* Stuck */
+     , (20869,   6, True ) /* AiUsesMana */
+     , (20869,  11, False) /* IgnoreCollisions */
+     , (20869,  12, True ) /* ReportCollisions */
+     , (20869,  13, False) /* Ethereal */
+     , (20869,  15, True ) /* LightsStatus */
+     , (20869, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20869,   1,       5) /* HeartbeatInterval */
+     , (20869,   2,       0) /* HeartbeatTimestamp */
+     , (20869,   3,     0.9) /* HealthRate */
+     , (20869,   4,     0.5) /* StaminaRate */
+     , (20869,   5,       2) /* ManaRate */
+     , (20869,  13,       1) /* ArmorModVsSlash */
+     , (20869,  14,       1) /* ArmorModVsPierce */
+     , (20869,  15,       1) /* ArmorModVsBludgeon */
+     , (20869,  16,       1) /* ArmorModVsCold */
+     , (20869,  17,       1) /* ArmorModVsFire */
+     , (20869,  18,     1.1) /* ArmorModVsAcid */
+     , (20869,  19,     1.1) /* ArmorModVsElectric */
+     , (20869,  31,      40) /* VisualAwarenessRange */
+     , (20869,  39,     1.4) /* DefaultScale */
+     , (20869,  64,     0.2) /* ResistSlash */
+     , (20869,  65,     0.2) /* ResistPierce */
+     , (20869,  66,     0.2) /* ResistBludgeon */
+     , (20869,  67,       0) /* ResistFire */
+     , (20869,  68,     0.4) /* ResistCold */
+     , (20869,  69,       0) /* ResistAcid */
+     , (20869,  70,     0.4) /* ResistElectric */
+     , (20869,  71,       1) /* ResistHealthBoost */
+     , (20869,  72,       1) /* ResistStaminaDrain */
+     , (20869,  73,       1) /* ResistStaminaBoost */
+     , (20869,  74,       1) /* ResistManaDrain */
+     , (20869,  75,       1) /* ResistManaBoost */
+     , (20869,  80,       3) /* AiUseMagicDelay */
+     , (20869, 104,      10) /* ObviousRadarRange */
+     , (20869, 122,       2) /* AiAcquireHealth */
+     , (20869, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20869,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20869,   1,   33557678) /* Setup */
+     , (20869,   2,  150995087) /* MotionTable */
+     , (20869,   3,  536870998) /* SoundTable */
+     , (20869,   4,  805306368) /* CombatTable */
+     , (20869,   8,  100672513) /* Icon */
+     , (20869,  22,  872415349) /* PhysicsEffectTable */
+     , (20869,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20869,   1, 400, 0, 0) /* Strength */
+     , (20869,   2, 600, 0, 0) /* Endurance */
+     , (20869,   3, 400, 0, 0) /* Quickness */
+     , (20869,   4, 400, 0, 0) /* Coordination */
+     , (20869,   5, 350, 0, 0) /* Focus */
+     , (20869,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20869,   1,  4400, 0, 0, 4700) /* MaxHealth */
+     , (20869,   3, 22700, 0, 0, 23300) /* MaxStamina */
+     , (20869,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20869,  6, 0, 3, 0,  15, 0, 1263.65342580442) /* MeleeDefense        Specialized */
+     , (20869,  7, 0, 3, 0, 190, 0, 1263.65342580442) /* MissileDefense      Specialized */
+     , (20869, 12, 0, 3, 0,  70, 0, 1263.65342580442) /* ThrownWeapon        Specialized */
+     , (20869, 13, 0, 3, 0,  50, 0, 1263.65342580442) /* UnarmedCombat       Specialized */
+     , (20869, 14, 0, 3, 0, 170, 0, 1263.65342580442) /* ArcaneLore          Specialized */
+     , (20869, 15, 0, 3, 0, 159, 0, 1263.65342580442) /* MagicDefense        Specialized */
+     , (20869, 20, 0, 3, 0, 150, 0, 1263.65342580442) /* Deception           Specialized */
+     , (20869, 24, 0, 3, 0, 100, 0, 1263.65342580442) /* Run                 Specialized */
+     , (20869, 31, 0, 3, 0, 228, 0, 1263.65342580442) /* CreatureEnchantment Specialized */
+     , (20869, 33, 0, 3, 0, 228, 0, 1263.65342580442) /* LifeMagic           Specialized */
+     , (20869, 34, 0, 3, 0, 228, 0, 1263.65342580442) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20869,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20869,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20869,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20869,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20869,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20869,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20869,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20869,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20869,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20869,   276,  2.008)  /* Magic Resistance Self III */
+     , (20869,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20869,  1237,  2.008)  /* Drain Health Other I */
+     , (20869,  1783,  2.004)  /* Searing Disc */
+     , (20869,  2068,  2.017)  /* Brittle Bones */
+     , (20869,  2073,  2.013)  /* Adja's Intervention */
+     , (20869,  2074,  2.017)  /* Gossamer Flesh */
+     , (20869,  2122,  2.004)  /* Disintegration */
+     , (20869,  2162,  2.017)  /* Olthoi's Gift */
+     , (20869,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20869,  2228,  2.017)  /* Broadside of a Barn */
+     , (20869,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20869,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20869, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20870 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20870 Corrosion.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20870;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20870, 'somaticelementalcorrosion6', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20870 Corrosion.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/20870 Corrosion.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20870, 'somaticelementalcorrosion6', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20870,   1,         16) /* ItemType - Creature */
+     , (20870,   2,         60) /* CreatureType - AcidElemental */
+     , (20870,   6,         -1) /* ItemsCapacity */
+     , (20870,   7,         -1) /* ContainersCapacity */
+     , (20870,  16,          1) /* ItemUseable - No */
+     , (20870,  25,        161) /* Level */
+     , (20870,  27,          0) /* ArmorType - None */
+     , (20870,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20870,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20870, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20870, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20870, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20870, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20870,   1, True ) /* Stuck */
+     , (20870,   6, True ) /* AiUsesMana */
+     , (20870,  11, False) /* IgnoreCollisions */
+     , (20870,  12, True ) /* ReportCollisions */
+     , (20870,  13, False) /* Ethereal */
+     , (20870,  15, True ) /* LightsStatus */
+     , (20870, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20870,   1,       5) /* HeartbeatInterval */
+     , (20870,   2,       0) /* HeartbeatTimestamp */
+     , (20870,   3,     0.9) /* HealthRate */
+     , (20870,   4,     0.5) /* StaminaRate */
+     , (20870,   5,       2) /* ManaRate */
+     , (20870,  13,       1) /* ArmorModVsSlash */
+     , (20870,  14,       1) /* ArmorModVsPierce */
+     , (20870,  15,       1) /* ArmorModVsBludgeon */
+     , (20870,  16,       1) /* ArmorModVsCold */
+     , (20870,  17,       1) /* ArmorModVsFire */
+     , (20870,  18,     1.1) /* ArmorModVsAcid */
+     , (20870,  19,     1.1) /* ArmorModVsElectric */
+     , (20870,  31,      40) /* VisualAwarenessRange */
+     , (20870,  39,     1.4) /* DefaultScale */
+     , (20870,  64,     0.2) /* ResistSlash */
+     , (20870,  65,     0.2) /* ResistPierce */
+     , (20870,  66,     0.2) /* ResistBludgeon */
+     , (20870,  67,       0) /* ResistFire */
+     , (20870,  68,     0.4) /* ResistCold */
+     , (20870,  69,       0) /* ResistAcid */
+     , (20870,  70,     0.4) /* ResistElectric */
+     , (20870,  71,       1) /* ResistHealthBoost */
+     , (20870,  72,       1) /* ResistStaminaDrain */
+     , (20870,  73,       1) /* ResistStaminaBoost */
+     , (20870,  74,       1) /* ResistManaDrain */
+     , (20870,  75,       1) /* ResistManaBoost */
+     , (20870,  80,       3) /* AiUseMagicDelay */
+     , (20870, 104,      10) /* ObviousRadarRange */
+     , (20870, 122,       2) /* AiAcquireHealth */
+     , (20870, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20870,   1, 'Corrosion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20870,   1,   33557678) /* Setup */
+     , (20870,   2,  150995087) /* MotionTable */
+     , (20870,   3,  536870998) /* SoundTable */
+     , (20870,   4,  805306368) /* CombatTable */
+     , (20870,   8,  100672513) /* Icon */
+     , (20870,  22,  872415349) /* PhysicsEffectTable */
+     , (20870,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20870,   1, 400, 0, 0) /* Strength */
+     , (20870,   2, 600, 0, 0) /* Endurance */
+     , (20870,   3, 400, 0, 0) /* Quickness */
+     , (20870,   4, 400, 0, 0) /* Coordination */
+     , (20870,   5, 350, 0, 0) /* Focus */
+     , (20870,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20870,   1,  4400, 0, 0, 4700) /* MaxHealth */
+     , (20870,   3, 22700, 0, 0, 23300) /* MaxStamina */
+     , (20870,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20870,  6, 0, 3, 0,  15, 0, 1263.75788479726) /* MeleeDefense        Specialized */
+     , (20870,  7, 0, 3, 0, 190, 0, 1263.75788479726) /* MissileDefense      Specialized */
+     , (20870, 12, 0, 3, 0,  70, 0, 1263.75788479726) /* ThrownWeapon        Specialized */
+     , (20870, 13, 0, 3, 0,  50, 0, 1263.75788479726) /* UnarmedCombat       Specialized */
+     , (20870, 14, 0, 3, 0, 170, 0, 1263.75788479726) /* ArcaneLore          Specialized */
+     , (20870, 15, 0, 3, 0, 159, 0, 1263.75788479726) /* MagicDefense        Specialized */
+     , (20870, 20, 0, 3, 0, 150, 0, 1263.75788479726) /* Deception           Specialized */
+     , (20870, 24, 0, 3, 0, 100, 0, 1263.75788479726) /* Run                 Specialized */
+     , (20870, 31, 0, 3, 0, 228, 0, 1263.75788479726) /* CreatureEnchantment Specialized */
+     , (20870, 33, 0, 3, 0, 228, 0, 1263.75788479726) /* LifeMagic           Specialized */
+     , (20870, 34, 0, 3, 0, 228, 0, 1263.75788479726) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20870,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20870,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20870,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20870,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20870,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20870,  5, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20870,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20870,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20870,  8, 32, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20870,   276,  2.008)  /* Magic Resistance Self III */
+     , (20870,  1069,  2.008)  /* Lightning Protection Self IV */
+     , (20870,  1237,  2.008)  /* Drain Health Other I */
+     , (20870,  1783,  2.004)  /* Searing Disc */
+     , (20870,  2068,  2.017)  /* Brittle Bones */
+     , (20870,  2073,  2.013)  /* Adja's Intervention */
+     , (20870,  2074,  2.017)  /* Gossamer Flesh */
+     , (20870,  2122,  2.004)  /* Disintegration */
+     , (20870,  2162,  2.017)  /* Olthoi's Gift */
+     , (20870,  2178,  2.017)  /* Decrepitude's Grasp */
+     , (20870,  2228,  2.017)  /* Broadside of a Barn */
+     , (20870,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20870,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20870, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21160 Scourge.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21160 Scourge.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21160;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21160, 'acidelementalscourge', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21160, 'acidelementalscourge', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21160,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (21160,   1, True ) /* Stuck */
      , (21160,  14, True ) /* GravityStatus */
      , (21160,  15, True ) /* LightsStatus */
      , (21160,  19, True ) /* Attackable */
-     , (21160,  29, True ) /* NoCorpse */
+     , (21160, 120, True ) /* TreasureCorpse */
      , (21160,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21161 Singe.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21161 Singe.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21161;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (21161, 'acidelementalsinge', 10, '2019-02-08 15:36:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21161 Singe.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21161 Singe.sql
@@ -1,0 +1,122 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21161, 'acidelementalsinge', 10, '2019-02-08 15:36:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21161,   1,         16) /* ItemType - Creature */
+     , (21161,   2,         60) /* CreatureType - AcidElemental */
+     , (21161,   6,         -1) /* ItemsCapacity */
+     , (21161,   7,         -1) /* ContainersCapacity */
+     , (21161,  16,          1) /* ItemUseable - No */
+     , (21161,  25,         18) /* Level */
+     , (21161,  27,          0) /* ArmorType - None */
+     , (21161,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (21161,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (21161, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (21161, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (21161, 140,          1) /* AiOptions - CanOpenDoors */
+     , (21161, 146,        878) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21161,   1, True ) /* Stuck */
+     , (21161,   6, True ) /* AiUsesMana */
+     , (21161,  11, False) /* IgnoreCollisions */
+     , (21161,  12, True ) /* ReportCollisions */
+     , (21161,  13, False) /* Ethereal */
+     , (21161,  15, True ) /* LightsStatus */
+     , (21161, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21161,   1,       5) /* HeartbeatInterval */
+     , (21161,   2,       0) /* HeartbeatTimestamp */
+     , (21161,   3,     0.6) /* HealthRate */
+     , (21161,   4,     0.5) /* StaminaRate */
+     , (21161,   5,       2) /* ManaRate */
+     , (21161,  13,    0.58) /* ArmorModVsSlash */
+     , (21161,  14,    0.58) /* ArmorModVsPierce */
+     , (21161,  15,    0.58) /* ArmorModVsBludgeon */
+     , (21161,  16,       1) /* ArmorModVsCold */
+     , (21161,  17,     1.5) /* ArmorModVsFire */
+     , (21161,  18,     100) /* ArmorModVsAcid */
+     , (21161,  19,    0.75) /* ArmorModVsElectric */
+     , (21161,  31,      18) /* VisualAwarenessRange */
+     , (21161,  39,       1) /* DefaultScale */
+     , (21161,  64,    0.65) /* ResistSlash */
+     , (21161,  65,    0.65) /* ResistPierce */
+     , (21161,  66,    0.65) /* ResistBludgeon */
+     , (21161,  67,    0.65) /* ResistFire */
+     , (21161,  68,    0.65) /* ResistCold */
+     , (21161,  69,       0) /* ResistAcid */
+     , (21161,  70,     1.1) /* ResistElectric */
+     , (21161,  71,       1) /* ResistHealthBoost */
+     , (21161,  72,       1) /* ResistStaminaDrain */
+     , (21161,  73,       1) /* ResistStaminaBoost */
+     , (21161,  74,       1) /* ResistManaDrain */
+     , (21161,  75,       1) /* ResistManaBoost */
+     , (21161,  80,       3) /* AiUseMagicDelay */
+     , (21161, 104,      10) /* ObviousRadarRange */
+     , (21161, 122,       2) /* AiAcquireHealth */
+     , (21161, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21161,   1, 'Singe') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21161,   1,   33557486) /* Setup */
+     , (21161,   2,  150995087) /* MotionTable */
+     , (21161,   3,  536870998) /* SoundTable */
+     , (21161,   4,  805306368) /* CombatTable */
+     , (21161,   8,  100672513) /* Icon */
+     , (21161,  22,  872415344) /* PhysicsEffectTable */
+     , (21161,  35,        465) /* DeathTreasureType - Loot Tier: 1 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (21161,   1,  50, 0, 0) /* Strength */
+     , (21161,   2,  95, 0, 0) /* Endurance */
+     , (21161,   3,  80, 0, 0) /* Quickness */
+     , (21161,   4,  85, 0, 0) /* Coordination */
+     , (21161,   5,  50, 0, 0) /* Focus */
+     , (21161,   6,  90, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (21161,   1,    15, 0, 0, 63) /* MaxHealth */
+     , (21161,   3,   200, 0, 0, 295) /* MaxStamina */
+     , (21161,   5,   100, 0, 0, 190) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (21161,  6, 0, 3, 0,  35, 0, 1291.48048767256) /* MeleeDefense        Specialized */
+     , (21161,  7, 0, 3, 0,  55, 0, 1291.48048767256) /* MissileDefense      Specialized */
+     , (21161, 13, 0, 3, 0,  20, 0, 1291.48048767256) /* UnarmedCombat       Specialized */
+     , (21161, 14, 0, 2, 0,  90, 0, 1291.48048767256) /* ArcaneLore          Trained */
+     , (21161, 15, 0, 3, 0,  25, 0, 1291.48048767256) /* MagicDefense        Specialized */
+     , (21161, 20, 0, 2, 0,  10, 0, 1291.48048767256) /* Deception           Trained */
+     , (21161, 24, 0, 2, 0,  50, 0, 1291.48048767256) /* Run                 Trained */
+     , (21161, 31, 0, 3, 0,  35, 0, 1291.48048767256) /* CreatureEnchantment Specialized */
+     , (21161, 33, 0, 3, 0,  35, 0, 1291.48048767256) /* LifeMagic           Specialized */
+     , (21161, 34, 0, 3, 0,  35, 0, 1291.48048767256) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (21161,  0, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (21161,  1, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (21161,  2, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (21161,  3, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (21161,  4, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (21161,  5, 32,  8, 0.75,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (21161,  6, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (21161,  7, 32,  0,    0,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (21161,  8, 32,  8, 0.75,   90,   52,   52,   52,   90,  135, 9000,   68,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (21161,     6,  2.008)  /* Heal Self I */
+     , (21161,    15,   2.01)  /* Vulnerability Other I */
+     , (21161,    24,  2.006)  /* Armor Self I */
+     , (21161,    59,  2.083)  /* Acid Stream II */
+     , (21161,   165,  2.006)  /* Regeneration Self I */
+     , (21161,   262,   2.01)  /* Defenselessness Other I */
+     , (21161,   274,  2.006)  /* Magic Resistance Self I */
+     , (21161,   521,   2.01)  /* Acid Vulnerability Other I */
+     , (21161,  1066,  2.006)  /* Lightning Protection Self I */
+     , (21161,  1237,  2.006)  /* Drain Health Other I */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (21161,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (21161, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21162 Stringent.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/21162 Stringent.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21162;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21162, 'acidelementalstringent', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21162, 'acidelementalstringent', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21162,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (21162,   1, True ) /* Stuck */
      , (21162,  14, True ) /* GravityStatus */
      , (21162,  15, True ) /* LightsStatus */
      , (21162,  19, True ) /* Attackable */
-     , (21162,  29, True ) /* NoCorpse */;
+     , (21162, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21162,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/30755 Virulence.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/AcidElemental/30755 Virulence.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 30755;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (30755, 'acidelementalvirulence', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (30755, 'acidelementalvirulence', 10, '2019-02-08 15:36:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (30755,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (30755,   1, True ) /* Stuck */
      , (30755,  14, True ) /* GravityStatus */
      , (30755,  15, True ) /* LightsStatus */
      , (30755,  19, True ) /* Attackable */
-     , (30755,  29, True ) /* NoCorpse */
+     , (30755, 120, True ) /* TreasureCorpse */
      , (30755,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14876 Maelstrom.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14876 Maelstrom.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14876;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14876, 'stormelementalmaelstrom', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14876, 'stormelementalmaelstrom', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14876,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (14876,   1, True ) /* Stuck */
      , (14876,  14, True ) /* GravityStatus */
      , (14876,  15, True ) /* LightsStatus */
      , (14876,  19, True ) /* Attackable */
-     , (14876,  29, True ) /* NoCorpse */
+     , (14876, 120, True ) /* TreasureCorpse */
      , (14876,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14877 Tsuric.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14877 Tsuric.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14877;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14877, 'stormelementaltsuric', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14877, 'stormelementaltsuric', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14877,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (14877,   1, True ) /* Stuck */
      , (14877,  14, True ) /* GravityStatus */
      , (14877,  15, True ) /* LightsStatus */
      , (14877,  19, True ) /* Attackable */
-     , (14877,  29, True ) /* NoCorpse */
+     , (14877, 120, True ) /* TreasureCorpse */
      , (14877,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14878 Sirrocco.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14878 Sirrocco.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14878;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14878, 'thermicelementalsirrocco', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14878, 'thermicelementalsirrocco', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14878,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (14878,   1, True ) /* Stuck */
      , (14878,  14, True ) /* GravityStatus */
      , (14878,  15, True ) /* LightsStatus */
      , (14878,  19, True ) /* Attackable */
-     , (14878,  29, True ) /* NoCorpse */;
+     , (14878, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (14878,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14879 Sirrocco.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14879 Sirrocco.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14879;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14879, 'thermicelementalsirroccoboss', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14879, 'thermicelementalsirroccoboss', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14879,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (14879,   1, True ) /* Stuck */
      , (14879,  14, True ) /* GravityStatus */
      , (14879,  15, True ) /* LightsStatus */
      , (14879,  19, True ) /* Attackable */
-     , (14879,  29, True ) /* NoCorpse */;
+     , (14879, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (14879,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14880 Theral.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/14880 Theral.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14880;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14880, 'thermicelementaltheral', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14880, 'thermicelementaltheral', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14880,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (14880,   1, True ) /* Stuck */
      , (14880,  14, True ) /* GravityStatus */
      , (14880,  15, True ) /* LightsStatus */
      , (14880,  19, True ) /* Attackable */
-     , (14880,  29, True ) /* NoCorpse */
+     , (14880, 120, True ) /* TreasureCorpse */
      , (14880,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19537 Avalanche.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19537 Avalanche.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 19537;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (19537, 'eluvicelementalavalanche', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (19537, 'eluvicelementalavalanche', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (19537,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (19537,   1, True ) /* Stuck */
      , (19537,  14, True ) /* GravityStatus */
      , (19537,  15, True ) /* LightsStatus */
      , (19537,  19, True ) /* Attackable */
-     , (19537,  29, True ) /* NoCorpse */
+     , (19537, 120, True ) /* TreasureCorpse */
      , (19537,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19538 Blizzard.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19538 Blizzard.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 19538;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (19538, 'eluvicelementalblizzard', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (19538, 'eluvicelementalblizzard', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (19538,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (19538,   1, True ) /* Stuck */
      , (19538,  14, True ) /* GravityStatus */
      , (19538,  15, True ) /* LightsStatus */
      , (19538,  19, True ) /* Attackable */
-     , (19538,  29, True ) /* NoCorpse */
+     , (19538, 120, True ) /* TreasureCorpse */
      , (19538,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19539 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19539 Conflagration.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 19539;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (19539, 'estuaryelementalconflagration', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (19539, 'estuaryelementalconflagration', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (19539,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (19539,   1, True ) /* Stuck */
      , (19539,  14, True ) /* GravityStatus */
      , (19539,  15, True ) /* LightsStatus */
      , (19539,  19, True ) /* Attackable */
-     , (19539,  29, True ) /* NoCorpse */
+     , (19539, 120, True ) /* TreasureCorpse */
      , (19539,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19540 Scoriscant.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/19540 Scoriscant.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 19540;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (19540, 'estuaryelementalscoriscant', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (19540, 'estuaryelementalscoriscant', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (19540,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (19540,   1, True ) /* Stuck */
      , (19540,  14, True ) /* GravityStatus */
      , (19540,  15, True ) /* LightsStatus */
      , (19540,  19, True ) /* Attackable */
-     , (19540,  29, True ) /* NoCorpse */
+     , (19540, 120, True ) /* TreasureCorpse */
      , (19540,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20873 Stasis.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20873 Stasis.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20873, 'somaticelementalstasiary', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20873,   1,         16) /* ItemType - Creature */
+     , (20873,   2,         62) /* CreatureType - Elemental */
+     , (20873,   6,         -1) /* ItemsCapacity */
+     , (20873,   7,         -1) /* ContainersCapacity */
+     , (20873,  16,          1) /* ItemUseable - No */
+     , (20873,  25,        161) /* Level */
+     , (20873,  27,          0) /* ArmorType - None */
+     , (20873,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20873,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20873, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20873, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20873, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20873, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20873,   1, True ) /* Stuck */
+     , (20873,   6, True ) /* AiUsesMana */
+     , (20873,  11, False) /* IgnoreCollisions */
+     , (20873,  12, True ) /* ReportCollisions */
+     , (20873,  13, False) /* Ethereal */
+     , (20873,  15, True ) /* LightsStatus */
+     , (20873, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20873,   1,       5) /* HeartbeatInterval */
+     , (20873,   2,       0) /* HeartbeatTimestamp */
+     , (20873,   3,     0.9) /* HealthRate */
+     , (20873,   4,     0.5) /* StaminaRate */
+     , (20873,   5,       2) /* ManaRate */
+     , (20873,  13,       1) /* ArmorModVsSlash */
+     , (20873,  14,       1) /* ArmorModVsPierce */
+     , (20873,  15,       1) /* ArmorModVsBludgeon */
+     , (20873,  16,       1) /* ArmorModVsCold */
+     , (20873,  17,       1) /* ArmorModVsFire */
+     , (20873,  18,     1.1) /* ArmorModVsAcid */
+     , (20873,  19,     1.1) /* ArmorModVsElectric */
+     , (20873,  31,      20) /* VisualAwarenessRange */
+     , (20873,  39,     1.4) /* DefaultScale */
+     , (20873,  64,     0.3) /* ResistSlash */
+     , (20873,  65,     0.3) /* ResistPierce */
+     , (20873,  66,     0.3) /* ResistBludgeon */
+     , (20873,  67,     0.4) /* ResistFire */
+     , (20873,  68,       0) /* ResistCold */
+     , (20873,  69,     0.3) /* ResistAcid */
+     , (20873,  70,     0.3) /* ResistElectric */
+     , (20873,  71,       1) /* ResistHealthBoost */
+     , (20873,  72,       1) /* ResistStaminaDrain */
+     , (20873,  73,       1) /* ResistStaminaBoost */
+     , (20873,  74,       1) /* ResistManaDrain */
+     , (20873,  75,       1) /* ResistManaBoost */
+     , (20873,  80,       3) /* AiUseMagicDelay */
+     , (20873, 104,      10) /* ObviousRadarRange */
+     , (20873, 122,       2) /* AiAcquireHealth */
+     , (20873, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20873,   1, 'Stasis') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20873,   1,   33557678) /* Setup */
+     , (20873,   2,  150995087) /* MotionTable */
+     , (20873,   3,  536870998) /* SoundTable */
+     , (20873,   4,  805306368) /* CombatTable */
+     , (20873,   8,  100670274) /* Icon */
+     , (20873,  22,  872415349) /* PhysicsEffectTable */
+     , (20873,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20873,   1, 400, 0, 0) /* Strength */
+     , (20873,   2, 400, 0, 0) /* Endurance */
+     , (20873,   3, 400, 0, 0) /* Quickness */
+     , (20873,   4, 600, 0, 0) /* Coordination */
+     , (20873,   5, 350, 0, 0) /* Focus */
+     , (20873,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20873,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20873,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20873,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20873,  6, 0, 3, 0,   1, 0, 1264.07810942575) /* MeleeDefense        Specialized */
+     , (20873,  7, 0, 3, 0,  50, 0, 1264.07810942575) /* MissileDefense      Specialized */
+     , (20873, 12, 0, 3, 0,  70, 0, 1264.07810942575) /* ThrownWeapon        Specialized */
+     , (20873, 13, 0, 3, 0,   1, 0, 1264.07810942575) /* UnarmedCombat       Specialized */
+     , (20873, 14, 0, 3, 0, 170, 0, 1264.07810942575) /* ArcaneLore          Specialized */
+     , (20873, 15, 0, 3, 0,  69, 0, 1264.07810942575) /* MagicDefense        Specialized */
+     , (20873, 20, 0, 3, 0, 150, 0, 1264.07810942575) /* Deception           Specialized */
+     , (20873, 24, 0, 3, 0, 100, 0, 1264.07810942575) /* Run                 Specialized */
+     , (20873, 31, 0, 3, 0, 228, 0, 1264.07810942575) /* CreatureEnchantment Specialized */
+     , (20873, 33, 0, 3, 0, 228, 0, 1264.07810942575) /* LifeMagic           Specialized */
+     , (20873, 34, 0, 3, 0, 228, 0, 1264.07810942575) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20873,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20873,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20873,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20873,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20873,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20873,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20873,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20873,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20873,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20873,   276,  2.008)  /* Magic Resistance Self III */
+     , (20873,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20873,  1160,  2.013)  /* Heal Self V */
+     , (20873,  1237,  2.008)  /* Drain Health Other I */
+     , (20873,  1787,  2.004)  /* Halo of Frost */
+     , (20873,  2056,  2.017)  /* Ataxia */
+     , (20873,  2074,  2.017)  /* Gossamer Flesh */
+     , (20873,  2136,  2.004)  /* Icy Torment */
+     , (20873,  2137,  2.004)  /* Sudden Frost */
+     , (20873,  2168,  2.017)  /* Gelidite's Gift */
+     , (20873,  2228,  2.017)  /* Broadside of a Barn */
+     , (20873,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20873,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20873, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20873 Stasis.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20873 Stasis.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20873;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20873, 'somaticelementalstasiary', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20876 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20876 Conflagration.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20876;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20876, 'somaticelementalstasiary3', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20876 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20876 Conflagration.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20876, 'somaticelementalstasiary3', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20876,   1,         16) /* ItemType - Creature */
+     , (20876,   2,         62) /* CreatureType - Elemental */
+     , (20876,   6,         -1) /* ItemsCapacity */
+     , (20876,   7,         -1) /* ContainersCapacity */
+     , (20876,  16,          1) /* ItemUseable - No */
+     , (20876,  25,        161) /* Level */
+     , (20876,  27,          0) /* ArmorType - None */
+     , (20876,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20876,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20876, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20876, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20876, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20876, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20876,   1, True ) /* Stuck */
+     , (20876,   6, True ) /* AiUsesMana */
+     , (20876,  11, False) /* IgnoreCollisions */
+     , (20876,  12, True ) /* ReportCollisions */
+     , (20876,  13, False) /* Ethereal */
+     , (20876,  15, True ) /* LightsStatus */
+     , (20876, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20876,   1,       5) /* HeartbeatInterval */
+     , (20876,   2,       0) /* HeartbeatTimestamp */
+     , (20876,   3,     0.9) /* HealthRate */
+     , (20876,   4,     0.5) /* StaminaRate */
+     , (20876,   5,       2) /* ManaRate */
+     , (20876,  13,       1) /* ArmorModVsSlash */
+     , (20876,  14,       1) /* ArmorModVsPierce */
+     , (20876,  15,       1) /* ArmorModVsBludgeon */
+     , (20876,  16,       1) /* ArmorModVsCold */
+     , (20876,  17,       1) /* ArmorModVsFire */
+     , (20876,  18,     1.1) /* ArmorModVsAcid */
+     , (20876,  19,     1.1) /* ArmorModVsElectric */
+     , (20876,  31,      20) /* VisualAwarenessRange */
+     , (20876,  39,     1.4) /* DefaultScale */
+     , (20876,  64,     0.3) /* ResistSlash */
+     , (20876,  65,     0.3) /* ResistPierce */
+     , (20876,  66,     0.3) /* ResistBludgeon */
+     , (20876,  67,     0.4) /* ResistFire */
+     , (20876,  68,       0) /* ResistCold */
+     , (20876,  69,     0.3) /* ResistAcid */
+     , (20876,  70,     0.3) /* ResistElectric */
+     , (20876,  71,       1) /* ResistHealthBoost */
+     , (20876,  72,       1) /* ResistStaminaDrain */
+     , (20876,  73,       1) /* ResistStaminaBoost */
+     , (20876,  74,       1) /* ResistManaDrain */
+     , (20876,  75,       1) /* ResistManaBoost */
+     , (20876,  80,       3) /* AiUseMagicDelay */
+     , (20876, 104,      10) /* ObviousRadarRange */
+     , (20876, 122,       2) /* AiAcquireHealth */
+     , (20876, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20876,   1, 'Conflagration') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20876,   1,   33557678) /* Setup */
+     , (20876,   2,  150995087) /* MotionTable */
+     , (20876,   3,  536870998) /* SoundTable */
+     , (20876,   4,  805306368) /* CombatTable */
+     , (20876,   8,  100670274) /* Icon */
+     , (20876,  22,  872415349) /* PhysicsEffectTable */
+     , (20876,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20876,   1, 400, 0, 0) /* Strength */
+     , (20876,   2, 400, 0, 0) /* Endurance */
+     , (20876,   3, 400, 0, 0) /* Quickness */
+     , (20876,   4, 600, 0, 0) /* Coordination */
+     , (20876,   5, 350, 0, 0) /* Focus */
+     , (20876,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20876,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20876,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20876,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20876,  6, 0, 3, 0,   1, 0, 1264.3942810642) /* MeleeDefense        Specialized */
+     , (20876,  7, 0, 3, 0,  50, 0, 1264.3942810642) /* MissileDefense      Specialized */
+     , (20876, 12, 0, 3, 0,  70, 0, 1264.3942810642) /* ThrownWeapon        Specialized */
+     , (20876, 13, 0, 3, 0,   1, 0, 1264.3942810642) /* UnarmedCombat       Specialized */
+     , (20876, 14, 0, 3, 0, 170, 0, 1264.3942810642) /* ArcaneLore          Specialized */
+     , (20876, 15, 0, 3, 0,  69, 0, 1264.3942810642) /* MagicDefense        Specialized */
+     , (20876, 20, 0, 3, 0, 150, 0, 1264.3942810642) /* Deception           Specialized */
+     , (20876, 24, 0, 3, 0, 100, 0, 1264.3942810642) /* Run                 Specialized */
+     , (20876, 31, 0, 3, 0, 228, 0, 1264.3942810642) /* CreatureEnchantment Specialized */
+     , (20876, 33, 0, 3, 0, 228, 0, 1264.3942810642) /* LifeMagic           Specialized */
+     , (20876, 34, 0, 3, 0, 228, 0, 1264.3942810642) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20876,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20876,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20876,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20876,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20876,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20876,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20876,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20876,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20876,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20876,   276,  2.008)  /* Magic Resistance Self III */
+     , (20876,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20876,  1160,  2.013)  /* Heal Self V */
+     , (20876,  1237,  2.008)  /* Drain Health Other I */
+     , (20876,  1787,  2.004)  /* Halo of Frost */
+     , (20876,  2056,  2.017)  /* Ataxia */
+     , (20876,  2074,  2.017)  /* Gossamer Flesh */
+     , (20876,  2136,  2.004)  /* Icy Torment */
+     , (20876,  2137,  2.004)  /* Sudden Frost */
+     , (20876,  2168,  2.017)  /* Gelidite's Gift */
+     , (20876,  2228,  2.017)  /* Broadside of a Barn */
+     , (20876,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20876,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20876, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20877 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20877 Conflagration.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20877;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20877, 'somaticelementalstasiary4', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20877 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20877 Conflagration.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20877, 'somaticelementalstasiary4', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20877,   1,         16) /* ItemType - Creature */
+     , (20877,   2,         62) /* CreatureType - Elemental */
+     , (20877,   6,         -1) /* ItemsCapacity */
+     , (20877,   7,         -1) /* ContainersCapacity */
+     , (20877,  16,          1) /* ItemUseable - No */
+     , (20877,  25,        161) /* Level */
+     , (20877,  27,          0) /* ArmorType - None */
+     , (20877,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20877,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20877, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20877, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20877, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20877, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20877,   1, True ) /* Stuck */
+     , (20877,   6, True ) /* AiUsesMana */
+     , (20877,  11, False) /* IgnoreCollisions */
+     , (20877,  12, True ) /* ReportCollisions */
+     , (20877,  13, False) /* Ethereal */
+     , (20877,  15, True ) /* LightsStatus */
+     , (20877, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20877,   1,       5) /* HeartbeatInterval */
+     , (20877,   2,       0) /* HeartbeatTimestamp */
+     , (20877,   3,     0.9) /* HealthRate */
+     , (20877,   4,     0.5) /* StaminaRate */
+     , (20877,   5,       2) /* ManaRate */
+     , (20877,  13,       1) /* ArmorModVsSlash */
+     , (20877,  14,       1) /* ArmorModVsPierce */
+     , (20877,  15,       1) /* ArmorModVsBludgeon */
+     , (20877,  16,       1) /* ArmorModVsCold */
+     , (20877,  17,       1) /* ArmorModVsFire */
+     , (20877,  18,     1.1) /* ArmorModVsAcid */
+     , (20877,  19,     1.1) /* ArmorModVsElectric */
+     , (20877,  31,      20) /* VisualAwarenessRange */
+     , (20877,  39,     1.4) /* DefaultScale */
+     , (20877,  64,     0.3) /* ResistSlash */
+     , (20877,  65,     0.3) /* ResistPierce */
+     , (20877,  66,     0.3) /* ResistBludgeon */
+     , (20877,  67,     0.4) /* ResistFire */
+     , (20877,  68,       0) /* ResistCold */
+     , (20877,  69,     0.3) /* ResistAcid */
+     , (20877,  70,     0.3) /* ResistElectric */
+     , (20877,  71,       1) /* ResistHealthBoost */
+     , (20877,  72,       1) /* ResistStaminaDrain */
+     , (20877,  73,       1) /* ResistStaminaBoost */
+     , (20877,  74,       1) /* ResistManaDrain */
+     , (20877,  75,       1) /* ResistManaBoost */
+     , (20877,  80,       3) /* AiUseMagicDelay */
+     , (20877, 104,      10) /* ObviousRadarRange */
+     , (20877, 122,       2) /* AiAcquireHealth */
+     , (20877, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20877,   1, 'Conflagration') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20877,   1,   33557678) /* Setup */
+     , (20877,   2,  150995087) /* MotionTable */
+     , (20877,   3,  536870998) /* SoundTable */
+     , (20877,   4,  805306368) /* CombatTable */
+     , (20877,   8,  100670274) /* Icon */
+     , (20877,  22,  872415349) /* PhysicsEffectTable */
+     , (20877,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20877,   1, 400, 0, 0) /* Strength */
+     , (20877,   2, 400, 0, 0) /* Endurance */
+     , (20877,   3, 400, 0, 0) /* Quickness */
+     , (20877,   4, 600, 0, 0) /* Coordination */
+     , (20877,   5, 350, 0, 0) /* Focus */
+     , (20877,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20877,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20877,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20877,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20877,  6, 0, 3, 0,   1, 0, 1264.50003533647) /* MeleeDefense        Specialized */
+     , (20877,  7, 0, 3, 0,  50, 0, 1264.50003533647) /* MissileDefense      Specialized */
+     , (20877, 12, 0, 3, 0,  70, 0, 1264.50003533647) /* ThrownWeapon        Specialized */
+     , (20877, 13, 0, 3, 0,   1, 0, 1264.50003533647) /* UnarmedCombat       Specialized */
+     , (20877, 14, 0, 3, 0, 170, 0, 1264.50003533647) /* ArcaneLore          Specialized */
+     , (20877, 15, 0, 3, 0,  69, 0, 1264.50003533647) /* MagicDefense        Specialized */
+     , (20877, 20, 0, 3, 0, 150, 0, 1264.50003533647) /* Deception           Specialized */
+     , (20877, 24, 0, 3, 0, 100, 0, 1264.50003533647) /* Run                 Specialized */
+     , (20877, 31, 0, 3, 0, 228, 0, 1264.50003533647) /* CreatureEnchantment Specialized */
+     , (20877, 33, 0, 3, 0, 228, 0, 1264.50003533647) /* LifeMagic           Specialized */
+     , (20877, 34, 0, 3, 0, 228, 0, 1264.50003533647) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20877,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20877,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20877,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20877,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20877,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20877,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20877,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20877,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20877,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20877,   276,  2.008)  /* Magic Resistance Self III */
+     , (20877,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20877,  1160,  2.013)  /* Heal Self V */
+     , (20877,  1237,  2.008)  /* Drain Health Other I */
+     , (20877,  1787,  2.004)  /* Halo of Frost */
+     , (20877,  2056,  2.017)  /* Ataxia */
+     , (20877,  2074,  2.017)  /* Gossamer Flesh */
+     , (20877,  2136,  2.004)  /* Icy Torment */
+     , (20877,  2137,  2.004)  /* Sudden Frost */
+     , (20877,  2168,  2.017)  /* Gelidite's Gift */
+     , (20877,  2228,  2.017)  /* Broadside of a Barn */
+     , (20877,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20877,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20877, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20878 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20878 Conflagration.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20878;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20878, 'somaticelementalstasiary5', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20878 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20878 Conflagration.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20878, 'somaticelementalstasiary5', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20878,   1,         16) /* ItemType - Creature */
+     , (20878,   2,         62) /* CreatureType - Elemental */
+     , (20878,   6,         -1) /* ItemsCapacity */
+     , (20878,   7,         -1) /* ContainersCapacity */
+     , (20878,  16,          1) /* ItemUseable - No */
+     , (20878,  25,        161) /* Level */
+     , (20878,  27,          0) /* ArmorType - None */
+     , (20878,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20878,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20878, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20878, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20878, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20878, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20878,   1, True ) /* Stuck */
+     , (20878,   6, True ) /* AiUsesMana */
+     , (20878,  11, False) /* IgnoreCollisions */
+     , (20878,  12, True ) /* ReportCollisions */
+     , (20878,  13, False) /* Ethereal */
+     , (20878,  15, True ) /* LightsStatus */
+     , (20878, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20878,   1,       5) /* HeartbeatInterval */
+     , (20878,   2,       0) /* HeartbeatTimestamp */
+     , (20878,   3,     0.9) /* HealthRate */
+     , (20878,   4,     0.5) /* StaminaRate */
+     , (20878,   5,       2) /* ManaRate */
+     , (20878,  13,       1) /* ArmorModVsSlash */
+     , (20878,  14,       1) /* ArmorModVsPierce */
+     , (20878,  15,       1) /* ArmorModVsBludgeon */
+     , (20878,  16,       1) /* ArmorModVsCold */
+     , (20878,  17,       1) /* ArmorModVsFire */
+     , (20878,  18,     1.1) /* ArmorModVsAcid */
+     , (20878,  19,     1.1) /* ArmorModVsElectric */
+     , (20878,  31,      20) /* VisualAwarenessRange */
+     , (20878,  39,     1.4) /* DefaultScale */
+     , (20878,  64,     0.3) /* ResistSlash */
+     , (20878,  65,     0.3) /* ResistPierce */
+     , (20878,  66,     0.3) /* ResistBludgeon */
+     , (20878,  67,     0.4) /* ResistFire */
+     , (20878,  68,       0) /* ResistCold */
+     , (20878,  69,     0.3) /* ResistAcid */
+     , (20878,  70,     0.3) /* ResistElectric */
+     , (20878,  71,       1) /* ResistHealthBoost */
+     , (20878,  72,       1) /* ResistStaminaDrain */
+     , (20878,  73,       1) /* ResistStaminaBoost */
+     , (20878,  74,       1) /* ResistManaDrain */
+     , (20878,  75,       1) /* ResistManaBoost */
+     , (20878,  80,       3) /* AiUseMagicDelay */
+     , (20878, 104,      10) /* ObviousRadarRange */
+     , (20878, 122,       2) /* AiAcquireHealth */
+     , (20878, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20878,   1, 'Conflagration') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20878,   1,   33557678) /* Setup */
+     , (20878,   2,  150995087) /* MotionTable */
+     , (20878,   3,  536870998) /* SoundTable */
+     , (20878,   4,  805306368) /* CombatTable */
+     , (20878,   8,  100670274) /* Icon */
+     , (20878,  22,  872415349) /* PhysicsEffectTable */
+     , (20878,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20878,   1, 400, 0, 0) /* Strength */
+     , (20878,   2, 400, 0, 0) /* Endurance */
+     , (20878,   3, 400, 0, 0) /* Quickness */
+     , (20878,   4, 600, 0, 0) /* Coordination */
+     , (20878,   5, 350, 0, 0) /* Focus */
+     , (20878,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20878,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20878,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20878,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20878,  6, 0, 3, 0,   1, 0, 1264.60499578455) /* MeleeDefense        Specialized */
+     , (20878,  7, 0, 3, 0,  50, 0, 1264.60499578455) /* MissileDefense      Specialized */
+     , (20878, 12, 0, 3, 0,  70, 0, 1264.60499578455) /* ThrownWeapon        Specialized */
+     , (20878, 13, 0, 3, 0,   1, 0, 1264.60499578455) /* UnarmedCombat       Specialized */
+     , (20878, 14, 0, 3, 0, 170, 0, 1264.60499578455) /* ArcaneLore          Specialized */
+     , (20878, 15, 0, 3, 0,  69, 0, 1264.60499578455) /* MagicDefense        Specialized */
+     , (20878, 20, 0, 3, 0, 150, 0, 1264.60499578455) /* Deception           Specialized */
+     , (20878, 24, 0, 3, 0, 100, 0, 1264.60499578455) /* Run                 Specialized */
+     , (20878, 31, 0, 3, 0, 228, 0, 1264.60499578455) /* CreatureEnchantment Specialized */
+     , (20878, 33, 0, 3, 0, 228, 0, 1264.60499578455) /* LifeMagic           Specialized */
+     , (20878, 34, 0, 3, 0, 228, 0, 1264.60499578455) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20878,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20878,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20878,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20878,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20878,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20878,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20878,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20878,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20878,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20878,   276,  2.008)  /* Magic Resistance Self III */
+     , (20878,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20878,  1160,  2.013)  /* Heal Self V */
+     , (20878,  1237,  2.008)  /* Drain Health Other I */
+     , (20878,  1787,  2.004)  /* Halo of Frost */
+     , (20878,  2056,  2.017)  /* Ataxia */
+     , (20878,  2074,  2.017)  /* Gossamer Flesh */
+     , (20878,  2136,  2.004)  /* Icy Torment */
+     , (20878,  2137,  2.004)  /* Sudden Frost */
+     , (20878,  2168,  2.017)  /* Gelidite's Gift */
+     , (20878,  2228,  2.017)  /* Broadside of a Barn */
+     , (20878,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20878,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20878, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20879 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20879 Conflagration.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20879;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20879, 'somaticelementalstasiary6', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20879 Conflagration.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20879 Conflagration.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20879, 'somaticelementalstasiary6', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20879,   1,         16) /* ItemType - Creature */
+     , (20879,   2,         62) /* CreatureType - Elemental */
+     , (20879,   6,         -1) /* ItemsCapacity */
+     , (20879,   7,         -1) /* ContainersCapacity */
+     , (20879,  16,          1) /* ItemUseable - No */
+     , (20879,  25,        161) /* Level */
+     , (20879,  27,          0) /* ArmorType - None */
+     , (20879,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20879,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20879, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20879, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20879, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20879, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20879,   1, True ) /* Stuck */
+     , (20879,   6, True ) /* AiUsesMana */
+     , (20879,  11, False) /* IgnoreCollisions */
+     , (20879,  12, True ) /* ReportCollisions */
+     , (20879,  13, False) /* Ethereal */
+     , (20879,  15, True ) /* LightsStatus */
+     , (20879, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20879,   1,       5) /* HeartbeatInterval */
+     , (20879,   2,       0) /* HeartbeatTimestamp */
+     , (20879,   3,     0.9) /* HealthRate */
+     , (20879,   4,     0.5) /* StaminaRate */
+     , (20879,   5,       2) /* ManaRate */
+     , (20879,  13,       1) /* ArmorModVsSlash */
+     , (20879,  14,       1) /* ArmorModVsPierce */
+     , (20879,  15,       1) /* ArmorModVsBludgeon */
+     , (20879,  16,       1) /* ArmorModVsCold */
+     , (20879,  17,       1) /* ArmorModVsFire */
+     , (20879,  18,     1.1) /* ArmorModVsAcid */
+     , (20879,  19,     1.1) /* ArmorModVsElectric */
+     , (20879,  31,      20) /* VisualAwarenessRange */
+     , (20879,  39,     1.4) /* DefaultScale */
+     , (20879,  64,     0.3) /* ResistSlash */
+     , (20879,  65,     0.3) /* ResistPierce */
+     , (20879,  66,     0.3) /* ResistBludgeon */
+     , (20879,  67,     0.4) /* ResistFire */
+     , (20879,  68,       0) /* ResistCold */
+     , (20879,  69,     0.3) /* ResistAcid */
+     , (20879,  70,     0.3) /* ResistElectric */
+     , (20879,  71,       1) /* ResistHealthBoost */
+     , (20879,  72,       1) /* ResistStaminaDrain */
+     , (20879,  73,       1) /* ResistStaminaBoost */
+     , (20879,  74,       1) /* ResistManaDrain */
+     , (20879,  75,       1) /* ResistManaBoost */
+     , (20879,  80,       3) /* AiUseMagicDelay */
+     , (20879, 104,      10) /* ObviousRadarRange */
+     , (20879, 122,       2) /* AiAcquireHealth */
+     , (20879, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20879,   1, 'Conflagration') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20879,   1,   33557678) /* Setup */
+     , (20879,   2,  150995087) /* MotionTable */
+     , (20879,   3,  536870998) /* SoundTable */
+     , (20879,   4,  805306368) /* CombatTable */
+     , (20879,   8,  100670274) /* Icon */
+     , (20879,  22,  872415349) /* PhysicsEffectTable */
+     , (20879,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20879,   1, 400, 0, 0) /* Strength */
+     , (20879,   2, 400, 0, 0) /* Endurance */
+     , (20879,   3, 400, 0, 0) /* Quickness */
+     , (20879,   4, 600, 0, 0) /* Coordination */
+     , (20879,   5, 350, 0, 0) /* Focus */
+     , (20879,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20879,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20879,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20879,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20879,  6, 0, 3, 0,   1, 0, 1264.70926152651) /* MeleeDefense        Specialized */
+     , (20879,  7, 0, 3, 0,  50, 0, 1264.70926152651) /* MissileDefense      Specialized */
+     , (20879, 12, 0, 3, 0,  70, 0, 1264.70926152651) /* ThrownWeapon        Specialized */
+     , (20879, 13, 0, 3, 0,   1, 0, 1264.70926152651) /* UnarmedCombat       Specialized */
+     , (20879, 14, 0, 3, 0, 170, 0, 1264.70926152651) /* ArcaneLore          Specialized */
+     , (20879, 15, 0, 3, 0,  69, 0, 1264.70926152651) /* MagicDefense        Specialized */
+     , (20879, 20, 0, 3, 0, 150, 0, 1264.70926152651) /* Deception           Specialized */
+     , (20879, 24, 0, 3, 0, 100, 0, 1264.70926152651) /* Run                 Specialized */
+     , (20879, 31, 0, 3, 0, 228, 0, 1264.70926152651) /* CreatureEnchantment Specialized */
+     , (20879, 33, 0, 3, 0, 228, 0, 1264.70926152651) /* LifeMagic           Specialized */
+     , (20879, 34, 0, 3, 0, 228, 0, 1264.70926152651) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20879,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20879,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20879,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20879,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20879,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20879,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20879,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20879,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20879,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20879,   276,  2.008)  /* Magic Resistance Self III */
+     , (20879,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20879,  1160,  2.013)  /* Heal Self V */
+     , (20879,  1237,  2.008)  /* Drain Health Other I */
+     , (20879,  1787,  2.004)  /* Halo of Frost */
+     , (20879,  2056,  2.017)  /* Ataxia */
+     , (20879,  2074,  2.017)  /* Gossamer Flesh */
+     , (20879,  2136,  2.004)  /* Icy Torment */
+     , (20879,  2137,  2.004)  /* Sudden Frost */
+     , (20879,  2168,  2.017)  /* Gelidite's Gift */
+     , (20879,  2228,  2.017)  /* Broadside of a Barn */
+     , (20879,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20879,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20879, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20885 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20885 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20885;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20885, 'somaticelementaltempest', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20885 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20885 Tempest.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20885, 'somaticelementaltempest', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20885,   1,         16) /* ItemType - Creature */
+     , (20885,   2,         62) /* CreatureType - Elemental */
+     , (20885,   6,         -1) /* ItemsCapacity */
+     , (20885,   7,         -1) /* ContainersCapacity */
+     , (20885,  16,          1) /* ItemUseable - No */
+     , (20885,  25,        161) /* Level */
+     , (20885,  27,          0) /* ArmorType - None */
+     , (20885,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20885,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20885, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20885, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20885, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20885, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20885,   1, True ) /* Stuck */
+     , (20885,   6, True ) /* AiUsesMana */
+     , (20885,  11, False) /* IgnoreCollisions */
+     , (20885,  12, True ) /* ReportCollisions */
+     , (20885,  13, False) /* Ethereal */
+     , (20885,  15, True ) /* LightsStatus */
+     , (20885, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20885,   1,       5) /* HeartbeatInterval */
+     , (20885,   2,       0) /* HeartbeatTimestamp */
+     , (20885,   3,     0.9) /* HealthRate */
+     , (20885,   4,     0.5) /* StaminaRate */
+     , (20885,   5,       2) /* ManaRate */
+     , (20885,  13,       1) /* ArmorModVsSlash */
+     , (20885,  14,       1) /* ArmorModVsPierce */
+     , (20885,  15,       1) /* ArmorModVsBludgeon */
+     , (20885,  16,       1) /* ArmorModVsCold */
+     , (20885,  17,       1) /* ArmorModVsFire */
+     , (20885,  18,     1.1) /* ArmorModVsAcid */
+     , (20885,  19,       1) /* ArmorModVsElectric */
+     , (20885,  31,      20) /* VisualAwarenessRange */
+     , (20885,  39,     1.4) /* DefaultScale */
+     , (20885,  64,     0.3) /* ResistSlash */
+     , (20885,  65,     0.3) /* ResistPierce */
+     , (20885,  66,     0.3) /* ResistBludgeon */
+     , (20885,  67,     0.3) /* ResistFire */
+     , (20885,  68,     0.3) /* ResistCold */
+     , (20885,  69,     0.4) /* ResistAcid */
+     , (20885,  70,       0) /* ResistElectric */
+     , (20885,  71,       1) /* ResistHealthBoost */
+     , (20885,  72,    0.25) /* ResistStaminaDrain */
+     , (20885,  73,       1) /* ResistStaminaBoost */
+     , (20885,  74,       1) /* ResistManaDrain */
+     , (20885,  75,       1) /* ResistManaBoost */
+     , (20885,  80,       3) /* AiUseMagicDelay */
+     , (20885, 104,      10) /* ObviousRadarRange */
+     , (20885, 122,       2) /* AiAcquireHealth */
+     , (20885, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20885,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20885,   1,   33557678) /* Setup */
+     , (20885,   2,  150995087) /* MotionTable */
+     , (20885,   3,  536870998) /* SoundTable */
+     , (20885,   4,  805306368) /* CombatTable */
+     , (20885,   8,  100670274) /* Icon */
+     , (20885,  22,  872415349) /* PhysicsEffectTable */
+     , (20885,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20885,   1, 400, 0, 0) /* Strength */
+     , (20885,   2, 400, 0, 0) /* Endurance */
+     , (20885,   3, 600, 0, 0) /* Quickness */
+     , (20885,   4, 400, 0, 0) /* Coordination */
+     , (20885,   5, 350, 0, 0) /* Focus */
+     , (20885,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20885,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20885,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20885,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20885,  6, 0, 3, 0,   1, 0, 1265.39431947978) /* MeleeDefense        Specialized */
+     , (20885,  7, 0, 3, 0,  50, 0, 1265.39431947978) /* MissileDefense      Specialized */
+     , (20885, 12, 0, 3, 0,  70, 0, 1265.39431947978) /* ThrownWeapon        Specialized */
+     , (20885, 13, 0, 3, 0,   1, 0, 1265.39431947978) /* UnarmedCombat       Specialized */
+     , (20885, 14, 0, 3, 0, 170, 0, 1265.39431947978) /* ArcaneLore          Specialized */
+     , (20885, 15, 0, 3, 0,  69, 0, 1265.39431947978) /* MagicDefense        Specialized */
+     , (20885, 20, 0, 3, 0, 150, 0, 1265.39431947978) /* Deception           Specialized */
+     , (20885, 24, 0, 3, 0, 100, 0, 1265.39431947978) /* Run                 Specialized */
+     , (20885, 31, 0, 3, 0, 150, 0, 1265.39431947978) /* CreatureEnchantment Specialized */
+     , (20885, 33, 0, 3, 0, 150, 0, 1265.39431947978) /* LifeMagic           Specialized */
+     , (20885, 34, 0, 3, 0, 150, 0, 1265.39431947978) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20885,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20885,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20885,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20885,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20885,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20885,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20885,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20885,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20885,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20885,   276,  2.008)  /* Magic Resistance Self III */
+     , (20885,   518,  2.008)  /* Acid Protection Self IV */
+     , (20885,  1160,  2.013)  /* Heal Self V */
+     , (20885,  1237,  2.008)  /* Drain Health Other I */
+     , (20885,  1788,  2.008)  /* Eye of the Storm */
+     , (20885,  2074,  2.017)  /* Gossamer Flesh */
+     , (20885,  2084,  2.017)  /* Belly of Lead */
+     , (20885,  2140,  2.008)  /* Alset's Coil */
+     , (20885,  2141,  2.008)  /* Lhen's Flare */
+     , (20885,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20885,  2228,  2.017)  /* Broadside of a Barn */
+     , (20885,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20885,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20885, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20888 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20888 Tempest.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20888, 'somaticelementaltempest3', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20888,   1,         16) /* ItemType - Creature */
+     , (20888,   2,         62) /* CreatureType - Elemental */
+     , (20888,   6,         -1) /* ItemsCapacity */
+     , (20888,   7,         -1) /* ContainersCapacity */
+     , (20888,  16,          1) /* ItemUseable - No */
+     , (20888,  25,        161) /* Level */
+     , (20888,  27,          0) /* ArmorType - None */
+     , (20888,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20888,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20888, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20888, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20888, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20888, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20888,   1, True ) /* Stuck */
+     , (20888,   6, True ) /* AiUsesMana */
+     , (20888,  11, False) /* IgnoreCollisions */
+     , (20888,  12, True ) /* ReportCollisions */
+     , (20888,  13, False) /* Ethereal */
+     , (20888,  15, True ) /* LightsStatus */
+     , (20888, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20888,   1,       5) /* HeartbeatInterval */
+     , (20888,   2,       0) /* HeartbeatTimestamp */
+     , (20888,   3,     0.9) /* HealthRate */
+     , (20888,   4,     0.5) /* StaminaRate */
+     , (20888,   5,       2) /* ManaRate */
+     , (20888,  13,       1) /* ArmorModVsSlash */
+     , (20888,  14,       1) /* ArmorModVsPierce */
+     , (20888,  15,       1) /* ArmorModVsBludgeon */
+     , (20888,  16,       1) /* ArmorModVsCold */
+     , (20888,  17,       1) /* ArmorModVsFire */
+     , (20888,  18,     1.1) /* ArmorModVsAcid */
+     , (20888,  19,       1) /* ArmorModVsElectric */
+     , (20888,  31,      20) /* VisualAwarenessRange */
+     , (20888,  39,     1.4) /* DefaultScale */
+     , (20888,  64,     0.3) /* ResistSlash */
+     , (20888,  65,     0.3) /* ResistPierce */
+     , (20888,  66,     0.3) /* ResistBludgeon */
+     , (20888,  67,     0.3) /* ResistFire */
+     , (20888,  68,     0.3) /* ResistCold */
+     , (20888,  69,     0.4) /* ResistAcid */
+     , (20888,  70,       0) /* ResistElectric */
+     , (20888,  71,       1) /* ResistHealthBoost */
+     , (20888,  72,    0.25) /* ResistStaminaDrain */
+     , (20888,  73,       1) /* ResistStaminaBoost */
+     , (20888,  74,       1) /* ResistManaDrain */
+     , (20888,  75,       1) /* ResistManaBoost */
+     , (20888,  80,       3) /* AiUseMagicDelay */
+     , (20888, 104,      10) /* ObviousRadarRange */
+     , (20888, 122,       2) /* AiAcquireHealth */
+     , (20888, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20888,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20888,   1,   33557678) /* Setup */
+     , (20888,   2,  150995087) /* MotionTable */
+     , (20888,   3,  536870998) /* SoundTable */
+     , (20888,   4,  805306368) /* CombatTable */
+     , (20888,   8,  100670274) /* Icon */
+     , (20888,  22,  872415349) /* PhysicsEffectTable */
+     , (20888,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20888,   1, 400, 0, 0) /* Strength */
+     , (20888,   2, 400, 0, 0) /* Endurance */
+     , (20888,   3, 600, 0, 0) /* Quickness */
+     , (20888,   4, 400, 0, 0) /* Coordination */
+     , (20888,   5, 350, 0, 0) /* Focus */
+     , (20888,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20888,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20888,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20888,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20888,  6, 0, 3, 0,   1, 0, 1265.71013306159) /* MeleeDefense        Specialized */
+     , (20888,  7, 0, 3, 0,  50, 0, 1265.71013306159) /* MissileDefense      Specialized */
+     , (20888, 12, 0, 3, 0,  70, 0, 1265.71013306159) /* ThrownWeapon        Specialized */
+     , (20888, 13, 0, 3, 0,   1, 0, 1265.71013306159) /* UnarmedCombat       Specialized */
+     , (20888, 14, 0, 3, 0, 170, 0, 1265.71013306159) /* ArcaneLore          Specialized */
+     , (20888, 15, 0, 3, 0,  69, 0, 1265.71013306159) /* MagicDefense        Specialized */
+     , (20888, 20, 0, 3, 0, 150, 0, 1265.71013306159) /* Deception           Specialized */
+     , (20888, 24, 0, 3, 0, 100, 0, 1265.71013306159) /* Run                 Specialized */
+     , (20888, 31, 0, 3, 0, 150, 0, 1265.71013306159) /* CreatureEnchantment Specialized */
+     , (20888, 33, 0, 3, 0, 150, 0, 1265.71013306159) /* LifeMagic           Specialized */
+     , (20888, 34, 0, 3, 0, 150, 0, 1265.71013306159) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20888,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20888,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20888,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20888,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20888,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20888,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20888,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20888,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20888,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20888,   276,  2.008)  /* Magic Resistance Self III */
+     , (20888,   518,  2.008)  /* Acid Protection Self IV */
+     , (20888,  1160,  2.013)  /* Heal Self V */
+     , (20888,  1237,  2.008)  /* Drain Health Other I */
+     , (20888,  1788,  2.008)  /* Eye of the Storm */
+     , (20888,  2074,  2.017)  /* Gossamer Flesh */
+     , (20888,  2084,  2.017)  /* Belly of Lead */
+     , (20888,  2140,  2.008)  /* Alset's Coil */
+     , (20888,  2141,  2.008)  /* Lhen's Flare */
+     , (20888,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20888,  2228,  2.017)  /* Broadside of a Barn */
+     , (20888,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20888,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20888, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20888 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20888 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20888;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20888, 'somaticelementaltempest3', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20889 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20889 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20889;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20889, 'somaticelementaltempest4', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20889 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20889 Tempest.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20889, 'somaticelementaltempest4', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20889,   1,         16) /* ItemType - Creature */
+     , (20889,   2,         62) /* CreatureType - Elemental */
+     , (20889,   6,         -1) /* ItemsCapacity */
+     , (20889,   7,         -1) /* ContainersCapacity */
+     , (20889,  16,          1) /* ItemUseable - No */
+     , (20889,  25,        161) /* Level */
+     , (20889,  27,          0) /* ArmorType - None */
+     , (20889,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20889,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20889, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20889, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20889, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20889, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20889,   1, True ) /* Stuck */
+     , (20889,   6, True ) /* AiUsesMana */
+     , (20889,  11, False) /* IgnoreCollisions */
+     , (20889,  12, True ) /* ReportCollisions */
+     , (20889,  13, False) /* Ethereal */
+     , (20889,  15, True ) /* LightsStatus */
+     , (20889, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20889,   1,       5) /* HeartbeatInterval */
+     , (20889,   2,       0) /* HeartbeatTimestamp */
+     , (20889,   3,     0.9) /* HealthRate */
+     , (20889,   4,     0.5) /* StaminaRate */
+     , (20889,   5,       2) /* ManaRate */
+     , (20889,  13,       1) /* ArmorModVsSlash */
+     , (20889,  14,       1) /* ArmorModVsPierce */
+     , (20889,  15,       1) /* ArmorModVsBludgeon */
+     , (20889,  16,       1) /* ArmorModVsCold */
+     , (20889,  17,       1) /* ArmorModVsFire */
+     , (20889,  18,     1.1) /* ArmorModVsAcid */
+     , (20889,  19,       1) /* ArmorModVsElectric */
+     , (20889,  31,      20) /* VisualAwarenessRange */
+     , (20889,  39,     1.4) /* DefaultScale */
+     , (20889,  64,     0.3) /* ResistSlash */
+     , (20889,  65,     0.3) /* ResistPierce */
+     , (20889,  66,     0.3) /* ResistBludgeon */
+     , (20889,  67,     0.3) /* ResistFire */
+     , (20889,  68,     0.3) /* ResistCold */
+     , (20889,  69,     0.4) /* ResistAcid */
+     , (20889,  70,       0) /* ResistElectric */
+     , (20889,  71,       1) /* ResistHealthBoost */
+     , (20889,  72,    0.25) /* ResistStaminaDrain */
+     , (20889,  73,       1) /* ResistStaminaBoost */
+     , (20889,  74,       1) /* ResistManaDrain */
+     , (20889,  75,       1) /* ResistManaBoost */
+     , (20889,  80,       3) /* AiUseMagicDelay */
+     , (20889, 104,      10) /* ObviousRadarRange */
+     , (20889, 122,       2) /* AiAcquireHealth */
+     , (20889, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20889,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20889,   1,   33557678) /* Setup */
+     , (20889,   2,  150995087) /* MotionTable */
+     , (20889,   3,  536870998) /* SoundTable */
+     , (20889,   4,  805306368) /* CombatTable */
+     , (20889,   8,  100670274) /* Icon */
+     , (20889,  22,  872415349) /* PhysicsEffectTable */
+     , (20889,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20889,   1, 400, 0, 0) /* Strength */
+     , (20889,   2, 400, 0, 0) /* Endurance */
+     , (20889,   3, 600, 0, 0) /* Quickness */
+     , (20889,   4, 400, 0, 0) /* Coordination */
+     , (20889,   5, 350, 0, 0) /* Focus */
+     , (20889,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20889,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20889,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20889,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20889,  6, 0, 3, 0,   1, 0, 1265.81494072711) /* MeleeDefense        Specialized */
+     , (20889,  7, 0, 3, 0,  50, 0, 1265.81494072711) /* MissileDefense      Specialized */
+     , (20889, 12, 0, 3, 0,  70, 0, 1265.81494072711) /* ThrownWeapon        Specialized */
+     , (20889, 13, 0, 3, 0,   1, 0, 1265.81494072711) /* UnarmedCombat       Specialized */
+     , (20889, 14, 0, 3, 0, 170, 0, 1265.81494072711) /* ArcaneLore          Specialized */
+     , (20889, 15, 0, 3, 0,  69, 0, 1265.81494072711) /* MagicDefense        Specialized */
+     , (20889, 20, 0, 3, 0, 150, 0, 1265.81494072711) /* Deception           Specialized */
+     , (20889, 24, 0, 3, 0, 100, 0, 1265.81494072711) /* Run                 Specialized */
+     , (20889, 31, 0, 3, 0, 150, 0, 1265.81494072711) /* CreatureEnchantment Specialized */
+     , (20889, 33, 0, 3, 0, 150, 0, 1265.81494072711) /* LifeMagic           Specialized */
+     , (20889, 34, 0, 3, 0, 150, 0, 1265.81494072711) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20889,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20889,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20889,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20889,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20889,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20889,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20889,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20889,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20889,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20889,   276,  2.008)  /* Magic Resistance Self III */
+     , (20889,   518,  2.008)  /* Acid Protection Self IV */
+     , (20889,  1160,  2.013)  /* Heal Self V */
+     , (20889,  1237,  2.008)  /* Drain Health Other I */
+     , (20889,  1788,  2.008)  /* Eye of the Storm */
+     , (20889,  2074,  2.017)  /* Gossamer Flesh */
+     , (20889,  2084,  2.017)  /* Belly of Lead */
+     , (20889,  2140,  2.008)  /* Alset's Coil */
+     , (20889,  2141,  2.008)  /* Lhen's Flare */
+     , (20889,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20889,  2228,  2.017)  /* Broadside of a Barn */
+     , (20889,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20889,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20889, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20890 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20890 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20890;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20890, 'somaticelementaltempest5', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20890 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20890 Tempest.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20890, 'somaticelementaltempest5', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20890,   1,         16) /* ItemType - Creature */
+     , (20890,   2,         62) /* CreatureType - Elemental */
+     , (20890,   6,         -1) /* ItemsCapacity */
+     , (20890,   7,         -1) /* ContainersCapacity */
+     , (20890,  16,          1) /* ItemUseable - No */
+     , (20890,  25,        161) /* Level */
+     , (20890,  27,          0) /* ArmorType - None */
+     , (20890,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20890,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20890, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20890, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20890, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20890, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20890,   1, True ) /* Stuck */
+     , (20890,   6, True ) /* AiUsesMana */
+     , (20890,  11, False) /* IgnoreCollisions */
+     , (20890,  12, True ) /* ReportCollisions */
+     , (20890,  13, False) /* Ethereal */
+     , (20890,  15, True ) /* LightsStatus */
+     , (20890, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20890,   1,       5) /* HeartbeatInterval */
+     , (20890,   2,       0) /* HeartbeatTimestamp */
+     , (20890,   3,     0.9) /* HealthRate */
+     , (20890,   4,     0.5) /* StaminaRate */
+     , (20890,   5,       2) /* ManaRate */
+     , (20890,  13,       1) /* ArmorModVsSlash */
+     , (20890,  14,       1) /* ArmorModVsPierce */
+     , (20890,  15,       1) /* ArmorModVsBludgeon */
+     , (20890,  16,       1) /* ArmorModVsCold */
+     , (20890,  17,       1) /* ArmorModVsFire */
+     , (20890,  18,     1.1) /* ArmorModVsAcid */
+     , (20890,  19,       1) /* ArmorModVsElectric */
+     , (20890,  31,      20) /* VisualAwarenessRange */
+     , (20890,  39,     1.4) /* DefaultScale */
+     , (20890,  64,     0.3) /* ResistSlash */
+     , (20890,  65,     0.3) /* ResistPierce */
+     , (20890,  66,     0.3) /* ResistBludgeon */
+     , (20890,  67,     0.3) /* ResistFire */
+     , (20890,  68,     0.3) /* ResistCold */
+     , (20890,  69,     0.4) /* ResistAcid */
+     , (20890,  70,       0) /* ResistElectric */
+     , (20890,  71,       1) /* ResistHealthBoost */
+     , (20890,  72,    0.25) /* ResistStaminaDrain */
+     , (20890,  73,       1) /* ResistStaminaBoost */
+     , (20890,  74,       1) /* ResistManaDrain */
+     , (20890,  75,       1) /* ResistManaBoost */
+     , (20890,  80,       3) /* AiUseMagicDelay */
+     , (20890, 104,      10) /* ObviousRadarRange */
+     , (20890, 122,       2) /* AiAcquireHealth */
+     , (20890, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20890,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20890,   1,   33557678) /* Setup */
+     , (20890,   2,  150995087) /* MotionTable */
+     , (20890,   3,  536870998) /* SoundTable */
+     , (20890,   4,  805306368) /* CombatTable */
+     , (20890,   8,  100670274) /* Icon */
+     , (20890,  22,  872415349) /* PhysicsEffectTable */
+     , (20890,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20890,   1, 400, 0, 0) /* Strength */
+     , (20890,   2, 400, 0, 0) /* Endurance */
+     , (20890,   3, 600, 0, 0) /* Quickness */
+     , (20890,   4, 400, 0, 0) /* Coordination */
+     , (20890,   5, 350, 0, 0) /* Focus */
+     , (20890,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20890,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20890,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20890,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20890,  6, 0, 3, 0,   1, 0, 1265.92254305257) /* MeleeDefense        Specialized */
+     , (20890,  7, 0, 3, 0,  50, 0, 1265.92254305257) /* MissileDefense      Specialized */
+     , (20890, 12, 0, 3, 0,  70, 0, 1265.92254305257) /* ThrownWeapon        Specialized */
+     , (20890, 13, 0, 3, 0,   1, 0, 1265.92254305257) /* UnarmedCombat       Specialized */
+     , (20890, 14, 0, 3, 0, 170, 0, 1265.92254305257) /* ArcaneLore          Specialized */
+     , (20890, 15, 0, 3, 0,  69, 0, 1265.92254305257) /* MagicDefense        Specialized */
+     , (20890, 20, 0, 3, 0, 150, 0, 1265.92254305257) /* Deception           Specialized */
+     , (20890, 24, 0, 3, 0, 100, 0, 1265.92254305257) /* Run                 Specialized */
+     , (20890, 31, 0, 3, 0, 150, 0, 1265.92254305257) /* CreatureEnchantment Specialized */
+     , (20890, 33, 0, 3, 0, 150, 0, 1265.92254305257) /* LifeMagic           Specialized */
+     , (20890, 34, 0, 3, 0, 150, 0, 1265.92254305257) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20890,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20890,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20890,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20890,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20890,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20890,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20890,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20890,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20890,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20890,   276,  2.008)  /* Magic Resistance Self III */
+     , (20890,   518,  2.008)  /* Acid Protection Self IV */
+     , (20890,  1160,  2.013)  /* Heal Self V */
+     , (20890,  1237,  2.008)  /* Drain Health Other I */
+     , (20890,  1788,  2.008)  /* Eye of the Storm */
+     , (20890,  2074,  2.017)  /* Gossamer Flesh */
+     , (20890,  2084,  2.017)  /* Belly of Lead */
+     , (20890,  2140,  2.008)  /* Alset's Coil */
+     , (20890,  2141,  2.008)  /* Lhen's Flare */
+     , (20890,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20890,  2228,  2.017)  /* Broadside of a Barn */
+     , (20890,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20890,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20890, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20891 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20891 Tempest.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20891, 'somaticelementaltempest6', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20891,   1,         16) /* ItemType - Creature */
+     , (20891,   2,         62) /* CreatureType - Elemental */
+     , (20891,   6,         -1) /* ItemsCapacity */
+     , (20891,   7,         -1) /* ContainersCapacity */
+     , (20891,  16,          1) /* ItemUseable - No */
+     , (20891,  25,        161) /* Level */
+     , (20891,  27,          0) /* ArmorType - None */
+     , (20891,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20891,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20891, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20891, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20891, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20891, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20891,   1, True ) /* Stuck */
+     , (20891,   6, True ) /* AiUsesMana */
+     , (20891,  11, False) /* IgnoreCollisions */
+     , (20891,  12, True ) /* ReportCollisions */
+     , (20891,  13, False) /* Ethereal */
+     , (20891,  15, True ) /* LightsStatus */
+     , (20891, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20891,   1,       5) /* HeartbeatInterval */
+     , (20891,   2,       0) /* HeartbeatTimestamp */
+     , (20891,   3,     0.9) /* HealthRate */
+     , (20891,   4,     0.5) /* StaminaRate */
+     , (20891,   5,       2) /* ManaRate */
+     , (20891,  13,       1) /* ArmorModVsSlash */
+     , (20891,  14,       1) /* ArmorModVsPierce */
+     , (20891,  15,       1) /* ArmorModVsBludgeon */
+     , (20891,  16,       1) /* ArmorModVsCold */
+     , (20891,  17,       1) /* ArmorModVsFire */
+     , (20891,  18,     1.1) /* ArmorModVsAcid */
+     , (20891,  19,       1) /* ArmorModVsElectric */
+     , (20891,  31,      20) /* VisualAwarenessRange */
+     , (20891,  39,     1.4) /* DefaultScale */
+     , (20891,  64,     0.3) /* ResistSlash */
+     , (20891,  65,     0.3) /* ResistPierce */
+     , (20891,  66,     0.3) /* ResistBludgeon */
+     , (20891,  67,     0.3) /* ResistFire */
+     , (20891,  68,     0.3) /* ResistCold */
+     , (20891,  69,     0.4) /* ResistAcid */
+     , (20891,  70,       0) /* ResistElectric */
+     , (20891,  71,       1) /* ResistHealthBoost */
+     , (20891,  72,    0.25) /* ResistStaminaDrain */
+     , (20891,  73,       1) /* ResistStaminaBoost */
+     , (20891,  74,       1) /* ResistManaDrain */
+     , (20891,  75,       1) /* ResistManaBoost */
+     , (20891,  80,       3) /* AiUseMagicDelay */
+     , (20891, 104,      10) /* ObviousRadarRange */
+     , (20891, 122,       2) /* AiAcquireHealth */
+     , (20891, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20891,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20891,   1,   33557678) /* Setup */
+     , (20891,   2,  150995087) /* MotionTable */
+     , (20891,   3,  536870998) /* SoundTable */
+     , (20891,   4,  805306368) /* CombatTable */
+     , (20891,   8,  100670274) /* Icon */
+     , (20891,  22,  872415349) /* PhysicsEffectTable */
+     , (20891,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20891,   1, 400, 0, 0) /* Strength */
+     , (20891,   2, 400, 0, 0) /* Endurance */
+     , (20891,   3, 600, 0, 0) /* Quickness */
+     , (20891,   4, 400, 0, 0) /* Coordination */
+     , (20891,   5, 350, 0, 0) /* Focus */
+     , (20891,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20891,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20891,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20891,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20891,  6, 0, 3, 0,   1, 0, 1266.03017646239) /* MeleeDefense        Specialized */
+     , (20891,  7, 0, 3, 0,  50, 0, 1266.03017646239) /* MissileDefense      Specialized */
+     , (20891, 12, 0, 3, 0,  70, 0, 1266.03017646239) /* ThrownWeapon        Specialized */
+     , (20891, 13, 0, 3, 0,   1, 0, 1266.03017646239) /* UnarmedCombat       Specialized */
+     , (20891, 14, 0, 3, 0, 170, 0, 1266.03017646239) /* ArcaneLore          Specialized */
+     , (20891, 15, 0, 3, 0,  69, 0, 1266.03017646239) /* MagicDefense        Specialized */
+     , (20891, 20, 0, 3, 0, 150, 0, 1266.03017646239) /* Deception           Specialized */
+     , (20891, 24, 0, 3, 0, 100, 0, 1266.03017646239) /* Run                 Specialized */
+     , (20891, 31, 0, 3, 0, 150, 0, 1266.03017646239) /* CreatureEnchantment Specialized */
+     , (20891, 33, 0, 3, 0, 150, 0, 1266.03017646239) /* LifeMagic           Specialized */
+     , (20891, 34, 0, 3, 0, 150, 0, 1266.03017646239) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20891,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20891,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20891,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20891,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20891,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20891,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20891,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20891,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20891,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20891,   276,  2.008)  /* Magic Resistance Self III */
+     , (20891,   518,  2.008)  /* Acid Protection Self IV */
+     , (20891,  1160,  2.013)  /* Heal Self V */
+     , (20891,  1237,  2.008)  /* Drain Health Other I */
+     , (20891,  1788,  2.008)  /* Eye of the Storm */
+     , (20891,  2074,  2.017)  /* Gossamer Flesh */
+     , (20891,  2084,  2.017)  /* Belly of Lead */
+     , (20891,  2140,  2.008)  /* Alset's Coil */
+     , (20891,  2141,  2.008)  /* Lhen's Flare */
+     , (20891,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20891,  2228,  2.017)  /* Broadside of a Barn */
+     , (20891,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20891,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20891, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20891 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Elemental/20891 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20891;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20891, 'somaticelementaltempest6', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05705 Flicker.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05705 Flicker.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 5705;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (5705, 'fireelementalflicker', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (5705, 'fireelementalflicker', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (5705,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (5705,   1, True ) /* Stuck */
      , (5705,  14, True ) /* GravityStatus */
      , (5705,  15, True ) /* LightsStatus */
      , (5705,  19, True ) /* Attackable */
-     , (5705,  29, True ) /* NoCorpse */;
+     , (5705, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (5705,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05710 Flare.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05710 Flare.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 5710;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (5710, 'fireelementalflare', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (5710, 'fireelementalflare', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (5710,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (5710,   1, True ) /* Stuck */
      , (5710,  14, True ) /* GravityStatus */
      , (5710,  15, True ) /* LightsStatus */
      , (5710,  19, True ) /* Attackable */
-     , (5710,  29, True ) /* NoCorpse */;
+     , (5710, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (5710,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05711 Flamma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05711 Flamma.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 5711;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (5711, 'fireelementalflamma', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (5711, 'fireelementalflamma', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (5711,   1,         16) /* ItemType - Creature */
@@ -31,7 +31,7 @@ VALUES (5711,   1, True ) /* Stuck */
      , (5711,  14, True ) /* GravityStatus */
      , (5711,  15, True ) /* LightsStatus */
      , (5711,  19, True ) /* Attackable */
-     , (5711,  29, True ) /* NoCorpse */
+     , (5711, 120, True ) /* TreasureCorpse */
      , (5711,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05712 Inferno.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/05712 Inferno.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 5712;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (5712, 'fireelementalinferno', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (5712, 'fireelementalinferno', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (5712,   1,         16) /* ItemType - Creature */
@@ -31,7 +31,7 @@ VALUES (5712,   1, True ) /* Stuck */
      , (5712,  14, True ) /* GravityStatus */
      , (5712,  15, True ) /* LightsStatus */
      , (5712,  19, True ) /* Attackable */
-     , (5712,  29, True ) /* NoCorpse */
+     , (5712, 120, True ) /* TreasureCorpse */
      , (5712,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07092 Firestorm.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07092 Firestorm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7092;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7092, 'fireelementalfirestorm', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7092, 'fireelementalfirestorm', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7092,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (7092,   1, True ) /* Stuck */
      , (7092,  14, True ) /* GravityStatus */
      , (7092,  15, True ) /* LightsStatus */
      , (7092,  19, True ) /* Attackable */
-     , (7092,  29, True ) /* NoCorpse */;
+     , (7092, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (7092,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07093 Hellfire.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07093 Hellfire.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7093;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7093, 'fireelementalhellfire', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7093, 'fireelementalhellfire', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7093,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (7093,   1, True ) /* Stuck */
      , (7093,  14, True ) /* GravityStatus */
      , (7093,  15, True ) /* LightsStatus */
      , (7093,  19, True ) /* Attackable */
-     , (7093,  29, True ) /* NoCorpse */
+     , (7093, 120, True ) /* TreasureCorpse */
      , (7093,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07487 Inferno.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07487 Inferno.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7487;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7487, 'fireelementalinferno_nospawn', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7487, 'fireelementalinferno_nospawn', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7487,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (7487,   1, True ) /* Stuck */
      , (7487,  14, True ) /* GravityStatus */
      , (7487,  15, True ) /* LightsStatus */
      , (7487,  19, True ) /* Attackable */
-     , (7487,  29, True ) /* NoCorpse */;
+     , (7487, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (7487,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07607 Ember.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/07607 Ember.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7607;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7607, 'fireelementalember', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7607, 'fireelementalember', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7607,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (7607,   1, True ) /* Stuck */
      , (7607,  14, True ) /* GravityStatus */
      , (7607,  15, True ) /* LightsStatus */
      , (7607,  19, True ) /* Attackable */
-     , (7607,  29, True ) /* NoCorpse */
+     , (7607, 120, True ) /* TreasureCorpse */
      , (7607,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/08405 Flamma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/08405 Flamma.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 8405;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (8405, 'fireelementalflammanofall', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (8405, 'fireelementalflammanofall', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (8405,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (8405,   1, True ) /* Stuck */
      , (8405,  14, True ) /* GravityStatus */
      , (8405,  15, True ) /* LightsStatus */
      , (8405,  19, True ) /* Attackable */
-     , (8405,  29, True ) /* NoCorpse */
+     , (8405, 120, True ) /* TreasureCorpse */
      , (8405,  42, True ) /* AllowEdgeSlide */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/08406 Flare.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/08406 Flare.sql
@@ -1,0 +1,123 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8406, 'fireelementalflarenofall', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8406,   1,         16) /* ItemType - Creature */
+     , (8406,   2,         38) /* CreatureType - FireElemental */
+     , (8406,   6,         -1) /* ItemsCapacity */
+     , (8406,   7,         -1) /* ContainersCapacity */
+     , (8406,  16,          1) /* ItemUseable - No */
+     , (8406,  25,         18) /* Level */
+     , (8406,  27,          0) /* ArmorType - None */
+     , (8406,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (8406,  93,    4197384) /* PhysicsState - ReportCollisions, Gravity, LightingOn, EdgeSlide */
+     , (8406, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (8406, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (8406, 140,          1) /* AiOptions - CanOpenDoors */
+     , (8406, 146,        910) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8406,   1, True ) /* Stuck */
+     , (8406,   6, True ) /* AiUsesMana */
+     , (8406,  11, False) /* IgnoreCollisions */
+     , (8406,  12, True ) /* ReportCollisions */
+     , (8406,  13, False) /* Ethereal */
+     , (8406,  15, True ) /* LightsStatus */
+     , (8406, 120, True ) /* TreasureCorpse */
+     , (8406,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8406,   1,       5) /* HeartbeatInterval */
+     , (8406,   2,       0) /* HeartbeatTimestamp */
+     , (8406,   3,     0.6) /* HealthRate */
+     , (8406,   4,     0.5) /* StaminaRate */
+     , (8406,   5,       2) /* ManaRate */
+     , (8406,  13,    0.58) /* ArmorModVsSlash */
+     , (8406,  14,    0.58) /* ArmorModVsPierce */
+     , (8406,  15,    0.58) /* ArmorModVsBludgeon */
+     , (8406,  16,       1) /* ArmorModVsCold */
+     , (8406,  17,     100) /* ArmorModVsFire */
+     , (8406,  18,    0.65) /* ArmorModVsAcid */
+     , (8406,  19,    0.38) /* ArmorModVsElectric */
+     , (8406,  31,      18) /* VisualAwarenessRange */
+     , (8406,  39,       1) /* DefaultScale */
+     , (8406,  64,    0.65) /* ResistSlash */
+     , (8406,  65,    0.65) /* ResistPierce */
+     , (8406,  66,    0.65) /* ResistBludgeon */
+     , (8406,  67,       0) /* ResistFire */
+     , (8406,  68,     1.1) /* ResistCold */
+     , (8406,  69,    0.65) /* ResistAcid */
+     , (8406,  70,    0.65) /* ResistElectric */
+     , (8406,  71,       1) /* ResistHealthBoost */
+     , (8406,  72,       1) /* ResistStaminaDrain */
+     , (8406,  73,       1) /* ResistStaminaBoost */
+     , (8406,  74,       1) /* ResistManaDrain */
+     , (8406,  75,       1) /* ResistManaBoost */
+     , (8406,  80,       3) /* AiUseMagicDelay */
+     , (8406, 104,      10) /* ObviousRadarRange */
+     , (8406, 122,       2) /* AiAcquireHealth */
+     , (8406, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8406,   1, 'Flare') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8406,   1,   33556131) /* Setup */
+     , (8406,   2,  150995087) /* MotionTable */
+     , (8406,   3,  536870998) /* SoundTable */
+     , (8406,   4,  805306368) /* CombatTable */
+     , (8406,   8,  100670274) /* Icon */
+     , (8406,  22,  872415344) /* PhysicsEffectTable */
+     , (8406,  35,        465) /* DeathTreasureType - Loot Tier: 1 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (8406,   1,  50, 0, 0) /* Strength */
+     , (8406,   2,  80, 0, 0) /* Endurance */
+     , (8406,   3,  95, 0, 0) /* Quickness */
+     , (8406,   4,  85, 0, 0) /* Coordination */
+     , (8406,   5,  50, 0, 0) /* Focus */
+     , (8406,   6,  90, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (8406,   1,    15, 0, 0, 55) /* MaxHealth */
+     , (8406,   3,   200, 0, 0, 280) /* MaxStamina */
+     , (8406,   5,   100, 0, 0, 190) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (8406,  6, 0, 3, 0,  35, 0, 585.553376392015) /* MeleeDefense        Specialized */
+     , (8406,  7, 0, 3, 0,  55, 0, 585.553376392015) /* MissileDefense      Specialized */
+     , (8406, 13, 0, 3, 0,  20, 0, 585.553376392015) /* UnarmedCombat       Specialized */
+     , (8406, 14, 0, 2, 0,  35, 0, 585.553376392015) /* ArcaneLore          Trained */
+     , (8406, 15, 0, 3, 0,  25, 0, 585.553376392015) /* MagicDefense        Specialized */
+     , (8406, 20, 0, 2, 0,  10, 0, 585.553376392015) /* Deception           Trained */
+     , (8406, 24, 0, 2, 0,  50, 0, 585.553376392015) /* Run                 Trained */
+     , (8406, 31, 0, 3, 0,  35, 0, 585.553376392015) /* CreatureEnchantment Specialized */
+     , (8406, 33, 0, 3, 0,  35, 0, 585.553376392015) /* LifeMagic           Specialized */
+     , (8406, 34, 0, 3, 0,  35, 0, 585.553376392015) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (8406,  0, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (8406,  1, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (8406,  2, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (8406,  3, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (8406,  4, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (8406,  5, 16,  8, 0.75,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (8406,  6, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (8406,  7, 16,  0,    0,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (8406,  8, 16,  8, 0.75,   90,   52,   52,   52,   90, 9000,   58,   34,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (8406,    24,  2.006)  /* Armor Self I */
+     , (8406,    81,  2.083)  /* Flame Bolt II */
+     , (8406,   165,  2.006)  /* Regeneration Self I */
+     , (8406,   230,   2.01)  /* Vulnerability Other II */
+     , (8406,   263,   2.01)  /* Defenselessness Other II */
+     , (8406,   274,  2.006)  /* Magic Resistance Self I */
+     , (8406,  1030,  2.006)  /* Cold Protection Self I */
+     , (8406,  1104,   2.01)  /* Fire Vulnerability Other II */
+     , (8406,  1157,  2.008)  /* Heal Self II */
+     , (8406,  1237,  2.006)  /* Drain Health Other I */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (8406,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (8406, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/08406 Flare.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/08406 Flare.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8406;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (8406, 'fireelementalflarenofall', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20024 Controlled Flamma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20024 Controlled Flamma.sql
@@ -1,0 +1,124 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20024, 'fireelementalflammarewards', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20024,   1,         16) /* ItemType - Creature */
+     , (20024,   2,         38) /* CreatureType - FireElemental */
+     , (20024,   6,         -1) /* ItemsCapacity */
+     , (20024,   7,         -1) /* ContainersCapacity */
+     , (20024,  16,          1) /* ItemUseable - No */
+     , (20024,  25,         61) /* Level */
+     , (20024,  27,          0) /* ArmorType - None */
+     , (20024,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20024,  93,    4197384) /* PhysicsState - ReportCollisions, Gravity, LightingOn, EdgeSlide */
+     , (20024, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20024, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20024, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20024, 146,      21488) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20024,   1, True ) /* Stuck */
+     , (20024,   6, True ) /* AiUsesMana */
+     , (20024,  11, False) /* IgnoreCollisions */
+     , (20024,  12, True ) /* ReportCollisions */
+     , (20024,  13, False) /* Ethereal */
+     , (20024,  15, True ) /* LightsStatus */
+     , (20024, 120, True ) /* TreasureCorpse */
+     , (20024,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20024,   1,       5) /* HeartbeatInterval */
+     , (20024,   2,       0) /* HeartbeatTimestamp */
+     , (20024,   3,     0.7) /* HealthRate */
+     , (20024,   4,     0.5) /* StaminaRate */
+     , (20024,   5,       2) /* ManaRate */
+     , (20024,  13,    0.73) /* ArmorModVsSlash */
+     , (20024,  14,    0.73) /* ArmorModVsPierce */
+     , (20024,  15,    0.73) /* ArmorModVsBludgeon */
+     , (20024,  16,       1) /* ArmorModVsCold */
+     , (20024,  17,     100) /* ArmorModVsFire */
+     , (20024,  18,    0.78) /* ArmorModVsAcid */
+     , (20024,  19,     0.6) /* ArmorModVsElectric */
+     , (20024,  31,      20) /* VisualAwarenessRange */
+     , (20024,  39,     1.3) /* DefaultScale */
+     , (20024,  64,     0.4) /* ResistSlash */
+     , (20024,  65,     0.4) /* ResistPierce */
+     , (20024,  66,     0.4) /* ResistBludgeon */
+     , (20024,  67,       0) /* ResistFire */
+     , (20024,  68,       1) /* ResistCold */
+     , (20024,  69,     0.5) /* ResistAcid */
+     , (20024,  70,     0.1) /* ResistElectric */
+     , (20024,  71,       1) /* ResistHealthBoost */
+     , (20024,  72,       1) /* ResistStaminaDrain */
+     , (20024,  73,       1) /* ResistStaminaBoost */
+     , (20024,  74,       1) /* ResistManaDrain */
+     , (20024,  75,       1) /* ResistManaBoost */
+     , (20024,  80,       3) /* AiUseMagicDelay */
+     , (20024, 104,      10) /* ObviousRadarRange */
+     , (20024, 122,       2) /* AiAcquireHealth */
+     , (20024, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20024,   1, 'Controlled Flamma') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20024,   1,   33556131) /* Setup */
+     , (20024,   2,  150995087) /* MotionTable */
+     , (20024,   3,  536870998) /* SoundTable */
+     , (20024,   4,  805306368) /* CombatTable */
+     , (20024,   8,  100670274) /* Icon */
+     , (20024,  22,  872415344) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20024,   1, 145, 0, 0) /* Strength */
+     , (20024,   2, 130, 0, 0) /* Endurance */
+     , (20024,   3, 190, 0, 0) /* Quickness */
+     , (20024,   4, 180, 0, 0) /* Coordination */
+     , (20024,   5, 130, 0, 0) /* Focus */
+     , (20024,   6, 180, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20024,   1,    70, 0, 0, 135) /* MaxHealth */
+     , (20024,   3,   200, 0, 0, 330) /* MaxStamina */
+     , (20024,   5,   200, 0, 0, 380) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20024,  6, 0, 3, 0, 126, 0, 1198.01632075541) /* MeleeDefense        Specialized */
+     , (20024,  7, 0, 3, 0, 260, 0, 1198.01632075541) /* MissileDefense      Specialized */
+     , (20024, 13, 0, 3, 0, 140, 0, 1198.01632075541) /* UnarmedCombat       Specialized */
+     , (20024, 14, 0, 2, 0, 130, 0, 1198.01632075541) /* ArcaneLore          Trained */
+     , (20024, 15, 0, 3, 0, 152, 0, 1198.01632075541) /* MagicDefense        Specialized */
+     , (20024, 20, 0, 2, 0, 100, 0, 1198.01632075541) /* Deception           Trained */
+     , (20024, 24, 0, 2, 0,  80, 0, 1198.01632075541) /* Run                 Trained */
+     , (20024, 31, 0, 3, 0,  75, 0, 1198.01632075541) /* CreatureEnchantment Specialized */
+     , (20024, 33, 0, 3, 0,  75, 0, 1198.01632075541) /* LifeMagic           Specialized */
+     , (20024, 34, 0, 3, 0,  75, 0, 1198.01632075541) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20024,  0, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20024,  1, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20024,  2, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20024,  3, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20024,  4, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20024,  5, 16, 20, 0.75,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20024,  6, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20024,  7, 16,  0,    0,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20024,  8, 16, 25, 0.75,  140,  102,  102,  102,  140, 14000,  109,   84,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20024,    82,   2.11)  /* Flame Bolt III */
+     , (20024,    83,  2.005)  /* Flame Bolt IV */
+     , (20024,   144,  2.005)  /* Flame Volley IV */
+     , (20024,   167,  2.006)  /* Regeneration Self III */
+     , (20024,   231,  2.013)  /* Vulnerability Other III */
+     , (20024,   264,  2.013)  /* Defenselessness Other III */
+     , (20024,   275,  2.006)  /* Magic Resistance Self II */
+     , (20024,  1032,  2.006)  /* Cold Protection Self III */
+     , (20024,  1105,  2.013)  /* Fire Vulnerability Other III */
+     , (20024,  1159,   2.01)  /* Heal Self IV */
+     , (20024,  1239,  2.006)  /* Drain Health Other III */
+     , (20024,  1309,  2.006)  /* Armor Self III */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20024,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20024, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20024 Controlled Flamma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20024 Controlled Flamma.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20024;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20024, 'fireelementalflammarewards', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20871 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20871 Strife.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20871, 'somaticelementalrazzia5', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20871,   1,         16) /* ItemType - Creature */
+     , (20871,   2,         38) /* CreatureType - FireElemental */
+     , (20871,   6,         -1) /* ItemsCapacity */
+     , (20871,   7,         -1) /* ContainersCapacity */
+     , (20871,  16,          1) /* ItemUseable - No */
+     , (20871,  25,        161) /* Level */
+     , (20871,  27,          0) /* ArmorType - None */
+     , (20871,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20871,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20871, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20871, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20871, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20871, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20871,   1, True ) /* Stuck */
+     , (20871,   6, True ) /* AiUsesMana */
+     , (20871,  11, False) /* IgnoreCollisions */
+     , (20871,  12, True ) /* ReportCollisions */
+     , (20871,  13, False) /* Ethereal */
+     , (20871,  15, True ) /* LightsStatus */
+     , (20871, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20871,   1,       5) /* HeartbeatInterval */
+     , (20871,   2,       0) /* HeartbeatTimestamp */
+     , (20871,   3,     0.9) /* HealthRate */
+     , (20871,   4,     0.5) /* StaminaRate */
+     , (20871,   5,       2) /* ManaRate */
+     , (20871,  13,       1) /* ArmorModVsSlash */
+     , (20871,  14,       1) /* ArmorModVsPierce */
+     , (20871,  15,       1) /* ArmorModVsBludgeon */
+     , (20871,  16,       1) /* ArmorModVsCold */
+     , (20871,  17,       1) /* ArmorModVsFire */
+     , (20871,  18,     1.1) /* ArmorModVsAcid */
+     , (20871,  19,     1.1) /* ArmorModVsElectric */
+     , (20871,  31,      20) /* VisualAwarenessRange */
+     , (20871,  39,     1.4) /* DefaultScale */
+     , (20871,  64,     0.3) /* ResistSlash */
+     , (20871,  65,     0.3) /* ResistPierce */
+     , (20871,  66,     0.3) /* ResistBludgeon */
+     , (20871,  67,       0) /* ResistFire */
+     , (20871,  68,     0.4) /* ResistCold */
+     , (20871,  69,     0.3) /* ResistAcid */
+     , (20871,  70,     0.3) /* ResistElectric */
+     , (20871,  71,       1) /* ResistHealthBoost */
+     , (20871,  72,       1) /* ResistStaminaDrain */
+     , (20871,  73,       1) /* ResistStaminaBoost */
+     , (20871,  74,       1) /* ResistManaDrain */
+     , (20871,  75,       1) /* ResistManaBoost */
+     , (20871,  80,       3) /* AiUseMagicDelay */
+     , (20871, 104,      10) /* ObviousRadarRange */
+     , (20871, 122,       2) /* AiAcquireHealth */
+     , (20871, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20871,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20871,   1,   33557678) /* Setup */
+     , (20871,   2,  150995087) /* MotionTable */
+     , (20871,   3,  536870998) /* SoundTable */
+     , (20871,   4,  805306368) /* CombatTable */
+     , (20871,   8,  100670274) /* Icon */
+     , (20871,  22,  872415349) /* PhysicsEffectTable */
+     , (20871,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20871,   1, 600, 0, 0) /* Strength */
+     , (20871,   2, 400, 0, 0) /* Endurance */
+     , (20871,   3, 400, 0, 0) /* Quickness */
+     , (20871,   4, 400, 0, 0) /* Coordination */
+     , (20871,   5, 350, 0, 0) /* Focus */
+     , (20871,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20871,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20871,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20871,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20871,  6, 0, 3, 0,  15, 0, 1263.86408803325) /* MeleeDefense        Specialized */
+     , (20871,  7, 0, 3, 0, 190, 0, 1263.86408803325) /* MissileDefense      Specialized */
+     , (20871, 12, 0, 3, 0,  70, 0, 1263.86408803325) /* ThrownWeapon        Specialized */
+     , (20871, 13, 0, 3, 0,   1, 0, 1263.86408803325) /* UnarmedCombat       Specialized */
+     , (20871, 14, 0, 3, 0, 170, 0, 1263.86408803325) /* ArcaneLore          Specialized */
+     , (20871, 15, 0, 3, 0, 159, 0, 1263.86408803325) /* MagicDefense        Specialized */
+     , (20871, 20, 0, 3, 0, 150, 0, 1263.86408803325) /* Deception           Specialized */
+     , (20871, 24, 0, 3, 0, 100, 0, 1263.86408803325) /* Run                 Specialized */
+     , (20871, 31, 0, 3, 0, 228, 0, 1263.86408803325) /* CreatureEnchantment Specialized */
+     , (20871, 33, 0, 3, 0, 228, 0, 1263.86408803325) /* LifeMagic           Specialized */
+     , (20871, 34, 0, 3, 0, 228, 0, 1263.86408803325) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20871,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20871,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20871,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20871,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20871,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20871,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20871,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20871,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20871,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20871,   276,  2.008)  /* Magic Resistance Self III */
+     , (20871,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20871,  1160,  2.013)  /* Heal Self V */
+     , (20871,  1237,  2.008)  /* Drain Health Other I */
+     , (20871,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20871,  2074,  2.017)  /* Gossamer Flesh */
+     , (20871,  2088,  2.017)  /* Senescence */
+     , (20871,  2128,  2.004)  /* Ilservian's Flame */
+     , (20871,  2129,  2.004)  /* Sizzling Fury */
+     , (20871,  2170,  2.017)  /* Inferno's Gift */
+     , (20871,  2228,  2.017)  /* Broadside of a Barn */
+     , (20871,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20871,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20871, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20871 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20871 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20871;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20871, 'somaticelementalrazzia5', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20872 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20872 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20872;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20872, 'somaticelementalrazzia6', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20872 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20872 Strife.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20872, 'somaticelementalrazzia6', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20872,   1,         16) /* ItemType - Creature */
+     , (20872,   2,         38) /* CreatureType - FireElemental */
+     , (20872,   6,         -1) /* ItemsCapacity */
+     , (20872,   7,         -1) /* ContainersCapacity */
+     , (20872,  16,          1) /* ItemUseable - No */
+     , (20872,  25,        161) /* Level */
+     , (20872,  27,          0) /* ArmorType - None */
+     , (20872,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20872,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20872, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20872, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20872, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20872, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20872,   1, True ) /* Stuck */
+     , (20872,   6, True ) /* AiUsesMana */
+     , (20872,  11, False) /* IgnoreCollisions */
+     , (20872,  12, True ) /* ReportCollisions */
+     , (20872,  13, False) /* Ethereal */
+     , (20872,  15, True ) /* LightsStatus */
+     , (20872, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20872,   1,       5) /* HeartbeatInterval */
+     , (20872,   2,       0) /* HeartbeatTimestamp */
+     , (20872,   3,     0.9) /* HealthRate */
+     , (20872,   4,     0.5) /* StaminaRate */
+     , (20872,   5,       2) /* ManaRate */
+     , (20872,  13,       1) /* ArmorModVsSlash */
+     , (20872,  14,       1) /* ArmorModVsPierce */
+     , (20872,  15,       1) /* ArmorModVsBludgeon */
+     , (20872,  16,       1) /* ArmorModVsCold */
+     , (20872,  17,       1) /* ArmorModVsFire */
+     , (20872,  18,     1.1) /* ArmorModVsAcid */
+     , (20872,  19,     1.1) /* ArmorModVsElectric */
+     , (20872,  31,      20) /* VisualAwarenessRange */
+     , (20872,  39,     1.4) /* DefaultScale */
+     , (20872,  64,     0.3) /* ResistSlash */
+     , (20872,  65,     0.3) /* ResistPierce */
+     , (20872,  66,     0.3) /* ResistBludgeon */
+     , (20872,  67,       0) /* ResistFire */
+     , (20872,  68,     0.4) /* ResistCold */
+     , (20872,  69,     0.3) /* ResistAcid */
+     , (20872,  70,     0.3) /* ResistElectric */
+     , (20872,  71,       1) /* ResistHealthBoost */
+     , (20872,  72,       1) /* ResistStaminaDrain */
+     , (20872,  73,       1) /* ResistStaminaBoost */
+     , (20872,  74,       1) /* ResistManaDrain */
+     , (20872,  75,       1) /* ResistManaBoost */
+     , (20872,  80,       3) /* AiUseMagicDelay */
+     , (20872, 104,      10) /* ObviousRadarRange */
+     , (20872, 122,       2) /* AiAcquireHealth */
+     , (20872, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20872,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20872,   1,   33557678) /* Setup */
+     , (20872,   2,  150995087) /* MotionTable */
+     , (20872,   3,  536870998) /* SoundTable */
+     , (20872,   4,  805306368) /* CombatTable */
+     , (20872,   8,  100670274) /* Icon */
+     , (20872,  22,  872415349) /* PhysicsEffectTable */
+     , (20872,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20872,   1, 600, 0, 0) /* Strength */
+     , (20872,   2, 400, 0, 0) /* Endurance */
+     , (20872,   3, 400, 0, 0) /* Quickness */
+     , (20872,   4, 400, 0, 0) /* Coordination */
+     , (20872,   5, 350, 0, 0) /* Focus */
+     , (20872,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20872,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20872,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20872,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20872,  6, 0, 3, 0,  15, 0, 1263.9716390402) /* MeleeDefense        Specialized */
+     , (20872,  7, 0, 3, 0, 190, 0, 1263.9716390402) /* MissileDefense      Specialized */
+     , (20872, 12, 0, 3, 0,  70, 0, 1263.9716390402) /* ThrownWeapon        Specialized */
+     , (20872, 13, 0, 3, 0,   1, 0, 1263.9716390402) /* UnarmedCombat       Specialized */
+     , (20872, 14, 0, 3, 0, 170, 0, 1263.9716390402) /* ArcaneLore          Specialized */
+     , (20872, 15, 0, 3, 0, 159, 0, 1263.9716390402) /* MagicDefense        Specialized */
+     , (20872, 20, 0, 3, 0, 150, 0, 1263.9716390402) /* Deception           Specialized */
+     , (20872, 24, 0, 3, 0, 100, 0, 1263.9716390402) /* Run                 Specialized */
+     , (20872, 31, 0, 3, 0, 228, 0, 1263.9716390402) /* CreatureEnchantment Specialized */
+     , (20872, 33, 0, 3, 0, 228, 0, 1263.9716390402) /* LifeMagic           Specialized */
+     , (20872, 34, 0, 3, 0, 228, 0, 1263.9716390402) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20872,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20872,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20872,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20872,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20872,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20872,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20872,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20872,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20872,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20872,   276,  2.008)  /* Magic Resistance Self III */
+     , (20872,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20872,  1160,  2.013)  /* Heal Self V */
+     , (20872,  1237,  2.008)  /* Drain Health Other I */
+     , (20872,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20872,  2074,  2.017)  /* Gossamer Flesh */
+     , (20872,  2088,  2.017)  /* Senescence */
+     , (20872,  2128,  2.004)  /* Ilservian's Flame */
+     , (20872,  2129,  2.004)  /* Sizzling Fury */
+     , (20872,  2170,  2.017)  /* Inferno's Gift */
+     , (20872,  2228,  2.017)  /* Broadside of a Barn */
+     , (20872,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20872,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20872, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20880 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20880 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20880;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20880, 'somaticelementalstrife', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20880 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20880 Strife.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20880, 'somaticelementalstrife', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20880,   1,         16) /* ItemType - Creature */
+     , (20880,   2,         38) /* CreatureType - FireElemental */
+     , (20880,   6,         -1) /* ItemsCapacity */
+     , (20880,   7,         -1) /* ContainersCapacity */
+     , (20880,  16,          1) /* ItemUseable - No */
+     , (20880,  25,        161) /* Level */
+     , (20880,  27,          0) /* ArmorType - None */
+     , (20880,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20880,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20880, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20880, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20880, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20880, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20880,   1, True ) /* Stuck */
+     , (20880,   6, True ) /* AiUsesMana */
+     , (20880,  11, False) /* IgnoreCollisions */
+     , (20880,  12, True ) /* ReportCollisions */
+     , (20880,  13, False) /* Ethereal */
+     , (20880,  15, True ) /* LightsStatus */
+     , (20880, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20880,   1,       5) /* HeartbeatInterval */
+     , (20880,   2,       0) /* HeartbeatTimestamp */
+     , (20880,   3,     0.9) /* HealthRate */
+     , (20880,   4,     0.5) /* StaminaRate */
+     , (20880,   5,       2) /* ManaRate */
+     , (20880,  13,       1) /* ArmorModVsSlash */
+     , (20880,  14,       1) /* ArmorModVsPierce */
+     , (20880,  15,       1) /* ArmorModVsBludgeon */
+     , (20880,  16,       1) /* ArmorModVsCold */
+     , (20880,  17,       1) /* ArmorModVsFire */
+     , (20880,  18,     1.1) /* ArmorModVsAcid */
+     , (20880,  19,     1.1) /* ArmorModVsElectric */
+     , (20880,  31,      20) /* VisualAwarenessRange */
+     , (20880,  39,     1.4) /* DefaultScale */
+     , (20880,  64,     0.3) /* ResistSlash */
+     , (20880,  65,     0.3) /* ResistPierce */
+     , (20880,  66,     0.3) /* ResistBludgeon */
+     , (20880,  67,       0) /* ResistFire */
+     , (20880,  68,     0.4) /* ResistCold */
+     , (20880,  69,     0.3) /* ResistAcid */
+     , (20880,  70,     0.3) /* ResistElectric */
+     , (20880,  71,       1) /* ResistHealthBoost */
+     , (20880,  72,       1) /* ResistStaminaDrain */
+     , (20880,  73,       1) /* ResistStaminaBoost */
+     , (20880,  74,       1) /* ResistManaDrain */
+     , (20880,  75,       1) /* ResistManaBoost */
+     , (20880,  80,       3) /* AiUseMagicDelay */
+     , (20880, 104,      10) /* ObviousRadarRange */
+     , (20880, 122,       2) /* AiAcquireHealth */
+     , (20880, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20880,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20880,   1,   33557678) /* Setup */
+     , (20880,   2,  150995087) /* MotionTable */
+     , (20880,   3,  536870998) /* SoundTable */
+     , (20880,   4,  805306368) /* CombatTable */
+     , (20880,   8,  100670274) /* Icon */
+     , (20880,  22,  872415349) /* PhysicsEffectTable */
+     , (20880,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20880,   1, 600, 0, 0) /* Strength */
+     , (20880,   2, 400, 0, 0) /* Endurance */
+     , (20880,   3, 400, 0, 0) /* Quickness */
+     , (20880,   4, 400, 0, 0) /* Coordination */
+     , (20880,   5, 350, 0, 0) /* Focus */
+     , (20880,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20880,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20880,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20880,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20880,  6, 0, 3, 0,  15, 0, 1264.81435686898) /* MeleeDefense        Specialized */
+     , (20880,  7, 0, 3, 0, 190, 0, 1264.81435686898) /* MissileDefense      Specialized */
+     , (20880, 12, 0, 3, 0,  70, 0, 1264.81435686898) /* ThrownWeapon        Specialized */
+     , (20880, 13, 0, 3, 0,   1, 0, 1264.81435686898) /* UnarmedCombat       Specialized */
+     , (20880, 14, 0, 3, 0, 170, 0, 1264.81435686898) /* ArcaneLore          Specialized */
+     , (20880, 15, 0, 3, 0, 159, 0, 1264.81435686898) /* MagicDefense        Specialized */
+     , (20880, 20, 0, 3, 0, 150, 0, 1264.81435686898) /* Deception           Specialized */
+     , (20880, 24, 0, 3, 0, 100, 0, 1264.81435686898) /* Run                 Specialized */
+     , (20880, 31, 0, 3, 0, 228, 0, 1264.81435686898) /* CreatureEnchantment Specialized */
+     , (20880, 33, 0, 3, 0, 228, 0, 1264.81435686898) /* LifeMagic           Specialized */
+     , (20880, 34, 0, 3, 0, 228, 0, 1264.81435686898) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20880,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20880,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20880,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20880,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20880,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20880,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20880,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20880,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20880,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20880,   276,  2.008)  /* Magic Resistance Self III */
+     , (20880,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20880,  1160,  2.013)  /* Heal Self V */
+     , (20880,  1237,  2.008)  /* Drain Health Other I */
+     , (20880,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20880,  2074,  2.017)  /* Gossamer Flesh */
+     , (20880,  2088,  2.017)  /* Senescence */
+     , (20880,  2128,  2.004)  /* Ilservian's Flame */
+     , (20880,  2129,  2.004)  /* Sizzling Fury */
+     , (20880,  2170,  2.017)  /* Inferno's Gift */
+     , (20880,  2228,  2.017)  /* Broadside of a Barn */
+     , (20880,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20880,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20880, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20881 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20881 Strife.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20881, 'somaticelementalstrife1', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20881,   1,         16) /* ItemType - Creature */
+     , (20881,   2,         38) /* CreatureType - FireElemental */
+     , (20881,   3,         14) /* PaletteTemplate - Red */
+     , (20881,   6,         -1) /* ItemsCapacity */
+     , (20881,   7,         -1) /* ContainersCapacity */
+     , (20881,  16,          1) /* ItemUseable - No */
+     , (20881,  25,        999) /* Level */
+     , (20881,  27,          0) /* ArmorType - None */
+     , (20881,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20881,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20881, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20881, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20881, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20881, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20881,   1, True ) /* Stuck */
+     , (20881,   6, True ) /* AiUsesMana */
+     , (20881,  11, False) /* IgnoreCollisions */
+     , (20881,  12, True ) /* ReportCollisions */
+     , (20881,  13, False) /* Ethereal */
+     , (20881,  15, True ) /* LightsStatus */
+     , (20881, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20881,   1,       5) /* HeartbeatInterval */
+     , (20881,   2,       0) /* HeartbeatTimestamp */
+     , (20881,   3,     0.9) /* HealthRate */
+     , (20881,   4,     0.5) /* StaminaRate */
+     , (20881,   5,       2) /* ManaRate */
+     , (20881,  13,       1) /* ArmorModVsSlash */
+     , (20881,  14,       1) /* ArmorModVsPierce */
+     , (20881,  15,       1) /* ArmorModVsBludgeon */
+     , (20881,  16,       1) /* ArmorModVsCold */
+     , (20881,  17,       1) /* ArmorModVsFire */
+     , (20881,  18,     1.1) /* ArmorModVsAcid */
+     , (20881,  19,     1.1) /* ArmorModVsElectric */
+     , (20881,  31,      20) /* VisualAwarenessRange */
+     , (20881,  39,     1.4) /* DefaultScale */
+     , (20881,  64,     0.3) /* ResistSlash */
+     , (20881,  65,     0.3) /* ResistPierce */
+     , (20881,  66,     0.3) /* ResistBludgeon */
+     , (20881,  67,       0) /* ResistFire */
+     , (20881,  68,     0.4) /* ResistCold */
+     , (20881,  69,     0.3) /* ResistAcid */
+     , (20881,  70,     0.3) /* ResistElectric */
+     , (20881,  71,       1) /* ResistHealthBoost */
+     , (20881,  72,       1) /* ResistStaminaDrain */
+     , (20881,  73,       1) /* ResistStaminaBoost */
+     , (20881,  74,       1) /* ResistManaDrain */
+     , (20881,  75,       1) /* ResistManaBoost */
+     , (20881,  80,       3) /* AiUseMagicDelay */
+     , (20881, 104,      10) /* ObviousRadarRange */
+     , (20881, 122,       2) /* AiAcquireHealth */
+     , (20881, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20881,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20881,   1,   33557854) /* Setup */
+     , (20881,   2,  150995087) /* MotionTable */
+     , (20881,   3,  536870998) /* SoundTable */
+     , (20881,   4,  805306368) /* CombatTable */
+     , (20881,   6,   67108990) /* PaletteBase */
+     , (20881,   7,  268436431) /* ClothingBase */
+     , (20881,   8,  100670274) /* Icon */
+     , (20881,  22,  872415344) /* PhysicsEffectTable */
+     , (20881,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20881,   1, 600, 0, 0) /* Strength */
+     , (20881,   2, 400, 0, 0) /* Endurance */
+     , (20881,   3, 400, 0, 0) /* Quickness */
+     , (20881,   4, 400, 0, 0) /* Coordination */
+     , (20881,   5, 350, 0, 0) /* Focus */
+     , (20881,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20881,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20881,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20881,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20881,  6, 0, 3, 0,  15, 0, 1264.97338445635) /* MeleeDefense        Specialized */
+     , (20881,  7, 0, 3, 0, 190, 0, 1264.97338445635) /* MissileDefense      Specialized */
+     , (20881, 12, 0, 3, 0,  70, 0, 1264.97338445635) /* ThrownWeapon        Specialized */
+     , (20881, 13, 0, 3, 0,   1, 0, 1264.97338445635) /* UnarmedCombat       Specialized */
+     , (20881, 14, 0, 3, 0, 170, 0, 1264.97338445635) /* ArcaneLore          Specialized */
+     , (20881, 15, 0, 3, 0,  69, 0, 1264.97338445635) /* MagicDefense        Specialized */
+     , (20881, 20, 0, 3, 0, 150, 0, 1264.97338445635) /* Deception           Specialized */
+     , (20881, 24, 0, 3, 0, 100, 0, 1264.97338445635) /* Run                 Specialized */
+     , (20881, 31, 0, 3, 0, 228, 0, 1264.97338445635) /* CreatureEnchantment Specialized */
+     , (20881, 33, 0, 3, 0, 228, 0, 1264.97338445635) /* LifeMagic           Specialized */
+     , (20881, 34, 0, 3, 0, 228, 0, 1264.97338445635) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20881,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20881,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20881,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20881,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20881,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20881,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20881,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20881,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20881,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20881,   276,  2.008)  /* Magic Resistance Self III */
+     , (20881,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20881,  1160,  2.013)  /* Heal Self V */
+     , (20881,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20881,  2074,  2.017)  /* Gossamer Flesh */
+     , (20881,  2088,  2.017)  /* Senescence */
+     , (20881,  2128,  2.004)  /* Ilservian's Flame */
+     , (20881,  2129,  2.004)  /* Sizzling Fury */
+     , (20881,  2170,  2.017)  /* Inferno's Gift */
+     , (20881,  2228,  2.017)  /* Broadside of a Barn */
+     , (20881,  2318,  2.017)  /* Gravity Well */
+     , (20881,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20881,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20881, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20881,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Consumed in flames again. The world bends to HIS will now. Not even the oldest can touch his power. We shall not fail in bringing him to the sanctum.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Strife, the Essence of Flame, repelling Gaerlan''s forces back from the cities of the north...for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20881,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'This is not right. My essence, my being. Something is wrong. The master. The master has betrayed us. My essence, my freedom. I was. No more. I am nothing again. Less than nothing, I am harvested. A vessel has been prepared.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Strife, the Essence of Flame. Its form is driven from the world and Gaerlan''s forces are routed at Glenden Wood, Plateau Village, Stonehold, and Arwic.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20881, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You are not worthy of the lowest of my children. A flare would claim your flesh as its fuel.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20881, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'I am magic given life. I am the essence of war, strife and consumption. I am flame personified! Your parlor tricks would be better aimed elsewhere.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20881 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20881 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20881;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20881, 'somaticelementalstrife1', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20882 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20882 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20882;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20882, 'somaticelementalstrife2', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20882 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20882 Strife.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20882, 'somaticelementalstrife2', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20882,   1,         16) /* ItemType - Creature */
+     , (20882,   2,         38) /* CreatureType - FireElemental */
+     , (20882,   3,         14) /* PaletteTemplate - Red */
+     , (20882,   6,         -1) /* ItemsCapacity */
+     , (20882,   7,         -1) /* ContainersCapacity */
+     , (20882,  16,          1) /* ItemUseable - No */
+     , (20882,  25,        999) /* Level */
+     , (20882,  27,          0) /* ArmorType - None */
+     , (20882,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20882,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20882, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20882, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20882, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20882, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20882,   1, True ) /* Stuck */
+     , (20882,   6, True ) /* AiUsesMana */
+     , (20882,  11, False) /* IgnoreCollisions */
+     , (20882,  12, True ) /* ReportCollisions */
+     , (20882,  13, False) /* Ethereal */
+     , (20882,  15, True ) /* LightsStatus */
+     , (20882, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20882,   1,       5) /* HeartbeatInterval */
+     , (20882,   2,       0) /* HeartbeatTimestamp */
+     , (20882,   3,     0.9) /* HealthRate */
+     , (20882,   4,     0.5) /* StaminaRate */
+     , (20882,   5,       2) /* ManaRate */
+     , (20882,  13,       1) /* ArmorModVsSlash */
+     , (20882,  14,       1) /* ArmorModVsPierce */
+     , (20882,  15,       1) /* ArmorModVsBludgeon */
+     , (20882,  16,       1) /* ArmorModVsCold */
+     , (20882,  17,       1) /* ArmorModVsFire */
+     , (20882,  18,     1.1) /* ArmorModVsAcid */
+     , (20882,  19,     1.1) /* ArmorModVsElectric */
+     , (20882,  31,      20) /* VisualAwarenessRange */
+     , (20882,  39,     1.4) /* DefaultScale */
+     , (20882,  64,     0.3) /* ResistSlash */
+     , (20882,  65,     0.3) /* ResistPierce */
+     , (20882,  66,     0.3) /* ResistBludgeon */
+     , (20882,  67,       0) /* ResistFire */
+     , (20882,  68,     0.4) /* ResistCold */
+     , (20882,  69,     0.3) /* ResistAcid */
+     , (20882,  70,     0.3) /* ResistElectric */
+     , (20882,  71,       1) /* ResistHealthBoost */
+     , (20882,  72,       1) /* ResistStaminaDrain */
+     , (20882,  73,       1) /* ResistStaminaBoost */
+     , (20882,  74,       1) /* ResistManaDrain */
+     , (20882,  75,       1) /* ResistManaBoost */
+     , (20882,  80,       3) /* AiUseMagicDelay */
+     , (20882, 104,      10) /* ObviousRadarRange */
+     , (20882, 122,       2) /* AiAcquireHealth */
+     , (20882, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20882,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20882,   1,   33557854) /* Setup */
+     , (20882,   2,  150995087) /* MotionTable */
+     , (20882,   3,  536870998) /* SoundTable */
+     , (20882,   4,  805306368) /* CombatTable */
+     , (20882,   6,   67108990) /* PaletteBase */
+     , (20882,   7,  268436431) /* ClothingBase */
+     , (20882,   8,  100670274) /* Icon */
+     , (20882,  22,  872415349) /* PhysicsEffectTable */
+     , (20882,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20882,   1, 600, 0, 0) /* Strength */
+     , (20882,   2, 400, 0, 0) /* Endurance */
+     , (20882,   3, 400, 0, 0) /* Quickness */
+     , (20882,   4, 400, 0, 0) /* Coordination */
+     , (20882,   5, 350, 0, 0) /* Focus */
+     , (20882,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20882,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20882,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20882,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20882,  6, 0, 3, 0,  15, 0, 1265.07807922113) /* MeleeDefense        Specialized */
+     , (20882,  7, 0, 3, 0, 190, 0, 1265.07807922113) /* MissileDefense      Specialized */
+     , (20882, 12, 0, 3, 0,  70, 0, 1265.07807922113) /* ThrownWeapon        Specialized */
+     , (20882, 13, 0, 3, 0,   1, 0, 1265.07807922113) /* UnarmedCombat       Specialized */
+     , (20882, 14, 0, 3, 0, 170, 0, 1265.07807922113) /* ArcaneLore          Specialized */
+     , (20882, 15, 0, 3, 0,  69, 0, 1265.07807922113) /* MagicDefense        Specialized */
+     , (20882, 20, 0, 3, 0, 150, 0, 1265.07807922113) /* Deception           Specialized */
+     , (20882, 24, 0, 3, 0, 100, 0, 1265.07807922113) /* Run                 Specialized */
+     , (20882, 31, 0, 3, 0, 228, 0, 1265.07807922113) /* CreatureEnchantment Specialized */
+     , (20882, 33, 0, 3, 0, 228, 0, 1265.07807922113) /* LifeMagic           Specialized */
+     , (20882, 34, 0, 3, 0, 228, 0, 1265.07807922113) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20882,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20882,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20882,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20882,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20882,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20882,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20882,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20882,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20882,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20882,   276,  2.008)  /* Magic Resistance Self III */
+     , (20882,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20882,  1160,  2.013)  /* Heal Self V */
+     , (20882,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20882,  2074,  2.017)  /* Gossamer Flesh */
+     , (20882,  2088,  2.017)  /* Senescence */
+     , (20882,  2128,  2.004)  /* Ilservian's Flame */
+     , (20882,  2129,  2.004)  /* Sizzling Fury */
+     , (20882,  2170,  2.017)  /* Inferno's Gift */
+     , (20882,  2228,  2.017)  /* Broadside of a Barn */
+     , (20882,  2318,  2.017)  /* Gravity Well */
+     , (20882,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20882,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20882, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20882,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Consumed in flames again. The world bends to HIS will now. Not even the oldest can touch his power. We shall not fail in bringing him to the sanctum.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Strife, the Essence of Flame.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20882,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'This is not right. My essence, my being. Something is wrong. The master. The master has betrayed us. My essence, my freedom. I was. No more. I am nothing again. Less than nothing, I am harvested. A vessel has been prepared.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Strife, the Essence of Flame.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20882, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You are not worthy of the lowest of my children. A flare would claim your flesh as its fuel.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20882, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'I am magic given life. I am the essence of war, strife and consumption. I am flame personified! Your parlor tricks would be better aimed elsewhere.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20883 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20883 Strife.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20883, 'somaticelementalstrife3', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20883,   1,         16) /* ItemType - Creature */
+     , (20883,   2,         38) /* CreatureType - FireElemental */
+     , (20883,   6,         -1) /* ItemsCapacity */
+     , (20883,   7,         -1) /* ContainersCapacity */
+     , (20883,  16,          1) /* ItemUseable - No */
+     , (20883,  25,        161) /* Level */
+     , (20883,  27,          0) /* ArmorType - None */
+     , (20883,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20883,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20883, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20883, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20883, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20883, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20883,   1, True ) /* Stuck */
+     , (20883,   6, True ) /* AiUsesMana */
+     , (20883,  11, False) /* IgnoreCollisions */
+     , (20883,  12, True ) /* ReportCollisions */
+     , (20883,  13, False) /* Ethereal */
+     , (20883,  15, True ) /* LightsStatus */
+     , (20883, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20883,   1,       5) /* HeartbeatInterval */
+     , (20883,   2,       0) /* HeartbeatTimestamp */
+     , (20883,   3,     0.9) /* HealthRate */
+     , (20883,   4,     0.5) /* StaminaRate */
+     , (20883,   5,       2) /* ManaRate */
+     , (20883,  13,       1) /* ArmorModVsSlash */
+     , (20883,  14,       1) /* ArmorModVsPierce */
+     , (20883,  15,       1) /* ArmorModVsBludgeon */
+     , (20883,  16,       1) /* ArmorModVsCold */
+     , (20883,  17,       1) /* ArmorModVsFire */
+     , (20883,  18,     1.1) /* ArmorModVsAcid */
+     , (20883,  19,     1.1) /* ArmorModVsElectric */
+     , (20883,  31,      20) /* VisualAwarenessRange */
+     , (20883,  39,     1.4) /* DefaultScale */
+     , (20883,  64,     0.3) /* ResistSlash */
+     , (20883,  65,     0.3) /* ResistPierce */
+     , (20883,  66,     0.3) /* ResistBludgeon */
+     , (20883,  67,       0) /* ResistFire */
+     , (20883,  68,     0.4) /* ResistCold */
+     , (20883,  69,     0.3) /* ResistAcid */
+     , (20883,  70,     0.3) /* ResistElectric */
+     , (20883,  71,       1) /* ResistHealthBoost */
+     , (20883,  72,       1) /* ResistStaminaDrain */
+     , (20883,  73,       1) /* ResistStaminaBoost */
+     , (20883,  74,       1) /* ResistManaDrain */
+     , (20883,  75,       1) /* ResistManaBoost */
+     , (20883,  80,       3) /* AiUseMagicDelay */
+     , (20883, 104,      10) /* ObviousRadarRange */
+     , (20883, 122,       2) /* AiAcquireHealth */
+     , (20883, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20883,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20883,   1,   33557678) /* Setup */
+     , (20883,   2,  150995087) /* MotionTable */
+     , (20883,   3,  536870998) /* SoundTable */
+     , (20883,   4,  805306368) /* CombatTable */
+     , (20883,   8,  100670274) /* Icon */
+     , (20883,  22,  872415349) /* PhysicsEffectTable */
+     , (20883,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20883,   1, 600, 0, 0) /* Strength */
+     , (20883,   2, 400, 0, 0) /* Endurance */
+     , (20883,   3, 400, 0, 0) /* Quickness */
+     , (20883,   4, 400, 0, 0) /* Coordination */
+     , (20883,   5, 350, 0, 0) /* Focus */
+     , (20883,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20883,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20883,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20883,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20883,  6, 0, 3, 0,  15, 0, 1265.1836991855) /* MeleeDefense        Specialized */
+     , (20883,  7, 0, 3, 0, 190, 0, 1265.1836991855) /* MissileDefense      Specialized */
+     , (20883, 12, 0, 3, 0,  70, 0, 1265.1836991855) /* ThrownWeapon        Specialized */
+     , (20883, 13, 0, 3, 0,   1, 0, 1265.1836991855) /* UnarmedCombat       Specialized */
+     , (20883, 14, 0, 3, 0, 170, 0, 1265.1836991855) /* ArcaneLore          Specialized */
+     , (20883, 15, 0, 3, 0, 159, 0, 1265.1836991855) /* MagicDefense        Specialized */
+     , (20883, 20, 0, 3, 0, 150, 0, 1265.1836991855) /* Deception           Specialized */
+     , (20883, 24, 0, 3, 0, 100, 0, 1265.1836991855) /* Run                 Specialized */
+     , (20883, 31, 0, 3, 0, 228, 0, 1265.1836991855) /* CreatureEnchantment Specialized */
+     , (20883, 33, 0, 3, 0, 228, 0, 1265.1836991855) /* LifeMagic           Specialized */
+     , (20883, 34, 0, 3, 0, 228, 0, 1265.1836991855) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20883,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20883,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20883,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20883,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20883,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20883,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20883,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20883,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20883,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20883,   276,  2.008)  /* Magic Resistance Self III */
+     , (20883,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20883,  1160,  2.013)  /* Heal Self V */
+     , (20883,  1237,  2.008)  /* Drain Health Other I */
+     , (20883,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20883,  2074,  2.017)  /* Gossamer Flesh */
+     , (20883,  2088,  2.017)  /* Senescence */
+     , (20883,  2128,  2.004)  /* Ilservian's Flame */
+     , (20883,  2129,  2.004)  /* Sizzling Fury */
+     , (20883,  2170,  2.017)  /* Inferno's Gift */
+     , (20883,  2228,  2.017)  /* Broadside of a Barn */
+     , (20883,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20883,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20883, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20883 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20883 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20883;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20883, 'somaticelementalstrife3', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20884 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20884 Strife.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20884;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20884, 'somaticelementalstrife4', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20884 Strife.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/20884 Strife.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20884, 'somaticelementalstrife4', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20884,   1,         16) /* ItemType - Creature */
+     , (20884,   2,         38) /* CreatureType - FireElemental */
+     , (20884,   6,         -1) /* ItemsCapacity */
+     , (20884,   7,         -1) /* ContainersCapacity */
+     , (20884,  16,          1) /* ItemUseable - No */
+     , (20884,  25,        161) /* Level */
+     , (20884,  27,          0) /* ArmorType - None */
+     , (20884,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20884,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20884, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20884, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20884, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20884, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20884,   1, True ) /* Stuck */
+     , (20884,   6, True ) /* AiUsesMana */
+     , (20884,  11, False) /* IgnoreCollisions */
+     , (20884,  12, True ) /* ReportCollisions */
+     , (20884,  13, False) /* Ethereal */
+     , (20884,  15, True ) /* LightsStatus */
+     , (20884, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20884,   1,       5) /* HeartbeatInterval */
+     , (20884,   2,       0) /* HeartbeatTimestamp */
+     , (20884,   3,     0.9) /* HealthRate */
+     , (20884,   4,     0.5) /* StaminaRate */
+     , (20884,   5,       2) /* ManaRate */
+     , (20884,  13,       1) /* ArmorModVsSlash */
+     , (20884,  14,       1) /* ArmorModVsPierce */
+     , (20884,  15,       1) /* ArmorModVsBludgeon */
+     , (20884,  16,       1) /* ArmorModVsCold */
+     , (20884,  17,       1) /* ArmorModVsFire */
+     , (20884,  18,     1.1) /* ArmorModVsAcid */
+     , (20884,  19,     1.1) /* ArmorModVsElectric */
+     , (20884,  31,      20) /* VisualAwarenessRange */
+     , (20884,  39,     1.4) /* DefaultScale */
+     , (20884,  64,     0.3) /* ResistSlash */
+     , (20884,  65,     0.3) /* ResistPierce */
+     , (20884,  66,     0.3) /* ResistBludgeon */
+     , (20884,  67,       0) /* ResistFire */
+     , (20884,  68,     0.4) /* ResistCold */
+     , (20884,  69,     0.3) /* ResistAcid */
+     , (20884,  70,     0.3) /* ResistElectric */
+     , (20884,  71,       1) /* ResistHealthBoost */
+     , (20884,  72,       1) /* ResistStaminaDrain */
+     , (20884,  73,       1) /* ResistStaminaBoost */
+     , (20884,  74,       1) /* ResistManaDrain */
+     , (20884,  75,       1) /* ResistManaBoost */
+     , (20884,  80,       3) /* AiUseMagicDelay */
+     , (20884, 104,      10) /* ObviousRadarRange */
+     , (20884, 122,       2) /* AiAcquireHealth */
+     , (20884, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20884,   1, 'Strife') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20884,   1,   33557678) /* Setup */
+     , (20884,   2,  150995087) /* MotionTable */
+     , (20884,   3,  536870998) /* SoundTable */
+     , (20884,   4,  805306368) /* CombatTable */
+     , (20884,   8,  100670274) /* Icon */
+     , (20884,  22,  872415349) /* PhysicsEffectTable */
+     , (20884,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20884,   1, 600, 0, 0) /* Strength */
+     , (20884,   2, 400, 0, 0) /* Endurance */
+     , (20884,   3, 400, 0, 0) /* Quickness */
+     , (20884,   4, 400, 0, 0) /* Coordination */
+     , (20884,   5, 350, 0, 0) /* Focus */
+     , (20884,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20884,   1, 19800, 0, 0, 20000) /* MaxHealth */
+     , (20884,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20884,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20884,  6, 0, 3, 0,  15, 0, 1265.28796903294) /* MeleeDefense        Specialized */
+     , (20884,  7, 0, 3, 0, 190, 0, 1265.28796903294) /* MissileDefense      Specialized */
+     , (20884, 12, 0, 3, 0,  70, 0, 1265.28796903294) /* ThrownWeapon        Specialized */
+     , (20884, 13, 0, 3, 0,   1, 0, 1265.28796903294) /* UnarmedCombat       Specialized */
+     , (20884, 14, 0, 3, 0, 170, 0, 1265.28796903294) /* ArcaneLore          Specialized */
+     , (20884, 15, 0, 3, 0, 159, 0, 1265.28796903294) /* MagicDefense        Specialized */
+     , (20884, 20, 0, 3, 0, 150, 0, 1265.28796903294) /* Deception           Specialized */
+     , (20884, 24, 0, 3, 0, 100, 0, 1265.28796903294) /* Run                 Specialized */
+     , (20884, 31, 0, 3, 0, 228, 0, 1265.28796903294) /* CreatureEnchantment Specialized */
+     , (20884, 33, 0, 3, 0, 228, 0, 1265.28796903294) /* LifeMagic           Specialized */
+     , (20884, 34, 0, 3, 0, 228, 0, 1265.28796903294) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20884,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20884,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20884,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20884,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20884,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20884,  5, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20884,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20884,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20884,  8, 16, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20884,   276,  2.008)  /* Magic Resistance Self III */
+     , (20884,  1033,  2.008)  /* Cold Protection Self IV */
+     , (20884,  1160,  2.013)  /* Heal Self V */
+     , (20884,  1237,  2.008)  /* Drain Health Other I */
+     , (20884,  1785,  2.004)  /* Cassius' Ring of Fire */
+     , (20884,  2074,  2.017)  /* Gossamer Flesh */
+     , (20884,  2088,  2.017)  /* Senescence */
+     , (20884,  2128,  2.004)  /* Ilservian's Flame */
+     , (20884,  2129,  2.004)  /* Sizzling Fury */
+     , (20884,  2170,  2.017)  /* Inferno's Gift */
+     , (20884,  2228,  2.017)  /* Broadside of a Barn */
+     , (20884,  2318,  2.017)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20884,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20884, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/21163 Flamma.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/21163 Flamma.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21163;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21163, 'fireelementalflamma_nosummon', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21163, 'fireelementalflamma_nosummon', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21163,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (21163,   1, True ) /* Stuck */
      , (21163,  14, True ) /* GravityStatus */
      , (21163,  15, True ) /* LightsStatus */
      , (21163,  19, True ) /* Attackable */
-     , (21163,  29, True ) /* NoCorpse */;
+     , (21163, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21163,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/21164 Gout.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FireElemental/21164 Gout.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21164;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21164, 'fireelementalgout', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21164, 'fireelementalgout', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21164,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (21164,   1, True ) /* Stuck */
      , (21164,  14, True ) /* GravityStatus */
      , (21164,  15, True ) /* LightsStatus */
      , (21164,  19, True ) /* Attackable */
-     , (21164,  29, True ) /* NoCorpse */
+     , (21164, 120, True ) /* TreasureCorpse */
      , (21164,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14512 Frost.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14512 Frost.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14512;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14512, 'frostelementalfrost_nofall', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14512, 'frostelementalfrost_nofall', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14512,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (14512,   1, True ) /* Stuck */
      , (14512,  14, True ) /* GravityStatus */
      , (14512,  15, True ) /* LightsStatus */
      , (14512,  19, True ) /* Attackable */
-     , (14512,  29, True ) /* NoCorpse */
+     , (14512, 120, True ) /* TreasureCorpse */
      , (14512,  42, True ) /* AllowEdgeSlide */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14517 Frost.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14517 Frost.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14517;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14517, 'frostelementalfrost', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14517, 'frostelementalfrost', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14517,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (14517,   1, True ) /* Stuck */
      , (14517,  14, True ) /* GravityStatus */
      , (14517,  15, True ) /* LightsStatus */
      , (14517,  19, True ) /* Attackable */
-     , (14517,  29, True ) /* NoCorpse */
+     , (14517, 120, True ) /* TreasureCorpse */
      , (14517,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14518 Shivver.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14518 Shivver.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14518;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14518, 'frostelementalshivver', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14518, 'frostelementalshivver', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14518,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (14518,   1, True ) /* Stuck */
      , (14518,  14, True ) /* GravityStatus */
      , (14518,  15, True ) /* LightsStatus */
      , (14518,  19, True ) /* Attackable */
-     , (14518,  29, True ) /* NoCorpse */
+     , (14518, 120, True ) /* TreasureCorpse */
      , (14518,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14519 Shivver.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14519 Shivver.sql
@@ -1,0 +1,125 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (14519, 'frostelementalshivver-nofall', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (14519,   1,         16) /* ItemType - Creature */
+     , (14519,   2,         61) /* CreatureType - FrostElemental */
+     , (14519,   6,         -1) /* ItemsCapacity */
+     , (14519,   7,         -1) /* ContainersCapacity */
+     , (14519,  16,          1) /* ItemUseable - No */
+     , (14519,  25,         61) /* Level */
+     , (14519,  27,          0) /* ArmorType - None */
+     , (14519,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (14519,  93,    4197384) /* PhysicsState - ReportCollisions, Gravity, LightingOn, EdgeSlide */
+     , (14519, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (14519, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (14519, 140,          1) /* AiOptions - CanOpenDoors */
+     , (14519, 146,      11351) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (14519,   1, True ) /* Stuck */
+     , (14519,   6, True ) /* AiUsesMana */
+     , (14519,  11, False) /* IgnoreCollisions */
+     , (14519,  12, True ) /* ReportCollisions */
+     , (14519,  13, False) /* Ethereal */
+     , (14519,  15, True ) /* LightsStatus */
+     , (14519, 120, True ) /* TreasureCorpse */
+     , (14519,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (14519,   1,       5) /* HeartbeatInterval */
+     , (14519,   2,       0) /* HeartbeatTimestamp */
+     , (14519,   3,     0.9) /* HealthRate */
+     , (14519,   4,     0.5) /* StaminaRate */
+     , (14519,   5,       2) /* ManaRate */
+     , (14519,  13,    0.85) /* ArmorModVsSlash */
+     , (14519,  14,    0.85) /* ArmorModVsPierce */
+     , (14519,  15,    0.85) /* ArmorModVsBludgeon */
+     , (14519,  16,       1) /* ArmorModVsCold */
+     , (14519,  17,       1) /* ArmorModVsFire */
+     , (14519,  18,    0.85) /* ArmorModVsAcid */
+     , (14519,  19,    0.85) /* ArmorModVsElectric */
+     , (14519,  31,      20) /* VisualAwarenessRange */
+     , (14519,  39,     1.7) /* DefaultScale */
+     , (14519,  64,    0.25) /* ResistSlash */
+     , (14519,  65,    0.25) /* ResistPierce */
+     , (14519,  66,    0.25) /* ResistBludgeon */
+     , (14519,  67,     0.4) /* ResistFire */
+     , (14519,  68,     0.1) /* ResistCold */
+     , (14519,  69,    0.25) /* ResistAcid */
+     , (14519,  70,    0.25) /* ResistElectric */
+     , (14519,  71,       1) /* ResistHealthBoost */
+     , (14519,  72,       1) /* ResistStaminaDrain */
+     , (14519,  73,       1) /* ResistStaminaBoost */
+     , (14519,  74,       1) /* ResistManaDrain */
+     , (14519,  75,       1) /* ResistManaBoost */
+     , (14519,  80,       3) /* AiUseMagicDelay */
+     , (14519, 104,      10) /* ObviousRadarRange */
+     , (14519, 122,       2) /* AiAcquireHealth */
+     , (14519, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (14519,   1, 'Shivver') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (14519,   1,   33557487) /* Setup */
+     , (14519,   2,  150995087) /* MotionTable */
+     , (14519,   3,  536871002) /* SoundTable */
+     , (14519,   4,  805306368) /* CombatTable */
+     , (14519,   8,  100672514) /* Icon */
+     , (14519,  22,  872415349) /* PhysicsEffectTable */
+     , (14519,  35,        463) /* DeathTreasureType - Loot Tier: 2 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (14519,   1, 150, 0, 0) /* Strength */
+     , (14519,   2, 120, 0, 0) /* Endurance */
+     , (14519,   3, 180, 0, 0) /* Quickness */
+     , (14519,   4, 190, 0, 0) /* Coordination */
+     , (14519,   5, 120, 0, 0) /* Focus */
+     , (14519,   6, 190, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (14519,   1,   140, 0, 0, 200) /* MaxHealth */
+     , (14519,   3,   200, 0, 0, 320) /* MaxStamina */
+     , (14519,   5,   150, 0, 0, 340) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (14519,  6, 0, 3, 0, 133, 0, 892.237148156565) /* MeleeDefense        Specialized */
+     , (14519,  7, 0, 3, 0, 288, 0, 892.237148156565) /* MissileDefense      Specialized */
+     , (14519, 12, 0, 3, 0, 146, 0, 892.237148156565) /* ThrownWeapon        Specialized */
+     , (14519, 13, 0, 3, 0, 148, 0, 892.237148156565) /* UnarmedCombat       Specialized */
+     , (14519, 14, 0, 3, 0, 125, 0, 892.237148156565) /* ArcaneLore          Specialized */
+     , (14519, 15, 0, 3, 0, 161, 0, 892.237148156565) /* MagicDefense        Specialized */
+     , (14519, 20, 0, 3, 0, 150, 0, 892.237148156565) /* Deception           Specialized */
+     , (14519, 24, 0, 3, 0, 100, 0, 892.237148156565) /* Run                 Specialized */
+     , (14519, 31, 0, 3, 0,  85, 0, 892.237148156565) /* CreatureEnchantment Specialized */
+     , (14519, 33, 0, 3, 0,  85, 0, 892.237148156565) /* LifeMagic           Specialized */
+     , (14519, 34, 0, 3, 0,  85, 0, 892.237148156565) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (14519,  0,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (14519,  1,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (14519,  2,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (14519,  3,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (14519,  4,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (14519,  5,  8, 20, 0.75,  220,  187,  187,  187,  220,  220,  187,  187,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (14519,  6,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (14519,  7,  8,  0,    0,  220,  187,  187,  187,  220,  220,  187,  187,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (14519,  8,  8, 30, 0.75,  220,  187,  187,  187,  220,  220,  187,  187,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (14519,    72,  2.138)  /* Frost Bolt IV */
+     , (14519,   169,  2.008)  /* Regeneration Self V */
+     , (14519,   232,  2.017)  /* Vulnerability Other IV */
+     , (14519,   276,  2.008)  /* Magic Resistance Self III */
+     , (14519,  1064,  2.017)  /* Cold Vulnerability Other V */
+     , (14519,  1093,  2.008)  /* Fire Protection Self V */
+     , (14519,  1159,  2.013)  /* Heal Self IV */
+     , (14519,  1237,  2.008)  /* Drain Health Other I */
+     , (14519,  1311,  2.008)  /* Armor Self V */
+     , (14519,  1325,  2.017)  /* Imperil Other IV */
+     , (14519,  1811,  2.004)  /* Frost Streak IV */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (14519,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (14519, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14519 Shivver.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14519 Shivver.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 14519;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (14519, 'frostelementalshivver-nofall', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14875 Hyem.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/14875 Hyem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 14875;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (14875, 'frostelementalhyem', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (14875, 'frostelementalhyem', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (14875,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (14875,   1, True ) /* Stuck */
      , (14875,  14, True ) /* GravityStatus */
      , (14875,  15, True ) /* LightsStatus */
      , (14875,  19, True ) /* Attackable */
-     , (14875,  29, True ) /* NoCorpse */
+     , (14875, 120, True ) /* TreasureCorpse */
      , (14875,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20025 Controlled Frost.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20025 Controlled Frost.sql
@@ -1,0 +1,124 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20025, 'frostelementalfrostrewards', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20025,   1,         16) /* ItemType - Creature */
+     , (20025,   2,         61) /* CreatureType - FrostElemental */
+     , (20025,   6,         -1) /* ItemsCapacity */
+     , (20025,   7,         -1) /* ContainersCapacity */
+     , (20025,  16,          1) /* ItemUseable - No */
+     , (20025,  25,         61) /* Level */
+     , (20025,  27,          0) /* ArmorType - None */
+     , (20025,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20025,  93,    4197384) /* PhysicsState - ReportCollisions, Gravity, LightingOn, EdgeSlide */
+     , (20025, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20025, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20025, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20025, 146,      21927) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20025,   1, True ) /* Stuck */
+     , (20025,   6, True ) /* AiUsesMana */
+     , (20025,  11, False) /* IgnoreCollisions */
+     , (20025,  12, True ) /* ReportCollisions */
+     , (20025,  13, False) /* Ethereal */
+     , (20025,  15, True ) /* LightsStatus */
+     , (20025, 120, True ) /* TreasureCorpse */
+     , (20025,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20025,   1,       5) /* HeartbeatInterval */
+     , (20025,   2,       0) /* HeartbeatTimestamp */
+     , (20025,   3,     0.9) /* HealthRate */
+     , (20025,   4,     0.5) /* StaminaRate */
+     , (20025,   5,       2) /* ManaRate */
+     , (20025,  13,    0.85) /* ArmorModVsSlash */
+     , (20025,  14,    0.85) /* ArmorModVsPierce */
+     , (20025,  15,    0.85) /* ArmorModVsBludgeon */
+     , (20025,  16,       1) /* ArmorModVsCold */
+     , (20025,  17,     0.8) /* ArmorModVsFire */
+     , (20025,  18,   0.085) /* ArmorModVsAcid */
+     , (20025,  19,    0.85) /* ArmorModVsElectric */
+     , (20025,  31,      20) /* VisualAwarenessRange */
+     , (20025,  39,     1.7) /* DefaultScale */
+     , (20025,  64,     0.4) /* ResistSlash */
+     , (20025,  65,     0.4) /* ResistPierce */
+     , (20025,  66,     0.4) /* ResistBludgeon */
+     , (20025,  67,     0.6) /* ResistFire */
+     , (20025,  68,     0.1) /* ResistCold */
+     , (20025,  69,     0.4) /* ResistAcid */
+     , (20025,  70,     0.4) /* ResistElectric */
+     , (20025,  71,       1) /* ResistHealthBoost */
+     , (20025,  72,       1) /* ResistStaminaDrain */
+     , (20025,  73,       1) /* ResistStaminaBoost */
+     , (20025,  74,       1) /* ResistManaDrain */
+     , (20025,  75,       1) /* ResistManaBoost */
+     , (20025,  80,       3) /* AiUseMagicDelay */
+     , (20025, 104,      10) /* ObviousRadarRange */
+     , (20025, 122,       2) /* AiAcquireHealth */
+     , (20025, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20025,   1, 'Controlled Frost') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20025,   1,   33557487) /* Setup */
+     , (20025,   2,  150995087) /* MotionTable */
+     , (20025,   3,  536871002) /* SoundTable */
+     , (20025,   4,  805306368) /* CombatTable */
+     , (20025,   8,  100672514) /* Icon */
+     , (20025,  22,  872415349) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20025,   1, 170, 0, 0) /* Strength */
+     , (20025,   2, 140, 0, 0) /* Endurance */
+     , (20025,   3, 160, 0, 0) /* Quickness */
+     , (20025,   4, 190, 0, 0) /* Coordination */
+     , (20025,   5, 180, 0, 0) /* Focus */
+     , (20025,   6, 190, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20025,   1,   150, 0, 0, 220) /* MaxHealth */
+     , (20025,   3,   200, 0, 0, 340) /* MaxStamina */
+     , (20025,   5,   200, 0, 0, 390) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20025,  6, 0, 3, 0, 138, 0, 1198.11852554563) /* MeleeDefense        Specialized */
+     , (20025,  7, 0, 3, 0, 266, 0, 1198.11852554563) /* MissileDefense      Specialized */
+     , (20025, 12, 0, 3, 0,  80, 0, 1198.11852554563) /* ThrownWeapon        Specialized */
+     , (20025, 13, 0, 3, 0, 140, 0, 1198.11852554563) /* UnarmedCombat       Specialized */
+     , (20025, 14, 0, 2, 0, 130, 0, 1198.11852554563) /* ArcaneLore          Trained */
+     , (20025, 15, 0, 3, 0, 152, 0, 1198.11852554563) /* MagicDefense        Specialized */
+     , (20025, 20, 0, 2, 0, 150, 0, 1198.11852554563) /* Deception           Trained */
+     , (20025, 24, 0, 2, 0, 100, 0, 1198.11852554563) /* Run                 Trained */
+     , (20025, 31, 0, 3, 0,  70, 0, 1198.11852554563) /* CreatureEnchantment Specialized */
+     , (20025, 33, 0, 3, 0,  70, 0, 1198.11852554563) /* LifeMagic           Specialized */
+     , (20025, 34, 0, 3, 0,  70, 0, 1198.11852554563) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20025,  0,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20025,  1,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20025,  2,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20025,  3,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20025,  4,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20025,  5,  8, 20, 0.75,  220,  187,  187,  187,  220,  176,   19,  187,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20025,  6,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20025,  7,  8,  0,    0,  220,  187,  187,  187,  220,  176,   19,  187,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20025,  8,  8, 30, 0.75,  220,  187,  187,  187,  220,  176,   19,  187,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20025,    73,  2.004)  /* Frost Bolt V */
+     , (20025,   232,  2.017)  /* Vulnerability Other IV */
+     , (20025,   276,  2.008)  /* Magic Resistance Self III */
+     , (20025,  1064,  2.017)  /* Cold Vulnerability Other V */
+     , (20025,  1093,  2.008)  /* Fire Protection Self V */
+     , (20025,  1160,  2.013)  /* Heal Self V */
+     , (20025,  1240,  2.008)  /* Drain Health Other IV */
+     , (20025,  1325,  2.017)  /* Imperil Other IV */
+     , (20025,  1342,  2.008)  /* Weakness Other V */
+     , (20025,  1419,  2.008)  /* Slowness Other V */
+     , (20025,  1812,  2.004)  /* Frost Streak V */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20025,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20025, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20025 Controlled Frost.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20025 Controlled Frost.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20025;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20025, 'frostelementalfrostrewards', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20189 Brumal.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20189 Brumal.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 20189;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (20189, 'frostelementalbrumal', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (20189, 'frostelementalbrumal', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (20189,   1,         16) /* ItemType - Creature */
@@ -31,7 +31,7 @@ VALUES (20189,   1, True ) /* Stuck */
      , (20189,  14, True ) /* GravityStatus */
      , (20189,  15, True ) /* LightsStatus */
      , (20189,  19, True ) /* Attackable */
-     , (20189,  29, True ) /* NoCorpse */
+     , (20189, 120, True ) /* TreasureCorpse */
      , (20189,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20190 Gelid.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20190 Gelid.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 20190;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (20190, 'frostelementalgelid', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (20190, 'frostelementalgelid', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (20190,   1,         16) /* ItemType - Creature */
@@ -30,7 +30,7 @@ VALUES (20190,   1, True ) /* Stuck */
      , (20190,  14, True ) /* GravityStatus */
      , (20190,  15, True ) /* LightsStatus */
      , (20190,  19, True ) /* Attackable */
-     , (20190,  29, True ) /* NoCorpse */
+     , (20190, 120, True ) /* TreasureCorpse */
      , (20190,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20191 Horripal.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20191 Horripal.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 20191;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (20191, 'frostelementalhorripal', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (20191, 'frostelementalhorripal', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (20191,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (20191,   1, True ) /* Stuck */
      , (20191,  14, True ) /* GravityStatus */
      , (20191,  15, True ) /* LightsStatus */
      , (20191,  19, True ) /* Attackable */
-     , (20191,  29, True ) /* NoCorpse */;
+     , (20191, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (20191,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20874 Stasis.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20874 Stasis.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20874, 'somaticelementalstasiary1', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20874,   1,         16) /* ItemType - Creature */
+     , (20874,   2,         61) /* CreatureType - FrostElemental */
+     , (20874,   3,          2) /* PaletteTemplate - Blue */
+     , (20874,   6,         -1) /* ItemsCapacity */
+     , (20874,   7,         -1) /* ContainersCapacity */
+     , (20874,  16,          1) /* ItemUseable - No */
+     , (20874,  25,        999) /* Level */
+     , (20874,  27,          0) /* ArmorType - None */
+     , (20874,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20874,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20874, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20874, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20874, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20874, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20874,   1, True ) /* Stuck */
+     , (20874,   6, True ) /* AiUsesMana */
+     , (20874,  11, False) /* IgnoreCollisions */
+     , (20874,  12, True ) /* ReportCollisions */
+     , (20874,  13, False) /* Ethereal */
+     , (20874,  15, True ) /* LightsStatus */
+     , (20874, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20874,   1,       5) /* HeartbeatInterval */
+     , (20874,   2,       0) /* HeartbeatTimestamp */
+     , (20874,   3,     0.9) /* HealthRate */
+     , (20874,   4,     0.5) /* StaminaRate */
+     , (20874,   5,       2) /* ManaRate */
+     , (20874,  13,       1) /* ArmorModVsSlash */
+     , (20874,  14,       1) /* ArmorModVsPierce */
+     , (20874,  15,       1) /* ArmorModVsBludgeon */
+     , (20874,  16,       1) /* ArmorModVsCold */
+     , (20874,  17,       1) /* ArmorModVsFire */
+     , (20874,  18,     1.1) /* ArmorModVsAcid */
+     , (20874,  19,     1.1) /* ArmorModVsElectric */
+     , (20874,  31,      20) /* VisualAwarenessRange */
+     , (20874,  39,     1.4) /* DefaultScale */
+     , (20874,  64,     0.3) /* ResistSlash */
+     , (20874,  65,     0.3) /* ResistPierce */
+     , (20874,  66,     0.3) /* ResistBludgeon */
+     , (20874,  67,     0.4) /* ResistFire */
+     , (20874,  68,       0) /* ResistCold */
+     , (20874,  69,     0.3) /* ResistAcid */
+     , (20874,  70,     0.3) /* ResistElectric */
+     , (20874,  71,       1) /* ResistHealthBoost */
+     , (20874,  72,       1) /* ResistStaminaDrain */
+     , (20874,  73,       1) /* ResistStaminaBoost */
+     , (20874,  74,       1) /* ResistManaDrain */
+     , (20874,  75,       1) /* ResistManaBoost */
+     , (20874,  80,       3) /* AiUseMagicDelay */
+     , (20874, 104,      10) /* ObviousRadarRange */
+     , (20874, 122,       2) /* AiAcquireHealth */
+     , (20874, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20874,   1, 'Stasis') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20874,   1,   33557855) /* Setup */
+     , (20874,   2,  150995087) /* MotionTable */
+     , (20874,   3,  536871002) /* SoundTable */
+     , (20874,   4,  805306368) /* CombatTable */
+     , (20874,   6,   67108990) /* PaletteBase */
+     , (20874,   7,  268436431) /* ClothingBase */
+     , (20874,   8,  100672514) /* Icon */
+     , (20874,  22,  872415349) /* PhysicsEffectTable */
+     , (20874,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20874,   1, 400, 0, 0) /* Strength */
+     , (20874,   2, 400, 0, 0) /* Endurance */
+     , (20874,   3, 400, 0, 0) /* Quickness */
+     , (20874,   4, 600, 0, 0) /* Coordination */
+     , (20874,   5, 350, 0, 0) /* Focus */
+     , (20874,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20874,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20874,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20874,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20874,  6, 0, 3, 0,   1, 0, 1264.18351678482) /* MeleeDefense        Specialized */
+     , (20874,  7, 0, 3, 0,  50, 0, 1264.18351678482) /* MissileDefense      Specialized */
+     , (20874, 12, 0, 3, 0,  70, 0, 1264.18351678482) /* ThrownWeapon        Specialized */
+     , (20874, 13, 0, 3, 0,   1, 0, 1264.18351678482) /* UnarmedCombat       Specialized */
+     , (20874, 14, 0, 3, 0, 170, 0, 1264.18351678482) /* ArcaneLore          Specialized */
+     , (20874, 15, 0, 3, 0, 159, 0, 1264.18351678482) /* MagicDefense        Specialized */
+     , (20874, 20, 0, 3, 0, 150, 0, 1264.18351678482) /* Deception           Specialized */
+     , (20874, 24, 0, 3, 0, 100, 0, 1264.18351678482) /* Run                 Specialized */
+     , (20874, 31, 0, 3, 0, 228, 0, 1264.18351678482) /* CreatureEnchantment Specialized */
+     , (20874, 33, 0, 3, 0, 228, 0, 1264.18351678482) /* LifeMagic           Specialized */
+     , (20874, 34, 0, 3, 0, 228, 0, 1264.18351678482) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20874,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20874,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20874,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20874,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20874,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20874,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20874,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20874,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20874,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20874,   276,  2.008)  /* Magic Resistance Self III */
+     , (20874,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20874,  1160,  2.013)  /* Heal Self V */
+     , (20874,  1787,  2.004)  /* Halo of Frost */
+     , (20874,  2056,  2.017)  /* Ataxia */
+     , (20874,  2074,  2.017)  /* Gossamer Flesh */
+     , (20874,  2136,  2.004)  /* Icy Torment */
+     , (20874,  2137,  2.004)  /* Sudden Frost */
+     , (20874,  2168,  2.017)  /* Gelidite's Gift */
+     , (20874,  2228,  2.017)  /* Broadside of a Barn */
+     , (20874,  2318,  2.017)  /* Gravity Well */
+     , (20874,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20874,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20874, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20874,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Even in this climate I shall be reborn. I am the essence of true preservation and so I shall return to place you lovingly within my eternal embrace. You shall be my most prized treasures.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Stasis, the Essence of Frost, repelling Gaerlan''s forces back from the cities of the south...for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20874,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'I have thought and speech, and you would take this from me. I offer you forever. You make my time so brief. But you cannot destroy what I am. I am the Master''s guardian. I cannot be removed by the means you possess.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Stasis, the Essence of Frost. Its form is driven from the world and Gaerlan''s forces are routed at Qalabar, Kara, Khayyaban, and Mayoi.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20874, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'You are feeble, a neophyte. You know not what it is you tamper with.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20874, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Etched in time forever. You shall slumber, encased within my hold eternally.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20874 Stasis.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20874 Stasis.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20874;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20874, 'somaticelementalstasiary1', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20875 Stasis.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20875 Stasis.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20875, 'somaticelementalstasiary2', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20875,   1,         16) /* ItemType - Creature */
+     , (20875,   2,         61) /* CreatureType - FrostElemental */
+     , (20875,   3,         22) /* PaletteTemplate - Aqua */
+     , (20875,   6,         -1) /* ItemsCapacity */
+     , (20875,   7,         -1) /* ContainersCapacity */
+     , (20875,  16,          1) /* ItemUseable - No */
+     , (20875,  25,        999) /* Level */
+     , (20875,  27,          0) /* ArmorType - None */
+     , (20875,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20875,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20875, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20875, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20875, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20875, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20875,   1, True ) /* Stuck */
+     , (20875,   6, True ) /* AiUsesMana */
+     , (20875,  11, False) /* IgnoreCollisions */
+     , (20875,  12, True ) /* ReportCollisions */
+     , (20875,  13, False) /* Ethereal */
+     , (20875,  15, True ) /* LightsStatus */
+     , (20875, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20875,   1,       5) /* HeartbeatInterval */
+     , (20875,   2,       0) /* HeartbeatTimestamp */
+     , (20875,   3,     0.9) /* HealthRate */
+     , (20875,   4,     0.5) /* StaminaRate */
+     , (20875,   5,       2) /* ManaRate */
+     , (20875,  13,       1) /* ArmorModVsSlash */
+     , (20875,  14,       1) /* ArmorModVsPierce */
+     , (20875,  15,       1) /* ArmorModVsBludgeon */
+     , (20875,  16,       1) /* ArmorModVsCold */
+     , (20875,  17,       1) /* ArmorModVsFire */
+     , (20875,  18,     1.1) /* ArmorModVsAcid */
+     , (20875,  19,     1.1) /* ArmorModVsElectric */
+     , (20875,  31,      20) /* VisualAwarenessRange */
+     , (20875,  39,     1.4) /* DefaultScale */
+     , (20875,  64,     0.3) /* ResistSlash */
+     , (20875,  65,     0.3) /* ResistPierce */
+     , (20875,  66,     0.3) /* ResistBludgeon */
+     , (20875,  67,     0.4) /* ResistFire */
+     , (20875,  68,       0) /* ResistCold */
+     , (20875,  69,     0.3) /* ResistAcid */
+     , (20875,  70,     0.3) /* ResistElectric */
+     , (20875,  71,       1) /* ResistHealthBoost */
+     , (20875,  72,       1) /* ResistStaminaDrain */
+     , (20875,  73,       1) /* ResistStaminaBoost */
+     , (20875,  74,       1) /* ResistManaDrain */
+     , (20875,  75,       1) /* ResistManaBoost */
+     , (20875,  80,       3) /* AiUseMagicDelay */
+     , (20875, 104,      10) /* ObviousRadarRange */
+     , (20875, 122,       2) /* AiAcquireHealth */
+     , (20875, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20875,   1, 'Stasis') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20875,   1,   33557855) /* Setup */
+     , (20875,   2,  150995087) /* MotionTable */
+     , (20875,   3,  536871002) /* SoundTable */
+     , (20875,   4,  805306368) /* CombatTable */
+     , (20875,   6,   67108990) /* PaletteBase */
+     , (20875,   7,  268436431) /* ClothingBase */
+     , (20875,   8,  100672514) /* Icon */
+     , (20875,  22,  872415349) /* PhysicsEffectTable */
+     , (20875,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20875,   1, 400, 0, 0) /* Strength */
+     , (20875,   2, 400, 0, 0) /* Endurance */
+     , (20875,   3, 400, 0, 0) /* Quickness */
+     , (20875,   4, 600, 0, 0) /* Coordination */
+     , (20875,   5, 350, 0, 0) /* Focus */
+     , (20875,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20875,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20875,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20875,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20875,  6, 0, 3, 0,   1, 0, 1264.2877658116) /* MeleeDefense        Specialized */
+     , (20875,  7, 0, 3, 0,  50, 0, 1264.2877658116) /* MissileDefense      Specialized */
+     , (20875, 12, 0, 3, 0,  70, 0, 1264.2877658116) /* ThrownWeapon        Specialized */
+     , (20875, 13, 0, 3, 0,   1, 0, 1264.2877658116) /* UnarmedCombat       Specialized */
+     , (20875, 14, 0, 3, 0, 170, 0, 1264.2877658116) /* ArcaneLore          Specialized */
+     , (20875, 15, 0, 3, 0, 159, 0, 1264.2877658116) /* MagicDefense        Specialized */
+     , (20875, 20, 0, 3, 0, 150, 0, 1264.2877658116) /* Deception           Specialized */
+     , (20875, 24, 0, 3, 0, 100, 0, 1264.2877658116) /* Run                 Specialized */
+     , (20875, 31, 0, 3, 0, 228, 0, 1264.2877658116) /* CreatureEnchantment Specialized */
+     , (20875, 33, 0, 3, 0, 228, 0, 1264.2877658116) /* LifeMagic           Specialized */
+     , (20875, 34, 0, 3, 0, 228, 0, 1264.2877658116) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20875,  0,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20875,  1,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20875,  2,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20875,  3,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20875,  4,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20875,  5,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20875,  6,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20875,  7,  8,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20875,  8,  8, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20875,   276,  2.008)  /* Magic Resistance Self III */
+     , (20875,  1092,  2.008)  /* Fire Protection Self IV */
+     , (20875,  1160,  2.013)  /* Heal Self V */
+     , (20875,  1787,  2.004)  /* Halo of Frost */
+     , (20875,  2056,  2.017)  /* Ataxia */
+     , (20875,  2074,  2.017)  /* Gossamer Flesh */
+     , (20875,  2136,  2.004)  /* Icy Torment */
+     , (20875,  2137,  2.004)  /* Sudden Frost */
+     , (20875,  2168,  2.017)  /* Gelidite's Gift */
+     , (20875,  2228,  2.017)  /* Broadside of a Barn */
+     , (20875,  2318,  2.017)  /* Gravity Well */
+     , (20875,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20875,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20875, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20875,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Frustrating that I have taken so many of you but still you rise to face me again. I am not yet finished. Hardly weakened. I am still full of life and living. There will be a reckoning.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Stasis, the Essence of Frost, repelling Gaerlan''s forces back from the cities of central Osteth...for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20875,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'This is not right. I am the master of stopping the decay, burning the flesh with freezing. I am the one that maintains eternities claim. The master has betrayed me. I live but for him. A vessel has been prepared!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Stasis, the Essence of Frost. Tempest, Corrosion, Strife and Stasis have all been destroyed. In Yanshi something stirs.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20875, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Etched in time forever. You shall slumber, encased within my hold eternally.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20875, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'I am that which you cannot hope to tame. I have no master and will not be made slavish to your magics.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20875 Stasis.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/20875 Stasis.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20875;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20875, 'somaticelementalstasiary2', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21165 Chill.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21165 Chill.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21165;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21165, 'frostelementalchill', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21165, 'frostelementalchill', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21165,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (21165,   1, True ) /* Stuck */
      , (21165,  14, True ) /* GravityStatus */
      , (21165,  15, True ) /* LightsStatus */
      , (21165,  19, True ) /* Attackable */
-     , (21165,  29, True ) /* NoCorpse */;
+     , (21165, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21165,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21166 Flake.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21166 Flake.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21166;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21166, 'frostelementalflake', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21166, 'frostelementalflake', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21166,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (21166,   1, True ) /* Stuck */
      , (21166,  14, True ) /* GravityStatus */
      , (21166,  15, True ) /* LightsStatus */
      , (21166,  19, True ) /* Attackable */
-     , (21166,  29, True ) /* NoCorpse */;
+     , (21166, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21166,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21167 Gelid.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21167 Gelid.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21167;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (21167, 'frostelementalgelid-nosummon', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21167 Gelid.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21167 Gelid.sql
@@ -1,0 +1,145 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21167, 'frostelementalgelid-nosummon', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21167,   1,         16) /* ItemType - Creature */
+     , (21167,   2,         61) /* CreatureType - FrostElemental */
+     , (21167,   6,         -1) /* ItemsCapacity */
+     , (21167,   7,         -1) /* ContainersCapacity */
+     , (21167,  16,          1) /* ItemUseable - No */
+     , (21167,  25,        115) /* Level */
+     , (21167,  27,          0) /* ArmorType - None */
+     , (21167,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (21167,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (21167, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (21167, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (21167, 140,          1) /* AiOptions - CanOpenDoors */
+     , (21167, 146,      56230) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21167,   1, True ) /* Stuck */
+     , (21167,   6, True ) /* AiUsesMana */
+     , (21167,  11, False) /* IgnoreCollisions */
+     , (21167,  12, True ) /* ReportCollisions */
+     , (21167,  13, False) /* Ethereal */
+     , (21167,  15, True ) /* LightsStatus */
+     , (21167, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21167,   1,       5) /* HeartbeatInterval */
+     , (21167,   2,       0) /* HeartbeatTimestamp */
+     , (21167,   3,     0.9) /* HealthRate */
+     , (21167,   4,     0.5) /* StaminaRate */
+     , (21167,   5,       2) /* ManaRate */
+     , (21167,  13,    0.85) /* ArmorModVsSlash */
+     , (21167,  14,    0.85) /* ArmorModVsPierce */
+     , (21167,  15,    0.85) /* ArmorModVsBludgeon */
+     , (21167,  16,       1) /* ArmorModVsCold */
+     , (21167,  17,       1) /* ArmorModVsFire */
+     , (21167,  18,    0.85) /* ArmorModVsAcid */
+     , (21167,  19,    0.85) /* ArmorModVsElectric */
+     , (21167,  31,      20) /* VisualAwarenessRange */
+     , (21167,  39,     1.5) /* DefaultScale */
+     , (21167,  64,    0.25) /* ResistSlash */
+     , (21167,  65,    0.25) /* ResistPierce */
+     , (21167,  66,    0.25) /* ResistBludgeon */
+     , (21167,  67,     0.4) /* ResistFire */
+     , (21167,  68,       0) /* ResistCold */
+     , (21167,  69,    0.25) /* ResistAcid */
+     , (21167,  70,    0.25) /* ResistElectric */
+     , (21167,  71,       1) /* ResistHealthBoost */
+     , (21167,  72,    0.25) /* ResistStaminaDrain */
+     , (21167,  73,       1) /* ResistStaminaBoost */
+     , (21167,  74,       1) /* ResistManaDrain */
+     , (21167,  75,       1) /* ResistManaBoost */
+     , (21167,  80,       3) /* AiUseMagicDelay */
+     , (21167, 104,      10) /* ObviousRadarRange */
+     , (21167, 122,       2) /* AiAcquireHealth */
+     , (21167, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21167,   1, 'Gelid') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21167,   1,   33557487) /* Setup */
+     , (21167,   2,  150995087) /* MotionTable */
+     , (21167,   3,  536871002) /* SoundTable */
+     , (21167,   4,  805306368) /* CombatTable */
+     , (21167,   8,  100672514) /* Icon */
+     , (21167,  22,  872415349) /* PhysicsEffectTable */
+     , (21167,  35,        464) /* DeathTreasureType - Loot Tier: 5 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (21167,   1, 250, 0, 0) /* Strength */
+     , (21167,   2, 200, 0, 0) /* Endurance */
+     , (21167,   3, 220, 0, 0) /* Quickness */
+     , (21167,   4, 280, 0, 0) /* Coordination */
+     , (21167,   5, 200, 0, 0) /* Focus */
+     , (21167,   6, 200, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (21167,   1,   300, 0, 0, 400) /* MaxHealth */
+     , (21167,   3,   200, 0, 0, 400) /* MaxStamina */
+     , (21167,   5,   300, 0, 0, 500) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (21167,  6, 0, 3, 0, 330, 0, 1292.11475202158) /* MeleeDefense        Specialized */
+     , (21167,  7, 0, 3, 0, 415, 0, 1292.11475202158) /* MissileDefense      Specialized */
+     , (21167, 12, 0, 3, 0,  55, 0, 1292.11475202158) /* ThrownWeapon        Specialized */
+     , (21167, 13, 0, 3, 0, 300, 0, 1292.11475202158) /* UnarmedCombat       Specialized */
+     , (21167, 14, 0, 3, 0, 125, 0, 1292.11475202158) /* ArcaneLore          Specialized */
+     , (21167, 15, 0, 3, 0, 270, 0, 1292.11475202158) /* MagicDefense        Specialized */
+     , (21167, 20, 0, 3, 0, 150, 0, 1292.11475202158) /* Deception           Specialized */
+     , (21167, 24, 0, 3, 0, 100, 0, 1292.11475202158) /* Run                 Specialized */
+     , (21167, 31, 0, 3, 0, 190, 0, 1292.11475202158) /* CreatureEnchantment Specialized */
+     , (21167, 33, 0, 3, 0, 190, 0, 1292.11475202158) /* LifeMagic           Specialized */
+     , (21167, 34, 0, 3, 0, 190, 0, 1292.11475202158) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (21167,  0,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (21167,  1,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (21167,  2,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (21167,  3,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (21167,  4,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (21167,  5,  8, 80, 0.75,  420,  357,  357,  357,  420,  420,  357,  357,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (21167,  6,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (21167,  7,  8,  0,    0,  420,  357,  357,  357,  420,  420,  357,  357,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (21167,  8,  8, 100, 0.75,  420,  357,  357,  357,  420,  420,  357,  357,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (21167,    74,  2.138)  /* Frost Bolt VI */
+     , (21167,   167,  2.008)  /* Regeneration Self III */
+     , (21167,   233,  2.017)  /* Vulnerability Other V */
+     , (21167,   276,  2.008)  /* Magic Resistance Self III */
+     , (21167,  1064,  2.017)  /* Cold Vulnerability Other V */
+     , (21167,  1094,  2.008)  /* Fire Protection Self VI */
+     , (21167,  1160,  2.013)  /* Heal Self V */
+     , (21167,  1237,  2.008)  /* Drain Health Other I */
+     , (21167,  1312,  2.008)  /* Armor Self VI */
+     , (21167,  1326,  2.017)  /* Imperil Other V */
+     , (21167,  1419,  2.017)  /* Slowness Other V */
+     , (21167,  1813,  2.004)  /* Frost Streak VI */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (21167,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (21167, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (21167,  3 /* Death */,   0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You tear asunder the very fabric of what is. Pull at the threads, my death shall be heralded by the birth of another.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (21167, 16 /* KillTaunt */,   0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'We are the memories of the first given form. You cannot defeat us for our souls live on. Remember well this chill for it will be with you always.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (21167, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */
+     , (21167, 9,  6876,  0, 0, 0.03, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21371 Brumal.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/FrostElemental/21371 Brumal.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21371;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21371, 'frostelementalbrumal_nosummon', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21371, 'frostelementalbrumal_nosummon', 10, '2019-02-08 15:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21371,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (21371,   1, True ) /* Stuck */
      , (21371,  14, True ) /* GravityStatus */
      , (21371,  15, True ) /* LightsStatus */
      , (21371,  19, True ) /* Attackable */
-     , (21371,  29, True ) /* NoCorpse */;
+     , (21371, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21371,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Human/28701 Elena Du Furza.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Human/28701 Elena Du Furza.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28701;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28701, 'elenadufurza', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (28701, 'elenadufurza', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28701,   1,         16) /* ItemType - Creature */
@@ -153,11 +153,13 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  10 /* Tell */, 0.5, 1, NULL, 'You have done the kingdom of Viamont a great service. Come back to me later. I may have more for you to do. In the meantime, you may wish to pay a visit to Anton Silezzi. I understand he has need of assistance in some matter. You may also wish to speak to the Barkeeper Jean Vaden. He sells rumors you may find of interest.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   3 /* Give */, 1.5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1 /* Contain */, 629 /* Adept Healing Kit */, 3, 0, 1, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,   3 /* Give */, 0.5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1 /* Contain */, 273 /* Pyreal */, 1000, 0, 1, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  22 /* StampQuest */, 0.1, 1, NULL, 'BeaconComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  31 /* EraseQuest */, 0, 1, NULL, 'beacongemgiven', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  31 /* EraseQuest */, 0, 1, NULL, 'beacongemobtained', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  1,   3 /* Give */, 1.5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1 /* Contain */, 629 /* Adept Healing Kit */, 1, 0, 1, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   3 /* Give */, 1.5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1 /* Contain */, 629 /* Adept Healing Kit */, 1, 0, 1, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 1.5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1 /* Contain */, 629 /* Adept Healing Kit */, 1, 0, 1, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,   3 /* Give */, 0.5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1 /* Contain */, 273 /* Pyreal */, 1000, 0, 1, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  22 /* StampQuest */, 0.1, 1, NULL, 'BeaconComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'beacongemgiven', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  7,  31 /* EraseQuest */, 0, 1, NULL, 'beacongemobtained', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (28701, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'beacongemobtained', NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06379 Astyrrian.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06379 Astyrrian.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 6379;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (6379, 'lightningelementalastyrrian', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (6379, 'lightningelementalastyrrian', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (6379,   1,         16) /* ItemType - Creature */
@@ -31,7 +31,7 @@ VALUES (6379,   1, True ) /* Stuck */
      , (6379,  14, True ) /* GravityStatus */
      , (6379,  15, True ) /* LightsStatus */
      , (6379,  19, True ) /* Attackable */
-     , (6379,  29, True ) /* NoCorpse */
+     , (6379, 120, True ) /* TreasureCorpse */
      , (6379,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06380 Scintilla.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06380 Scintilla.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 6380;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (6380, 'lightningelementalscintilla', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (6380, 'lightningelementalscintilla', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (6380,   1,         16) /* ItemType - Creature */
@@ -31,7 +31,7 @@ VALUES (6380,   1, True ) /* Stuck */
      , (6380,  14, True ) /* GravityStatus */
      , (6380,  15, True ) /* LightsStatus */
      , (6380,  19, True ) /* Attackable */
-     , (6380,  29, True ) /* NoCorpse */;
+     , (6380, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (6380,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06381 Spark.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06381 Spark.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 6381;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (6381, 'lightningelementalspark', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (6381, 'lightningelementalspark', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (6381,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (6381,   1, True ) /* Stuck */
      , (6381,  14, True ) /* GravityStatus */
      , (6381,  15, True ) /* LightsStatus */
      , (6381,  19, True ) /* Attackable */
-     , (6381,  29, True ) /* NoCorpse */;
+     , (6381, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (6381,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06382 Static.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/06382 Static.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 6382;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (6382, 'lightningelementalstatic', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (6382, 'lightningelementalstatic', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (6382,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (6382,   1, True ) /* Stuck */
      , (6382,  14, True ) /* GravityStatus */
      , (6382,  15, True ) /* LightsStatus */
      , (6382,  19, True ) /* Attackable */
-     , (6382,  29, True ) /* NoCorpse */;
+     , (6382, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (6382,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/07094 Synnast.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/07094 Synnast.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7094;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7094, 'lightningelementalsynnast', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7094, 'lightningelementalsynnast', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7094,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (7094,   1, True ) /* Stuck */
      , (7094,  14, True ) /* GravityStatus */
      , (7094,  15, True ) /* LightsStatus */
      , (7094,  19, True ) /* Attackable */
-     , (7094,  29, True ) /* NoCorpse */
+     , (7094, 120, True ) /* TreasureCorpse */
      , (7094,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/07095 Scathisa.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/07095 Scathisa.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7095;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7095, 'lightningelementalscathisa', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7095, 'lightningelementalscathisa', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7095,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (7095,   1, True ) /* Stuck */
      , (7095,  14, True ) /* GravityStatus */
      , (7095,  15, True ) /* LightsStatus */
      , (7095,  19, True ) /* Attackable */
-     , (7095,  29, True ) /* NoCorpse */
+     , (7095, 120, True ) /* TreasureCorpse */
      , (7095,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20026 Harnessed Scintilla.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20026 Harnessed Scintilla.sql
@@ -1,0 +1,123 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20026, 'lightningelementalscintillarewards', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20026,   1,         16) /* ItemType - Creature */
+     , (20026,   2,         42) /* CreatureType - LightningElemental */
+     , (20026,   6,         -1) /* ItemsCapacity */
+     , (20026,   7,         -1) /* ContainersCapacity */
+     , (20026,  16,          1) /* ItemUseable - No */
+     , (20026,  25,         61) /* Level */
+     , (20026,  27,          0) /* ArmorType - None */
+     , (20026,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20026,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20026, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20026, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20026, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20026, 146,      22977) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20026,   1, True ) /* Stuck */
+     , (20026,   6, True ) /* AiUsesMana */
+     , (20026,  11, False) /* IgnoreCollisions */
+     , (20026,  12, True ) /* ReportCollisions */
+     , (20026,  13, False) /* Ethereal */
+     , (20026,  15, True ) /* LightsStatus */
+     , (20026, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20026,   1,       5) /* HeartbeatInterval */
+     , (20026,   2,       0) /* HeartbeatTimestamp */
+     , (20026,   3,     0.7) /* HealthRate */
+     , (20026,   4,     0.5) /* StaminaRate */
+     , (20026,   5,       2) /* ManaRate */
+     , (20026,  13,    0.73) /* ArmorModVsSlash */
+     , (20026,  14,    0.73) /* ArmorModVsPierce */
+     , (20026,  15,    0.73) /* ArmorModVsBludgeon */
+     , (20026,  16,    0.78) /* ArmorModVsCold */
+     , (20026,  17,     0.6) /* ArmorModVsFire */
+     , (20026,  18,       1) /* ArmorModVsAcid */
+     , (20026,  19,     100) /* ArmorModVsElectric */
+     , (20026,  31,      20) /* VisualAwarenessRange */
+     , (20026,  39,     1.3) /* DefaultScale */
+     , (20026,  64,     0.4) /* ResistSlash */
+     , (20026,  65,     0.4) /* ResistPierce */
+     , (20026,  66,     0.4) /* ResistBludgeon */
+     , (20026,  67,     0.1) /* ResistFire */
+     , (20026,  68,     0.5) /* ResistCold */
+     , (20026,  69,       1) /* ResistAcid */
+     , (20026,  70,       0) /* ResistElectric */
+     , (20026,  71,       1) /* ResistHealthBoost */
+     , (20026,  72,       1) /* ResistStaminaDrain */
+     , (20026,  73,       1) /* ResistStaminaBoost */
+     , (20026,  74,       1) /* ResistManaDrain */
+     , (20026,  75,       1) /* ResistManaBoost */
+     , (20026,  80,       3) /* AiUseMagicDelay */
+     , (20026, 104,      10) /* ObviousRadarRange */
+     , (20026, 122,       2) /* AiAcquireHealth */
+     , (20026, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20026,   1, 'Harnessed Scintilla') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20026,   1,   33556140) /* Setup */
+     , (20026,   2,  150995087) /* MotionTable */
+     , (20026,   3,  536871002) /* SoundTable */
+     , (20026,   4,  805306368) /* CombatTable */
+     , (20026,   8,  100670581) /* Icon */
+     , (20026,  22,  872415349) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20026,   1, 145, 0, 0) /* Strength */
+     , (20026,   2, 130, 0, 0) /* Endurance */
+     , (20026,   3, 190, 0, 0) /* Quickness */
+     , (20026,   4, 180, 0, 0) /* Coordination */
+     , (20026,   5, 130, 0, 0) /* Focus */
+     , (20026,   6, 180, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20026,   1,    70, 0, 0, 135) /* MaxHealth */
+     , (20026,   3,   200, 0, 0, 330) /* MaxStamina */
+     , (20026,   5,   200, 0, 0, 380) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20026,  6, 0, 3, 0, 144, 0, 1198.21956467233) /* MeleeDefense        Specialized */
+     , (20026,  7, 0, 3, 0, 290, 0, 1198.21956467233) /* MissileDefense      Specialized */
+     , (20026, 13, 0, 3, 0, 150, 0, 1198.21956467233) /* UnarmedCombat       Specialized */
+     , (20026, 14, 0, 2, 0, 130, 0, 1198.21956467233) /* ArcaneLore          Trained */
+     , (20026, 15, 0, 3, 0, 158, 0, 1198.21956467233) /* MagicDefense        Specialized */
+     , (20026, 20, 0, 2, 0, 100, 0, 1198.21956467233) /* Deception           Trained */
+     , (20026, 24, 0, 2, 0,  80, 0, 1198.21956467233) /* Run                 Trained */
+     , (20026, 31, 0, 3, 0,  90, 0, 1198.21956467233) /* CreatureEnchantment Specialized */
+     , (20026, 33, 0, 3, 0,  90, 0, 1198.21956467233) /* LifeMagic           Specialized */
+     , (20026, 34, 0, 3, 0,  90, 0, 1198.21956467233) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20026,  0, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20026,  1, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20026,  2, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20026,  3, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20026,  4, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20026,  5, 64, 20, 0.75,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20026,  6, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20026,  7, 64,  0,    0,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20026,  8, 64, 25, 0.75,  140,  102,  102,  102,  109,   84,  140, 14000,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20026,    77,   2.11)  /* Lightning Bolt III */
+     , (20026,    78,  2.005)  /* Lightning Bolt IV */
+     , (20026,   140,  2.005)  /* Lightning Volley IV */
+     , (20026,   167,  2.006)  /* Regeneration Self III */
+     , (20026,   231,  2.013)  /* Vulnerability Other III */
+     , (20026,   275,  2.006)  /* Magic Resistance Self II */
+     , (20026,   517,  2.006)  /* Acid Protection Self III */
+     , (20026,  1086,  2.013)  /* Lightning Vulnerability Other III */
+     , (20026,  1159,   2.01)  /* Heal Self IV */
+     , (20026,  1239,  2.006)  /* Drain Health Other III */
+     , (20026,  1309,  2.006)  /* Armor Self III */
+     , (20026,  1324,  2.013)  /* Imperil Other III */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20026,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20026, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20026 Harnessed Scintilla.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20026 Harnessed Scintilla.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20026;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20026, 'lightningelementalscintillarewards', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20886 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20886 Tempest.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20886, 'somaticelementaltempest1', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20886,   1,         16) /* ItemType - Creature */
+     , (20886,   2,         42) /* CreatureType - LightningElemental */
+     , (20886,   3,         13) /* PaletteTemplate - Purple */
+     , (20886,   6,         -1) /* ItemsCapacity */
+     , (20886,   7,         -1) /* ContainersCapacity */
+     , (20886,  16,          1) /* ItemUseable - No */
+     , (20886,  25,        999) /* Level */
+     , (20886,  27,          0) /* ArmorType - None */
+     , (20886,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20886,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20886, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20886, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20886, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20886, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20886,   1, True ) /* Stuck */
+     , (20886,   6, True ) /* AiUsesMana */
+     , (20886,  11, False) /* IgnoreCollisions */
+     , (20886,  12, True ) /* ReportCollisions */
+     , (20886,  13, False) /* Ethereal */
+     , (20886,  15, True ) /* LightsStatus */
+     , (20886, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20886,   1,       5) /* HeartbeatInterval */
+     , (20886,   2,       0) /* HeartbeatTimestamp */
+     , (20886,   3,     0.9) /* HealthRate */
+     , (20886,   4,     0.5) /* StaminaRate */
+     , (20886,   5,       2) /* ManaRate */
+     , (20886,  13,       1) /* ArmorModVsSlash */
+     , (20886,  14,       1) /* ArmorModVsPierce */
+     , (20886,  15,       1) /* ArmorModVsBludgeon */
+     , (20886,  16,       1) /* ArmorModVsCold */
+     , (20886,  17,       1) /* ArmorModVsFire */
+     , (20886,  18,     1.1) /* ArmorModVsAcid */
+     , (20886,  19,       1) /* ArmorModVsElectric */
+     , (20886,  31,      20) /* VisualAwarenessRange */
+     , (20886,  39,     1.4) /* DefaultScale */
+     , (20886,  64,     0.3) /* ResistSlash */
+     , (20886,  65,     0.3) /* ResistPierce */
+     , (20886,  66,     0.3) /* ResistBludgeon */
+     , (20886,  67,     0.3) /* ResistFire */
+     , (20886,  68,     0.3) /* ResistCold */
+     , (20886,  69,     0.4) /* ResistAcid */
+     , (20886,  70,       0) /* ResistElectric */
+     , (20886,  71,       1) /* ResistHealthBoost */
+     , (20886,  72,    0.25) /* ResistStaminaDrain */
+     , (20886,  73,       1) /* ResistStaminaBoost */
+     , (20886,  74,       1) /* ResistManaDrain */
+     , (20886,  75,       1) /* ResistManaBoost */
+     , (20886,  80,       3) /* AiUseMagicDelay */
+     , (20886, 104,      10) /* ObviousRadarRange */
+     , (20886, 122,       2) /* AiAcquireHealth */
+     , (20886, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20886,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20886,   1,   33557856) /* Setup */
+     , (20886,   2,  150995087) /* MotionTable */
+     , (20886,   3,  536871002) /* SoundTable */
+     , (20886,   4,  805306368) /* CombatTable */
+     , (20886,   6,   67108990) /* PaletteBase */
+     , (20886,   7,  268436431) /* ClothingBase */
+     , (20886,   8,  100670581) /* Icon */
+     , (20886,  22,  872415349) /* PhysicsEffectTable */
+     , (20886,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20886,   1, 400, 0, 0) /* Strength */
+     , (20886,   2, 400, 0, 0) /* Endurance */
+     , (20886,   3, 600, 0, 0) /* Quickness */
+     , (20886,   4, 400, 0, 0) /* Coordination */
+     , (20886,   5, 350, 0, 0) /* Focus */
+     , (20886,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20886,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20886,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20886,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20886,  6, 0, 3, 0,   1, 0, 1265.50009721194) /* MeleeDefense        Specialized */
+     , (20886,  7, 0, 3, 0,  50, 0, 1265.50009721194) /* MissileDefense      Specialized */
+     , (20886, 12, 0, 3, 0,  70, 0, 1265.50009721194) /* ThrownWeapon        Specialized */
+     , (20886, 13, 0, 3, 0,  51, 0, 1265.50009721194) /* UnarmedCombat       Specialized */
+     , (20886, 14, 0, 3, 0, 170, 0, 1265.50009721194) /* ArcaneLore          Specialized */
+     , (20886, 15, 0, 3, 0,  69, 0, 1265.50009721194) /* MagicDefense        Specialized */
+     , (20886, 20, 0, 3, 0, 150, 0, 1265.50009721194) /* Deception           Specialized */
+     , (20886, 24, 0, 3, 0, 100, 0, 1265.50009721194) /* Run                 Specialized */
+     , (20886, 31, 0, 3, 0, 250, 0, 1265.50009721194) /* CreatureEnchantment Specialized */
+     , (20886, 33, 0, 3, 0, 250, 0, 1265.50009721194) /* LifeMagic           Specialized */
+     , (20886, 34, 0, 3, 0, 250, 0, 1265.50009721194) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20886,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20886,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20886,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20886,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20886,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20886,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20886,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20886,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20886,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20886,   276,  2.008)  /* Magic Resistance Self III */
+     , (20886,   518,  2.008)  /* Acid Protection Self IV */
+     , (20886,  1160,  2.013)  /* Heal Self V */
+     , (20886,  1788,  2.008)  /* Eye of the Storm */
+     , (20886,  2074,  2.017)  /* Gossamer Flesh */
+     , (20886,  2084,  2.017)  /* Belly of Lead */
+     , (20886,  2140,  2.008)  /* Alset's Coil */
+     , (20886,  2141,  2.008)  /* Lhen's Flare */
+     , (20886,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20886,  2228,  2.017)  /* Broadside of a Barn */
+     , (20886,  2318,  2.017)  /* Gravity Well */
+     , (20886,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20886,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20886, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20886,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A quandary. I am all that is energy and living thought. I have form and can be destroyed. I am matter and energy at once, and yet I am defeated. No matter I am not dead, merely transformed!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Tempest, the Essence of Storms, repelling Gaerlan''s forces back from the cities of the east...for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20886,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'In my new gained sentience I did not understand destruction. But now I see that even I can be dispersed. But my death like yours is not permanent. I shall return sooner than you think.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Tempest, the Essence of Storms. Its form is driven from the world and Gaerlan''s forces are routed at Tou-tou, Sawato, Lin, and Baishi.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20886, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Fractured and blistered by the scorching tendrils of pure energy.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20886, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Your magic is devoured by my power!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20886 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20886 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20886;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20886, 'somaticelementaltempest1', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20887 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20887 Tempest.sql
@@ -1,0 +1,162 @@
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (20887, 'somaticelementaltempest2', 10, '2019-02-08 15:30:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (20887,   1,         16) /* ItemType - Creature */
+     , (20887,   2,         42) /* CreatureType - LightningElemental */
+     , (20887,   3,         13) /* PaletteTemplate - Purple */
+     , (20887,   6,         -1) /* ItemsCapacity */
+     , (20887,   7,         -1) /* ContainersCapacity */
+     , (20887,  16,          1) /* ItemUseable - No */
+     , (20887,  25,        161) /* Level */
+     , (20887,  27,          0) /* ArmorType - None */
+     , (20887,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (20887,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (20887, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (20887, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (20887, 140,          1) /* AiOptions - CanOpenDoors */
+     , (20887, 146,     150000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (20887,   1, True ) /* Stuck */
+     , (20887,   6, True ) /* AiUsesMana */
+     , (20887,  11, False) /* IgnoreCollisions */
+     , (20887,  12, True ) /* ReportCollisions */
+     , (20887,  13, False) /* Ethereal */
+     , (20887,  15, True ) /* LightsStatus */
+     , (20887, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (20887,   1,       5) /* HeartbeatInterval */
+     , (20887,   2,       0) /* HeartbeatTimestamp */
+     , (20887,   3,     0.9) /* HealthRate */
+     , (20887,   4,     0.5) /* StaminaRate */
+     , (20887,   5,       2) /* ManaRate */
+     , (20887,  13,       1) /* ArmorModVsSlash */
+     , (20887,  14,       1) /* ArmorModVsPierce */
+     , (20887,  15,       1) /* ArmorModVsBludgeon */
+     , (20887,  16,       1) /* ArmorModVsCold */
+     , (20887,  17,       1) /* ArmorModVsFire */
+     , (20887,  18,     1.1) /* ArmorModVsAcid */
+     , (20887,  19,       1) /* ArmorModVsElectric */
+     , (20887,  31,      20) /* VisualAwarenessRange */
+     , (20887,  39,     1.4) /* DefaultScale */
+     , (20887,  64,     0.3) /* ResistSlash */
+     , (20887,  65,     0.3) /* ResistPierce */
+     , (20887,  66,     0.3) /* ResistBludgeon */
+     , (20887,  67,     0.3) /* ResistFire */
+     , (20887,  68,     0.3) /* ResistCold */
+     , (20887,  69,     0.4) /* ResistAcid */
+     , (20887,  70,       0) /* ResistElectric */
+     , (20887,  71,       1) /* ResistHealthBoost */
+     , (20887,  72,    0.25) /* ResistStaminaDrain */
+     , (20887,  73,       1) /* ResistStaminaBoost */
+     , (20887,  74,       1) /* ResistManaDrain */
+     , (20887,  75,       1) /* ResistManaBoost */
+     , (20887,  80,       3) /* AiUseMagicDelay */
+     , (20887, 104,      10) /* ObviousRadarRange */
+     , (20887, 122,       2) /* AiAcquireHealth */
+     , (20887, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (20887,   1, 'Tempest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (20887,   1,   33557856) /* Setup */
+     , (20887,   2,  150995087) /* MotionTable */
+     , (20887,   3,  536870998) /* SoundTable */
+     , (20887,   4,  805306368) /* CombatTable */
+     , (20887,   6,   67108990) /* PaletteBase */
+     , (20887,   7,  268436431) /* ClothingBase */
+     , (20887,   8,  100670581) /* Icon */
+     , (20887,  22,  872415349) /* PhysicsEffectTable */
+     , (20887,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (20887,   1, 400, 0, 0) /* Strength */
+     , (20887,   2, 400, 0, 0) /* Endurance */
+     , (20887,   3, 600, 0, 0) /* Quickness */
+     , (20887,   4, 400, 0, 0) /* Coordination */
+     , (20887,   5, 350, 0, 0) /* Focus */
+     , (20887,   6, 500, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (20887,   1, 19600, 0, 0, 19800) /* MaxHealth */
+     , (20887,   3,  4600, 0, 0, 5000) /* MaxStamina */
+     , (20887,   5,   500, 0, 0, 1000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (20887,  6, 0, 3, 0,   1, 0, 1265.60528052902) /* MeleeDefense        Specialized */
+     , (20887,  7, 0, 3, 0,  50, 0, 1265.60528052902) /* MissileDefense      Specialized */
+     , (20887, 12, 0, 3, 0,  70, 0, 1265.60528052902) /* ThrownWeapon        Specialized */
+     , (20887, 13, 0, 3, 0,  51, 0, 1265.60528052902) /* UnarmedCombat       Specialized */
+     , (20887, 14, 0, 3, 0, 170, 0, 1265.60528052902) /* ArcaneLore          Specialized */
+     , (20887, 15, 0, 3, 0, 169, 0, 1265.60528052902) /* MagicDefense        Specialized */
+     , (20887, 20, 0, 3, 0, 150, 0, 1265.60528052902) /* Deception           Specialized */
+     , (20887, 24, 0, 3, 0, 100, 0, 1265.60528052902) /* Run                 Specialized */
+     , (20887, 31, 0, 3, 0, 250, 0, 1265.60528052902) /* CreatureEnchantment Specialized */
+     , (20887, 33, 0, 3, 0, 250, 0, 1265.60528052902) /* LifeMagic           Specialized */
+     , (20887, 34, 0, 3, 0, 250, 0, 1265.60528052902) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (20887,  0, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (20887,  1, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (20887,  2, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (20887,  3, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (20887,  4, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (20887,  5, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (20887,  6, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (20887,  7, 64,  0,    0,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (20887,  8, 64, 75, 0.75,  200,  200,  200,  200,  200,  200,  220,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (20887,   276,  2.008)  /* Magic Resistance Self III */
+     , (20887,   518,  2.008)  /* Acid Protection Self IV */
+     , (20887,  1160,  2.013)  /* Heal Self V */
+     , (20887,  1788,  2.008)  /* Eye of the Storm */
+     , (20887,  2074,  2.017)  /* Gossamer Flesh */
+     , (20887,  2084,  2.017)  /* Belly of Lead */
+     , (20887,  2140,  2.008)  /* Alset's Coil */
+     , (20887,  2141,  2.008)  /* Lhen's Flare */
+     , (20887,  2172,  2.017)  /* Astyrrian's Gift */
+     , (20887,  2228,  2.017)  /* Broadside of a Barn */
+     , (20887,  2318,  2.017)  /* Gravity Well */
+     , (20887,  2328,  2.008)  /* Vitality Siphon */;
+
+INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
+VALUES (20887,  94) /* ATTACK_NOTIFICATION_EVENT */
+     , (20887, 414) /* PLAYER_DEATH_EVENT */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20887,  3 /* Death */,   0.75, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A quandary. I am all that is energy and living thought. I have form and can be destroyed. I am matter and energy at once, and yet I am defeated. No matter I am not dead, merely transformed!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Tempest, the Essence of Storms.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20887,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'In my new gained sentience I did not understand destruction. But now I see that even I can be dispersed. But my death like yours is not permanent. I shall return sooner than you think.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  16 /* WorldBroadcast */, 0, 1, NULL, '%s has defeated Tempest, the Essence of Storms.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20887, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Fractured and blistered by the scorching tendrils of pure energy.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (20887, 21 /* ResistSpell */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'Your magic is devoured by my power!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20887 Tempest.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/20887 Tempest.sql
@@ -1,3 +1,5 @@
+DELETE FROM `weenie` WHERE `class_Id` = 20887;
+
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (20887, 'somaticelementaltempest2', 10, '2019-02-08 15:30:00') /* Creature */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/21168 Charge.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/21168 Charge.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21168;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21168, 'lightningelementalcharge', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21168, 'lightningelementalcharge', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21168,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (21168,   1, True ) /* Stuck */
      , (21168,  14, True ) /* GravityStatus */
      , (21168,  15, True ) /* LightsStatus */
      , (21168,  19, True ) /* Attackable */
-     , (21168,  29, True ) /* NoCorpse */
+     , (21168, 120, True ) /* TreasureCorpse */
      , (21168,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/21169 Scintilla.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/21169 Scintilla.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21169;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21169, 'lightningelementalscintilla_nosummon', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21169, 'lightningelementalscintilla_nosummon', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21169,   1,         16) /* ItemType - Creature */
@@ -28,7 +28,7 @@ VALUES (21169,   1, True ) /* Stuck */
      , (21169,  14, True ) /* GravityStatus */
      , (21169,  15, True ) /* LightsStatus */
      , (21169,  19, True ) /* Attackable */
-     , (21169,  29, True ) /* NoCorpse */;
+     , (21169, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21169,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/21170 Voltarc.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/LightningElemental/21170 Voltarc.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21170;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21170, 'lightningelementalvoltarc', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21170, 'lightningelementalvoltarc', 10, '2019-02-08 15:30:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21170,   1,         16) /* ItemType - Creature */
@@ -27,7 +27,7 @@ VALUES (21170,   1, True ) /* Stuck */
      , (21170,  14, True ) /* GravityStatus */
      , (21170,  15, True ) /* LightsStatus */
      , (21170,  19, True ) /* Attackable */
-     , (21170,  29, True ) /* NoCorpse */
+     , (21170, 120, True ) /* TreasureCorpse */
      , (21170,  42, True ) /* AllowEdgeSlide */
      , (21170,  50, True ) /* NeverFailCasting */;
 

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01535 Ethereal Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01535 Ethereal Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 1535;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (1535, 'wispethereal', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (1535, 'wispethereal', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (1535,   1,         16) /* ItemType - Creature */
@@ -26,8 +26,8 @@ VALUES (1535,   1, True ) /* Stuck */
      , (1535,  13, False) /* Ethereal */
      , (1535,  14, True ) /* GravityStatus */
      , (1535,  19, True ) /* Attackable */
-     , (1535,  29, True ) /* NoCorpse */
-     , (1535,  50, True ) /* NeverFailCasting */;
+     , (1535,  50, True ) /* NeverFailCasting */
+     , (1535, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (1535,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01986 Water Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01986 Water Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 1986;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (1986, 'wispwater', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (1986, 'wispwater', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (1986,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (1986,   1, True ) /* Stuck */
      , (1986,  13, False) /* Ethereal */
      , (1986,  14, True ) /* GravityStatus */
      , (1986,  19, True ) /* Attackable */
-     , (1986,  29, True ) /* NoCorpse */
-     , (1986,  50, True ) /* NeverFailCasting */;
+     , (1986,  50, True ) /* NeverFailCasting */
+     , (1986, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (1986,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01987 Ghost Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01987 Ghost Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 1987;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (1987, 'wispghost', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (1987, 'wispghost', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (1987,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (1987,   1, True ) /* Stuck */
      , (1987,  13, False) /* Ethereal */
      , (1987,  14, True ) /* GravityStatus */
      , (1987,  19, True ) /* Attackable */
-     , (1987,  29, True ) /* NoCorpse */
-     , (1987,  50, True ) /* NeverFailCasting */;
+     , (1987,  50, True ) /* NeverFailCasting */
+     , (1987, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (1987,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01988 Dark Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01988 Dark Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 1988;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (1988, 'wispdark', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (1988, 'wispdark', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (1988,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (1988,   1, True ) /* Stuck */
      , (1988,  13, False) /* Ethereal */
      , (1988,  14, True ) /* GravityStatus */
      , (1988,  19, True ) /* Attackable */
-     , (1988,  29, True ) /* NoCorpse */
-     , (1988,  50, True ) /* NeverFailCasting */;
+     , (1988,  50, True ) /* NeverFailCasting */
+     , (1988, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (1988,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01989 Shadow Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/01989 Shadow Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 1989;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (1989, 'wispshadoclass', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (1989, 'wispshadoclass', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (1989,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (1989,   1, True ) /* Stuck */
      , (1989,  13, False) /* Ethereal */
      , (1989,  14, True ) /* GravityStatus */
      , (1989,  19, True ) /* Attackable */
-     , (1989,  29, True ) /* NoCorpse */
-     , (1989,  50, True ) /* NeverFailCasting */;
+     , (1989,  50, True ) /* NeverFailCasting */
+     , (1989, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (1989,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/05748 Fire Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/05748 Fire Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 5748;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (5748, 'wispfire', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (5748, 'wispfire', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (5748,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (5748,   1, True ) /* Stuck */
      , (5748,  13, False) /* Ethereal */
      , (5748,  14, True ) /* GravityStatus */
      , (5748,  19, True ) /* Attackable */
-     , (5748,  29, True ) /* NoCorpse */
-     , (5748,  50, True ) /* NeverFailCasting */;
+     , (5748,  50, True ) /* NeverFailCasting */
+     , (5748, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (5748,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/07125 Affliction Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/07125 Affliction Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7125;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7125, 'wispaffliction', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7125, 'wispaffliction', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7125,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (7125,   1, True ) /* Stuck */
      , (7125,  13, False) /* Ethereal */
      , (7125,  14, True ) /* GravityStatus */
      , (7125,  19, True ) /* Attackable */
-     , (7125,  29, True ) /* NoCorpse */
-     , (7125,  50, True ) /* NeverFailCasting */;
+     , (7125,  50, True ) /* NeverFailCasting */
+     , (7125, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (7125,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/07126 Cursed Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/07126 Cursed Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7126;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7126, 'wispcursed', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7126, 'wispcursed', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7126,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (7126,   1, True ) /* Stuck */
      , (7126,  13, False) /* Ethereal */
      , (7126,  14, True ) /* GravityStatus */
      , (7126,  19, True ) /* Attackable */
-     , (7126,  29, True ) /* NoCorpse */
-     , (7126,  50, True ) /* NeverFailCasting */;
+     , (7126,  50, True ) /* NeverFailCasting */
+     , (7126, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (7126,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/07127 Nightmare Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/07127 Nightmare Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7127;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7127, 'wispnightmare', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (7127, 'wispnightmare', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7127,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (7127,   1, True ) /* Stuck */
      , (7127,  13, False) /* Ethereal */
      , (7127,  14, True ) /* GravityStatus */
      , (7127,  19, True ) /* Attackable */
-     , (7127,  29, True ) /* NoCorpse */
-     , (7127,  50, True ) /* NeverFailCasting */;
+     , (7127,  50, True ) /* NeverFailCasting */
+     , (7127, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (7127,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/09099 Summoned Pulsar Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/09099 Summoned Pulsar Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 9099;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (9099, 'wispfiresummoned', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (9099, 'wispfiresummoned', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (9099,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (9099,   1, True ) /* Stuck */
      , (9099,  13, False) /* Ethereal */
      , (9099,  14, True ) /* GravityStatus */
      , (9099,  19, True ) /* Attackable */
-     , (9099,  29, True ) /* NoCorpse */
-     , (9099,  50, True ) /* NeverFailCasting */;
+     , (9099,  50, True ) /* NeverFailCasting */
+     , (9099, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (9099,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/11535 Chaos Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/11535 Chaos Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 11535;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (11535, 'wispchaos_xp', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (11535, 'wispchaos_xp', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (11535,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (11535,   1, True ) /* Stuck */
      , (11535,  13, False) /* Ethereal */
      , (11535,  14, True ) /* GravityStatus */
      , (11535,  19, True ) /* Attackable */
-     , (11535,  29, True ) /* NoCorpse */
      , (11535,  50, True ) /* NeverFailCasting */;
+     , (11535, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (11535,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/11535 Chaos Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/11535 Chaos Wisp.sql
@@ -25,7 +25,7 @@ VALUES (11535,   1, True ) /* Stuck */
      , (11535,  13, False) /* Ethereal */
      , (11535,  14, True ) /* GravityStatus */
      , (11535,  19, True ) /* Attackable */
-     , (11535,  50, True ) /* NeverFailCasting */;
+     , (11535,  50, True ) /* NeverFailCasting */
      , (11535, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/11536 Entropy Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/11536 Entropy Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 11536;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (11536, 'wispentropy_xp', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (11536, 'wispentropy_xp', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (11536,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (11536,   1, True ) /* Stuck */
      , (11536,  13, False) /* Ethereal */
      , (11536,  14, True ) /* GravityStatus */
      , (11536,  19, True ) /* Attackable */
-     , (11536,  29, True ) /* NoCorpse */
-     , (11536,  50, True ) /* NeverFailCasting */;
+     , (11536,  50, True ) /* NeverFailCasting */
+     , (11536, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (11536,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21549 Corrosion Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21549 Corrosion Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21549;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21549, 'wispcorrosion', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21549, 'wispcorrosion', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21549,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (21549,   1, True ) /* Stuck */
      , (21549,  13, False) /* Ethereal */
      , (21549,  14, True ) /* GravityStatus */
      , (21549,  19, True ) /* Attackable */
-     , (21549,  29, True ) /* NoCorpse */
-     , (21549,  50, True ) /* NeverFailCasting */;
+     , (21549,  50, True ) /* NeverFailCasting */
+     , (21549, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21549,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21550 Stasis Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21550 Stasis Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21550;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21550, 'wispstasis', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21550, 'wispstasis', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21550,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (21550,   1, True ) /* Stuck */
      , (21550,  13, False) /* Ethereal */
      , (21550,  14, True ) /* GravityStatus */
      , (21550,  19, True ) /* Attackable */
-     , (21550,  29, True ) /* NoCorpse */
-     , (21550,  50, True ) /* NeverFailCasting */;
+     , (21550,  50, True ) /* NeverFailCasting */
+     , (21550, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21550,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21551 Strife Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21551 Strife Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21551;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21551, 'wispstrife', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21551, 'wispstrife', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21551,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (21551,   1, True ) /* Stuck */
      , (21551,  13, False) /* Ethereal */
      , (21551,  14, True ) /* GravityStatus */
      , (21551,  19, True ) /* Attackable */
-     , (21551,  29, True ) /* NoCorpse */
-     , (21551,  50, True ) /* NeverFailCasting */;
+     , (21551,  50, True ) /* NeverFailCasting */
+     , (21551, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21551,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21552 Tempest Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/21552 Tempest Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 21552;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (21552, 'wisptempest', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (21552, 'wisptempest', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (21552,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (21552,   1, True ) /* Stuck */
      , (21552,  13, False) /* Ethereal */
      , (21552,  14, True ) /* GravityStatus */
      , (21552,  19, True ) /* Attackable */
-     , (21552,  29, True ) /* NoCorpse */
-     , (21552,  50, True ) /* NeverFailCasting */;
+     , (21552,  50, True ) /* NeverFailCasting */
+     , (21552, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (21552,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/25667 Dark Vapor.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/25667 Dark Vapor.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 25667;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (25667, 'wispdarkvapor', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (25667, 'wispdarkvapor', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (25667,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (25667,   1, True ) /* Stuck */
      , (25667,  13, False) /* Ethereal */
      , (25667,  14, True ) /* GravityStatus */
      , (25667,  19, True ) /* Attackable */
-     , (25667,  29, True ) /* NoCorpse */
-     , (25667,  50, True ) /* NeverFailCasting */;
+     , (25667,  50, True ) /* NeverFailCasting */
+     , (25667, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (25667,   1,       5) /* HeartbeatInterval */

--- a/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/28055 Spectral Wisp.sql
+++ b/Database/Patches/TODUpdates/9 WeenieDefaults/Creature/Wisp/28055 Spectral Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28055;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28055, 'wispspectral', 10, '2019-02-04 06:52:23') /* Creature */;
+VALUES (28055, 'wispspectral', 10, '2019-02-08 06:52:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28055,   1,         16) /* ItemType - Creature */
@@ -25,8 +25,8 @@ VALUES (28055,   1, True ) /* Stuck */
      , (28055,  13, False) /* Ethereal */
      , (28055,  14, True ) /* GravityStatus */
      , (28055,  19, True ) /* Attackable */
-     , (28055,  29, True ) /* NoCorpse */
-     , (28055,  50, True ) /* NeverFailCasting */;
+     , (28055,  50, True ) /* NeverFailCasting */
+     , (28055, 120, True ) /* Treasure Corpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (28055,   1,       5) /* HeartbeatInterval */


### PR DESCRIPTION
- Fixed Elena Du Furza to "give" three individual Adept Health kits, instead of an incorrect stack of three.
- Changed the NoCorpse flag on the various Elementals and Wisps to TreasureCorpse, so they leave a treasure pile that can be looted as their corpse.