### PR TITLE
Correct vitals for Geomancer Golems

### DIFF
--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48879 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48879 Golem.sql
@@ -84,9 +84,9 @@ VALUES (48879,   1, 130, 0, 0) /* Strength */
      , (48879,   6, 100, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48879,   1, 10, 0, 0, 350) /* MaxHealth */
-     , (48879,   3, 10, 0, 0, 450) /* MaxStamina */
-     , (48879,   5, 10, 0, 0, 220) /* MaxMana */;
+VALUES (48879,   1, 350, 0, 0, 430) /* MaxHealth */
+     , (48879,   3, 450, 0, 0, 610) /* MaxStamina */
+     , (48879,   5, 220, 0, 0, 400) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48879,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48881 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48881 Golem.sql
@@ -81,7 +81,7 @@ VALUES (48881,   1,   33556426) /* Setup */
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (48881,   1, 190, 0, 0) /* Strength */
      , (48881,   2, 220, 0, 0) /* Endurance */
-     , (48881,   3, 2300, 0, 0) /* Quickness */
+     , (48881,   3, 230, 0, 0) /* Quickness */
      , (48881,   4, 140, 0, 0) /* Coordination */
      , (48881,   5, 150, 0, 0) /* Focus */
      , (48881,   6, 150, 0, 0) /* Self */;

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48881 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48881 Golem.sql
@@ -87,9 +87,9 @@ VALUES (48881,   1, 190, 0, 0) /* Strength */
      , (48881,   6, 150, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48881,   1, 10, 0, 0, 760) /* MaxHealth */
-     , (48881,   3, 10, 0, 0, 900) /* MaxStamina */
-     , (48881,   5, 10, 0, 0, 600) /* MaxMana */;
+VALUES (48881,   1, 760, 0, 0,  870) /* MaxHealth */
+     , (48881,   3, 900, 0, 0, 1120) /* MaxStamina */
+     , (48881,   5, 600, 0, 0,  750) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48881,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48883 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48883 Golem.sql
@@ -84,9 +84,9 @@ VALUES (48883,   1, 170, 0, 0) /* Strength */
      , (48883,   6, 130, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48883,   1, 10, 0, 0, 670) /* MaxHealth */
-     , (48883,   3, 10, 0, 0, 800) /* MaxStamina */
-     , (48883,   5, 10, 0, 0, 500) /* MaxMana */;
+VALUES (48883,   1, 670, 0, 0,  770) /* MaxHealth */
+     , (48883,   3, 800, 0, 0, 1000) /* MaxStamina */
+     , (48883,   5, 500, 0, 0,  630) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48883,  6, 0, 3, 0, 185, 0, 0) /* MeleeDefense        Specialized */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48885 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48885 Golem.sql
@@ -84,9 +84,9 @@ VALUES (48885,   1, 210, 0, 0) /* Strength */
      , (48885,   6, 170, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48885,   1, 10, 0, 0, 800) /* MaxHealth */
-     , (48885,   3, 10, 0, 0, 950) /* MaxStamina */
-     , (48885,   5, 10, 0, 0, 650) /* MaxMana */;
+VALUES (48885,   1, 800, 0, 0,  920) /* MaxHealth */
+     , (48885,   3, 950, 0, 0, 1190) /* MaxStamina */
+     , (48885,   5, 650, 0, 0,  820) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48885,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48887 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48887 Golem.sql
@@ -82,9 +82,9 @@ VALUES (48887,   1, 100, 0, 0) /* Strength */
      , (48887,   6,  60, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48887,   1, 10, 0, 0, 80) /* MaxHealth */
-     , (48887,   3, 10, 0, 0, 100) /* MaxStamina */
-     , (48887,   5, 10, 0, 0, 100) /* MaxMana */;
+VALUES (48887,   1,  80, 0, 0, 135) /* MaxHealth */
+     , (48887,   3, 100, 0, 0, 210) /* MaxStamina */
+     , (48887,   5, 100, 0, 0, 160) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48887,  6, 0, 3, 0,  54, 0, 0) /* MeleeDefense        Specialized */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48889 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48889 Golem.sql
@@ -83,9 +83,9 @@ VALUES (48889,   1, 150, 0, 0) /* Strength */
      , (48889,   6, 110, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48889,   1, 10, 0, 0, 580) /* MaxHealth */
-     , (48889,   3, 10, 0, 0, 750) /* MaxStamina */
-     , (48889,   5, 10, 0, 0, 350) /* MaxMana */;
+VALUES (48889,   1, 580, 0, 0, 670) /* MaxHealth */
+     , (48889,   3, 750, 0, 0, 930) /* MaxStamina */
+     , (48889,   5, 350, 0, 0, 460) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48889,  6, 0, 3, 0, 240, 0, 0) /* MeleeDefense        Specialized */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48891 Golem.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CombatPet/48891 Golem.sql
@@ -81,9 +81,9 @@ VALUES (48891,   1, 120, 0, 0) /* Strength */
      , (48891,   6,  80, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (48891,   1, 10, 0, 0,  65) /* MaxHealth */
-     , (48891,   3, 10, 0, 0, 250) /* MaxStamina */
-     , (48891,   5, 10, 0, 0, 200) /* MaxMana */;
+VALUES (48891,   1, 200, 0, 0, 265) /* MaxHealth */
+     , (48891,   3, 250, 0, 0, 380) /* MaxStamina */
+     , (48891,   5, 200, 0, 0, 280) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (48891,  6, 0, 3, 0, 115, 0, 0) /* MeleeDefense        Specialized */


### PR DESCRIPTION
- Correct vitals for Geomancer Golems: init_Level should equal current_level minus attribute contribution
