### PR TITLE
fixing Olthoi Rippers spawning too many ninjas

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Olthoi/31005 Olthoi Ripper.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Olthoi/31005 Olthoi Ripper.sql
@@ -41,7 +41,6 @@ VALUES (31005,   1,       5) /* HeartbeatInterval */
      , (31005,  31,      24) /* VisualAwarenessRange */
      , (31005,  34,     0.5) /* PowerupTime */
      , (31005,  36,       1) /* ChargeSpeed */
-     , (31005,  41,     300) /* RegenerationInterval */
      , (31005,  43,       1) /* GeneratorRadius */
      , (31005,  64,    0.75) /* ResistSlash */
      , (31005,  65,       1) /* ResistPierce */


### PR DESCRIPTION
This is a fix specifically for ACE generators