### PR TITLE
Add missing attuned prop

### DIFF
--- a/Database/Patches/2009-12-GainingGround/9 WeenieDefaults/MissileLauncher/41893 Enhanced Assault Bow.sql
+++ b/Database/Patches/2009-12-GainingGround/9 WeenieDefaults/MissileLauncher/41893 Enhanced Assault Bow.sql
@@ -1,0 +1,76 @@
+DELETE FROM `weenie` WHERE `class_Id` = 41893;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (41893, 'ace41893-enhancedassaultbow', 3, '2019-09-27 11:34:19') /* MissileLauncher */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (41893,   1,        256) /* ItemType - MissileWeapon */
+     , (41893,   3,         14) /* PaletteTemplate - Red */
+     , (41893,   5,        400) /* EncumbranceVal */
+     , (41893,   8,        220) /* Mass */
+     , (41893,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (41893,  16,          1) /* ItemUseable - No */
+     , (41893,  18,          1) /* UiEffects - Magical */
+     , (41893,  19,      25000) /* Value */
+     , (41893,  44,         14) /* Damage */
+     , (41893,  45,          2) /* DamageType - Pierce */
+     , (41893,  46,         16) /* DefaultCombatStyle - Bow */
+     , (41893,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (41893,  49,         40) /* WeaponTime */
+     , (41893,  50,          1) /* AmmoType - Arrow */
+     , (41893,  51,          2) /* CombatUse - Missle */
+     , (41893,  52,          2) /* ParentLocation - LeftHand */
+     , (41893,  53,          3) /* PlacementPosition - LeftHand */
+     , (41893,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (41893, 106,        400) /* ItemSpellcraft */
+     , (41893, 107,        478) /* ItemCurMana */
+     , (41893, 108,        600) /* ItemMaxMana */
+     , (41893, 109,        120) /* ItemDifficulty */
+     , (41893, 151,          2) /* HookType - Wall */
+     , (41893, 158,          2) /* WieldRequirements - RawSkill */
+     , (41893, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (41893, 160,        360) /* WieldDifficulty */
+     , (41893, 166,          6) /* SlayerCreatureType - Tumerok */
+     , (41893, 263,          2) /* ResistanceModifierType */
+     , (41893, 353,          8) /* WeaponType - Bow */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (41893,  11, True ) /* IgnoreCollisions */
+     , (41893,  13, True ) /* Ethereal */
+     , (41893,  14, True ) /* GravityStatus */
+     , (41893,  15, True ) /* LightsStatus */
+     , (41893,  19, True ) /* Attackable */
+     , (41893,  22, True ) /* Inscribable */
+     , (41893,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (41893,   5, -0.025000000372529) /* ManaRate */
+     , (41893,  21,    0.75) /* WeaponLength */
+     , (41893,  22,       0) /* DamageVariance */
+     , (41893,  26, 26.2999992370605) /* MaximumVelocity */
+     , (41893,  29, 1.14999997615814) /* WeaponDefense */
+     , (41893,  39, 1.20000004768372) /* DefaultScale */
+     , (41893,  62,       1) /* WeaponOffense */
+     , (41893,  63, 2.29999995231628) /* DamageMod */
+     , (41893,  77,       1) /* PhysicsScriptIntensity */
+     , (41893, 138,     2.5) /* SlayerDamageBonus */
+     , (41893, 157,       1) /* ResistanceModifier */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (41893,   1, 'Enhanced Assault Bow') /* Name */
+     , (41893,  16, 'A reward for defeating the leaders of the Gromnie Clan.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (41893,   1,   33558206) /* Setup */
+     , (41893,   3,  536870932) /* SoundTable */
+     , (41893,   6,   67111919) /* PaletteBase */
+     , (41893,   7,  268436199) /* ClothingBase */
+     , (41893,   8,  100671743) /* Icon */
+     , (41893,  19,         88) /* ActivationAnimation */
+     , (41893,  22,  872415275) /* PhysicsEffectTable */
+     , (41893,  30,         88) /* PhysicsScript - Create */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (41893,  2004,      2)  /* Warrior's Vitality */
+     , (41893,  2059,      2)  /* Honed Control */
+     , (41893,  2096,      2)  /* Aura of Infected Caress */;

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/Caster/45956 Seasoned Explorer Nether Staff.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/Caster/45956 Seasoned Explorer Nether Staff.sql
@@ -38,7 +38,7 @@ VALUES (45956,   5,  -0.025) /* ManaRate */
      , (45956,  39,     0.6) /* DefaultScale */
      , (45956, 144,    0.08) /* ManaConversionMod */
      , (45956, 147,       1) /* CriticalFrequency */
-     , (45956, 152,    1.17) /* ElementalDamageMod */;
+     , (45956, 152,    1.10) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (45956,   1, 'Seasoned Explorer Nether Staff') /* Name */;

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70211 Seasoned Explorer Knife.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70211 Seasoned Explorer Knife.sql
@@ -23,6 +23,7 @@ VALUES (70211,   1,          1) /* ItemType - MeleeWeapon */
      , (70211, 107,        400) /* ItemCurMana */
      , (70211, 108,        400) /* ItemMaxMana */
      , (70211, 109,        100) /* ItemDifficulty */
+     , (70211, 114,          1) /* Attuned - Attuned */
      , (70211, 150,        103) /* HookPlacement - Hook */
      , (70211, 151,          2) /* HookType - Wall */
      , (70211, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70211 Seasoned Explorer Knife.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70211 Seasoned Explorer Knife.sql
@@ -34,7 +34,8 @@ VALUES (70211,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70211,  22, True ) /* Inscribable */
-     , (70211,  69, False) /* IsSellable */;
+     , (70211,  69, False) /* IsSellable */
+     , (70211,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70211,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70215 Seasoned Explorer Budiaq.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70215 Seasoned Explorer Budiaq.sql
@@ -23,6 +23,7 @@ VALUES (70215,   1,          1) /* ItemType - MeleeWeapon */
      , (70215, 107,        400) /* ItemCurMana */
      , (70215, 108,        400) /* ItemMaxMana */
      , (70215, 109,        100) /* ItemDifficulty */
+     , (70215, 114,          1) /* Attuned - Attuned */
      , (70215, 150,        103) /* HookPlacement - Hook */
      , (70215, 151,          2) /* HookType - Wall */
      , (70215, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70215 Seasoned Explorer Budiaq.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70215 Seasoned Explorer Budiaq.sql
@@ -34,7 +34,8 @@ VALUES (70215,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70215,  22, True ) /* Inscribable */
-     , (70215,  69, False) /* IsSellable */;
+     , (70215,  69, False) /* IsSellable */
+     , (70215,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70215,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70217 Seasoned Explorer Bastone.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70217 Seasoned Explorer Bastone.sql
@@ -34,7 +34,8 @@ VALUES (70217,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70217,  22, True ) /* Inscribable */
-     , (70217,  69, False) /* IsSellable */;
+     , (70217,  69, False) /* IsSellable */
+     , (70217,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70217,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70217 Seasoned Explorer Bastone.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70217 Seasoned Explorer Bastone.sql
@@ -23,6 +23,7 @@ VALUES (70217,   1,          1) /* ItemType - MeleeWeapon */
      , (70217, 107,        400) /* ItemCurMana */
      , (70217, 108,        400) /* ItemMaxMana */
      , (70217, 109,        100) /* ItemDifficulty */
+     , (70217, 114,          1) /* Attuned - Attuned */
      , (70217, 150,        103) /* HookPlacement - Hook */
      , (70217, 151,          2) /* HookType - Wall */
      , (70217, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70219 Seasoned Explorer Simi.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70219 Seasoned Explorer Simi.sql
@@ -23,6 +23,7 @@ VALUES (70219,   1,          1) /* ItemType - MeleeWeapon */
      , (70219, 107,        400) /* ItemCurMana */
      , (70219, 108,        400) /* ItemMaxMana */
      , (70219, 109,        100) /* ItemDifficulty */
+     , (70219, 114,          1) /* Attuned - Attuned */
      , (70219, 150,        103) /* HookPlacement - Hook */
      , (70219, 151,          2) /* HookType - Wall */
      , (70219, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70219 Seasoned Explorer Simi.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70219 Seasoned Explorer Simi.sql
@@ -34,7 +34,8 @@ VALUES (70219,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70219,  22, True ) /* Inscribable */
-     , (70219,  69, False) /* IsSellable */;
+     , (70219,  69, False) /* IsSellable */
+     , (70219,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70219,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70221 Seasoned Explorer Nekode.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70221 Seasoned Explorer Nekode.sql
@@ -34,7 +34,8 @@ VALUES (70221,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70221,  22, True ) /* Inscribable */
-     , (70221,  69, False) /* IsSellable */;
+     , (70221,  69, False) /* IsSellable */
+     , (70221,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70221,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70221 Seasoned Explorer Nekode.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70221 Seasoned Explorer Nekode.sql
@@ -23,6 +23,7 @@ VALUES (70221,   1,          1) /* ItemType - MeleeWeapon */
      , (70221, 107,        400) /* ItemCurMana */
      , (70221, 108,        400) /* ItemMaxMana */
      , (70221, 109,        100) /* ItemDifficulty */
+     , (70221, 114,          1) /* Attuned - Attuned */
      , (70221, 150,        103) /* HookPlacement - Hook */
      , (70221, 151,          2) /* HookType - Wall */
      , (70221, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70223 Seasoned Explorer Claw.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70223 Seasoned Explorer Claw.sql
@@ -34,7 +34,8 @@ VALUES (70223,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70223,  22, True ) /* Inscribable */
-     , (70223,  69, False) /* IsSellable */;
+     , (70223,  69, False) /* IsSellable */
+     , (70223,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70223,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70223 Seasoned Explorer Claw.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70223 Seasoned Explorer Claw.sql
@@ -23,6 +23,7 @@ VALUES (70223,   1,          1) /* ItemType - MeleeWeapon */
      , (70223, 107,        400) /* ItemCurMana */
      , (70223, 108,        400) /* ItemMaxMana */
      , (70223, 109,        100) /* ItemDifficulty */
+     , (70223, 114,          1) /* Attuned - Attuned */
      , (70223, 150,        103) /* HookPlacement - Hook */
      , (70223, 151,          2) /* HookType - Wall */
      , (70223, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70225 Seasoned Explorer Quarter Staff.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70225 Seasoned Explorer Quarter Staff.sql
@@ -23,6 +23,7 @@ VALUES (70225,   1,          1) /* ItemType - MeleeWeapon */
      , (70225, 107,        400) /* ItemCurMana */
      , (70225, 108,        400) /* ItemMaxMana */
      , (70225, 109,        100) /* ItemDifficulty */
+     , (70225, 114,          1) /* Attuned - Attuned */
      , (70225, 150,        103) /* HookPlacement - Hook */
      , (70225, 151,          2) /* HookType - Wall */
      , (70225, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70225 Seasoned Explorer Quarter Staff.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70225 Seasoned Explorer Quarter Staff.sql
@@ -34,7 +34,8 @@ VALUES (70225,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70225,  22, True ) /* Inscribable */
-     , (70225,  69, False) /* IsSellable */;
+     , (70225,  69, False) /* IsSellable */
+     , (70225,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70225,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70227 Seasoned Explorer Dirk.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70227 Seasoned Explorer Dirk.sql
@@ -23,6 +23,7 @@ VALUES (70227,   1,          1) /* ItemType - MeleeWeapon */
      , (70227, 107,        400) /* ItemCurMana */
      , (70227, 108,        400) /* ItemMaxMana */
      , (70227, 109,        100) /* ItemDifficulty */
+     , (70227, 114,          1) /* Attuned - Attuned */
      , (70227, 150,        103) /* HookPlacement - Hook */
      , (70227, 151,          2) /* HookType - Wall */
      , (70227, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70227 Seasoned Explorer Dirk.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70227 Seasoned Explorer Dirk.sql
@@ -34,7 +34,8 @@ VALUES (70227,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70227,  22, True ) /* Inscribable */
-     , (70227,  69, False) /* IsSellable */;
+     , (70227,  69, False) /* IsSellable */
+     , (70227,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70227,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70229 Seasoned Explorer Hand Axe.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70229 Seasoned Explorer Hand Axe.sql
@@ -23,6 +23,7 @@ VALUES (70229,   1,          1) /* ItemType - MeleeWeapon */
      , (70229, 107,        400) /* ItemCurMana */
      , (70229, 108,        400) /* ItemMaxMana */
      , (70229, 109,        100) /* ItemDifficulty */
+     , (70229, 114,          1) /* Attuned - Attuned */
      , (70229, 150,        103) /* HookPlacement - Hook */
      , (70229, 151,          2) /* HookType - Wall */
      , (70229, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70229 Seasoned Explorer Hand Axe.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70229 Seasoned Explorer Hand Axe.sql
@@ -34,7 +34,8 @@ VALUES (70229,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70229,  22, True ) /* Inscribable */
-     , (70229,  69, False) /* IsSellable */;
+     , (70229,  69, False) /* IsSellable */
+     , (70229,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70229,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70231 Seasoned Explorer Trident.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70231 Seasoned Explorer Trident.sql
@@ -23,6 +23,7 @@ VALUES (70231,   1,          1) /* ItemType - MeleeWeapon */
      , (70231, 107,        400) /* ItemCurMana */
      , (70231, 108,        400) /* ItemMaxMana */
      , (70231, 109,        100) /* ItemDifficulty */
+     , (70231, 114,          1) /* Attuned - Attuned */
      , (70231, 150,        103) /* HookPlacement - Hook */
      , (70231, 151,          2) /* HookType - Wall */
      , (70231, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70231 Seasoned Explorer Trident.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70231 Seasoned Explorer Trident.sql
@@ -34,7 +34,8 @@ VALUES (70231,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70231,  22, True ) /* Inscribable */
-     , (70231,  69, False) /* IsSellable */;
+     , (70231,  69, False) /* IsSellable */
+     , (70231,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70231,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70233 Seasoned Explorer Stick.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70233 Seasoned Explorer Stick.sql
@@ -34,7 +34,8 @@ VALUES (70233,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70233,  22, True ) /* Inscribable */
-     , (70233,  69, False) /* IsSellable */;
+     , (70233,  69, False) /* IsSellable */
+     , (70233,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70233,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70233 Seasoned Explorer Stick.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70233 Seasoned Explorer Stick.sql
@@ -23,6 +23,7 @@ VALUES (70233,   1,          1) /* ItemType - MeleeWeapon */
      , (70233, 107,        400) /* ItemCurMana */
      , (70233, 108,        400) /* ItemMaxMana */
      , (70233, 109,        100) /* ItemDifficulty */
+     , (70233, 114,          1) /* Attuned - Attuned */
      , (70233, 150,        103) /* HookPlacement - Hook */
      , (70233, 151,          2) /* HookType - Wall */
      , (70233, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70235 Seasoned Explorer Ken.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70235 Seasoned Explorer Ken.sql
@@ -36,7 +36,8 @@ VALUES (70235,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70235,  22, True ) /* Inscribable */
-     , (70235,  69, False) /* IsSellable */;
+     , (70235,  69, False) /* IsSellable */
+     , (70235,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70235,   5,  -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70235 Seasoned Explorer Ken.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70235 Seasoned Explorer Ken.sql
@@ -25,6 +25,7 @@ VALUES (70235,   1,          1) /* ItemType - MeleeWeapon */
      , (70235, 107,        400) /* ItemCurMana */
      , (70235, 108,        400) /* ItemMaxMana */
      , (70235, 109,        100) /* ItemDifficulty */
+     , (70235, 114,          1) /* Attuned - Attuned */
      , (70235, 150,        103) /* HookPlacement - Hook */
      , (70235, 151,          2) /* HookType - Wall */
      , (70235, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70237 Seasoned Explorer Board with Nail.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70237 Seasoned Explorer Board with Nail.sql
@@ -23,6 +23,7 @@ VALUES (70237,   1,          1) /* ItemType - MeleeWeapon */
      , (70237, 107,        400) /* ItemCurMana */
      , (70237, 108,        400) /* ItemMaxMana */
      , (70237, 109,        100) /* ItemDifficulty */
+     , (70237, 114,          1) /* Attuned - Attuned */
      , (70237, 150,        103) /* HookPlacement - Hook */
      , (70237, 151,          2) /* HookType - Wall */
      , (70237, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70237 Seasoned Explorer Board with Nail.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70237 Seasoned Explorer Board with Nail.sql
@@ -34,7 +34,8 @@ VALUES (70237,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70237,  22, True ) /* Inscribable */
-     , (70237,  69, False) /* IsSellable */;
+     , (70237,  69, False) /* IsSellable */
+     , (70237,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70237,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70239 Seasoned Explorer Khanjar.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70239 Seasoned Explorer Khanjar.sql
@@ -23,6 +23,7 @@ VALUES (70239,   1,          1) /* ItemType - MeleeWeapon */
      , (70239, 107,        400) /* ItemCurMana */
      , (70239, 108,        400) /* ItemMaxMana */
      , (70239, 109,        100) /* ItemDifficulty */
+     , (70239, 114,          1) /* Attuned - Attuned */
      , (70239, 150,        103) /* HookPlacement - Hook */
      , (70239, 151,          2) /* HookType - Wall */
      , (70239, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70239 Seasoned Explorer Khanjar.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70239 Seasoned Explorer Khanjar.sql
@@ -34,7 +34,8 @@ VALUES (70239,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70239,  22, True ) /* Inscribable */
-     , (70239,  69, False) /* IsSellable */;
+     , (70239,  69, False) /* IsSellable */
+     , (70239,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70239,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70241 Seasoned Explorer Spiked Club.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70241 Seasoned Explorer Spiked Club.sql
@@ -34,7 +34,8 @@ VALUES (70241,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70241,  22, True ) /* Inscribable */
-     , (70241,  69, False) /* IsSellable */;
+     , (70241,  69, False) /* IsSellable */
+     , (70241,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70241,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70241 Seasoned Explorer Spiked Club.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70241 Seasoned Explorer Spiked Club.sql
@@ -23,6 +23,7 @@ VALUES (70241,   1,          1) /* ItemType - MeleeWeapon */
      , (70241, 107,        400) /* ItemCurMana */
      , (70241, 108,        400) /* ItemMaxMana */
      , (70241, 109,        100) /* ItemDifficulty */
+     , (70241, 114,          1) /* Attuned - Attuned */
      , (70241, 150,        103) /* HookPlacement - Hook */
      , (70241, 151,          2) /* HookType - Wall */
      , (70241, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70243 Seasoned Explorer Yari.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70243 Seasoned Explorer Yari.sql
@@ -34,7 +34,8 @@ VALUES (70243,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70243,  22, True ) /* Inscribable */
-     , (70243,  69, False) /* IsSellable */;
+     , (70243,  69, False) /* IsSellable */
+     , (70243,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70243,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70243 Seasoned Explorer Yari.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70243 Seasoned Explorer Yari.sql
@@ -23,6 +23,7 @@ VALUES (70243,   1,          1) /* ItemType - MeleeWeapon */
      , (70243, 107,        400) /* ItemCurMana */
      , (70243, 108,        400) /* ItemMaxMana */
      , (70243, 109,        100) /* ItemDifficulty */
+     , (70243, 114,          1) /* Attuned - Attuned */
      , (70243, 150,        103) /* HookPlacement - Hook */
      , (70243, 151,          2) /* HookType - Wall */
      , (70243, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70245 Seasoned Explorer Tungi.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70245 Seasoned Explorer Tungi.sql
@@ -23,6 +23,7 @@ VALUES (70245,   1,          1) /* ItemType - MeleeWeapon */
      , (70245, 107,        400) /* ItemCurMana */
      , (70245, 108,        400) /* ItemMaxMana */
      , (70245, 109,        100) /* ItemDifficulty */
+     , (70245, 114,          1) /* Attuned - Attuned */
      , (70245, 150,        103) /* HookPlacement - Hook */
      , (70245, 151,          2) /* HookType - Wall */
      , (70245, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70245 Seasoned Explorer Tungi.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70245 Seasoned Explorer Tungi.sql
@@ -34,7 +34,8 @@ VALUES (70245,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70245,  22, True ) /* Inscribable */
-     , (70245,  69, False) /* IsSellable */;
+     , (70245,  69, False) /* IsSellable */
+     , (70245,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70245,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70247 Seasoned Explorer Shamshir.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70247 Seasoned Explorer Shamshir.sql
@@ -23,6 +23,7 @@ VALUES (70247,   1,          1) /* ItemType - MeleeWeapon */
      , (70247, 107,        400) /* ItemCurMana */
      , (70247, 108,        400) /* ItemMaxMana */
      , (70247, 109,        100) /* ItemDifficulty */
+     , (70247, 114,          1) /* Attuned - Attuned */
      , (70247, 150,        103) /* HookPlacement - Hook */
      , (70247, 151,          2) /* HookType - Wall */
      , (70247, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70247 Seasoned Explorer Shamshir.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70247 Seasoned Explorer Shamshir.sql
@@ -34,7 +34,8 @@ VALUES (70247,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70247,  22, True ) /* Inscribable */
-     , (70247,  69, False) /* IsSellable */;
+     , (70247,  69, False) /* IsSellable */
+     , (70247,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70247,   5,  -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70249 Seasoned Explorer Katar.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70249 Seasoned Explorer Katar.sql
@@ -34,7 +34,8 @@ VALUES (70249,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70249,  22, True ) /* Inscribable */
-     , (70249,  69, False) /* IsSellable */;
+     , (70249,  69, False) /* IsSellable */
+     , (70249,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70249,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70249 Seasoned Explorer Katar.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70249 Seasoned Explorer Katar.sql
@@ -22,6 +22,7 @@ VALUES (70249,   1,          1) /* ItemType - MeleeWeapon */
      , (70249, 106,        250) /* ItemSpellcraft */
      , (70249, 107,        400) /* ItemCurMana */
      , (70249, 108,        400) /* ItemMaxMana */
+     , (70249, 114,          1) /* Attuned - Attuned */
      , (70249, 109,        100) /* ItemDifficulty */
      , (70249, 150,        103) /* HookPlacement - Hook */
      , (70249, 151,          2) /* HookType - Wall */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70251 Seasoned Explorer Morning Star.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70251 Seasoned Explorer Morning Star.sql
@@ -23,6 +23,7 @@ VALUES (70251,   1,          1) /* ItemType - MeleeWeapon */
      , (70251, 107,        400) /* ItemCurMana */
      , (70251, 108,        400) /* ItemMaxMana */
      , (70251, 109,        100) /* ItemDifficulty */
+     , (70251, 114,          1) /* Attuned - Attuned */
      , (70251, 150,        103) /* HookPlacement - Hook */
      , (70251, 151,          2) /* HookType - Wall */
      , (70251, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70251 Seasoned Explorer Morning Star.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70251 Seasoned Explorer Morning Star.sql
@@ -34,7 +34,8 @@ VALUES (70251,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70251,  22, True ) /* Inscribable */
-     , (70251,  69, False) /* IsSellable */;
+     , (70251,  69, False) /* IsSellable */
+     , (70251,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70251,   5, -0.025) /* ManaRate */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70253 Seasoned Explorer Greataxe.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70253 Seasoned Explorer Greataxe.sql
@@ -35,6 +35,7 @@ VALUES (70253,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70253,  22, True ) /* Inscribable */
+     , (70253,  69, False) /* IsSellable */
      , (70253,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70253 Seasoned Explorer Greataxe.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70253 Seasoned Explorer Greataxe.sql
@@ -23,6 +23,7 @@ VALUES (70253,   1,          1) /* ItemType - MeleeWeapon */
      , (70253, 107,        400) /* ItemCurMana */
      , (70253, 108,        400) /* ItemMaxMana */
      , (70253, 109,        100) /* ItemDifficulty */
+     , (70253, 114,          1) /* Attuned - Attuned */
      , (70253, 150,        103) /* HookPlacement - Hook */
      , (70253, 151,          2) /* HookType - Wall */
      , (70253, 158,          2) /* WieldRequirements - RawSkill */

--- a/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70254 Amateur Explorer Greataxe.sql
+++ b/Database/Patches/2010-08-TheRisenPrincess/9 WeenieDefaults/MeleeWeapon/70254 Amateur Explorer Greataxe.sql
@@ -34,7 +34,7 @@ VALUES (70254,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70254,  22, True ) /* Inscribable */
-     , (70254,  99, True ) /* Ivoryable */;
+     , (70254,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (70254,   5, -0.025) /* ManaRate */


### PR DESCRIPTION
- Fix ElementalDamageMod on Seasoned Explorer Nether Staff
- Add missing Attuned property to Seasoned Explorer melee weapons
