### PR TITLE
Updated drop locations for several recall spells

### DIFF
--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03865 Glenden Wood Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03865 Glenden Wood Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 3865;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (3865, 'Glenden Wood Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (3865, 'Glenden Wood Recall', 2695102501, 96.302, 119.847, 59.955, 0.7071068, 0, 0, -0.7071068, '2019-08-09 13:00:00');
+/* @teleloc 0xA0A40025 [96.302 119.847 59.955] 0.7071068 0 0 -0.7071068 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03930 Whispering Blade Chapterhouse Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03930 Whispering Blade Chapterhouse Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 3930;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (3930, 'Whispering Blade Chapterhouse Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (3930, 'Whispering Blade Chapterhouse Recall', 8454440, 80, -10, 0, 0, 0, 0, -1, '2019-08-09 16:00:00');
+/* @teleloc 0x00810128 [80 -10 0] 0 0 0 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03930 Whispering Blade Chapterhouse Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03930 Whispering Blade Chapterhouse Recall.sql
@@ -2,4 +2,4 @@ DELETE FROM `spell` WHERE `id` = 3930;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
 VALUES (3930, 'Whispering Blade Chapterhouse Recall', 8454440, 80, -10, 0, 0, 0, 0, -1, '2019-08-09 16:00:00');
-/* @teleloc 0x00810128 [80 -10 0] 0 0 0 */
+/* @teleloc 0x00810128 [80 -10 0] 0 0 0 -1 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04084 Bur Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04084 Bur Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 4084;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (4084, 'Bur Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (4084, 'Bur Recall', 10224199, 160, -70, -17.995, 0.7071068, 0, 0, -0.7071068, '2019-08-09 13:00:00');
+/* @teleloc 0x009C0247 [160 -70 -17.995] 0.7071068 0 0 -0.7071068 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04128 Call of the Mhoire Forge.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04128 Call of the Mhoire Forge.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 4128;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (4128, 'Call of the Mhoire Forge', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (4128, 'Call of the Mhoire Forge', 1210908932, 86.8, 137.6, -14.795, 1, 0, 0, 0, '2019-08-09 13:00:00');
+/* @teleloc 0x482D0104 [86.8 137.6 -14.795] 1 0 0 0 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04198 Paradox-touched Olthoi Infested Area Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04198 Paradox-touched Olthoi Infested Area Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 4198;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (4198, 'Paradox-touched Olthoi Infested Area Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (4198, 'Paradox-touched Olthoi Infested Area Recall', 3300261890, 22.70858, 26.04498, 318.005, -0.9238795, 0, 0, -0.3826835, '2019-08-09 13:00:00');
+/* @teleloc 0xC4B60002 [22.70858 26.04498 318.005] -0.9238795 0 0 -0.3826835 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04213 Colosseum Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04213 Colosseum Recall.sql
@@ -2,4 +2,4 @@ DELETE FROM `spell` WHERE `id` = 4213;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
 VALUES (4213, 'Colosseum Recall', 11469080, 40, -13.1651, 0.005, 1, 0, 0, 0, '2019-08-09 13:00:00');
-/* @teleloc 0xAF0118 [40 -13.1651 0.005] 1 0 0 0 */
+/* @teleloc 0x00AF0118 [40 -13.1651 0.005] 1 0 0 0 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04213 Colosseum Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04213 Colosseum Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 4213;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (4213, 'Colosseum Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (4213, 'Colosseum Recall', 11469080, 40, -13.1651, 0.005, 1, 0, 0, 0, '2019-08-09 13:00:00');
+/* @teleloc 0xAF0118 [40 -13.1651 0.005] 1 0 0 0 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04214 Return to the Keep.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04214 Return to the Keep.sql
@@ -2,4 +2,4 @@ DELETE FROM `spell` WHERE `id` = 4214;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
 VALUES (4214, 'Return to the Keep', 722599977, 120.64, 1.55, 48.005, 0.0871558, 0, 0, -0.9961947, '2019-08-09 13:00:00');
-/* @teleloc 0x2b120029 [120.64 1.55 48.005] 0.0871558 0 0 -0.9961947 */
+/* @teleloc 0x2B120029 [120.64 1.55 48.005] 0.0871558 0 0 -0.9961947 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04214 Return to the Keep.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/04214 Return to the Keep.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 4214;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (4214, 'Return to the Keep', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (4214, 'Return to the Keep', 722599977, 120.64, 1.55, 48.005, 0.0871558, 0, 0, -0.9961947, '2019-08-09 13:00:00');
+/* @teleloc 0x2b120029 [120.64 1.55 48.005] 0.0871558 0 0 -0.9961947 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05330 Gear Knight Invasion Area Camp Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05330 Gear Knight Invasion Area Camp Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 5330;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (5330, 'Gear Knight Invasion Area Camp Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (5330, 'Gear Knight Invasion Area Camp Recall', 663158845, 173.4282, 96.90477, 113.7788, -0.9998896, 0, 0, -0.01486166, '2019-08-09 13:00:00');
+/* @teleloc 0x2787003D [173.4282 96.90477 113.7788] -0.9998896 0 0 -0.01486166 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05541 Lost City of Neftet Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05541 Lost City of Neftet Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 5541;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (5541, 'Lost City of Neftet Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (5541, 'Lost City of Neftet Recall', 2271412238, 40.45744, 129.2806, 8.01, -0.7071068, 0, 0, -0.7071068, '2019-08-09 13:00:00');
+/* @teleloc 0x8763000E [40.45744 129.2806 8.01] -0.7071068 0 0 -0.7071068 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06150 Rynthid Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06150 Rynthid Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 6150;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (6150, 'Rynthid Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (6150, 'Rynthid Recall', 808583196, 83.3, 89.2, 133, -0.6427876, 0, 0, -0.7660444, '2019-08-09 13:00:00');
+/* @teleloc 0x3032001C [83.3 89.2 133] -0.6427876 0 0 -0.7660444 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06321 Viridian Rise Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06321 Viridian Rise Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 6321;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (6321, 'Viridian Rise Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (6321, 'Viridian Rise Recall', 3007905811, 67.3, 64.3, 56.37167, 0.9659258, 0, 0, -0.258819, '2019-08-09 13:00:00');
+/* @teleloc 0xB3490013 [67.3 64.3 56.37167] 0.9659258 0 0 -0.258819 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06322 Viridian Rise Great Tree Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06322 Viridian Rise Great Tree Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 6322;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (6322, 'Viridian Rise Great Tree Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (6322, 'Viridian Rise Great Tree Recall', 3024748601, 191.8, 11.6, 117.9883, 0.9961947, 0, 0, -0.08715574, '2019-08-09 13:00:00');
+/* @teleloc 0xB44A0039 [191.8 11.6 117.9883] 0.9961947 0 0 -0.08715574 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06326 Eldrytch Web Stronghold Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06326 Eldrytch Web Stronghold Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 6326;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (6326, 'Eldrytch Web Stronghold Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (6326, 'Eldrytch Web Stronghold Recall', 3181379619, 96.28983, 51.04814, -0.09500003, 0.9238795, 0, 0, -0.3826835, '2019-08-09 13:00:00');
+/* @teleloc 0xBDA00023 [96.28983 51.04814 -0.09500003] 0.9238795 0 0 -0.3826835 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06327 Radiant Blood Stronghold Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/06327 Radiant Blood Stronghold Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 6327;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (6327, 'Radiant Blood Stronghold Recall', 23069349, 80, -160, 0.005, 1, 0, 0, 0, '2019-03-18 09:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (6327, 'Radiant Blood Stronghold Recall', 2156855316, 55.81149, 83.31913, 124.005, 1, 0, 0, -1, '2019-08-09 13:00:00');
+/* @teleloc 0x808F0014 [55.81149 83.31913 124.005] 1 0 0 -1 */


### PR DESCRIPTION
Updated drop locations for the following recall spells:
Glenden Wood Recall
Bur Recall
Call of the Mhoire Forge
Paradox-touched Olthoi Infested Area Recall
Colosseum Recall
Return to the Keep
Gear Knight Invasion Area Camp Recall
Lost City of Neftet Recall
Rynthid Recall
Viridian Rise Recall
Viridian Rise Great Tree Recall
Eldrytch Web Stronghold Recall
Radiant Blood Stronghold Recall
