### PR TITLE
fixing Aura of Infected Spirit Caress

### DIFF
--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03259 Aura of Infected Spirit Caress.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03259 Aura of Infected Spirit Caress.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3259;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3259, 'Aura of Infected Spirit Caress', 36872 /* Float, SingleStat, Additive */, 170 /* WeaponAuraElemental */, 0.07, '2019-03-18 09:00:00');
+VALUES (3259, 'Aura of Infected Spirit Caress', 36872 /* Float, SingleStat, Additive */, 170 /* WeaponAuraElemental */, 0.07, '2019-08-23 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03259 Aura of Infected Spirit Caress.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/03259 Aura of Infected Spirit Caress.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3259;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3259, 'Aura of Infected Spirit Caress', 36872 /* Float, SingleStat, Additive */, 152 /* ElementalDamageMod */, 0.07, '2019-03-18 09:00:00');
+VALUES (3259, 'Aura of Infected Spirit Caress', 36872 /* Float, SingleStat, Additive */, 170 /* WeaponAuraElemental */, 0.07, '2019-03-18 09:00:00');


### PR DESCRIPTION
Note that server operators should run Database/Optional/Shard/2019-07-12-00-Match_World_Spells_In_Biota_Enchantment_Registry.sql after upgrading to this world release