### PR TITLE
Loot tier adjustments and updates from LSD

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/3 TreasureTable/Death/00998.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/3 TreasureTable/Death/00998.sql
@@ -1,4 +1,4 @@
-DELETE FROM `treasure_death` WHERE `treasure_Type` = 999;
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 998;
 
 INSERT INTO `treasure_death` (`treasure_Type`, `tier`, `loot_Quality_Mod`, `unknown_Chances`, `item_Chance`, `item_Min_Amount`, `item_Max_Amount`, `item_Treasure_Type_Selection_Chances`, `magic_Item_Chance`, `magic_Item_Min_Amount`, `magic_Item_Max_Amount`, `magic_Item_Treasure_Type_Selection_Chances`, `mundane_Item_Chance`, `mundane_Item_Min_Amount`, `mundane_Item_Max_Amount`, `mundane_Item_Type_Selection_Chances`, `last_Modified`)
-VALUES (455, 7, 0, 19, 100, 1, 2, 8, 100, 1, 2, 8, 100, 0, 1, 7, '2005-04-20 10:00:00');
+VALUES (461, 7, 0, 19, 0, 0, 0, 1, 100, 2, 3, 8, 100, 1, 2, 8, '2019-04-20 10:00:00');

--- a/Database/Patches/2005-07-ThroneOfDestiny/3 TreasureTable/Death/00999.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/3 TreasureTable/Death/00999.sql
@@ -1,4 +1,4 @@
-DELETE FROM `treasure_death` WHERE `treasure_Type` = 1000;
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 455;
 
 INSERT INTO `treasure_death` (`treasure_Type`, `tier`, `loot_Quality_Mod`, `unknown_Chances`, `item_Chance`, `item_Min_Amount`, `item_Max_Amount`, `item_Treasure_Type_Selection_Chances`, `magic_Item_Chance`, `magic_Item_Min_Amount`, `magic_Item_Max_Amount`, `magic_Item_Treasure_Type_Selection_Chances`, `mundane_Item_Chance`, `mundane_Item_Min_Amount`, `mundane_Item_Max_Amount`, `mundane_Item_Type_Selection_Chances`, `last_Modified`)
-VALUES (1000, 7, 0, 19, 100, 1, 2, 8, 100, 2, 3, 8, 100, 1, 2, 7, '2019-04-20 10:00:00');
+VALUES (455, 7, 0, 19, 100, 1, 2, 8, 100, 1, 2, 8, 100, 0, 1, 7, '2005-04-20 10:00:00');

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/CraftTool/TinkeringMaterial/20988 Salvaged Mahogany.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/CraftTool/TinkeringMaterial/20988 Salvaged Mahogany.sql
@@ -8,6 +8,7 @@ VALUES (20988,   1, 1073741824) /* ItemType - TinkeringMaterial */
      , (20988,   3,         14) /* PaletteTemplate - Red */
      , (20988,   5,        100) /* EncumbranceVal */
      , (20988,   8,        100) /* Mass */
+     , (20988,   9,          0) /* ValidLocations - None */
      , (20988,  11,          1) /* MaxStackSize */
      , (20988,  12,          1) /* StackSize */
      , (20988,  13,        100) /* StackUnitEncumbrance */
@@ -16,22 +17,15 @@ VALUES (20988,   1, 1073741824) /* ItemType - TinkeringMaterial */
      , (20988,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (20988,  19,         10) /* Value */
      , (20988,  33,          1) /* Bonded - Bonded */
-     , (20988,  53,        101) /* PlacementPosition */
      , (20988,  91,        100) /* MaxStructure */
      , (20988,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (20988,  94,        256) /* TargetType - MissileWeapon */
-     , (20988, 105,         27) /* ItemWorkmanship */
      , (20988, 131,         74) /* MaterialType - Mahogany */
      , (20988, 150,        103) /* HookPlacement - Hook */
-     , (20988, 151,          9) /* HookType - Floor, Yard */
-     , (20988, 170,          4) /* NumItemsInMaterial */;
+     , (20988, 151,          9) /* HookType - Floor, Yard */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (20988,  11, True ) /* IgnoreCollisions */
-     , (20988,  13, True ) /* Ethereal */
-     , (20988,  14, True ) /* GravityStatus */
-     , (20988,  19, True ) /* Attackable */
-     , (20988,  22, True ) /* Inscribable */
+VALUES (20988,  22, True ) /* Inscribable */
      , (20988,  23, True ) /* DestroyOnSell */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/CraftTool/TinkeringMaterial/21050 Salvaged Green Garnet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/CraftTool/TinkeringMaterial/21050 Salvaged Green Garnet.sql
@@ -8,6 +8,7 @@ VALUES (21050,   1, 1073741824) /* ItemType - TinkeringMaterial */
      , (21050,   3,          2) /* PaletteTemplate - Blue */
      , (21050,   5,        100) /* EncumbranceVal */
      , (21050,   8,        100) /* Mass */
+     , (21050,   9,          0) /* ValidLocations - None */
      , (21050,  11,          1) /* MaxStackSize */
      , (21050,  12,          1) /* StackSize */
      , (21050,  13,        100) /* StackUnitEncumbrance */
@@ -19,11 +20,9 @@ VALUES (21050,   1, 1073741824) /* ItemType - TinkeringMaterial */
      , (21050,  91,        100) /* MaxStructure */
      , (21050,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (21050,  94,      32768) /* TargetType - Caster */
-     , (21050, 105,         10) /* ItemWorkmanship */
      , (21050, 131,         23) /* MaterialType - GreenGarnet */
      , (21050, 150,        103) /* HookPlacement - Hook */
-     , (21050, 151,          9) /* HookType - Floor, Yard */
-     , (21050, 170,         10) /* NumItemsInMaterial */;
+     , (21050, 151,          9) /* HookType - Floor, Yard */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (21050,  22, True ) /* Inscribable */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/43399 Void Magic Warden of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/43399 Void Magic Warden of Enlightenment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43399;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43399, 'ace43399-voidmagicwardenofenlightenment', 10, '2019-04-08 04:44:07') /* Creature */;
+VALUES (43399, 'ace43399-voidmagicwardenofenlightenment', 10, '2019-04-20 19:14:13') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43399,   1,         16) /* ItemType - Creature */
@@ -53,3 +53,11 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (43399,   1,     0, 0, 0, 0) /* MaxHealth */
      , (43399,   3,     0, 0, 0, 0) /* MaxStamina */
      , (43399,   5,     0, 0, 0, 0) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (43399,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0.1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 43400 /* Void Magic Gem of Enlightenment */, 1, 0, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/45390 Dirty Fighting Warden of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/45390 Dirty Fighting Warden of Enlightenment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45390;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45390, 'ace45390-dirtyfightingwardenofenlightenment', 10, '2019-04-08 04:44:07') /* Creature */;
+VALUES (45390, 'ace45390-dirtyfightingwardenofenlightenment', 10, '2019-04-20 19:14:13') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45390,   1,         16) /* ItemType - Creature */
@@ -53,3 +53,11 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (45390,   1,     0, 0, 0, 0) /* MaxHealth */
      , (45390,   3,     0, 0, 0, 0) /* MaxStamina */
      , (45390,   5,     0, 0, 0, 0) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45390,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0.1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 45380 /* Dirty Fighting Gem of Enlightenment */, 1, 0, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/45392 Recklessness Warden of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/45392 Recklessness Warden of Enlightenment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45392;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45392, 'ace45392-recklessnesswardenofenlightenment', 10, '2019-04-08 04:44:07') /* Creature */;
+VALUES (45392, 'ace45392-recklessnesswardenofenlightenment', 10, '2019-04-20 19:14:13') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45392,   1,         16) /* ItemType - Creature */
@@ -53,3 +53,11 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (45392,   1,     0, 0, 0, 0) /* MaxHealth */
      , (45392,   3,     0, 0, 0, 0) /* MaxStamina */
      , (45392,   5,     0, 0, 0, 0) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45392,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0.1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 45382 /* Recklessness Gem of Enlightenment */, 1, 0, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/45394 Sneak Attack Warden of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/45394 Sneak Attack Warden of Enlightenment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45394;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45394, 'ace45394-sneakattackwardenofenlightenment', 10, '2019-04-08 04:44:07') /* Creature */;
+VALUES (45394, 'ace45394-sneakattackwardenofenlightenment', 10, '2019-04-20 19:14:13') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45394,   1,         16) /* ItemType - Creature */
@@ -53,3 +53,11 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (45394,   1,     0, 0, 0, 0) /* MaxHealth */
      , (45394,   3,     0, 0, 0, 0) /* MaxStamina */
      , (45394,   5,     0, 0, 0, 0) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45394,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0.1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 45384 /* Sneak Attack Gem of Enlightenment */, 1, 0, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/49483 Summoning Warden of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Device/49483 Summoning Warden of Enlightenment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49483;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49483, 'ace49483-summoningwardenofenlightenment', 10, '2019-04-08 04:44:07') /* Creature */;
+VALUES (49483, 'ace49483-summoningwardenofenlightenment', 10, '2019-04-20 19:14:13') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49483,   1,         16) /* ItemType - Creature */
@@ -53,3 +53,11 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (49483,   1,     0, 0, 0, 0) /* MaxHealth */
      , (49483,   3,     0, 0, 0, 0) /* MaxStamina */
      , (49483,   5,     0, 0, 0, 0) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (49483,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0.1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 49484 /* Summoning Gem of Enlightenment */, 1, 0, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28659 Uber Penguin.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28659 Uber Penguin.sql
@@ -75,7 +75,7 @@ VALUES (28659,   1,   33559122) /* Setup */
      , (28659,   7,  268436945) /* ClothingBase */
      , (28659,   8,  100677366) /* Icon */
      , (28659,  22,  872415411) /* PhysicsEffectTable */
-     , (28659,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+     , (28659,  35,        998) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (28659,   1, 800, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28659 Uber Penguin.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28659 Uber Penguin.sql
@@ -75,7 +75,7 @@ VALUES (28659,   1,   33559122) /* Setup */
      , (28659,   7,  268436945) /* ClothingBase */
      , (28659,   8,  100677366) /* Icon */
      , (28659,  22,  872415411) /* PhysicsEffectTable */
-     , (28659,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+     , (28659,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (28659,   1, 800, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28661 Uber Penguin.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28661 Uber Penguin.sql
@@ -75,7 +75,7 @@ VALUES (28661,   1,   33559122) /* Setup */
      , (28661,   7,  268436945) /* ClothingBase */
      , (28661,   8,  100677366) /* Icon */
      , (28661,  22,  872415411) /* PhysicsEffectTable */
-     , (28661,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+     , (28661,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (28661,   1, 700, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28661 Uber Penguin.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Penguin/28661 Uber Penguin.sql
@@ -75,7 +75,7 @@ VALUES (28661,   1,   33559122) /* Setup */
      , (28661,   7,  268436945) /* ClothingBase */
      , (28661,   8,  100677366) /* Icon */
      , (28661,  22,  872415411) /* PhysicsEffectTable */
-     , (28661,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+     , (28661,  35,        998) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (28661,   1, 700, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31021 Puffball Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31021 Puffball Thrungus.sql
@@ -75,7 +75,7 @@ VALUES (31021,   1,   33559123) /* Setup */
      , (31021,   7,  268436890) /* ClothingBase */
      , (31021,   8,  100677367) /* Icon */
      , (31021,  22,  872415411) /* PhysicsEffectTable */
-     , (31021,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
+     , (31021,  35,        999) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31021,   1, 565, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31022 Jelly Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31022 Jelly Thrungus.sql
@@ -75,7 +75,7 @@ VALUES (31022,   1,   33559123) /* Setup */
      , (31022,   7,  268436890) /* ClothingBase */
      , (31022,   8,  100677367) /* Icon */
      , (31022,  22,  872415411) /* PhysicsEffectTable */
-     , (31022,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
+     , (31022,  35,        999) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31022,   1, 565, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31023 Black Morel Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31023 Black Morel Thrungus.sql
@@ -75,7 +75,7 @@ VALUES (31023,   1,   33559123) /* Setup */
      , (31023,   7,  268436890) /* ClothingBase */
      , (31023,   8,  100677367) /* Icon */
      , (31023,  22,  872415411) /* PhysicsEffectTable */
-     , (31023,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
+     , (31023,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31023,   1, 589, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31023 Black Morel Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31023 Black Morel Thrungus.sql
@@ -75,7 +75,7 @@ VALUES (31023,   1,   33559123) /* Setup */
      , (31023,   7,  268436890) /* ClothingBase */
      , (31023,   8,  100677367) /* Icon */
      , (31023,  22,  872415411) /* PhysicsEffectTable */
-     , (31023,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+     , (31023,  35,        999) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31023,   1, 589, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31024 Mudwort Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31024 Mudwort Thrungus.sql
@@ -74,7 +74,7 @@ VALUES (31024,   1,   33559123) /* Setup */
      , (31024,   7,  268436890) /* ClothingBase */
      , (31024,   8,  100677367) /* Icon */
      , (31024,  22,  872415411) /* PhysicsEffectTable */
-     , (31024,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
+     , (31024,  35,        999) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31024,   1, 442, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31025 Fire Morel Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31025 Fire Morel Thrungus.sql
@@ -75,7 +75,7 @@ VALUES (31025,   1,   33559123) /* Setup */
      , (31025,   7,  268436890) /* ClothingBase */
      , (31025,   8,  100677367) /* Icon */
      , (31025,  22,  872415411) /* PhysicsEffectTable */
-     , (31025,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
+     , (31025,  35,        999) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31025,   1, 589, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31030 Mudwort Thrungus.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Thrungus/31030 Mudwort Thrungus.sql
@@ -74,7 +74,7 @@ VALUES (31030,   1,   33559123) /* Setup */
      , (31030,   7,  268436890) /* ClothingBase */
      , (31030,   8,  100677367) /* Icon */
      , (31030,  22,  872415411) /* PhysicsEffectTable */
-     , (31030,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
+     , (31030,  35,        999) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (31030,   1, 442, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Food/Misc/37516 Enhanced Mana Elixir.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Food/Misc/37516 Enhanced Mana Elixir.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37516;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37516, 'ace37516-enhancedmanaelixir', 18, '2019-04-20 19:14:13') /* Food */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37516,   1,        128) /* ItemType - Misc */
+     , (37516,   3,          2) /* PaletteTemplate - Blue */
+     , (37516,   5,         75) /* EncumbranceVal */
+     , (37516,   8,         45) /* Mass */
+     , (37516,  11,        100) /* MaxStackSize */
+     , (37516,  12,          1) /* StackSize */
+     , (37516,  13,        775) /* StackUnitEncumbrance */
+     , (37516,  14,         45) /* StackUnitMass */
+     , (37516,  15,       1000) /* StackUnitValue */
+     , (37516,  16,          8) /* ItemUseable - Contained */
+     , (37516,  18,          1) /* UiEffects - Magical */
+     , (37516,  19,       1000) /* Value */
+     , (37516,  33,          1) /* Bonded - Bonded */
+     , (37516,  53,        101) /* PlacementPosition - Resting */
+     , (37516,  89,          6) /* BoosterEnum - Mana */
+     , (37516,  90,        200) /* BoostValue */
+     , (37516,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37516, 114,          1) /* Attuned - Attuned */
+     , (37516, 150,        103) /* HookPlacement - Hook */
+     , (37516, 151,         11) /* HookType - Floor, Wall, Yard */
+     , (37516, 280,          5) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37516,  11, True ) /* IgnoreCollisions */
+     , (37516,  13, True ) /* Ethereal */
+     , (37516,  14, True ) /* GravityStatus */
+     , (37516,  19, True ) /* Attackable */
+     , (37516,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37516, 167,      30) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37516,   1, 'Enhanced Mana Elixir') /* Name */
+     , (37516,  14, 'Use this item to drink it.') /* Use */
+     , (37516,  15, 'This elixir has been enhanced by the Arcanum to be extra potent.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37516,   1,   33554603) /* Setup */
+     , (37516,   3,  536870932) /* SoundTable */
+     , (37516,   6,   67111919) /* PaletteBase */
+     , (37516,   7,  268435841) /* ClothingBase */
+     , (37516,   8,  100676324) /* Icon */
+     , (37516,  22,  872415275) /* PhysicsEffectTable */
+     , (37516,  23,         65) /* UseSound - Drink1 */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Food/Misc/37517 Enhanced Health Elixir.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Food/Misc/37517 Enhanced Health Elixir.sql
@@ -1,22 +1,28 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37517;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37517, 'ace37517-enhancedhealthelixir', 18, '2019-02-04 06:52:23') /* Food */;
+VALUES (37517, 'ace37517-enhancedhealthelixir', 18, '2019-04-20 19:14:13') /* Food */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37517,   1,        128) /* ItemType - Misc */
-     , (37517,   5,        750) /* EncumbranceVal */
+     , (37517,   3,         14) /* PaletteTemplate - Red */
+     , (37517,   5,         75) /* EncumbranceVal */
+     , (37517,   8,         45) /* Mass */
      , (37517,  11,        100) /* MaxStackSize */
      , (37517,  12,          1) /* StackSize */
+     , (37517,  13,        775) /* StackUnitEncumbrance */
+     , (37517,  14,         45) /* StackUnitMass */
+     , (37517,  15,       1000) /* StackUnitValue */
      , (37517,  16,          8) /* ItemUseable - Contained */
      , (37517,  18,          1) /* UiEffects - Magical */
-     , (37517,  19,      10000) /* Value */
+     , (37517,  19,       1000) /* Value */
      , (37517,  33,          1) /* Bonded - Bonded */
-     , (37517,  53,        101) /* PlacementPosition */
+     , (37517,  53,        101) /* PlacementPosition - Resting */
      , (37517,  89,          2) /* BoosterEnum - Health */
      , (37517,  90,        200) /* BoostValue */
      , (37517,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37517, 114,          1) /* Attuned - Attuned */
+     , (37517, 150,        103) /* HookPlacement - Hook */
      , (37517, 151,         11) /* HookType - Floor, Wall, Yard */
      , (37517, 280,          4) /* SharedCooldown */;
 
@@ -24,7 +30,8 @@ INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (37517,  11, True ) /* IgnoreCollisions */
      , (37517,  13, True ) /* Ethereal */
      , (37517,  14, True ) /* GravityStatus */
-     , (37517,  19, True ) /* Attackable */;
+     , (37517,  19, True ) /* Attackable */
+     , (37517,  23, True ) /* DestroyOnSell */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (37517, 167,      30) /* CooldownDuration */;
@@ -38,5 +45,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (37517,   1,   33554603) /* Setup */
      , (37517,   3,  536870932) /* SoundTable */
      , (37517,   6,   67111919) /* PaletteBase */
+     , (37517,   7,  268435816) /* ClothingBase */
      , (37517,   8,  100676312) /* Icon */
-     , (37517,  22,  872415275) /* PhysicsEffectTable */;
+     , (37517,  22,  872415275) /* PhysicsEffectTable */
+     , (37517,  23,         65) /* UseSound - Drink1 */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/30268 Sanamar Portal Gem.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/30268 Sanamar Portal Gem.sql
@@ -1,23 +1,30 @@
 DELETE FROM `weenie` WHERE `class_Id` = 30268;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (30268, 'gemportalsanamar', 38, '2019-02-04 06:52:23') /* Gem */;
+VALUES (30268, 'gemportalsanamar', 38, '2019-04-20 19:14:13') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (30268,   1,       2048) /* ItemType - Gem */
+     , (30268,   3,         82) /* PaletteTemplate - PinkPurple */
      , (30268,   5,         10) /* EncumbranceVal */
+     , (30268,   8,         10) /* Mass */
      , (30268,  11,         25) /* MaxStackSize */
      , (30268,  12,          1) /* StackSize */
+     , (30268,  13,         10) /* StackUnitEncumbrance */
+     , (30268,  14,         10) /* StackUnitMass */
+     , (30268,  15,        500) /* StackUnitValue */
      , (30268,  16,          8) /* ItemUseable - Contained */
      , (30268,  18,          1) /* UiEffects - Magical */
      , (30268,  19,        500) /* Value */
-     , (30268,  53,        101) /* PlacementPosition */
+     , (30268,  53,        101) /* PlacementPosition - Resting */
      , (30268,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
      , (30268,  94,         16) /* TargetType - Creature */
      , (30268, 106,        210) /* ItemSpellcraft */
+     , (30268, 107,         50) /* ItemCurMana */
      , (30268, 108,         50) /* ItemMaxMana */
      , (30268, 109,          0) /* ItemDifficulty */
      , (30268, 110,          0) /* ItemAllegianceRankLimit */
+     , (30268, 150,        103) /* HookPlacement - Hook */
      , (30268, 151,          2) /* HookType - Wall */
      , (30268, 280,       1000) /* SharedCooldown */;
 
@@ -26,23 +33,24 @@ VALUES (30268,  11, True ) /* IgnoreCollisions */
      , (30268,  13, True ) /* Ethereal */
      , (30268,  14, True ) /* GravityStatus */
      , (30268,  15, True ) /* LightsStatus */
-     , (30268,  19, True ) /* Attackable */;
+     , (30268,  19, True ) /* Attackable */
+     , (30268,  23, True ) /* DestroyOnSell */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (30268, 167,      15) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (30268,   1, 'Sanamar Portal Gem') /* Name */
-     , (30268,  16, 'Use this gem to summon a short-lived portal to Sanamar.  This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+     , (30268,  15, 'Use this gem to summon a short-lived portal to Sanamar. This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (30268,  16, 'Use this gem to summon a short-lived portal to Sanamar. This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (30268,   1,   33556769) /* Setup */
      , (30268,   3,  536870932) /* SoundTable */
      , (30268,   6,   67111919) /* PaletteBase */
+     , (30268,   7,  268435723) /* ClothingBase */
      , (30268,   8,  100674858) /* Icon */
      , (30268,  22,  872415275) /* PhysicsEffectTable */
      , (30268,  28,        157) /* Spell - Summon Primary Portal I */
-     , (30268,  31,      28709) /* LinkedPortalOne - Portal to Sanamar */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (30268,   157,      2)  /* Summon Primary Portal I */;
+     , (30268,  31,      42835) /* LinkedPortalOne - Portal to Sanamar */
+     , (30268,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/32081 Redspire Portal Gem.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/32081 Redspire Portal Gem.sql
@@ -1,0 +1,56 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32081;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32081, 'ace32081-redspireportalgem', 38, '2019-04-20 19:14:13') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32081,   1,       2048) /* ItemType - Gem */
+     , (32081,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (32081,   5,         10) /* EncumbranceVal */
+     , (32081,   8,         10) /* Mass */
+     , (32081,  11,         25) /* MaxStackSize */
+     , (32081,  12,          1) /* StackSize */
+     , (32081,  13,         10) /* StackUnitEncumbrance */
+     , (32081,  14,         10) /* StackUnitMass */
+     , (32081,  15,        500) /* StackUnitValue */
+     , (32081,  16,          8) /* ItemUseable - Contained */
+     , (32081,  18,          1) /* UiEffects - Magical */
+     , (32081,  19,        500) /* Value */
+     , (32081,  53,        101) /* PlacementPosition - Resting */
+     , (32081,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (32081,  94,         16) /* TargetType - Creature */
+     , (32081, 106,        210) /* ItemSpellcraft */
+     , (32081, 107,         50) /* ItemCurMana */
+     , (32081, 108,         50) /* ItemMaxMana */
+     , (32081, 109,          0) /* ItemDifficulty */
+     , (32081, 110,          0) /* ItemAllegianceRankLimit */
+     , (32081, 150,        103) /* HookPlacement - Hook */
+     , (32081, 151,          2) /* HookType - Wall */
+     , (32081, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32081,  11, True ) /* IgnoreCollisions */
+     , (32081,  13, True ) /* Ethereal */
+     , (32081,  14, True ) /* GravityStatus */
+     , (32081,  15, True ) /* LightsStatus */
+     , (32081,  19, True ) /* Attackable */
+     , (32081,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32081, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32081,   1, 'Redspire Portal Gem') /* Name */
+     , (32081,  15, 'Use this gem to summon a short-lived portal to Redspire. This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (32081,  16, 'Use this gem to summon a short-lived portal to Redspire. This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32081,   1,   33556769) /* Setup */
+     , (32081,   3,  536870932) /* SoundTable */
+     , (32081,   6,   67111919) /* PaletteBase */
+     , (32081,   7,  268435723) /* ClothingBase */
+     , (32081,   8,  100674856) /* Icon */
+     , (32081,  22,  872415275) /* PhysicsEffectTable */
+     , (32081,  28,        157) /* Spell - Summon Primary Portal I */
+     , (32081,  31,      42836) /* LinkedPortalOne - Portal to Redspire */
+     , (32081,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/45380 Dirty Fighting Gem of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/45380 Dirty Fighting Gem of Enlightenment.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 45380;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (45380, 'ace45380-dirtyfightinggemofenlightenment', 62, '2019-04-20 19:14:13') /* SkillAlterationDevice */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (45380,   1,       2048) /* ItemType - Gem */
+     , (45380,   3,          8) /* PaletteTemplate - Green */
+     , (45380,   5,         10) /* EncumbranceVal */
+     , (45380,  16,          8) /* ItemUseable - Contained */
+     , (45380,  19,          0) /* Value */
+     , (45380,  33,          1) /* Bonded - Bonded */
+     , (45380,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (45380, 114,          1) /* Attuned - Attuned */
+     , (45380, 185,          1) /* TypeOfAlteration */
+     , (45380, 186,         52) /* SkillToBeAltered */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (45380,  22, True ) /* Inscribable */
+     , (45380,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (45380,   1, 'Dirty Fighting Gem of Enlightenment') /* Name */
+     , (45380,  14, 'Use this gem to specialize a trained skill. It will cost you two skill credits to specialize the Dirty Fighting skill. ') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (45380,   1,   33558088) /* Setup */
+     , (45380,   6,   67111919) /* PaletteBase */
+     , (45380,   7,  268435723) /* ClothingBase */
+     , (45380,   8,  100673788) /* Icon */
+     , (45380,  50,  100692235) /* IconOverlay */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/45382 Recklessness Gem of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/45382 Recklessness Gem of Enlightenment.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 45382;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (45382, 'ace45382-recklessnessgemofenlightenment', 62, '2019-04-20 19:14:13') /* SkillAlterationDevice */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (45382,   1,       2048) /* ItemType - Gem */
+     , (45382,   3,          8) /* PaletteTemplate - Green */
+     , (45382,   5,         10) /* EncumbranceVal */
+     , (45382,  16,          8) /* ItemUseable - Contained */
+     , (45382,  19,          0) /* Value */
+     , (45382,  33,          1) /* Bonded - Bonded */
+     , (45382,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (45382, 114,          1) /* Attuned - Attuned */
+     , (45382, 185,          1) /* TypeOfAlteration */
+     , (45382, 186,         50) /* SkillToBeAltered */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (45382,  22, True ) /* Inscribable */
+     , (45382,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (45382,   1, 'Recklessness Gem of Enlightenment') /* Name */
+     , (45382,  14, 'Use this gem to specialize a trained skill. It will cost you two skill credits to specialize the Recklessness skill. ') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (45382,   1,   33558088) /* Setup */
+     , (45382,   6,   67111919) /* PaletteBase */
+     , (45382,   7,  268435723) /* ClothingBase */
+     , (45382,   8,  100673788) /* Icon */
+     , (45382,  50,  100673758) /* IconOverlay */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/45384 Sneak Attack Gem of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/45384 Sneak Attack Gem of Enlightenment.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 45384;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (45384, 'ace45384-sneakattackgemofenlightenment', 62, '2019-04-20 19:14:13') /* SkillAlterationDevice */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (45384,   1,       2048) /* ItemType - Gem */
+     , (45384,   3,          8) /* PaletteTemplate - Green */
+     , (45384,   5,         10) /* EncumbranceVal */
+     , (45384,  16,          8) /* ItemUseable - Contained */
+     , (45384,  19,          0) /* Value */
+     , (45384,  33,          1) /* Bonded - Bonded */
+     , (45384,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (45384, 114,          1) /* Attuned - Attuned */
+     , (45384, 185,          1) /* TypeOfAlteration */
+     , (45384, 186,         51) /* SkillToBeAltered */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (45384,  22, True ) /* Inscribable */
+     , (45384,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (45384,   1, 'Sneak Attack Gem of Enlightenment') /* Name */
+     , (45384,  14, 'Use this gem to specialize a trained skill. It will cost you two skill credits to specialize the Sneak Attack skill. ') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (45384,   1,   33558088) /* Setup */
+     , (45384,   6,   67111919) /* PaletteBase */
+     , (45384,   7,  268435723) /* ClothingBase */
+     , (45384,   8,  100673788) /* Icon */
+     , (45384,  50,  100692241) /* IconOverlay */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/49484 Summoning Gem of Enlightenment.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/SkillAlterationDevice/49484 Summoning Gem of Enlightenment.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 49484;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (49484, 'ace49484-summoninggemofenlightenment', 62, '2019-04-20 19:14:13') /* SkillAlterationDevice */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (49484,   1,       2048) /* ItemType - Gem */
+     , (49484,   3,          8) /* PaletteTemplate - Green */
+     , (49484,   5,         10) /* EncumbranceVal */
+     , (49484,  16,          8) /* ItemUseable - Contained */
+     , (49484,  19,          0) /* Value */
+     , (49484,  33,          1) /* Bonded - Bonded */
+     , (49484,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (49484, 114,          1) /* Attuned - Attuned */
+     , (49484, 185,          1) /* TypeOfAlteration */
+     , (49484, 186,         54) /* SkillToBeAltered */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (49484,  22, True ) /* Inscribable */
+     , (49484,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (49484,   1, 'Summoning Gem of Enlightenment') /* Name */
+     , (49484,  14, 'Use this gem to specialize a trained skill. It will cost you four skill credits to specialize the Summoning skill.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (49484,   1,   33558088) /* Setup */
+     , (49484,   6,   67111919) /* PaletteBase */
+     , (49484,   7,  268435723) /* ClothingBase */
+     , (49484,   8,  100673788) /* Icon */
+     , (49484,  50,  100693010) /* IconOverlay */;


### PR DESCRIPTION
- Adjustments for loot tier 7
- Add new skills Gems of Enlightenment
- Update new skills Wardens of Enlightenment to issue their gems
- Update Enhanced Health Elixir
- Add Enhanced Mana Elixir
- Add Redspire Portal Gem that uses newer LinkedPortalOne
- Update Sanamar Portal Gem to use newer LinkedPortalOne
