### PR TITLE
Update Loot Tier :: TuskerGuard

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25646 Long Leather Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25646 Long Leather Gauntlets.sql
@@ -1,12 +1,12 @@
 DELETE FROM `weenie` WHERE `class_Id` = 25646;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (25646, 'longgauntletsleatherneclass', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (25646, 'longgauntletsleathernew', 2, '2019-04-29 19:32:42') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (25646,   1,          2) /* ItemType - Armor */
      , (25646,   3,          4) /* PaletteTemplate - Brown */
-     , (25646,   4,      40960) /* ClothingPriority - OuterwearLowerArms, Hands */
+     , (25646,   4,      32768) /* ClothingPriority - Hands */
      , (25646,   5,        270) /* EncumbranceVal */
      , (25646,   8,         90) /* Mass */
      , (25646,   9,         32) /* ValidLocations - HandWear */
@@ -16,7 +16,7 @@ VALUES (25646,   1,          2) /* ItemType - Armor */
      , (25646,  28,         20) /* ArmorLevel */
      , (25646,  44,          0) /* Damage */
      , (25646,  45,          4) /* DamageType - Bludgeon */
-     , (25646,  53,        101) /* PlacementPosition */
+     , (25646,  53,        101) /* PlacementPosition - Resting */
      , (25646,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25646, 169,  151717134) /* TsysMutationData */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/01629 Tusker Guard.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/01629 Tusker Guard.sql
@@ -69,7 +69,7 @@ VALUES (1629,   1,   33556836) /* Setup */
      , (1629,   7,  268436063) /* ClothingBase */
      , (1629,   8,  100667443) /* Icon */
      , (1629,  22,  872415271) /* PhysicsEffectTable */
-     , (1629,  35,        456) /* DeathTreasureType - Loot Tier: 3 */;
+     , (1629,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (1629,   1, 210, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/21525 Tusker Guard.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/21525 Tusker Guard.sql
@@ -69,7 +69,7 @@ VALUES (21525,   1,   33556836) /* Setup */
      , (21525,   7,  268436063) /* ClothingBase */
      , (21525,   8,  100667443) /* Icon */
      , (21525,  22,  872415271) /* PhysicsEffectTable */
-     , (21525,  35,        456) /* DeathTreasureType - Loot Tier: 3 */;
+     , (21525,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (21525,   1, 210, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/22592 Tusker Guard.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/22592 Tusker Guard.sql
@@ -69,7 +69,7 @@ VALUES (22592,   1,   33556836) /* Setup */
      , (22592,   7,  268436063) /* ClothingBase */
      , (22592,   8,  100667443) /* Icon */
      , (22592,  22,  872415271) /* PhysicsEffectTable */
-     , (22592,  35,        456) /* DeathTreasureType - Loot Tier: 3 */;
+     , (22592,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (22592,   1, 210, 0, 0) /* Strength */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/22593 Tusker Guard.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/Tusker/22593 Tusker Guard.sql
@@ -69,7 +69,7 @@ VALUES (22593,   1,   33556836) /* Setup */
      , (22593,   7,  268436063) /* ClothingBase */
      , (22593,   8,  100667443) /* Icon */
      , (22593,  22,  872415271) /* PhysicsEffectTable */
-     , (22593,  35,        456) /* DeathTreasureType - Loot Tier: 3 */;
+     , (22593,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (22593,   1, 210, 0, 0) /* Strength */


### PR DESCRIPTION
- Update Tusker Guard loot tier profile to T4, up from T3, to match wiki
