### PR TITLE
Set NonTracking to True for later Arc spells.

### DIFF
--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05333 Bael'zharon's Nether Arc.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05333 Bael'zharon's Nether Arc.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5333;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5333, 'Bael''zharon''s Nether Arc', 1024 /* Nether */, 125, 75, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5333, 'Bael''zharon''s Nether Arc', 1024 /* Nether */, 125, 75, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05362 Nether Arc II.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05362 Nether Arc II.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5362;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5362, 'Nether Arc II', 1024 /* Nether */, 42, 42, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5362, 'Nether Arc II', 1024 /* Nether */, 42, 42, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05363 Nether Arc III.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05363 Nether Arc III.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5363;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5363, 'Nether Arc III', 1024 /* Nether */, 63, 52, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5363, 'Nether Arc III', 1024 /* Nether */, 63, 52, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05364 Nether Arc IV.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05364 Nether Arc IV.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5364;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5364, 'Nether Arc IV', 1024 /* Nether */, 73, 74, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5364, 'Nether Arc IV', 1024 /* Nether */, 73, 74, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05365 Nether Arc V.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05365 Nether Arc V.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5365;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5365, 'Nether Arc V', 1024 /* Nether */, 84, 94, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5365, 'Nether Arc V', 1024 /* Nether */, 84, 94, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05366 Nether Arc VI.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05366 Nether Arc VI.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5366;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5366, 'Nether Arc VI', 1024 /* Nether */, 105, 105, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5366, 'Nether Arc VI', 1024 /* Nether */, 105, 105, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05367 Nether Arc VII.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05367 Nether Arc VII.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5367;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5367, 'Nether Arc VII', 1024 /* Nether */, 168, 94, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5367, 'Nether Arc VII', 1024 /* Nether */, 168, 94, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05368 Incantation of Nether Arc.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05368 Incantation of Nether Arc.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5368;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5368, 'Incantation of Nether Arc', 1024 /* Nether */, 252, 73, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5368, 'Incantation of Nether Arc', 1024 /* Nether */, 252, 73, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05369 Nether Arc I.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05369 Nether Arc I.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5369;
 
-INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `last_Modified`)
-VALUES (5369, 'Nether Arc I', 1024 /* Nether */, 21, 31, 43232 /* Nether Arc */, 1, 0, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `non_Tracking`, `last_Modified`)
+VALUES (5369, 'Nether Arc I', 1024 /* Nether */, 21, 31, 43232 /* Nether Arc */, 1, 0, True, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05442 Acid Spit Arc 1.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05442 Acid Spit Arc 1.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5442;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (5442, 'Acid Spit Arc 1', 32 /* Acid */, 16, 15, 1633 /* Acid Stream */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-03-18 09:00:00');
+VALUES (5442, 'Acid Spit Arc 1', 32 /* Acid */, 16, 15, 1633 /* Acid Stream */, 1, 0, 0, 0, 0, True, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05443 Acid Spit Arc 2.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05443 Acid Spit Arc 2.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5443;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (5443, 'Acid Spit Arc 2', 32 /* Acid */, 16, 15, 1633 /* Acid Stream */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-03-18 09:00:00');
+VALUES (5443, 'Acid Spit Arc 2', 32 /* Acid */, 16, 15, 1633 /* Acid Stream */, 1, 0, 0, 0, 0, True, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05967 Galvanic Arc.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05967 Galvanic Arc.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5967;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (5967, 'Galvanic Arc', 64 /* Electric */, 68, 68, 1635 /* Lightning Bolt */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-03-18 09:00:00');
+VALUES (5967, 'Galvanic Arc', 64 /* Electric */, 68, 68, 1635 /* Lightning Bolt */, 1, 0, 0, 0, 0, True, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-07-22 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06162 Thorn Arc.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06162 Thorn Arc.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 6162;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (6162, 'Thorn Arc', 2 /* Pierce */, 16, 15, 1667 /* Force Bolt */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-03-18 09:00:00');
+VALUES (6162, 'Thorn Arc', 2 /* Pierce */, 16, 15, 1667 /* Force Bolt */, 1, 0, 0, 0, 0, True, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2019-07-22 09:00:00');


### PR DESCRIPTION
This should fix issues with Nether Arcs and some other spells that didn't have NonTracking set to true and would not be classified properly as Arc spells