### PR TITLE
Remove loot gen properties from quest item

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/22135 Frest Greelving's Emerald.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/22135 Frest Greelving's Emerald.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 22135;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (22135, 'jewelemeraldhauntedmansion', 38, '2019-02-04 06:52:23') /* Gem */;
+VALUES (22135, 'jewelemeraldhauntedmansion', 38, '2019-07-24 00:00:00') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (22135,   1,       2048) /* ItemType - Gem */
@@ -18,9 +18,7 @@ VALUES (22135,   1,       2048) /* ItemType - Gem */
      , (22135,  33,          1) /* Bonded - Bonded */
      , (22135,  53,        101) /* PlacementPosition */
      , (22135,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-     , (22135, 114,          1) /* Attuned - Attuned */
-     , (22135, 131,         21) /* MaterialType - Emerald */
-     , (22135, 169,   16777216) /* TsysMutationData */;
+     , (22135, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (22135,  11, True ) /* IgnoreCollisions */
@@ -38,5 +36,4 @@ VALUES (22135,   1,   33554809) /* Setup */
      , (22135,   6,   67111919) /* PaletteBase */
      , (22135,   7,  268435723) /* ClothingBase */
      , (22135,   8,  100668362) /* Icon */
-     , (22135,  22,  872415275) /* PhysicsEffectTable */
-     , (22135,  36,  234881046) /* MutateFilter */;
+     , (22135,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/22135 Frest Greelving's Emerald.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/22135 Frest Greelving's Emerald.sql
@@ -1,13 +1,14 @@
 DELETE FROM `weenie` WHERE `class_Id` = 22135;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (22135, 'jewelemeraldhauntedmansion', 38, '2019-07-24 00:00:00') /* Gem */;
+VALUES (22135, 'jewelemeraldhauntedmansion', 38, '2019-07-26 00:00:00') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (22135,   1,       2048) /* ItemType - Gem */
      , (22135,   3,          8) /* PaletteTemplate - Green */
      , (22135,   5,          5) /* EncumbranceVal */
      , (22135,   8,          5) /* Mass */
+     , (22135,   9,          0) /* ValidLocations - None */
      , (22135,  11,          1) /* MaxStackSize */
      , (22135,  12,          1) /* StackSize */
      , (22135,  13,          5) /* StackUnitEncumbrance */
@@ -16,16 +17,11 @@ VALUES (22135,   1,       2048) /* ItemType - Gem */
      , (22135,  16,          1) /* ItemUseable - No */
      , (22135,  19,       1000) /* Value */
      , (22135,  33,          1) /* Bonded - Bonded */
-     , (22135,  53,        101) /* PlacementPosition */
      , (22135,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (22135, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (22135,  11, True ) /* IgnoreCollisions */
-     , (22135,  13, True ) /* Ethereal */
-     , (22135,  14, True ) /* GravityStatus */
-     , (22135,  19, True ) /* Attackable */
-     , (22135,  22, True ) /* Inscribable */;
+VALUES (22135,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22135,   1, 'Frest Greelving''s Emerald') /* Name */;


### PR DESCRIPTION
- Remove loot gen properties from quest item; MaterialType causing the client to mangle the name
