### PR TITLE
Normalize Olthoi Armor AL values

### DIFF
--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37187 Olthoi Alduressa Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37187 Olthoi Alduressa Gauntlets.sql
@@ -9,7 +9,7 @@ VALUES (37187,   1,          2) /* ItemType - Armor */
      , (37187,   5,        544) /* EncumbranceVal */
      , (37187,   9,         32) /* ValidLocations - HandWear */
      , (37187,  16,          1) /* ItemUseable - No */
-     , (37187,  28,        308) /* ArmorLevel */
+     , (37187,  28,        225) /* ArmorLevel */
      , (37187,  53,        101) /* PlacementPosition - Resting */
      , (37187,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37187, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37188 Olthoi Amuli Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37188 Olthoi Amuli Gauntlets.sql
@@ -9,7 +9,7 @@ VALUES (37188,   1,          2) /* ItemType - Armor */
      , (37188,   5,        538) /* EncumbranceVal */
      , (37188,   9,         32) /* ValidLocations - HandWear */
      , (37188,  16,          1) /* ItemUseable - No */
-     , (37188,  28,        225) /* ArmorLevel */
+     , (37188,  28,        205) /* ArmorLevel */
      , (37188,  53,        101) /* PlacementPosition - Resting */
      , (37188,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37188, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37189 Olthoi Celdon Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37189 Olthoi Celdon Gauntlets.sql
@@ -9,7 +9,7 @@ VALUES (37189,   1,          2) /* ItemType - Armor */
      , (37189,   5,        560) /* EncumbranceVal */
      , (37189,   9,         32) /* ValidLocations - HandWear */
      , (37189,  16,          1) /* ItemUseable - No */
-     , (37189,  28,        301) /* ArmorLevel */
+     , (37189,  28,        225) /* ArmorLevel */
      , (37189,  53,        101) /* PlacementPosition */
      , (37189,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37189, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37190 Olthoi Koujia Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37190 Olthoi Koujia Gauntlets.sql
@@ -9,7 +9,7 @@ VALUES (37190,   1,          2) /* ItemType - Armor */
      , (37190,   5,        517) /* EncumbranceVal */
      , (37190,   9,         32) /* ValidLocations - HandWear */
      , (37190,  16,          1) /* ItemUseable - No */
-     , (37190,  28,        110) /* ArmorLevel */
+     , (37190,  28,        225) /* ArmorLevel */
      , (37190,  53,        101) /* PlacementPosition */
      , (37190,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37190, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37192 Olthoi Celdon Girth.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37192 Olthoi Celdon Girth.sql
@@ -9,7 +9,7 @@ VALUES (37192,   1,          2) /* ItemType - Armor */
      , (37192,   5,        820) /* EncumbranceVal */
      , (37192,   9,       1024) /* ValidLocations - AbdomenArmor */
      , (37192,  16,          1) /* ItemUseable - No */
-     , (37192,  28,        478) /* ArmorLevel */
+     , (37192,  28,        225) /* ArmorLevel */
      , (37192,  53,        101) /* PlacementPosition */
      , (37192,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37192, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37195 Olthoi Alduressa Helm.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37195 Olthoi Alduressa Helm.sql
@@ -9,7 +9,7 @@ VALUES (37195,   1,          2) /* ItemType - Armor */
      , (37195,   5,        277) /* EncumbranceVal */
      , (37195,   9,          1) /* ValidLocations - HeadWear */
      , (37195,  16,          1) /* ItemUseable - No */
-     , (37195,  28,        280) /* ArmorLevel */
+     , (37195,  28,        225) /* ArmorLevel */
      , (37195,  53,        101) /* PlacementPosition - Resting */
      , (37195,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37195, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37196 Olthoi Amuli Helm.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37196 Olthoi Amuli Helm.sql
@@ -9,7 +9,7 @@ VALUES (37196,   1,          2) /* ItemType - Armor */
      , (37196,   5,        322) /* EncumbranceVal */
      , (37196,   9,          1) /* ValidLocations - HeadWear */
      , (37196,  16,          1) /* ItemUseable - No */
-     , (37196,  28,        288) /* ArmorLevel */
+     , (37196,  28,        205) /* ArmorLevel */
      , (37196,  53,        101) /* PlacementPosition - Resting */
      , (37196,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37196, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37197 Olthoi Celdon Helm.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37197 Olthoi Celdon Helm.sql
@@ -9,7 +9,7 @@ VALUES (37197,   1,          2) /* ItemType - Armor */
      , (37197,   5,        357) /* EncumbranceVal */
      , (37197,   9,          1) /* ValidLocations - HeadWear */
      , (37197,  16,          1) /* ItemUseable - No */
-     , (37197,  28,        302) /* ArmorLevel */
+     , (37197,  28,        225) /* ArmorLevel */
      , (37197,  53,        101) /* PlacementPosition */
      , (37197,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37197, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37198 Olthoi Koujia Kabuton.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37198 Olthoi Koujia Kabuton.sql
@@ -9,7 +9,7 @@ VALUES (37198,   1,          2) /* ItemType - Armor */
      , (37198,   5,        426) /* EncumbranceVal */
      , (37198,   9,          1) /* ValidLocations - HeadWear */
      , (37198,  16,          1) /* ItemUseable - No */
-     , (37198,  28,        110) /* ArmorLevel */
+     , (37198,  28,        225) /* ArmorLevel */
      , (37198,  53,        101) /* PlacementPosition */
      , (37198,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37198, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37200 Olthoi Alduressa Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37200 Olthoi Alduressa Leggings.sql
@@ -9,7 +9,7 @@ VALUES (37200,   1,          2) /* ItemType - Armor */
      , (37200,   5,       2461) /* EncumbranceVal */
      , (37200,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
      , (37200,  16,          1) /* ItemUseable - No */
-     , (37200,  28,        704) /* ArmorLevel */
+     , (37200,  28,        225) /* ArmorLevel */
      , (37200,  53,        101) /* PlacementPosition - Resting */
      , (37200,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37200, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37201 Olthoi Amuli Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37201 Olthoi Amuli Leggings.sql
@@ -9,7 +9,7 @@ VALUES (37201,   1,          2) /* ItemType - Armor */
      , (37201,   5,       2634) /* EncumbranceVal */
      , (37201,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
      , (37201,  16,          1) /* ItemUseable - No */
-     , (37201,  28,        258) /* ArmorLevel */
+     , (37201,  28,        205) /* ArmorLevel */
      , (37201,  53,        101) /* PlacementPosition - Resting */
      , (37201,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37201, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37202 Olthoi Celdon Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37202 Olthoi Celdon Leggings.sql
@@ -9,7 +9,7 @@ VALUES (37202,   1,          2) /* ItemType - Armor */
      , (37202,   5,       1426) /* EncumbranceVal */
      , (37202,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
      , (37202,  16,          1) /* ItemUseable - No */
-     , (37202,  28,        310) /* ArmorLevel */
+     , (37202,  28,        225) /* ArmorLevel */
      , (37202,  53,        101) /* PlacementPosition */
      , (37202,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37202, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37203 Olthoi Koujia Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37203 Olthoi Koujia Leggings.sql
@@ -9,7 +9,7 @@ VALUES (37203,   1,          2) /* ItemType - Armor */
      , (37203,   5,       1251) /* EncumbranceVal */
      , (37203,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
      , (37203,  16,          1) /* ItemUseable - No */
-     , (37203,  28,        110) /* ArmorLevel */
+     , (37203,  28,        225) /* ArmorLevel */
      , (37203,  53,        101) /* PlacementPosition */
      , (37203,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37203, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37205 Olthoi Celdon Sleeves.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37205 Olthoi Celdon Sleeves.sql
@@ -9,7 +9,7 @@ VALUES (37205,   1,          2) /* ItemType - Armor */
      , (37205,   5,        930) /* EncumbranceVal */
      , (37205,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
      , (37205,  16,          1) /* ItemUseable - No */
-     , (37205,  28,        684) /* ArmorLevel */
+     , (37205,  28,        225) /* ArmorLevel */
      , (37205,  53,        101) /* PlacementPosition */
      , (37205,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
 	 , (37205, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37206 Olthoi Koujia Sleeves.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37206 Olthoi Koujia Sleeves.sql
@@ -9,7 +9,7 @@ VALUES (37206,   1,          2) /* ItemType - Armor */
      , (37206,   5,        643) /* EncumbranceVal */
      , (37206,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
      , (37206,  16,          1) /* ItemUseable - No */
-     , (37206,  28,        110) /* ArmorLevel */
+     , (37206,  28,        225) /* ArmorLevel */
      , (37206,  53,        101) /* PlacementPosition */
      , (37206,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37206, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37207 Olthoi Alduressa Boots.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37207 Olthoi Alduressa Boots.sql
@@ -9,7 +9,7 @@ VALUES (37207,   1,          2) /* ItemType - Armor */
      , (37207,   5,        374) /* EncumbranceVal */
      , (37207,   9,        256) /* ValidLocations - FootWear */
      , (37207,  16,          1) /* ItemUseable - No */
-     , (37207,  28,        724) /* ArmorLevel */
+     , (37207,  28,        225) /* ArmorLevel */
      , (37207,  53,        101) /* PlacementPosition - Resting */
      , (37207,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37207, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37208 Olthoi Amuli Sollerets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37208 Olthoi Amuli Sollerets.sql
@@ -9,7 +9,7 @@ VALUES (37208,   1,          2) /* ItemType - Armor */
      , (37208,   5,        365) /* EncumbranceVal */
      , (37208,   9,        256) /* ValidLocations - FootWear */
      , (37208,  16,          1) /* ItemUseable - No */
-     , (37208,  28,        300) /* ArmorLevel */
+     , (37208,  28,        205) /* ArmorLevel */
      , (37208,  53,        101) /* PlacementPosition - Resting */
      , (37208,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37208, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37209 Olthoi Celdon Sollerets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37209 Olthoi Celdon Sollerets.sql
@@ -9,7 +9,7 @@ VALUES (37209,   1,          2) /* ItemType - Armor */
      , (37209,   5,        319) /* EncumbranceVal */
      , (37209,   9,        256) /* ValidLocations - FootWear */
      , (37209,  16,          1) /* ItemUseable - No */
-     , (37209,  28,        285) /* ArmorLevel */
+     , (37209,  28,        225) /* ArmorLevel */
      , (37209,  53,        101) /* PlacementPosition */
      , (37209,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37209, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37211 Olthoi Koujia Sollerets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37211 Olthoi Koujia Sollerets.sql
@@ -9,7 +9,7 @@ VALUES (37211,   1,          2) /* ItemType - Armor */
      , (37211,   5,        275) /* EncumbranceVal */
      , (37211,   9,        256) /* ValidLocations - FootWear */
      , (37211,  16,          1) /* ItemUseable - No */
-     , (37211,  28,        330) /* ArmorLevel */
+     , (37211,  28,        225) /* ArmorLevel */
      , (37211,  53,        101) /* PlacementPosition - Resting */
      , (37211,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37211, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37214 Olthoi Celdon Breastplate.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37214 Olthoi Celdon Breastplate.sql
@@ -9,7 +9,7 @@ VALUES (37214,   1,          2) /* ItemType - Armor */
      , (37214,   5,       1681) /* EncumbranceVal */
      , (37214,   9,        512) /* ValidLocations - ChestArmor */
      , (37214,  16,          1) /* ItemUseable - No */
-     , (37214,  28,        259) /* ArmorLevel */
+     , (37214,  28,        225) /* ArmorLevel */
      , (37214,  53,        101) /* PlacementPosition */
      , (37214,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37214, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37215 Olthoi Koujia Breastplate.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37215 Olthoi Koujia Breastplate.sql
@@ -9,7 +9,7 @@ VALUES (37215,   1,          2) /* ItemType - Armor */
      , (37215,   5,       1063) /* EncumbranceVal */
      , (37215,   9,        512) /* ValidLocations - ChestArmor */
      , (37215,  16,          1) /* ItemUseable - No */
-     , (37215,  28,        110) /* ArmorLevel */
+     , (37215,  28,        225) /* ArmorLevel */
      , (37215,  53,        101) /* PlacementPosition */
      , (37215,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37215, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37217 Olthoi Alduressa Coat.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37217 Olthoi Alduressa Coat.sql
@@ -9,7 +9,7 @@ VALUES (37217,   1,          2) /* ItemType - Armor */
      , (37217,   5,       1337) /* EncumbranceVal */
      , (37217,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
      , (37217,  16,          1) /* ItemUseable - No */
-     , (37217,  28,        654) /* ArmorLevel */
+     , (37217,  28,        225) /* ArmorLevel */
      , (37217,  53,        101) /* PlacementPosition - Resting */
      , (37217,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37217, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37299 Olthoi Amuli Coat.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37299 Olthoi Amuli Coat.sql
@@ -9,7 +9,7 @@ VALUES (37299,   1,          2) /* ItemType - Armor */
      , (37299,   5,       1080) /* EncumbranceVal */
      , (37299,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
      , (37299,  16,          1) /* ItemUseable - No */
-     , (37299,  28,        272) /* ArmorLevel */
+     , (37299,  28,        205) /* ArmorLevel */
      , (37299,  53,        101) /* PlacementPosition - Resting */
      , (37299,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37299, 151,          2) /* HookType - Wall */


### PR DESCRIPTION
- Decrease or increase baseline AL values for Olthoi armor types, as appropriate, so when combined with a minor code revision in LootGenerationFactory_Clothing.cs GetArmorLevelModifier() method will result in armor being produced without over-inflated AL values
