### PR TITLE
Add Tricks and Treats patch items

### DIFF
--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06972 Ursuin Body with One Arm.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06972 Ursuin Body with One Arm.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6972;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6972, 0, 0, 0, 0, 70276 /* Ursuin Body with One Arm */, 1, 'You combine the Ursuin Legs to the Ursuin Torso.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6972;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6972, 32171 /* Ursuin Legs */, 32174 /* Ursuin Torso */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06973 Ursuin Body with Two Arms.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06973 Ursuin Body with Two Arms.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6973;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6973, 0, 0, 0, 0, 32172 /* Ursuin Body with Two Arms */, 1, 'You combine the Ursuin Arm to the Ursuin Torso.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6973;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6973, 32170 /* Ursuin Arm */, 32174 /* Ursuin Torso */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06974 Ursuin Body.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06974 Ursuin Body.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6974;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6974, 0, 0, 0, 0, 32180 /* Ursuin Body */, 1, 'You combine the Ursuin Arm to the Ursuin Body with One Arm.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6974;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6974, 32170 /* Ursuin Arm */, 70276 /* Ursuin Body with One Arm */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06975 Ursuin Body.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06975 Ursuin Body.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6975;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6975, 0, 0, 0, 0, 32180 /* Ursuin Body */, 1, 'You combine the Ursuin Legs to the Ursuin Body with Two Arms.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6975;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6975, 32171 /* Ursuin Legs */, 32172 /* Ursuin Body with Two Arms */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06976 Uncooked Ginger Bread Pumpkin.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06976 Uncooked Ginger Bread Pumpkin.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6976;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6976, 0, 39 /* Cooking */, 50, 0, 70295 /* Uncooked Ginger Bread Pumpkin */, 1, 'You cut out an Uncooked Ginger Bread Pumpkin.', 0, 0, 'You failed to combine the ingrediants', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6976;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6976, 32201 /* Pumpkin Cookie Cutter */, 14783 /* Ginger Bread Dough */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06977 Ginger Bread Pumpkin.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06977 Ginger Bread Pumpkin.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6977;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6977, 0, 39 /* Cooking */, 50, 0, 32210 /* Ginger Bread Pumpkin */, 1, 'You bake a perfect Ginger Bread Pumpkin.', 0, 0, 'You failed to combine the ingrediants', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6977;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6977, 4754 /* Baking Pan */, 70295 /* Uncooked Ginger Bread Pumpkin */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06978 Gem of Arcane Corruption.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06978 Gem of Arcane Corruption.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6978;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6978, 0, 0, 0, 0, 70313, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s corrupted essence.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6978;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6978, 32255 /* Gem of Arcane Corruption */, 29545 /* Noble Sollerets */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06979 Gem of Arcane Corruption.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06979 Gem of Arcane Corruption.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6979;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6979, 0, 0, 0, 0, 70315, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s corrupted essence.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6979;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6979, 32255 /* Gem of Arcane Corruption */, 29535 /* Noble Leggings */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06980 Gem of Arcane Corruption.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06980 Gem of Arcane Corruption.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6980;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6980, 0, 0, 0, 0, 70317, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s corrupted essence.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6980;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6980, 32255 /* Gem of Arcane Corruption */, 29521 /* Noble Gauntlets */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06981 Gem of Arcane Corruption.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06981 Gem of Arcane Corruption.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6981;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6981, 0, 0, 0, 0, 70318, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s corrupted essence.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6981;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6981, 32255 /* Gem of Arcane Corruption */, 29528 /* Noble Helm */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06982 Gem of Arcane Corruption.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06982 Gem of Arcane Corruption.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6982;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6982, 0, 0, 0, 0, 70320, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s corrupted essence.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6982;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6982, 32255 /* Gem of Arcane Corruption */, 29514 /* Noble Coat */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06983 Gem of Ardent Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06983 Gem of Ardent Loyalty.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6983;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6983, 0, 0, 0, 0, 70314, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s loyalty.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6983;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6983, 32254 /* Gem of Ardent Loyalty */, 29545 /* Noble Sollerets */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06984 Gem of Ardent Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06984 Gem of Ardent Loyalty.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6984;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6984, 0, 0, 0, 0, 70316, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s loyalty.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6984;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6984, 32254 /* Gem of Ardent Loyalty */, 29535 /* Noble Leggings */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06985 Gem of Ardent Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06985 Gem of Ardent Loyalty.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6985;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6985, 0, 0, 0, 0, 32249, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s loyalty.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6985;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6985, 32254 /* Gem of Ardent Loyalty */, 29521 /* Noble Gauntlets */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06986 Gem of Ardent Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06986 Gem of Ardent Loyalty.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6986;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6986, 0, 0, 0, 0, 70319, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s loyalty.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6986;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6986, 32254 /* Gem of Ardent Loyalty */, 29528 /* Noble Helm */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06987 Gem of Ardent Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/4 CraftTable/06987 Gem of Ardent Loyalty.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 6987;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6987, 0, 0, 0, 0, 70321, 1, 'The gem slides into the socket and imbues the armor with a spell to increase the wearer''s loyalty.', 0, 0, '', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2019-09-18 18:58:12');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6987;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6987, 32254 /* Gem of Ardent Loyalty */, 29514 /* Noble Coat */, '2019-09-18 18:58:12');

--- a/Database/Patches/2005-10-TricksAndTreats/6 LandBlockExtendedData/A1A4.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/6 LandBlockExtendedData/A1A4.sql
@@ -1,0 +1,3 @@
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (2048540715, 80021, 2711879718, 114.9668, 138.9591, 50.005, -0.943635, 0, 0, -0.330988, False, '2019-08-07 06:01:09'); /* Festival Vendor Generator */
+/* @teleloc 0xA1A40026 [114.966812 138.959106 50.005001] -0.943635 0.000000 0.000000 -0.330988 */

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/32226 Mistress Gabille's Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/32226 Mistress Gabille's Notes.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32226;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32226, 'ace32226-mistressgabillesnotes', 8, '2019-09-09 14:38:55') /* Book */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32226,   1,       8192) /* ItemType - Writable */
+     , (32226,   5,          5) /* EncumbranceVal */
+     , (32226,  16,          8) /* ItemUseable - Contained */
+     , (32226,  19,          0) /* Value */
+     , (32226,  53,        101) /* PlacementPosition - Resting */
+     , (32226,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32226, 174,          2) /* AppraisalPages */
+     , (32226, 175,          2) /* AppraisalMaxPages */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32226,  11, True ) /* IgnoreCollisions */
+     , (32226,  13, True ) /* Ethereal */
+     , (32226,  14, True ) /* GravityStatus */
+     , (32226,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32226,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32226,   1, 'Mistress Gabille''s Notes') /* Name */
+     , (32226,  15, 'The translated notes of the Viamontian Explorer, Mistress Gabille.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32226,   1,   33554773) /* Setup */
+     , (32226,   3,  536870932) /* SoundTable */
+     , (32226,   8,  100668176) /* Icon */
+     , (32226,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
+VALUES (32226, 0, 0);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (32226, 0, 4294967295, 'Mistress Gabille', '', False, 'I encountered a Mukkir today. We broke through the tunnels into the remains of a Falatacot installation, one that the Mukkir had taken over for their own purposes. Most fled before us, but we managed to run one to ground in a dead-ended tunnel. One of our Eaters had managed to bite off one of its legs. With its movement hampered, it was easy for the following Knights in my service to bring it to bay and pin it down. The spectacle reminded me of my training in the Royal Conservatory in Corcosa, pinning still-living insects to a sampling board. Of course, those creatures never squealed the way that this Mukkir did when I subjected it to the battery of tests...')
+     , (32226, 1, 4294967295, 'Mistress Gabille', '', False, 'These Mukkir are magic-touched. Like the Eaters and our own augmented Knights, these things did not come about by any natural means. I can practically smell the magical energy washing off it. It is also clear to me that this beast has little physically in common with the gladiator described in the Grael Rebellion text. Yet, the Song of Grael names the gladiator as "a spear of the Mukkir." Hopefully my colleagues have had more success reconciling this inconsistency.');

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/32229 Master Vaserio's Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/32229 Master Vaserio's Notes.sql
@@ -1,0 +1,41 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32229;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32229, 'ace32229-mastervaseriosnotes', 8, '2019-09-09 14:38:55') /* Book */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32229,   1,       8192) /* ItemType - Writable */
+     , (32229,   5,          5) /* EncumbranceVal */
+     , (32229,  16,          8) /* ItemUseable - Contained */
+     , (32229,  19,          0) /* Value */
+     , (32229,  53,        101) /* PlacementPosition - Resting */
+     , (32229,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32229, 174,          3) /* AppraisalPages */
+     , (32229, 175,          3) /* AppraisalMaxPages */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32229,  11, True ) /* IgnoreCollisions */
+     , (32229,  13, True ) /* Ethereal */
+     , (32229,  14, True ) /* GravityStatus */
+     , (32229,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32229,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32229,   1, 'Master Vaserio''s Notes') /* Name */
+     , (32229,  15, 'The translated notes of the Viamontian explorer, Master Vaserio.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32229,   1,   33554773) /* Setup */
+     , (32229,   3,  536870932) /* SoundTable */
+     , (32229,   8,  100668176) /* Icon */
+     , (32229,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
+VALUES (32229, 0, 0);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (32229, 0, 4294967295, 'Master Vaserio', '', True, 'After a long and seemingly fruitless dig, we finally managed to locate the underground Falatacot compound that our sources had told us we would find. The dark tunnels of the Falatacot were infested with Mukkir, most of which we managed to capture or slay. They provided me with enough living and dead test subjects to make significant strides in my appointed investigation.')
+     , (32229, 1, 4294967295, 'Master Vaserio', '', True, 'Would that I had a lifetime to research the wonder of these Mukkir. It is clear from the physical studies I have conducted upon them that they are certainly not the same creature as was described in the Grael Rebellion. Some great magical power intervened in the creation of these beasts. At first, I was unable to divine the nature of their magical augmentation. But a final clue was provided by a very brief encounter with one very strange Mukkir. It had the upper body of the Mukkir we have seen, but its lower body was shadow and mist - like the very powerful "Shadows" that haunt the lands of the Bloodless.')
+     , (32229, 2, 4294967295, 'Master Vaserio', '', True, 'It seems, then, that the "Living Shadow" that has seen mention in Falatacot texts is the link between a primitive humanoid gladiator and these spider-like creatures we know as Mukkir. The infusion of Shadow magic would also explain the variety of magical and elemental attacks employed by these Mukkir. The more I learn of this power borne of darkness, the more apprehensive I become. I will caution our King to tread cautiously as he further investigates the mysteries and powers of Grael.');

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/70272 Mistress Halmera's Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/70272 Mistress Halmera's Notes.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70272;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70272, 'ace70272-mistresshalmerasnotes', 8, '2019-09-09 14:38:55') /* Book */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70272,   1,       8192) /* ItemType - Writable */
+     , (70272,   5,          5) /* EncumbranceVal */
+     , (70272,  16,          8) /* ItemUseable - Contained */
+     , (70272,  19,          0) /* Value */
+     , (70272,  53,        101) /* PlacementPosition - Resting */
+     , (70272,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70272, 174,          2) /* AppraisalPages */
+     , (70272, 175,          2) /* AppraisalMaxPages */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70272,  11, True ) /* IgnoreCollisions */
+     , (70272,  13, True ) /* Ethereal */
+     , (70272,  14, True ) /* GravityStatus */
+     , (70272,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70272,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70272,   1, 'Mistress Halmera''s Notes') /* Name */
+     , (70272,  15, 'The translated notes of the Viamontian Explorer, Mistress Halmera.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70272,   1,   33554773) /* Setup */
+     , (70272,   3,  536870932) /* SoundTable */
+     , (70272,   8,  100668176) /* Icon */
+     , (70272,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
+VALUES (70272, 0, 0);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (70272, 0, 4294967295, 'Mistress Halmera', '', False, 'My search team has uncovered limited evidence of the Mukkir. A group of our Eaters fell upon one isolated Mukkir and overwhelmed it. From the wounds inflicted upon our hunting beasts, the Mukkir are quite vicious and capable fighters. All the same, the unfortunate and isolated creature was overwhelmed by the gnashing teeth of three enraged Eaters. Sadly, our beasts of hunting devoured most of the Mukkir''s carcass before one of my Knights could call them off. All that is left are hunks of torn meat and shards of chewed carapace.')
+     , (70272, 1, 4294967295, 'Mistress Halmera', '', False, 'The pieces of carapace are our primary subject of research at the moment. We have conducted some rudimentary tests and found that the Mukkir chitin is highly resistant to most forms of damage. It turns the slash of a sword and is flexible enough to hold up to the blow of a hammer. A properly aimed spear thrust, however, seems to be the most consistently effective attack. I have not, as yet, been able to find the time to test elemental damage types against Mukkir chitin.');

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/70274 Master Alizari's Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Book/70274 Master Alizari's Notes.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70274;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70274, 'ace70274-masteralizarisnotes', 8, '2019-09-09 14:38:55') /* Book */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70274,   1,       8192) /* ItemType - Writable */
+     , (70274,   5,          5) /* EncumbranceVal */
+     , (70274,  16,          8) /* ItemUseable - Contained */
+     , (70274,  19,          0) /* Value */
+     , (70274,  53,        101) /* PlacementPosition - Resting */
+     , (70274,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70274, 174,          2) /* AppraisalPages */
+     , (70274, 175,          2) /* AppraisalMaxPages */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70274,  11, True ) /* IgnoreCollisions */
+     , (70274,  13, True ) /* Ethereal */
+     , (70274,  14, True ) /* GravityStatus */
+     , (70274,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70274,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70274,   1, 'Master Alizari''s Notes') /* Name */
+     , (70274,  15, 'The translated notes of the Viamontian Explorer, Master Alizari.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70274,   1,   33554773) /* Setup */
+     , (70274,   3,  536870932) /* SoundTable */
+     , (70274,   8,  100668176) /* Icon */
+     , (70274,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
+VALUES (70274, 0, 0);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (70274, 0, 4294967295, 'Master Alizari', '', True, 'Despite the best efforts of skilled scouts and diviners, these "Mukkir" are difficult creatures to track down. We have had only limited contact with them, and those encounters have been fleeting and inconclusive. They are clever enough to avoid large parties, and dangerous enough to overwhelm our Knights and Eaters when they are out alone or in pairs. We came upon the corpse of one Eater that was perforated with multiple stab wounds and scorched with acid. Great hunks of soft, putrefied flesh were missing from the carcass - these Mukkir are the only creature we have encountered in this whole strange world that seem willing to eat the flesh of our hunting beasts.')
+     , (70274, 1, 4294967295, 'Master Alizari', '', True, 'We have found no evidence of advanced tool use with these Mukkir. I suppose it is a blessing that they employ no weapons in their fighting style, though it seems their natural weapons of claw, mandible, and acid breath are dangerous enough. Of course, I have not seen enough of the creatures to be able to say that we have seen the limit of their power.');

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32260 Plain Mukkir Orb.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32260 Plain Mukkir Orb.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32260;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32260, 'ace32260-plainmukkirorb', 35, '2019-09-14 16:53:08') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32260,   1,      32768) /* ItemType - Caster */
+     , (32260,   5,        100) /* EncumbranceVal */
+     , (32260,   9,   16777216) /* ValidLocations - Held */
+     , (32260,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (32260,  18,          1) /* UiEffects - Magical */
+     , (32260,  19,       1500) /* Value */
+     , (32260,  53,        101) /* PlacementPosition - Resting */
+     , (32260,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32260,  94,         16) /* TargetType - Creature */
+     , (32260, 106,        150) /* ItemSpellcraft */
+     , (32260, 107,       1000) /* ItemCurMana */
+     , (32260, 108,       1000) /* ItemMaxMana */
+     , (32260, 109,          0) /* ItemDifficulty */
+     , (32260, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32260,  11, True ) /* IgnoreCollisions */
+     , (32260,  13, True ) /* Ethereal */
+     , (32260,  14, True ) /* GravityStatus */
+     , (32260,  19, True ) /* Attackable */
+     , (32260,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32260,   5, -0.0333333015441895) /* ManaRate */
+     , (32260,  29,       1) /* WeaponDefense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32260,   1, 'Plain Mukkir Orb') /* Name */
+     , (32260,  16, 'A casting device fancifully crafted in the shape of a Mukkir''s head.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32260,   1,   33559761) /* Setup */
+     , (32260,   3,  536870932) /* SoundTable */
+     , (32260,   8,  100688412) /* Icon */
+     , (32260,  22,  872415275) /* PhysicsEffectTable */
+     , (32260,  28,       3861) /* Spell - Taste for Blood */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (32260,   681,      2)  /* Arcane Enlightenment Self IV */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32261 Solid Mukkir Orb.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32261 Solid Mukkir Orb.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32261;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32261, 'ace32261-solidmukkirorb', 35, '2019-09-14 16:53:08') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32261,   1,      32768) /* ItemType - Caster */
+     , (32261,   5,        100) /* EncumbranceVal */
+     , (32261,   9,   16777216) /* ValidLocations - Held */
+     , (32261,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (32261,  18,          1) /* UiEffects - Magical */
+     , (32261,  19,       2000) /* Value */
+     , (32261,  52,          1) /* ParentLocation - RightHand */
+     , (32261,  53,          1) /* PlacementPosition - RightHandCombat */
+     , (32261,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32261,  94,         16) /* TargetType - Creature */
+     , (32261, 106,        200) /* ItemSpellcraft */
+     , (32261, 107,       1200) /* ItemCurMana */
+     , (32261, 108,       1200) /* ItemMaxMana */
+     , (32261, 109,          0) /* ItemDifficulty */
+     , (32261, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32261,  11, True ) /* IgnoreCollisions */
+     , (32261,  13, True ) /* Ethereal */
+     , (32261,  14, True ) /* GravityStatus */
+     , (32261,  19, True ) /* Attackable */
+     , (32261,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32261,   5, -0.0333333015441895) /* ManaRate */
+     , (32261,  29,       1) /* WeaponDefense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32261,   1, 'Solid Mukkir Orb') /* Name */
+     , (32261,  16, 'A casting device fancifully crafted in the shape of a Mukkir''s head.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32261,   1,   33559761) /* Setup */
+     , (32261,   3,  536870932) /* SoundTable */
+     , (32261,   6,   67111919) /* PaletteBase */
+     , (32261,   8,  100688412) /* Icon */
+     , (32261,  22,  872415275) /* PhysicsEffectTable */
+     , (32261,  28,       3861) /* Spell - Taste for Blood */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (32261,   682,      2)  /* Arcane Enlightenment Self V */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32262 Detailed Mukkir Orb.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32262 Detailed Mukkir Orb.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32262;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32262, 'ace32262-detailedmukkirorb', 35, '2019-09-14 16:53:08') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32262,   1,      32768) /* ItemType - Caster */
+     , (32262,   5,        100) /* EncumbranceVal */
+     , (32262,   9,   16777216) /* ValidLocations - Held */
+     , (32262,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (32262,  18,          1) /* UiEffects - Magical */
+     , (32262,  19,       2500) /* Value */
+     , (32262,  53,        101) /* PlacementPosition - Resting */
+     , (32262,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32262,  94,         16) /* TargetType - Creature */
+     , (32262, 106,        250) /* ItemSpellcraft */
+     , (32262, 107,       1500) /* ItemCurMana */
+     , (32262, 108,       1500) /* ItemMaxMana */
+     , (32262, 109,          0) /* ItemDifficulty */
+     , (32262, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32262,  11, True ) /* IgnoreCollisions */
+     , (32262,  13, True ) /* Ethereal */
+     , (32262,  14, True ) /* GravityStatus */
+     , (32262,  19, True ) /* Attackable */
+     , (32262,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32262,   5, -0.0500000007450581) /* ManaRate */
+     , (32262,  29,       1) /* WeaponDefense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32262,   1, 'Detailed Mukkir Orb') /* Name */
+     , (32262,  16, 'A casting device fancifully crafted in the shape of a Mukkir''s head.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32262,   1,   33559761) /* Setup */
+     , (32262,   3,  536870932) /* SoundTable */
+     , (32262,   8,  100688412) /* Icon */
+     , (32262,  22,  872415275) /* PhysicsEffectTable */
+     , (32262,  28,       3861) /* Spell - Taste for Blood */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (32262,   683,      2)  /* Arcane Enlightenment Self VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32263 Intricate Mukkir Orb.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Caster/32263 Intricate Mukkir Orb.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32263;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32263, 'ace32263-intricatemukkirorb', 35, '2019-09-14 16:53:08') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32263,   1,      32768) /* ItemType - Caster */
+     , (32263,   5,        100) /* EncumbranceVal */
+     , (32263,   9,   16777216) /* ValidLocations - Held */
+     , (32263,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (32263,  18,          1) /* UiEffects - Magical */
+     , (32263,  19,       3000) /* Value */
+     , (32263,  53,        101) /* PlacementPosition - Resting */
+     , (32263,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32263,  94,         16) /* TargetType - Creature */
+     , (32263, 106,        300) /* ItemSpellcraft */
+     , (32263, 107,       1800) /* ItemCurMana */
+     , (32263, 108,       1800) /* ItemMaxMana */
+     , (32263, 109,          0) /* ItemDifficulty */
+     , (32263, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32263,  11, True ) /* IgnoreCollisions */
+     , (32263,  13, True ) /* Ethereal */
+     , (32263,  14, True ) /* GravityStatus */
+     , (32263,  19, True ) /* Attackable */
+     , (32263,  22, True ) /* Inscribable */
+     , (32263,  69, True ) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32263,   5, -0.0500000007450581) /* ManaRate */
+     , (32263,  29,       1) /* WeaponDefense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32263,   1, 'Intricate Mukkir Orb') /* Name */
+     , (32263,  16, 'A casting device fancifully crafted in the shape of a Mukkir''s head.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32263,   1,   33559761) /* Setup */
+     , (32263,   3,  536870932) /* SoundTable */
+     , (32263,   6,   67111919) /* PaletteBase */
+     , (32263,   8,  100688412) /* Icon */
+     , (32263,  22,  872415275) /* PhysicsEffectTable */
+     , (32263,  28,       3861) /* Spell - Taste for Blood */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (32263,  2195,      2)  /* Aliester's Blessing */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29514 Noble Coat.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29514 Noble Coat.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29514;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29514, 'coatnoble', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29514,   1,          2) /* ItemType - Armor */
+     , (29514,   3,         21) /* PaletteTemplate - Gold */
+     , (29514,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29514,   5,       1250) /* EncumbranceVal */
+     , (29514,   8,       1250) /* Mass */
+     , (29514,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29514,  16,          1) /* ItemUseable - No */
+     , (29514,  19,       8000) /* Value */
+     , (29514,  27,          2) /* ArmorType - Leather */
+     , (29514,  28,        400) /* ArmorLevel */
+     , (29514,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29514, 106,        400) /* ItemSpellcraft */
+     , (29514, 107,        800) /* ItemCurMana */
+     , (29514, 108,        800) /* ItemMaxMana */
+     , (29514, 109,        200) /* ItemDifficulty */
+     , (29514, 150,        103) /* HookPlacement - Hook */
+     , (29514, 151,          2) /* HookType - Wall */
+     , (29514, 158,          7) /* WieldRequirements - Level */
+     , (29514, 159,          1) /* WieldSkillType - Axe */
+     , (29514, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29514,  22, True ) /* Inscribable */
+     , (29514, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29514,   5, -0.0165999997407198) /* ManaRate */
+     , (29514,  12, 0.660000026226044) /* Shade */
+     , (29514,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29514,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29514,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29514,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29514,  17,       1) /* ArmorModVsFire */
+     , (29514,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29514,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29514, 110,       1) /* BulkMod */
+     , (29514, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29514,   1, 'Noble Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29514,   1,   33554642) /* Setup */
+     , (29514,   3,  536870932) /* SoundTable */
+     , (29514,   6,   67108990) /* PaletteBase */
+     , (29514,   7,  268436877) /* ClothingBase */
+     , (29514,   8,  100675042) /* Icon */
+     , (29514,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29514,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29514,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29514,  2108,      2)  /* Brogard's Defiance */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29515 Noble Coat of Balance.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29515 Noble Coat of Balance.sql
@@ -1,0 +1,60 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29515;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29515, 'coatnoblecoordination', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29515,   1,          2) /* ItemType - Armor */
+     , (29515,   3,         21) /* PaletteTemplate - Gold */
+     , (29515,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29515,   5,       1250) /* EncumbranceVal */
+     , (29515,   8,       1250) /* Mass */
+     , (29515,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29515,  16,          1) /* ItemUseable - No */
+     , (29515,  19,       8000) /* Value */
+     , (29515,  27,          2) /* ArmorType - Leather */
+     , (29515,  28,        400) /* ArmorLevel */
+     , (29515,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29515, 106,        400) /* ItemSpellcraft */
+     , (29515, 107,        800) /* ItemCurMana */
+     , (29515, 108,        800) /* ItemMaxMana */
+     , (29515, 109,        200) /* ItemDifficulty */
+     , (29515, 150,        103) /* HookPlacement - Hook */
+     , (29515, 151,          2) /* HookType - Wall */
+     , (29515, 158,          7) /* WieldRequirements - Level */
+     , (29515, 159,          1) /* WieldSkillType - Axe */
+     , (29515, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29515,  22, True ) /* Inscribable */
+     , (29515, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29515,   5, -0.0165999997407198) /* ManaRate */
+     , (29515,  12, 0.660000026226044) /* Shade */
+     , (29515,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29515,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29515,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29515,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29515,  17,       1) /* ArmorModVsFire */
+     , (29515,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29515,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29515, 110,       1) /* BulkMod */
+     , (29515, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29515,   1, 'Noble Coat of Balance') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29515,   1,   33554642) /* Setup */
+     , (29515,   3,  536870932) /* SoundTable */
+     , (29515,   6,   67108990) /* PaletteBase */
+     , (29515,   7,  268436877) /* ClothingBase */
+     , (29515,   8,  100675042) /* Icon */
+     , (29515,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29515,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29515,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29515,  2108,      2)  /* Brogard's Defiance */
+     , (29515,  3575,      2)  /* Perfect Balance */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29516 Noble Coat of Health.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29516 Noble Coat of Health.sql
@@ -1,0 +1,66 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29516;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29516, 'coatnobleendurance', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29516,   1,          2) /* ItemType - Armor */
+     , (29516,   3,         21) /* PaletteTemplate - Gold */
+     , (29516,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29516,   5,       1250) /* EncumbranceVal */
+     , (29516,   8,       1250) /* Mass */
+     , (29516,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29516,  16,          1) /* ItemUseable - No */
+     , (29516,  19,       8000) /* Value */
+     , (29516,  27,          2) /* ArmorType - Leather */
+     , (29516,  28,        400) /* ArmorLevel */
+     , (29516,  53,        101) /* PlacementPosition - Resting */
+     , (29516,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29516, 106,        400) /* ItemSpellcraft */
+     , (29516, 107,        800) /* ItemCurMana */
+     , (29516, 108,        800) /* ItemMaxMana */
+     , (29516, 109,        200) /* ItemDifficulty */
+     , (29516, 150,        103) /* HookPlacement - Hook */
+     , (29516, 151,          2) /* HookType - Wall */
+     , (29516, 158,          7) /* WieldRequirements - Level */
+     , (29516, 159,          1) /* WieldSkillType - Axe */
+     , (29516, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29516,  11, True ) /* IgnoreCollisions */
+     , (29516,  13, True ) /* Ethereal */
+     , (29516,  14, True ) /* GravityStatus */
+     , (29516,  19, True ) /* Attackable */
+     , (29516,  22, True ) /* Inscribable */
+     , (29516, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29516,   5, -0.0165999997407198) /* ManaRate */
+     , (29516,  12, 0.660000026226044) /* Shade */
+     , (29516,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29516,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29516,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29516,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29516,  17,       1) /* ArmorModVsFire */
+     , (29516,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29516,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29516, 110,       1) /* BulkMod */
+     , (29516, 111,       1) /* SizeMod */
+     , (29516, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29516,   1, 'Noble Coat of Health') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29516,   1,   33554642) /* Setup */
+     , (29516,   3,  536870932) /* SoundTable */
+     , (29516,   6,   67108990) /* PaletteBase */
+     , (29516,   7,  268436877) /* ClothingBase */
+     , (29516,   8,  100675042) /* Icon */
+     , (29516,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29516,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29516,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29516,  2108,      2)  /* Brogard's Defiance */
+     , (29516,  3576,      2)  /* Perfect Health */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29517 Noble Coat of Brilliance.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29517 Noble Coat of Brilliance.sql
@@ -1,0 +1,60 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29517;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29517, 'coatnoblefocus', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29517,   1,          2) /* ItemType - Armor */
+     , (29517,   3,         21) /* PaletteTemplate - Gold */
+     , (29517,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29517,   5,       1250) /* EncumbranceVal */
+     , (29517,   8,       1250) /* Mass */
+     , (29517,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29517,  16,          1) /* ItemUseable - No */
+     , (29517,  19,       8000) /* Value */
+     , (29517,  27,          2) /* ArmorType - Leather */
+     , (29517,  28,        400) /* ArmorLevel */
+     , (29517,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29517, 106,        400) /* ItemSpellcraft */
+     , (29517, 107,        800) /* ItemCurMana */
+     , (29517, 108,        800) /* ItemMaxMana */
+     , (29517, 109,        200) /* ItemDifficulty */
+     , (29517, 150,        103) /* HookPlacement - Hook */
+     , (29517, 151,          2) /* HookType - Wall */
+     , (29517, 158,          7) /* WieldRequirements - Level */
+     , (29517, 159,          1) /* WieldSkillType - Axe */
+     , (29517, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29517,  22, True ) /* Inscribable */
+     , (29517, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29517,   5, -0.0165999997407198) /* ManaRate */
+     , (29517,  12, 0.660000026226044) /* Shade */
+     , (29517,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29517,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29517,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29517,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29517,  17,       1) /* ArmorModVsFire */
+     , (29517,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29517,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29517, 110,       1) /* BulkMod */
+     , (29517, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29517,   1, 'Noble Coat of Brilliance') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29517,   1,   33554642) /* Setup */
+     , (29517,   3,  536870932) /* SoundTable */
+     , (29517,   6,   67108990) /* PaletteBase */
+     , (29517,   7,  268436877) /* ClothingBase */
+     , (29517,   8,  100675042) /* Icon */
+     , (29517,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29517,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29517,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29517,  2108,      2)  /* Brogard's Defiance */
+     , (29517,  3572,      2)  /* Inner Brilliance */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29518 Noble Coat of Speed.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29518 Noble Coat of Speed.sql
@@ -1,0 +1,60 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29518;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29518, 'coatnoblequickness', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29518,   1,          2) /* ItemType - Armor */
+     , (29518,   3,         21) /* PaletteTemplate - Gold */
+     , (29518,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29518,   5,       1250) /* EncumbranceVal */
+     , (29518,   8,       1250) /* Mass */
+     , (29518,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29518,  16,          1) /* ItemUseable - No */
+     , (29518,  19,       8000) /* Value */
+     , (29518,  27,          2) /* ArmorType - Leather */
+     , (29518,  28,        400) /* ArmorLevel */
+     , (29518,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29518, 106,        400) /* ItemSpellcraft */
+     , (29518, 107,        800) /* ItemCurMana */
+     , (29518, 108,        800) /* ItemMaxMana */
+     , (29518, 109,        200) /* ItemDifficulty */
+     , (29518, 150,        103) /* HookPlacement - Hook */
+     , (29518, 151,          2) /* HookType - Wall */
+     , (29518, 158,          7) /* WieldRequirements - Level */
+     , (29518, 159,          1) /* WieldSkillType - Axe */
+     , (29518, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29518,  22, True ) /* Inscribable */
+     , (29518, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29518,   5, -0.0165999997407198) /* ManaRate */
+     , (29518,  12, 0.660000026226044) /* Shade */
+     , (29518,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29518,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29518,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29518,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29518,  17,       1) /* ArmorModVsFire */
+     , (29518,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29518,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29518, 110,       1) /* BulkMod */
+     , (29518, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29518,   1, 'Noble Coat of Speed') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29518,   1,   33554642) /* Setup */
+     , (29518,   3,  536870932) /* SoundTable */
+     , (29518,   6,   67108990) /* PaletteBase */
+     , (29518,   7,  268436877) /* ClothingBase */
+     , (29518,   8,  100675042) /* Icon */
+     , (29518,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29518,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29518,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29518,  2108,      2)  /* Brogard's Defiance */
+     , (29518,  3577,      2)  /* Perfect Speed */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29519 Noble Coat of Will.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29519 Noble Coat of Will.sql
@@ -1,0 +1,65 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29519;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29519, 'coatnobleself', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29519,   1,          2) /* ItemType - Armor */
+     , (29519,   3,         21) /* PaletteTemplate - Gold */
+     , (29519,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29519,   5,       1250) /* EncumbranceVal */
+     , (29519,   8,       1250) /* Mass */
+     , (29519,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29519,  16,          1) /* ItemUseable - No */
+     , (29519,  19,       8000) /* Value */
+     , (29519,  27,          2) /* ArmorType - Leather */
+     , (29519,  28,        400) /* ArmorLevel */
+     , (29519,  53,        101) /* PlacementPosition - Resting */
+     , (29519,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29519, 106,        400) /* ItemSpellcraft */
+     , (29519, 107,        800) /* ItemCurMana */
+     , (29519, 108,        800) /* ItemMaxMana */
+     , (29519, 109,        200) /* ItemDifficulty */
+     , (29519, 150,        103) /* HookPlacement - Hook */
+     , (29519, 151,          2) /* HookType - Wall */
+     , (29519, 158,          7) /* WieldRequirements - Level */
+     , (29519, 159,          1) /* WieldSkillType - Axe */
+     , (29519, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29519,  11, True ) /* IgnoreCollisions */
+     , (29519,  13, True ) /* Ethereal */
+     , (29519,  14, True ) /* GravityStatus */
+     , (29519,  19, True ) /* Attackable */
+     , (29519,  22, True ) /* Inscribable */
+     , (29519, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29519,   5, -0.0165999997407198) /* ManaRate */
+     , (29519,  12, 0.660000026226044) /* Shade */
+     , (29519,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29519,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29519,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29519,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29519,  17,       1) /* ArmorModVsFire */
+     , (29519,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29519,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29519, 110,       1) /* BulkMod */
+     , (29519, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29519,   1, 'Noble Coat of Will') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29519,   1,   33554642) /* Setup */
+     , (29519,   3,  536870932) /* SoundTable */
+     , (29519,   6,   67108990) /* PaletteBase */
+     , (29519,   7,  268436877) /* ClothingBase */
+     , (29519,   8,  100675042) /* Icon */
+     , (29519,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29519,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29519,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29519,  2108,      2)  /* Brogard's Defiance */
+     , (29519,  3574,      2)  /* Inner Will */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29520 Noble Coat of Might.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29520 Noble Coat of Might.sql
@@ -1,0 +1,60 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29520;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29520, 'coatnoblestrength', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29520,   1,          2) /* ItemType - Armor */
+     , (29520,   3,         21) /* PaletteTemplate - Gold */
+     , (29520,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (29520,   5,       1250) /* EncumbranceVal */
+     , (29520,   8,       1250) /* Mass */
+     , (29520,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (29520,  16,          1) /* ItemUseable - No */
+     , (29520,  19,       8000) /* Value */
+     , (29520,  27,          2) /* ArmorType - Leather */
+     , (29520,  28,        400) /* ArmorLevel */
+     , (29520,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29520, 106,        400) /* ItemSpellcraft */
+     , (29520, 107,        800) /* ItemCurMana */
+     , (29520, 108,        800) /* ItemMaxMana */
+     , (29520, 109,        200) /* ItemDifficulty */
+     , (29520, 150,        103) /* HookPlacement - Hook */
+     , (29520, 151,          2) /* HookType - Wall */
+     , (29520, 158,          7) /* WieldRequirements - Level */
+     , (29520, 159,          1) /* WieldSkillType - Axe */
+     , (29520, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29520,  22, True ) /* Inscribable */
+     , (29520, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29520,   5, -0.0165999997407198) /* ManaRate */
+     , (29520,  12, 0.660000026226044) /* Shade */
+     , (29520,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29520,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29520,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29520,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29520,  17,       1) /* ArmorModVsFire */
+     , (29520,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29520,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29520, 110,       1) /* BulkMod */
+     , (29520, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29520,   1, 'Noble Coat of Might') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29520,   1,   33554642) /* Setup */
+     , (29520,   3,  536870932) /* SoundTable */
+     , (29520,   6,   67108990) /* PaletteBase */
+     , (29520,   7,  268436877) /* ClothingBase */
+     , (29520,   8,  100675042) /* Icon */
+     , (29520,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29520,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (29520,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (29520,  2108,      2)  /* Brogard's Defiance */
+     , (29520,  3573,      2)  /* Inner Might */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29521 Noble Gauntlets.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29521 Noble Gauntlets.sql
@@ -1,0 +1,60 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29521;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29521, 'gauntletsnoble', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29521,   1,          2) /* ItemType - Armor */
+     , (29521,   3,         21) /* PaletteTemplate - Gold */
+     , (29521,   4,      32768) /* ClothingPriority - Hands */
+     , (29521,   5,        150) /* EncumbranceVal */
+     , (29521,   8,        150) /* Mass */
+     , (29521,   9,         32) /* ValidLocations - HandWear */
+     , (29521,  16,          1) /* ItemUseable - No */
+     , (29521,  19,       8000) /* Value */
+     , (29521,  27,          2) /* ArmorType - Leather */
+     , (29521,  28,        400) /* ArmorLevel */
+     , (29521,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29521, 106,        400) /* ItemSpellcraft */
+     , (29521, 107,        800) /* ItemCurMana */
+     , (29521, 108,        800) /* ItemMaxMana */
+     , (29521, 109,        200) /* ItemDifficulty */
+     , (29521, 150,        103) /* HookPlacement - Hook */
+     , (29521, 151,          2) /* HookType - Wall */
+     , (29521, 158,          7) /* WieldRequirements - Level */
+     , (29521, 159,          1) /* WieldSkillType - Axe */
+     , (29521, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29521,  22, True ) /* Inscribable */
+     , (29521,  69, False) /* IsSellable */
+     , (29521, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29521,   5, -0.0165999997407198) /* ManaRate */
+     , (29521,  12, 0.660000026226044) /* Shade */
+     , (29521,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29521,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29521,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29521,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29521,  17,       1) /* ArmorModVsFire */
+     , (29521,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29521,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29521, 110,       1) /* BulkMod */
+     , (29521, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29521,   1, 'Noble Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29521,   1,   33554648) /* Setup */
+     , (29521,   3,  536870932) /* SoundTable */
+     , (29521,   6,   67108990) /* PaletteBase */
+     , (29521,   7,  268436875) /* ClothingBase */
+     , (29521,   8,  100674349) /* Icon */
+     , (29521,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29521,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29521,  2108,      2)  /* Brogard's Defiance */
+     , (29521,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29522 Noble Gauntlets of Balance.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29522 Noble Gauntlets of Balance.sql
@@ -1,0 +1,67 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29522;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29522, 'guantletsnoblecoordination', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29522,   1,          2) /* ItemType - Armor */
+     , (29522,   3,         21) /* PaletteTemplate - Gold */
+     , (29522,   4,      32768) /* ClothingPriority - Hands */
+     , (29522,   5,        150) /* EncumbranceVal */
+     , (29522,   8,        150) /* Mass */
+     , (29522,   9,         32) /* ValidLocations - HandWear */
+     , (29522,  16,          1) /* ItemUseable - No */
+     , (29522,  19,       8000) /* Value */
+     , (29522,  27,          2) /* ArmorType - Leather */
+     , (29522,  28,        400) /* ArmorLevel */
+     , (29522,  53,        101) /* PlacementPosition - Resting */
+     , (29522,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29522, 106,        400) /* ItemSpellcraft */
+     , (29522, 107,        800) /* ItemCurMana */
+     , (29522, 108,        800) /* ItemMaxMana */
+     , (29522, 109,        200) /* ItemDifficulty */
+     , (29522, 150,        103) /* HookPlacement - Hook */
+     , (29522, 151,          2) /* HookType - Wall */
+     , (29522, 158,          7) /* WieldRequirements - Level */
+     , (29522, 159,          1) /* WieldSkillType - Axe */
+     , (29522, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29522,  11, True ) /* IgnoreCollisions */
+     , (29522,  13, True ) /* Ethereal */
+     , (29522,  14, True ) /* GravityStatus */
+     , (29522,  19, True ) /* Attackable */
+     , (29522,  22, True ) /* Inscribable */
+     , (29522,  69, False) /* IsSellable */
+     , (29522, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29522,   5, -0.0165999997407198) /* ManaRate */
+     , (29522,  12, 0.660000026226044) /* Shade */
+     , (29522,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29522,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29522,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29522,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29522,  17,       1) /* ArmorModVsFire */
+     , (29522,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29522,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29522, 110,       1) /* BulkMod */
+     , (29522, 111,       1) /* SizeMod */
+     , (29522, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29522,   1, 'Noble Gauntlets of Balance') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29522,   1,   33554648) /* Setup */
+     , (29522,   3,  536870932) /* SoundTable */
+     , (29522,   6,   67108990) /* PaletteBase */
+     , (29522,   7,  268436875) /* ClothingBase */
+     , (29522,   8,  100674349) /* Icon */
+     , (29522,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29522,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29522,  2108,      2)  /* Brogard's Defiance */
+     , (29522,  3575,      2)  /* Perfect Balance */
+     , (29522,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29523 Noble Gauntlets of Health.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29523 Noble Gauntlets of Health.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29523;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29523, 'guantletsnobleendurance', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29523,   1,          2) /* ItemType - Armor */
+     , (29523,   3,         21) /* PaletteTemplate - Gold */
+     , (29523,   4,      32768) /* ClothingPriority - Hands */
+     , (29523,   5,        150) /* EncumbranceVal */
+     , (29523,   8,        150) /* Mass */
+     , (29523,   9,         32) /* ValidLocations - HandWear */
+     , (29523,  16,          1) /* ItemUseable - No */
+     , (29523,  19,       8000) /* Value */
+     , (29523,  27,          2) /* ArmorType - Leather */
+     , (29523,  28,        400) /* ArmorLevel */
+     , (29523,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29523, 106,        400) /* ItemSpellcraft */
+     , (29523, 107,        800) /* ItemCurMana */
+     , (29523, 108,        800) /* ItemMaxMana */
+     , (29523, 109,        200) /* ItemDifficulty */
+     , (29523, 150,        103) /* HookPlacement - Hook */
+     , (29523, 151,          2) /* HookType - Wall */
+     , (29523, 158,          7) /* WieldRequirements - Level */
+     , (29523, 159,          1) /* WieldSkillType - Axe */
+     , (29523, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29523,  22, True ) /* Inscribable */
+     , (29523,  69, False) /* IsSellable */
+     , (29523, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29523,   5, -0.0165999997407198) /* ManaRate */
+     , (29523,  12, 0.660000026226044) /* Shade */
+     , (29523,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29523,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29523,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29523,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29523,  17,       1) /* ArmorModVsFire */
+     , (29523,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29523,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29523, 110,       1) /* BulkMod */
+     , (29523, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29523,   1, 'Noble Gauntlets of Health') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29523,   1,   33554648) /* Setup */
+     , (29523,   3,  536870932) /* SoundTable */
+     , (29523,   6,   67108990) /* PaletteBase */
+     , (29523,   7,  268436875) /* ClothingBase */
+     , (29523,   8,  100674349) /* Icon */
+     , (29523,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29523,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29523,  2108,      2)  /* Brogard's Defiance */
+     , (29523,  3576,      2)  /* Perfect Health */
+     , (29523,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29524 Noble Gauntlets of Brilliance.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29524 Noble Gauntlets of Brilliance.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29524;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29524, 'guantletsnoblefocus', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29524,   1,          2) /* ItemType - Armor */
+     , (29524,   3,         21) /* PaletteTemplate - Gold */
+     , (29524,   4,      32768) /* ClothingPriority - Hands */
+     , (29524,   5,        150) /* EncumbranceVal */
+     , (29524,   8,        150) /* Mass */
+     , (29524,   9,         32) /* ValidLocations - HandWear */
+     , (29524,  16,          1) /* ItemUseable - No */
+     , (29524,  19,       8000) /* Value */
+     , (29524,  27,          2) /* ArmorType - Leather */
+     , (29524,  28,        400) /* ArmorLevel */
+     , (29524,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29524, 106,        400) /* ItemSpellcraft */
+     , (29524, 107,        800) /* ItemCurMana */
+     , (29524, 108,        800) /* ItemMaxMana */
+     , (29524, 109,        200) /* ItemDifficulty */
+     , (29524, 150,        103) /* HookPlacement - Hook */
+     , (29524, 151,          2) /* HookType - Wall */
+     , (29524, 158,          7) /* WieldRequirements - Level */
+     , (29524, 159,          1) /* WieldSkillType - Axe */
+     , (29524, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29524,  22, True ) /* Inscribable */
+     , (29524,  69, False) /* IsSellable */
+     , (29524, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29524,   5, -0.0165999997407198) /* ManaRate */
+     , (29524,  12, 0.660000026226044) /* Shade */
+     , (29524,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29524,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29524,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29524,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29524,  17,       1) /* ArmorModVsFire */
+     , (29524,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29524,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29524, 110,       1) /* BulkMod */
+     , (29524, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29524,   1, 'Noble Gauntlets of Brilliance') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29524,   1,   33554648) /* Setup */
+     , (29524,   3,  536870932) /* SoundTable */
+     , (29524,   6,   67108990) /* PaletteBase */
+     , (29524,   7,  268436875) /* ClothingBase */
+     , (29524,   8,  100674349) /* Icon */
+     , (29524,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29524,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29524,  2108,      2)  /* Brogard's Defiance */
+     , (29524,  3572,      2)  /* Inner Brilliance */
+     , (29524,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29525 Noble Gauntlets of Speed.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29525 Noble Gauntlets of Speed.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29525;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29525, 'guantletsnoblequickness', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29525,   1,          2) /* ItemType - Armor */
+     , (29525,   3,         21) /* PaletteTemplate - Gold */
+     , (29525,   4,      32768) /* ClothingPriority - Hands */
+     , (29525,   5,        150) /* EncumbranceVal */
+     , (29525,   8,        150) /* Mass */
+     , (29525,   9,         32) /* ValidLocations - HandWear */
+     , (29525,  16,          1) /* ItemUseable - No */
+     , (29525,  19,       8000) /* Value */
+     , (29525,  27,          2) /* ArmorType - Leather */
+     , (29525,  28,        400) /* ArmorLevel */
+     , (29525,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29525, 106,        400) /* ItemSpellcraft */
+     , (29525, 107,        800) /* ItemCurMana */
+     , (29525, 108,        800) /* ItemMaxMana */
+     , (29525, 109,        200) /* ItemDifficulty */
+     , (29525, 150,        103) /* HookPlacement - Hook */
+     , (29525, 151,          2) /* HookType - Wall */
+     , (29525, 158,          7) /* WieldRequirements - Level */
+     , (29525, 159,          1) /* WieldSkillType - Axe */
+     , (29525, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29525,  22, True ) /* Inscribable */
+     , (29525,  69, False) /* IsSellable */
+     , (29525, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29525,   5, -0.0165999997407198) /* ManaRate */
+     , (29525,  12, 0.660000026226044) /* Shade */
+     , (29525,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29525,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29525,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29525,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29525,  17,       1) /* ArmorModVsFire */
+     , (29525,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29525,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29525, 110,       1) /* BulkMod */
+     , (29525, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29525,   1, 'Noble Gauntlets of Speed') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29525,   1,   33554648) /* Setup */
+     , (29525,   3,  536870932) /* SoundTable */
+     , (29525,   6,   67108990) /* PaletteBase */
+     , (29525,   7,  268436875) /* ClothingBase */
+     , (29525,   8,  100674349) /* Icon */
+     , (29525,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29525,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29525,  2108,      2)  /* Brogard's Defiance */
+     , (29525,  3577,      2)  /* Perfect Speed */
+     , (29525,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29526 Noble Gauntlets of Will.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29526 Noble Gauntlets of Will.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29526;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29526, 'guantletsnobleself', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29526,   1,          2) /* ItemType - Armor */
+     , (29526,   3,         21) /* PaletteTemplate - Gold */
+     , (29526,   4,      32768) /* ClothingPriority - Hands */
+     , (29526,   5,        150) /* EncumbranceVal */
+     , (29526,   8,        150) /* Mass */
+     , (29526,   9,         32) /* ValidLocations - HandWear */
+     , (29526,  16,          1) /* ItemUseable - No */
+     , (29526,  19,       8000) /* Value */
+     , (29526,  27,          2) /* ArmorType - Leather */
+     , (29526,  28,        400) /* ArmorLevel */
+     , (29526,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29526, 106,        400) /* ItemSpellcraft */
+     , (29526, 107,        800) /* ItemCurMana */
+     , (29526, 108,        800) /* ItemMaxMana */
+     , (29526, 109,        200) /* ItemDifficulty */
+     , (29526, 150,        103) /* HookPlacement - Hook */
+     , (29526, 151,          2) /* HookType - Wall */
+     , (29526, 158,          7) /* WieldRequirements - Level */
+     , (29526, 159,          1) /* WieldSkillType - Axe */
+     , (29526, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29526,  22, True ) /* Inscribable */
+     , (29526,  69, False) /* IsSellable */
+     , (29526, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29526,   5, -0.0165999997407198) /* ManaRate */
+     , (29526,  12, 0.660000026226044) /* Shade */
+     , (29526,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29526,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29526,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29526,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29526,  17,       1) /* ArmorModVsFire */
+     , (29526,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29526,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29526, 110,       1) /* BulkMod */
+     , (29526, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29526,   1, 'Noble Gauntlets of Will') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29526,   1,   33554648) /* Setup */
+     , (29526,   3,  536870932) /* SoundTable */
+     , (29526,   6,   67108990) /* PaletteBase */
+     , (29526,   7,  268436875) /* ClothingBase */
+     , (29526,   8,  100674349) /* Icon */
+     , (29526,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29526,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29526,  2108,      2)  /* Brogard's Defiance */
+     , (29526,  3574,      2)  /* Inner Will */
+     , (29526,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29527 Noble Gauntlets of Strength.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29527 Noble Gauntlets of Strength.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29527;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29527, 'guantletsnoblestrength', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29527,   1,          2) /* ItemType - Armor */
+     , (29527,   3,         21) /* PaletteTemplate - Gold */
+     , (29527,   4,      32768) /* ClothingPriority - Hands */
+     , (29527,   5,        150) /* EncumbranceVal */
+     , (29527,   8,        150) /* Mass */
+     , (29527,   9,         32) /* ValidLocations - HandWear */
+     , (29527,  16,          1) /* ItemUseable - No */
+     , (29527,  19,       8000) /* Value */
+     , (29527,  27,          2) /* ArmorType - Leather */
+     , (29527,  28,        400) /* ArmorLevel */
+     , (29527,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29527, 106,        400) /* ItemSpellcraft */
+     , (29527, 107,        800) /* ItemCurMana */
+     , (29527, 108,        800) /* ItemMaxMana */
+     , (29527, 109,        200) /* ItemDifficulty */
+     , (29527, 150,        103) /* HookPlacement - Hook */
+     , (29527, 151,          2) /* HookType - Wall */
+     , (29527, 158,          7) /* WieldRequirements - Level */
+     , (29527, 159,          1) /* WieldSkillType - Axe */
+     , (29527, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29527,  22, True ) /* Inscribable */
+     , (29527,  69, False) /* IsSellable */
+     , (29527, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29527,   5, -0.0165999997407198) /* ManaRate */
+     , (29527,  12, 0.660000026226044) /* Shade */
+     , (29527,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29527,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29527,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29527,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29527,  17,       1) /* ArmorModVsFire */
+     , (29527,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29527,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29527, 110,       1) /* BulkMod */
+     , (29527, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29527,   1, 'Noble Gauntlets of Strength') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29527,   1,   33554648) /* Setup */
+     , (29527,   3,  536870932) /* SoundTable */
+     , (29527,   6,   67108990) /* PaletteBase */
+     , (29527,   7,  268436875) /* ClothingBase */
+     , (29527,   8,  100674349) /* Icon */
+     , (29527,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29527,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (29527,  2108,      2)  /* Brogard's Defiance */
+     , (29527,  3573,      2)  /* Inner Might */
+     , (29527,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29528 Noble Helm.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29528 Noble Helm.sql
@@ -1,0 +1,64 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29528;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29528, 'helmnoble', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29528,   1,          2) /* ItemType - Armor */
+     , (29528,   3,         21) /* PaletteTemplate - Gold */
+     , (29528,   4,      16384) /* ClothingPriority - Head */
+     , (29528,   5,        350) /* EncumbranceVal */
+     , (29528,   8,        350) /* Mass */
+     , (29528,   9,          1) /* ValidLocations - HeadWear */
+     , (29528,  16,          1) /* ItemUseable - No */
+     , (29528,  19,       8000) /* Value */
+     , (29528,  27,          2) /* ArmorType - Leather */
+     , (29528,  28,        400) /* ArmorLevel */
+     , (29528,  53,        101) /* PlacementPosition - Resting */
+     , (29528,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29528, 106,        400) /* ItemSpellcraft */
+     , (29528, 107,        800) /* ItemCurMana */
+     , (29528, 108,        800) /* ItemMaxMana */
+     , (29528, 109,        200) /* ItemDifficulty */
+     , (29528, 150,        103) /* HookPlacement - Hook */
+     , (29528, 151,          2) /* HookType - Wall */
+     , (29528, 158,          7) /* WieldRequirements - Level */
+     , (29528, 159,          1) /* WieldSkillType - Axe */
+     , (29528, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29528,  11, True ) /* IgnoreCollisions */
+     , (29528,  13, True ) /* Ethereal */
+     , (29528,  14, True ) /* GravityStatus */
+     , (29528,  19, True ) /* Attackable */
+     , (29528,  22, True ) /* Inscribable */
+     , (29528, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29528,   5, -0.0165999997407198) /* ManaRate */
+     , (29528,  12, 0.660000026226044) /* Shade */
+     , (29528,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29528,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29528,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29528,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29528,  17,       1) /* ArmorModVsFire */
+     , (29528,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29528,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29528, 110,       1) /* BulkMod */
+     , (29528, 111,       1) /* SizeMod */
+     , (29528, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29528,   1, 'Noble Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29528,   1,   33559080) /* Setup */
+     , (29528,   3,  536870932) /* SoundTable */
+     , (29528,   6,   67108990) /* PaletteBase */
+     , (29528,   7,  268436879) /* ClothingBase */
+     , (29528,   8,  100674952) /* Icon */
+     , (29528,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29528,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29528,  2108,      2)  /* Brogard's Defiance */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29529 Noble Helm of Balance.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29529 Noble Helm of Balance.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29529;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29529, 'helmnoblecoordination', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29529,   1,          2) /* ItemType - Armor */
+     , (29529,   3,         21) /* PaletteTemplate - Gold */
+     , (29529,   4,      16384) /* ClothingPriority - Head */
+     , (29529,   5,        350) /* EncumbranceVal */
+     , (29529,   8,        350) /* Mass */
+     , (29529,   9,          1) /* ValidLocations - HeadWear */
+     , (29529,  16,          1) /* ItemUseable - No */
+     , (29529,  19,       8000) /* Value */
+     , (29529,  27,          2) /* ArmorType - Leather */
+     , (29529,  28,        400) /* ArmorLevel */
+     , (29529,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29529, 106,        400) /* ItemSpellcraft */
+     , (29529, 107,        800) /* ItemCurMana */
+     , (29529, 108,        800) /* ItemMaxMana */
+     , (29529, 109,        200) /* ItemDifficulty */
+     , (29529, 150,        103) /* HookPlacement - Hook */
+     , (29529, 151,          2) /* HookType - Wall */
+     , (29529, 158,          7) /* WieldRequirements - Level */
+     , (29529, 159,          1) /* WieldSkillType - Axe */
+     , (29529, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29529,  22, True ) /* Inscribable */
+     , (29529, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29529,   5, -0.0165999997407198) /* ManaRate */
+     , (29529,  12, 0.660000026226044) /* Shade */
+     , (29529,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29529,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29529,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29529,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29529,  17,       1) /* ArmorModVsFire */
+     , (29529,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29529,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29529, 110,       1) /* BulkMod */
+     , (29529, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29529,   1, 'Noble Helm of Balance') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29529,   1,   33559080) /* Setup */
+     , (29529,   3,  536870932) /* SoundTable */
+     , (29529,   6,   67108990) /* PaletteBase */
+     , (29529,   7,  268436879) /* ClothingBase */
+     , (29529,   8,  100674952) /* Icon */
+     , (29529,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29529,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29529,  2108,      2)  /* Brogard's Defiance */
+     , (29529,  3575,      2)  /* Perfect Balance */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29530 Noble Helm of Health.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29530 Noble Helm of Health.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29530;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29530, 'helmnobleendurance', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29530,   1,          2) /* ItemType - Armor */
+     , (29530,   3,         21) /* PaletteTemplate - Gold */
+     , (29530,   4,      16384) /* ClothingPriority - Head */
+     , (29530,   5,        350) /* EncumbranceVal */
+     , (29530,   8,        350) /* Mass */
+     , (29530,   9,          1) /* ValidLocations - HeadWear */
+     , (29530,  16,          1) /* ItemUseable - No */
+     , (29530,  19,       8000) /* Value */
+     , (29530,  27,          2) /* ArmorType - Leather */
+     , (29530,  28,        400) /* ArmorLevel */
+     , (29530,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29530, 106,        400) /* ItemSpellcraft */
+     , (29530, 107,        800) /* ItemCurMana */
+     , (29530, 108,        800) /* ItemMaxMana */
+     , (29530, 109,        200) /* ItemDifficulty */
+     , (29530, 150,        103) /* HookPlacement - Hook */
+     , (29530, 151,          2) /* HookType - Wall */
+     , (29530, 158,          7) /* WieldRequirements - Level */
+     , (29530, 159,          1) /* WieldSkillType - Axe */
+     , (29530, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29530,  22, True ) /* Inscribable */
+     , (29530, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29530,   5, -0.0165999997407198) /* ManaRate */
+     , (29530,  12, 0.660000026226044) /* Shade */
+     , (29530,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29530,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29530,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29530,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29530,  17,       1) /* ArmorModVsFire */
+     , (29530,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29530,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29530, 110,       1) /* BulkMod */
+     , (29530, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29530,   1, 'Noble Helm of Health') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29530,   1,   33559080) /* Setup */
+     , (29530,   3,  536870932) /* SoundTable */
+     , (29530,   6,   67108990) /* PaletteBase */
+     , (29530,   7,  268436879) /* ClothingBase */
+     , (29530,   8,  100674952) /* Icon */
+     , (29530,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29530,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29530,  2108,      2)  /* Brogard's Defiance */
+     , (29530,  3576,      2)  /* Perfect Health */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29531 Noble Helm of Brilliance.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29531 Noble Helm of Brilliance.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29531;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29531, 'helmnoblefocus', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29531,   1,          2) /* ItemType - Armor */
+     , (29531,   3,         21) /* PaletteTemplate - Gold */
+     , (29531,   4,      16384) /* ClothingPriority - Head */
+     , (29531,   5,        350) /* EncumbranceVal */
+     , (29531,   8,        350) /* Mass */
+     , (29531,   9,          1) /* ValidLocations - HeadWear */
+     , (29531,  16,          1) /* ItemUseable - No */
+     , (29531,  19,       8000) /* Value */
+     , (29531,  27,          2) /* ArmorType - Leather */
+     , (29531,  28,        400) /* ArmorLevel */
+     , (29531,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29531, 106,        400) /* ItemSpellcraft */
+     , (29531, 107,        800) /* ItemCurMana */
+     , (29531, 108,        800) /* ItemMaxMana */
+     , (29531, 109,        200) /* ItemDifficulty */
+     , (29531, 150,        103) /* HookPlacement - Hook */
+     , (29531, 151,          2) /* HookType - Wall */
+     , (29531, 158,          7) /* WieldRequirements - Level */
+     , (29531, 159,          1) /* WieldSkillType - Axe */
+     , (29531, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29531,  22, True ) /* Inscribable */
+     , (29531, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29531,   5, -0.0165999997407198) /* ManaRate */
+     , (29531,  12, 0.660000026226044) /* Shade */
+     , (29531,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29531,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29531,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29531,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29531,  17,       1) /* ArmorModVsFire */
+     , (29531,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29531,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29531, 110,       1) /* BulkMod */
+     , (29531, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29531,   1, 'Noble Helm of Brilliance') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29531,   1,   33559080) /* Setup */
+     , (29531,   3,  536870932) /* SoundTable */
+     , (29531,   6,   67108990) /* PaletteBase */
+     , (29531,   7,  268436879) /* ClothingBase */
+     , (29531,   8,  100674952) /* Icon */
+     , (29531,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29531,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29531,  2108,      2)  /* Brogard's Defiance */
+     , (29531,  3572,      2)  /* Inner Brilliance */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29532 Noble Helm of Speed.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29532 Noble Helm of Speed.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29532;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29532, 'helmnoblequickness', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29532,   1,          2) /* ItemType - Armor */
+     , (29532,   3,         21) /* PaletteTemplate - Gold */
+     , (29532,   4,      16384) /* ClothingPriority - Head */
+     , (29532,   5,        350) /* EncumbranceVal */
+     , (29532,   8,        350) /* Mass */
+     , (29532,   9,          1) /* ValidLocations - HeadWear */
+     , (29532,  16,          1) /* ItemUseable - No */
+     , (29532,  19,       8000) /* Value */
+     , (29532,  27,          2) /* ArmorType - Leather */
+     , (29532,  28,        400) /* ArmorLevel */
+     , (29532,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29532, 106,        400) /* ItemSpellcraft */
+     , (29532, 107,        800) /* ItemCurMana */
+     , (29532, 108,        800) /* ItemMaxMana */
+     , (29532, 109,        200) /* ItemDifficulty */
+     , (29532, 150,        103) /* HookPlacement - Hook */
+     , (29532, 151,          2) /* HookType - Wall */
+     , (29532, 158,          7) /* WieldRequirements - Level */
+     , (29532, 159,          1) /* WieldSkillType - Axe */
+     , (29532, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29532,  22, True ) /* Inscribable */
+     , (29532, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29532,   5, -0.0165999997407198) /* ManaRate */
+     , (29532,  12, 0.660000026226044) /* Shade */
+     , (29532,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29532,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29532,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29532,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29532,  17,       1) /* ArmorModVsFire */
+     , (29532,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29532,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29532, 110,       1) /* BulkMod */
+     , (29532, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29532,   1, 'Noble Helm of Speed') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29532,   1,   33559080) /* Setup */
+     , (29532,   3,  536870932) /* SoundTable */
+     , (29532,   6,   67108990) /* PaletteBase */
+     , (29532,   7,  268436879) /* ClothingBase */
+     , (29532,   8,  100674952) /* Icon */
+     , (29532,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29532,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29532,  2108,      2)  /* Brogard's Defiance */
+     , (29532,  3577,      2)  /* Perfect Speed */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29533 Noble Helm of Will.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29533 Noble Helm of Will.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29533;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29533, 'helmnobleself', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29533,   1,          2) /* ItemType - Armor */
+     , (29533,   3,         21) /* PaletteTemplate - Gold */
+     , (29533,   4,      16384) /* ClothingPriority - Head */
+     , (29533,   5,        350) /* EncumbranceVal */
+     , (29533,   8,        350) /* Mass */
+     , (29533,   9,          1) /* ValidLocations - HeadWear */
+     , (29533,  16,          1) /* ItemUseable - No */
+     , (29533,  19,       8000) /* Value */
+     , (29533,  27,          2) /* ArmorType - Leather */
+     , (29533,  28,        400) /* ArmorLevel */
+     , (29533,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29533, 106,        400) /* ItemSpellcraft */
+     , (29533, 107,        800) /* ItemCurMana */
+     , (29533, 108,        800) /* ItemMaxMana */
+     , (29533, 109,        200) /* ItemDifficulty */
+     , (29533, 150,        103) /* HookPlacement - Hook */
+     , (29533, 151,          2) /* HookType - Wall */
+     , (29533, 158,          7) /* WieldRequirements - Level */
+     , (29533, 159,          1) /* WieldSkillType - Axe */
+     , (29533, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29533,  22, True ) /* Inscribable */
+     , (29533, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29533,   5, -0.0165999997407198) /* ManaRate */
+     , (29533,  12, 0.660000026226044) /* Shade */
+     , (29533,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29533,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29533,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29533,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29533,  17,       1) /* ArmorModVsFire */
+     , (29533,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29533,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29533, 110,       1) /* BulkMod */
+     , (29533, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29533,   1, 'Noble Helm of Will') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29533,   1,   33559080) /* Setup */
+     , (29533,   3,  536870932) /* SoundTable */
+     , (29533,   6,   67108990) /* PaletteBase */
+     , (29533,   7,  268436879) /* ClothingBase */
+     , (29533,   8,  100674952) /* Icon */
+     , (29533,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29533,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29533,  2108,      2)  /* Brogard's Defiance */
+     , (29533,  3574,      2)  /* Inner Will */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29534 Noble Helm of Might.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/29534 Noble Helm of Might.sql
@@ -1,0 +1,64 @@
+DELETE FROM `weenie` WHERE `class_Id` = 29534;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (29534, 'helmnoblestrength', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (29534,   1,          2) /* ItemType - Armor */
+     , (29534,   3,         21) /* PaletteTemplate - Gold */
+     , (29534,   4,      16384) /* ClothingPriority - Head */
+     , (29534,   5,        350) /* EncumbranceVal */
+     , (29534,   8,        350) /* Mass */
+     , (29534,   9,          1) /* ValidLocations - HeadWear */
+     , (29534,  16,          1) /* ItemUseable - No */
+     , (29534,  19,       8000) /* Value */
+     , (29534,  27,          2) /* ArmorType - Leather */
+     , (29534,  28,        400) /* ArmorLevel */
+     , (29534,  53,        101) /* PlacementPosition - Resting */
+     , (29534,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (29534, 106,        400) /* ItemSpellcraft */
+     , (29534, 107,        800) /* ItemCurMana */
+     , (29534, 108,        800) /* ItemMaxMana */
+     , (29534, 109,        200) /* ItemDifficulty */
+     , (29534, 150,        103) /* HookPlacement - Hook */
+     , (29534, 151,          2) /* HookType - Wall */
+     , (29534, 158,          7) /* WieldRequirements - Level */
+     , (29534, 159,          1) /* WieldSkillType - Axe */
+     , (29534, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (29534,  11, True ) /* IgnoreCollisions */
+     , (29534,  13, True ) /* Ethereal */
+     , (29534,  14, True ) /* GravityStatus */
+     , (29534,  19, True ) /* Attackable */
+     , (29534,  22, True ) /* Inscribable */
+     , (29534, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (29534,   5, -0.0165999997407198) /* ManaRate */
+     , (29534,  12, 0.660000026226044) /* Shade */
+     , (29534,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (29534,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (29534,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (29534,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (29534,  17,       1) /* ArmorModVsFire */
+     , (29534,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (29534,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (29534, 110,       1) /* BulkMod */
+     , (29534, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (29534,   1, 'Noble Helm of Might') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (29534,   1,   33559080) /* Setup */
+     , (29534,   3,  536870932) /* SoundTable */
+     , (29534,   6,   67108990) /* PaletteBase */
+     , (29534,   7,  268436879) /* ClothingBase */
+     , (29534,   8,  100674952) /* Icon */
+     , (29534,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (29534,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (29534,  2108,      2)  /* Brogard's Defiance */
+     , (29534,  3573,      2)  /* Inner Might */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32148 Shadow Wings Breastplate.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32148 Shadow Wings Breastplate.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32148;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32148, 'ace32148-shadowwingsbreastplate', 2, '2019-09-13 02:41:34') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32148,   1,          2) /* ItemType - Armor */
+     , (32148,   3,         39) /* PaletteTemplate - Black */
+     , (32148,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (32148,   5,       3100) /* EncumbranceVal */
+     , (32148,   8,        140) /* Mass */
+     , (32148,   9,        512) /* ValidLocations - ChestArmor */
+     , (32148,  16,          1) /* ItemUseable - No */
+     , (32148,  19,      10000) /* Value */
+     , (32148,  27,          2) /* ArmorType - Leather */
+     , (32148,  28,        210) /* ArmorLevel */
+     , (32148,  53,        101) /* PlacementPosition - Resting */
+     , (32148,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32148, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32148,  11, True ) /* IgnoreCollisions */
+     , (32148,  13, True ) /* Ethereal */
+     , (32148,  14, True ) /* GravityStatus */
+     , (32148,  19, True ) /* Attackable */
+     , (32148,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32148,  12, 0.660000026226044) /* Shade */
+     , (32148,  13, 1.29999995231628) /* ArmorModVsSlash */
+     , (32148,  14,       1) /* ArmorModVsPierce */
+     , (32148,  15,       1) /* ArmorModVsBludgeon */
+     , (32148,  16, 0.800000011920929) /* ArmorModVsCold */
+     , (32148,  17, 0.800000011920929) /* ArmorModVsFire */
+     , (32148,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (32148,  19,       1) /* ArmorModVsElectric */
+     , (32148, 110, 1.66999995708466) /* BulkMod */
+     , (32148, 111,     2.5) /* SizeMod */
+     , (32148, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32148,   1, 'Shadow Wings Breastplate') /* Name */
+     , (32148,  16, 'A modified Shadow Breastplate. Shadowy wings protrude from the shoulders.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32148,   1,   33559762) /* Setup */
+     , (32148,   3,  536870932) /* SoundTable */
+     , (32148,   6,   67108990) /* PaletteBase */
+     , (32148,   7,  268437067) /* ClothingBase */
+     , (32148,   8,  100688450) /* Icon */
+     , (32148,  22,  872415275) /* PhysicsEffectTable */
+     , (32148,  36,  234881042) /* MutateFilter */
+     , (32148,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32156 Maddened Fiun Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32156 Maddened Fiun Mask.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32156;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32156, 'ace32156-maddenedfiunmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32156,   1,          2) /* ItemType - Armor */
+     , (32156,   3,          4) /* PaletteTemplate - Brown */
+     , (32156,   4,      16384) /* ClothingPriority - Head */
+     , (32156,   5,        150) /* EncumbranceVal */
+     , (32156,   8,         75) /* Mass */
+     , (32156,   9,          1) /* ValidLocations - HeadWear */
+     , (32156,  16,          1) /* ItemUseable - No */
+     , (32156,  19,        200) /* Value */
+     , (32156,  27,          2) /* ArmorType - Leather */
+     , (32156,  28,         10) /* ArmorLevel */
+     , (32156,  53,        101) /* PlacementPosition - Resting */
+     , (32156,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32156, 150,        103) /* HookPlacement - Hook */
+     , (32156, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32156,  11, True ) /* IgnoreCollisions */
+     , (32156,  13, True ) /* Ethereal */
+     , (32156,  14, True ) /* GravityStatus */
+     , (32156,  19, True ) /* Attackable */
+     , (32156,  22, True ) /* Inscribable */
+     , (32156,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32156,  12, 0.660000026226044) /* Shade */
+     , (32156,  13,     0.5) /* ArmorModVsSlash */
+     , (32156,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32156,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32156,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32156,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32156,  18,    0.75) /* ArmorModVsAcid */
+     , (32156,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32156, 110,       1) /* BulkMod */
+     , (32156, 111,       1) /* SizeMod */
+     , (32156, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32156,   1, 'Maddened Fiun Mask') /* Name */
+     , (32156,  16, 'A mask crafted after the sad and tortured visage of the Maddened Fiun.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32156,   1,   33559764) /* Setup */
+     , (32156,   3,  536870932) /* SoundTable */
+     , (32156,   6,   67108990) /* PaletteBase */
+     , (32156,   7,  268437069) /* ClothingBase */
+     , (32156,   8,  100688432) /* Icon */
+     , (32156,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32157 Hollow Minion Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32157 Hollow Minion Mask.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32157;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32157, 'ace32157-hollowminionmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32157,   1,          2) /* ItemType - Armor */
+     , (32157,   3,          4) /* PaletteTemplate - Brown */
+     , (32157,   4,      16384) /* ClothingPriority - Head */
+     , (32157,   5,        150) /* EncumbranceVal */
+     , (32157,   8,         75) /* Mass */
+     , (32157,   9,          1) /* ValidLocations - HeadWear */
+     , (32157,  16,          1) /* ItemUseable - No */
+     , (32157,  19,        200) /* Value */
+     , (32157,  27,          2) /* ArmorType - Leather */
+     , (32157,  28,         10) /* ArmorLevel */
+     , (32157,  53,        101) /* PlacementPosition - Resting */
+     , (32157,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32157, 150,        103) /* HookPlacement - Hook */
+     , (32157, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32157,  11, True ) /* IgnoreCollisions */
+     , (32157,  13, True ) /* Ethereal */
+     , (32157,  14, True ) /* GravityStatus */
+     , (32157,  19, True ) /* Attackable */
+     , (32157,  22, True ) /* Inscribable */
+     , (32157,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32157,  12, 0.660000026226044) /* Shade */
+     , (32157,  13,     0.5) /* ArmorModVsSlash */
+     , (32157,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32157,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32157,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32157,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32157,  18,    0.75) /* ArmorModVsAcid */
+     , (32157,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32157, 110,       1) /* BulkMod */
+     , (32157, 111,       1) /* SizeMod */
+     , (32157, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32157,   1, 'Hollow Minion Mask') /* Name */
+     , (32157,  16, 'A mask bearing the cold, blank gaze of the Hollow Minion.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32157,   1,   33559765) /* Setup */
+     , (32157,   3,  536870932) /* SoundTable */
+     , (32157,   6,   67108990) /* PaletteBase */
+     , (32157,   7,  268437070) /* ClothingBase */
+     , (32157,   8,  100688433) /* Icon */
+     , (32157,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32158 Homunculus Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32158 Homunculus Mask.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32158;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32158, 'ace32158-homunculusmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32158,   1,          2) /* ItemType - Armor */
+     , (32158,   3,          4) /* PaletteTemplate - Brown */
+     , (32158,   4,      16384) /* ClothingPriority - Head */
+     , (32158,   5,        150) /* EncumbranceVal */
+     , (32158,   9,          1) /* ValidLocations - HeadWear */
+     , (32158,  16,          1) /* ItemUseable - No */
+     , (32158,  19,        200) /* Value */
+     , (32158,  28,         10) /* ArmorLevel */
+     , (32158,  53,        101) /* PlacementPosition - Resting */
+     , (32158,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32158, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32158,   1, False) /* Stuck */
+     , (32158,  11, True ) /* IgnoreCollisions */
+     , (32158,  13, True ) /* Ethereal */
+     , (32158,  14, True ) /* GravityStatus */
+     , (32158,  19, True ) /* Attackable */
+     , (32158,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32158,  12,       0) /* Shade */
+     , (32158,  13,     0.5) /* ArmorModVsSlash */
+     , (32158,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32158,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32158,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32158,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32158,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (32158,  19, 0.300000011920929) /* ArmorModVsElectric */
+     , (32158, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32158,   1, 'Homunculus Mask') /* Name */
+     , (32158,  16, 'A mask crafted after the visage of the sinister Homunculus. ') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32158,   1,   33559766) /* Setup */
+     , (32158,   3,  536870932) /* SoundTable */
+     , (32158,   7,  268437071) /* ClothingBase */
+     , (32158,   8,  100688434) /* Icon */
+     , (32158,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32159 Penguin Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32159 Penguin Mask.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32159;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32159, 'ace32159-penguinmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32159,   1,          2) /* ItemType - Armor */
+     , (32159,   3,          4) /* PaletteTemplate - Brown */
+     , (32159,   4,      16384) /* ClothingPriority - Head */
+     , (32159,   5,        150) /* EncumbranceVal */
+     , (32159,   9,          1) /* ValidLocations - HeadWear */
+     , (32159,  16,          1) /* ItemUseable - No */
+     , (32159,  19,        200) /* Value */
+     , (32159,  28,         10) /* ArmorLevel */
+     , (32159,  53,        101) /* PlacementPosition - Resting */
+     , (32159,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32159, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32159,   1, False) /* Stuck */
+     , (32159,  11, True ) /* IgnoreCollisions */
+     , (32159,  13, True ) /* Ethereal */
+     , (32159,  14, True ) /* GravityStatus */
+     , (32159,  19, True ) /* Attackable */
+     , (32159,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32159,  12,       0) /* Shade */
+     , (32159,  13,     0.5) /* ArmorModVsSlash */
+     , (32159,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32159,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32159,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32159,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32159,  18,    0.75) /* ArmorModVsAcid */
+     , (32159,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32159, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32159,   1, 'Penguin Mask') /* Name */
+     , (32159,  16, 'A mask crafted to resemble the head of the noble Penguin.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32159,   1,   33559767) /* Setup */
+     , (32159,   3,  536870932) /* SoundTable */
+     , (32159,   7,  268437072) /* ClothingBase */
+     , (32159,   8,  100688479) /* Icon */
+     , (32159,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32160 Uber Penguin Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32160 Uber Penguin Mask.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32160;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32160, 'ace32160-uberpenguinmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32160,   1,          2) /* ItemType - Armor */
+     , (32160,   3,          4) /* PaletteTemplate - Brown */
+     , (32160,   4,      16384) /* ClothingPriority - Head */
+     , (32160,   5,        150) /* EncumbranceVal */
+     , (32160,   8,         75) /* Mass */
+     , (32160,   9,          1) /* ValidLocations - HeadWear */
+     , (32160,  16,          1) /* ItemUseable - No */
+     , (32160,  19,        200) /* Value */
+     , (32160,  27,          2) /* ArmorType - Leather */
+     , (32160,  28,         10) /* ArmorLevel */
+     , (32160,  53,        101) /* PlacementPosition - Resting */
+     , (32160,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32160, 150,        103) /* HookPlacement - Hook */
+     , (32160, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32160,  11, True ) /* IgnoreCollisions */
+     , (32160,  13, True ) /* Ethereal */
+     , (32160,  14, True ) /* GravityStatus */
+     , (32160,  19, True ) /* Attackable */
+     , (32160,  22, True ) /* Inscribable */
+     , (32160,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32160,  12, 0.660000026226044) /* Shade */
+     , (32160,  13,     0.5) /* ArmorModVsSlash */
+     , (32160,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32160,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32160,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32160,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32160,  18,    0.75) /* ArmorModVsAcid */
+     , (32160,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32160, 110,       1) /* BulkMod */
+     , (32160, 111,       1) /* SizeMod */
+     , (32160, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32160,   1, 'Uber Penguin Mask') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32160,   1,   33559768) /* Setup */
+     , (32160,   3,  536870932) /* SoundTable */
+     , (32160,   6,   67108990) /* PaletteBase */
+     , (32160,   7,  268437073) /* ClothingBase */
+     , (32160,   8,  100688480) /* Icon */
+     , (32160,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32161 Ruschk Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32161 Ruschk Mask.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32161;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32161, 'ace32161-ruschkmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32161,   1,          2) /* ItemType - Armor */
+     , (32161,   3,          4) /* PaletteTemplate - Brown */
+     , (32161,   4,      16384) /* ClothingPriority - Head */
+     , (32161,   5,        150) /* EncumbranceVal */
+     , (32161,   9,          1) /* ValidLocations - HeadWear */
+     , (32161,  16,          1) /* ItemUseable - No */
+     , (32161,  19,        200) /* Value */
+     , (32161,  28,         10) /* ArmorLevel */
+     , (32161,  53,        101) /* PlacementPosition - Resting */
+     , (32161,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32161, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32161,   1, False) /* Stuck */
+     , (32161,  11, True ) /* IgnoreCollisions */
+     , (32161,  13, True ) /* Ethereal */
+     , (32161,  14, True ) /* GravityStatus */
+     , (32161,  19, True ) /* Attackable */
+     , (32161,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32161,  12,       0) /* Shade */
+     , (32161,  13,     0.5) /* ArmorModVsSlash */
+     , (32161,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32161,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32161,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32161,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32161,  18,    0.75) /* ArmorModVsAcid */
+     , (32161,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32161, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32161,   1, 'Ruschk Mask') /* Name */
+     , (32161,  16, 'A fearsome mask made from the head of a barbaric Ruschk.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32161,   1,   33559769) /* Setup */
+     , (32161,   3,  536870932) /* SoundTable */
+     , (32161,   7,  268437074) /* ClothingBase */
+     , (32161,   8,  100688435) /* Icon */
+     , (32161,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32162 Snowman Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32162 Snowman Mask.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32162;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32162, 'ace32162-snowmanmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32162,   1,          2) /* ItemType - Armor */
+     , (32162,   3,          4) /* PaletteTemplate - Brown */
+     , (32162,   4,      16384) /* ClothingPriority - Head */
+     , (32162,   5,        150) /* EncumbranceVal */
+     , (32162,   8,         75) /* Mass */
+     , (32162,   9,          1) /* ValidLocations - HeadWear */
+     , (32162,  16,          1) /* ItemUseable - No */
+     , (32162,  19,        200) /* Value */
+     , (32162,  27,          2) /* ArmorType - Leather */
+     , (32162,  28,         10) /* ArmorLevel */
+     , (32162,  53,        101) /* PlacementPosition - Resting */
+     , (32162,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32162, 150,        103) /* HookPlacement - Hook */
+     , (32162, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32162,  11, True ) /* IgnoreCollisions */
+     , (32162,  13, True ) /* Ethereal */
+     , (32162,  14, True ) /* GravityStatus */
+     , (32162,  19, True ) /* Attackable */
+     , (32162,  22, True ) /* Inscribable */
+     , (32162,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32162,  12, 0.660000026226044) /* Shade */
+     , (32162,  13, 0.449999988079071) /* ArmorModVsSlash */
+     , (32162,  14,     0.5) /* ArmorModVsPierce */
+     , (32162,  15,       1) /* ArmorModVsBludgeon */
+     , (32162,  16, 0.449999988079071) /* ArmorModVsCold */
+     , (32162,  17, 0.349999994039536) /* ArmorModVsFire */
+     , (32162,  18,     0.5) /* ArmorModVsAcid */
+     , (32162,  19, 0.300000011920929) /* ArmorModVsElectric */
+     , (32162, 110,       1) /* BulkMod */
+     , (32162, 111,       1) /* SizeMod */
+     , (32162, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32162,   1, 'Snowman Mask') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32162,   1,   33559770) /* Setup */
+     , (32162,   3,  536870932) /* SoundTable */
+     , (32162,   6,   67108990) /* PaletteBase */
+     , (32162,   7,  268437075) /* ClothingBase */
+     , (32162,   8,  100688436) /* Icon */
+     , (32162,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32163 Two Headed Snowman Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32163 Two Headed Snowman Mask.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32163;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32163, 'ace32163-twoheadedsnowmanmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32163,   1,          2) /* ItemType - Armor */
+     , (32163,   3,          4) /* PaletteTemplate - Brown */
+     , (32163,   4,      16384) /* ClothingPriority - Head */
+     , (32163,   5,        150) /* EncumbranceVal */
+     , (32163,   9,          1) /* ValidLocations - HeadWear */
+     , (32163,  16,          1) /* ItemUseable - No */
+     , (32163,  19,        200) /* Value */
+     , (32163,  28,         10) /* ArmorLevel */
+     , (32163,  53,        101) /* PlacementPosition - Resting */
+     , (32163,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32163, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32163,   1, False) /* Stuck */
+     , (32163,  11, True ) /* IgnoreCollisions */
+     , (32163,  13, True ) /* Ethereal */
+     , (32163,  14, True ) /* GravityStatus */
+     , (32163,  19, True ) /* Attackable */
+     , (32163,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32163,  12,       0) /* Shade */
+     , (32163,  13,     0.5) /* ArmorModVsSlash */
+     , (32163,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32163,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32163,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32163,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32163,  18,    0.75) /* ArmorModVsAcid */
+     , (32163,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32163, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32163,   1, 'Two Headed Snowman Mask') /* Name */
+     , (32163,  16, 'A mask crafted from the hollowed-out heads of a Two Headed Snowman.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32163,   1,   33559771) /* Setup */
+     , (32163,   3,  536870932) /* SoundTable */
+     , (32163,   7,  268437076) /* ClothingBase */
+     , (32163,   8,  100688431) /* Icon */
+     , (32163,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32165 Giant Snowman Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32165 Giant Snowman Mask.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32165;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32165, 'ace32165-giantsnowmanmask', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32165,   1,          2) /* ItemType - Armor */
+     , (32165,   3,          4) /* PaletteTemplate - Brown */
+     , (32165,   4,      16384) /* ClothingPriority - Head */
+     , (32165,   5,        200) /* EncumbranceVal */
+     , (32165,   8,         75) /* Mass */
+     , (32165,   9,          1) /* ValidLocations - HeadWear */
+     , (32165,  16,          1) /* ItemUseable - No */
+     , (32165,  19,        200) /* Value */
+     , (32165,  27,          2) /* ArmorType - Leather */
+     , (32165,  28,         10) /* ArmorLevel */
+     , (32165,  53,        101) /* PlacementPosition - Resting */
+     , (32165,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32165, 150,        103) /* HookPlacement - Hook */
+     , (32165, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32165,  11, True ) /* IgnoreCollisions */
+     , (32165,  13, True ) /* Ethereal */
+     , (32165,  14, True ) /* GravityStatus */
+     , (32165,  19, True ) /* Attackable */
+     , (32165,  22, True ) /* Inscribable */
+     , (32165,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32165,  12, 0.660000026226044) /* Shade */
+     , (32165,  13,     0.5) /* ArmorModVsSlash */
+     , (32165,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (32165,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32165,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (32165,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32165,  18,    0.75) /* ArmorModVsAcid */
+     , (32165,  19, 0.349999994039536) /* ArmorModVsElectric */
+     , (32165, 110,       1) /* BulkMod */
+     , (32165, 111,       1) /* SizeMod */
+     , (32165, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32165,   1, 'Giant Snowman Mask') /* Name */
+     , (32165,  16, 'A mask crafted from the hollowed-out head of a Giant Snowman.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32165,   1,   33559773) /* Setup */
+     , (32165,   3,  536870932) /* SoundTable */
+     , (32165,   6,   67108990) /* PaletteBase */
+     , (32165,   7,  268437078) /* ClothingBase */
+     , (32165,   8,  100688439) /* Icon */
+     , (32165,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32166 Snowman Mask with Hat.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32166 Snowman Mask with Hat.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32166;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32166, 'ace32166-snowmanmaskwithhat', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32166,   1,          2) /* ItemType - Armor */
+     , (32166,   3,          4) /* PaletteTemplate - Brown */
+     , (32166,   4,      16384) /* ClothingPriority - Head */
+     , (32166,   5,        300) /* EncumbranceVal */
+     , (32166,   8,         75) /* Mass */
+     , (32166,   9,          1) /* ValidLocations - HeadWear */
+     , (32166,  16,          1) /* ItemUseable - No */
+     , (32166,  19,        200) /* Value */
+     , (32166,  27,          2) /* ArmorType - Leather */
+     , (32166,  28,         10) /* ArmorLevel */
+     , (32166,  53,        101) /* PlacementPosition - Resting */
+     , (32166,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32166, 150,        103) /* HookPlacement - Hook */
+     , (32166, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32166,  11, True ) /* IgnoreCollisions */
+     , (32166,  13, True ) /* Ethereal */
+     , (32166,  14, True ) /* GravityStatus */
+     , (32166,  19, True ) /* Attackable */
+     , (32166,  22, True ) /* Inscribable */
+     , (32166,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32166,  12, 0.660000026226044) /* Shade */
+     , (32166,  13, 0.28999999165535) /* ArmorModVsSlash */
+     , (32166,  14,     0.5) /* ArmorModVsPierce */
+     , (32166,  15, 0.28999999165535) /* ArmorModVsBludgeon */
+     , (32166,  16, 0.28999999165535) /* ArmorModVsCold */
+     , (32166,  17, 0.430000007152557) /* ArmorModVsFire */
+     , (32166,  18, 0.28999999165535) /* ArmorModVsAcid */
+     , (32166,  19, 0.28999999165535) /* ArmorModVsElectric */
+     , (32166, 110,       1) /* BulkMod */
+     , (32166, 111,       1) /* SizeMod */
+     , (32166, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32166,   1, 'Snowman Mask with Hat') /* Name */
+     , (32166,  16, 'A Snowman Mask accessorized with a stylish hat.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32166,   1,   33559774) /* Setup */
+     , (32166,   3,  536870932) /* SoundTable */
+     , (32166,   6,   67108990) /* PaletteBase */
+     , (32166,   7,  268437079) /* ClothingBase */
+     , (32166,   8,  100688438) /* Icon */
+     , (32166,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32167 Snowman Mask with Fez.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32167 Snowman Mask with Fez.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32167;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32167, 'ace32167-snowmanmaskwithfez', 2, '2019-09-13 04:59:39') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32167,   1,          2) /* ItemType - Armor */
+     , (32167,   3,          4) /* PaletteTemplate - Brown */
+     , (32167,   4,      16384) /* ClothingPriority - Head */
+     , (32167,   5,        300) /* EncumbranceVal */
+     , (32167,   9,          1) /* ValidLocations - HeadWear */
+     , (32167,  16,          1) /* ItemUseable - No */
+     , (32167,  19,        200) /* Value */
+     , (32167,  28,         10) /* ArmorLevel */
+     , (32167,  53,        101) /* PlacementPosition - Resting */
+     , (32167,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32167, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32167,  11, True ) /* IgnoreCollisions */
+     , (32167,  13, True ) /* Ethereal */
+     , (32167,  14, True ) /* GravityStatus */
+     , (32167,  19, True ) /* Attackable */
+     , (32167,  22, True ) /* Inscribable */
+     , (32167,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32167,  12,       0) /* Shade */
+     , (32167,  13, 0.300000011920929) /* ArmorModVsSlash */
+     , (32167,  14,     0.5) /* ArmorModVsPierce */
+     , (32167,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (32167,  16, 0.300000011920929) /* ArmorModVsCold */
+     , (32167,  17, 0.400000005960464) /* ArmorModVsFire */
+     , (32167,  18, 0.300000011920929) /* ArmorModVsAcid */
+     , (32167,  19, 0.300000011920929) /* ArmorModVsElectric */
+     , (32167, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32167,   1, 'Snowman Mask with Fez') /* Name */
+     , (32167,  16, 'A Snowman Mask accessorized with a jaunty fez.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32167,   1,   33559772) /* Setup */
+     , (32167,   3,  536870932) /* SoundTable */
+     , (32167,   7,  268437077) /* ClothingBase */
+     , (32167,   8,  100688437) /* Icon */
+     , (32167,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32168 Dual Eye Patch.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32168 Dual Eye Patch.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32168;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32168, 'ace32168-dualeyepatch', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32168,   1,          2) /* ItemType - Armor */
+     , (32168,   3,         39) /* PaletteTemplate - Black */
+     , (32168,   4,      16384) /* ClothingPriority - Head */
+     , (32168,   5,         30) /* EncumbranceVal */
+     , (32168,   9,          1) /* ValidLocations - HeadWear */
+     , (32168,  16,          1) /* ItemUseable - No */
+     , (32168,  19,       1000) /* Value */
+     , (32168,  28,         10) /* ArmorLevel */
+     , (32168,  53,        101) /* PlacementPosition - Resting */
+     , (32168,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32168, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32168,   1, False) /* Stuck */
+     , (32168,  11, True ) /* IgnoreCollisions */
+     , (32168,  13, True ) /* Ethereal */
+     , (32168,  14, True ) /* GravityStatus */
+     , (32168,  19, True ) /* Attackable */
+     , (32168,  22, True ) /* Inscribable */
+     , (32168, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32168,  12,       0) /* Shade */
+     , (32168,  13, 0.449999988079071) /* ArmorModVsSlash */
+     , (32168,  14,     0.5) /* ArmorModVsPierce */
+     , (32168,  15,       1) /* ArmorModVsBludgeon */
+     , (32168,  16, 0.449999988079071) /* ArmorModVsCold */
+     , (32168,  17, 0.349999994039536) /* ArmorModVsFire */
+     , (32168,  18,     0.5) /* ArmorModVsAcid */
+     , (32168,  19, 0.300000011920929) /* ArmorModVsElectric */
+     , (32168, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32168,   1, 'Dual Eye Patch') /* Name */
+     , (32168,  16, 'A set of dashing eye patches for the bandit wanting to take a trip.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32168,   1,   33559791) /* Setup */
+     , (32168,   3,  536870932) /* SoundTable */
+     , (32168,   6,   67108990) /* PaletteBase */
+     , (32168,   7,  268437084) /* ClothingBase */
+     , (32168,   8,  100688452) /* Icon */
+     , (32168,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32249 Noble Gauntlets of Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/32249 Noble Gauntlets of Loyalty.sql
@@ -1,0 +1,62 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32249;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32249, 'ace32249-noblegauntletsofloyalty', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32249,   1,          2) /* ItemType - Armor */
+     , (32249,   3,         21) /* PaletteTemplate - Gold */
+     , (32249,   4,      32768) /* ClothingPriority - Hands */
+     , (32249,   5,        150) /* EncumbranceVal */
+     , (32249,   8,        150) /* Mass */
+     , (32249,   9,         32) /* ValidLocations - HandWear */
+     , (32249,  16,          1) /* ItemUseable - No */
+     , (32249,  19,       8000) /* Value */
+     , (32249,  27,          2) /* ArmorType - Leather */
+     , (32249,  28,        400) /* ArmorLevel */
+     , (32249,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32249, 106,        400) /* ItemSpellcraft */
+     , (32249, 107,        800) /* ItemCurMana */
+     , (32249, 108,        800) /* ItemMaxMana */
+     , (32249, 109,        200) /* ItemDifficulty */
+     , (32249, 150,        103) /* HookPlacement - Hook */
+     , (32249, 151,          2) /* HookType - Wall */
+     , (32249, 158,          7) /* WieldRequirements - Level */
+     , (32249, 159,          1) /* WieldSkillType - Axe */
+     , (32249, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32249,  22, True ) /* Inscribable */
+     , (32249,  69, False) /* IsSellable */
+     , (32249, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32249,   5, -0.0165999997407198) /* ManaRate */
+     , (32249,  12, 0.660000026226044) /* Shade */
+     , (32249,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (32249,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (32249,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (32249,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (32249,  17,       1) /* ArmorModVsFire */
+     , (32249,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (32249,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (32249, 110,       1) /* BulkMod */
+     , (32249, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32249,   1, 'Noble Gauntlets of Loyalty') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32249,   1,   33554648) /* Setup */
+     , (32249,   3,  536870932) /* SoundTable */
+     , (32249,   6,   67108990) /* PaletteBase */
+     , (32249,   7,  268436875) /* ClothingBase */
+     , (32249,   8,  100674349) /* Icon */
+     , (32249,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (32249,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (32249,  2108,      2)  /* Brogard's Defiance */
+     , (32249,  3853,      2)  /* Ardent Defense */
+     , (32249,  3854,      2)  /* True Loyalty */
+     , (32249,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/34025 Falatacot Abbess Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/34025 Falatacot Abbess Mask.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34025;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34025, 'ace34025-falatacotabbessmask', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34025,   1,          2) /* ItemType - Armor */
+     , (34025,   3,         69) /* PaletteTemplate - YellowSlime */
+     , (34025,   4,      16384) /* ClothingPriority - Head */
+     , (34025,   5,        150) /* EncumbranceVal */
+     , (34025,   9,          1) /* ValidLocations - HeadWear */
+     , (34025,  16,          1) /* ItemUseable - No */
+     , (34025,  19,        200) /* Value */
+     , (34025,  27,          2) /* ArmorType - Leather */
+     , (34025,  28,         10) /* ArmorLevel */
+     , (34025,  53,        101) /* PlacementPosition - Resting */
+     , (34025,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (34025, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34025,  11, True ) /* IgnoreCollisions */
+     , (34025,  13, True ) /* Ethereal */
+     , (34025,  14, True ) /* GravityStatus */
+     , (34025,  19, True ) /* Attackable */
+     , (34025,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34025,  13,     0.5) /* ArmorModVsSlash */
+     , (34025,  14, 0.400000005960464) /* ArmorModVsPierce */
+     , (34025,  15, 0.400000005960464) /* ArmorModVsBludgeon */
+     , (34025,  16, 0.600000023841858) /* ArmorModVsCold */
+     , (34025,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (34025,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (34025,  19, 0.300000011920929) /* ArmorModVsElectric */
+     , (34025, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34025,   1, 'Falatacot Abbess Mask') /* Name */
+     , (34025,  15, 'A gruesome mask, crafted from the head of an Undead Falatacot.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34025,   1,   33560102) /* Setup */
+     , (34025,   3,  536870932) /* SoundTable */
+     , (34025,   6,   67108990) /* PaletteBase */
+     , (34025,   7,  268437151) /* ClothingBase */
+     , (34025,   8,  100689124) /* Icon */
+     , (34025,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/39027 Armored Sclavus Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/39027 Armored Sclavus Mask.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 39027;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (39027, 'ace39027-armoredsclavusmask', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (39027,   1,          2) /* ItemType - Armor */
+     , (39027,   3,          4) /* PaletteTemplate - Brown */
+     , (39027,   4,      16384) /* ClothingPriority - Head */
+     , (39027,   5,        200) /* EncumbranceVal */
+     , (39027,   9,          1) /* ValidLocations - HeadWear */
+     , (39027,  10,          1) /* CurrentWieldedLocation - HeadWear */
+     , (39027,  19,        500) /* Value */
+     , (39027,  28,         10) /* ArmorLevel */
+     , (39027, 107,          0) /* ItemCurMana */
+     , (39027, 108,          0) /* ItemMaxMana */
+     , (39027, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (39027,  11, True ) /* IgnoreCollisions */
+     , (39027,  13, True ) /* Ethereal */
+     , (39027,  14, True ) /* GravityStatus */
+     , (39027,  19, True ) /* Attackable */
+     , (39027,  22, True ) /* Inscribable */
+     , (39027,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (39027,  13,     0.5) /* ArmorModVsSlash */
+     , (39027,  14,   0.375) /* ArmorModVsPierce */
+     , (39027,  15,    0.25) /* ArmorModVsBludgeon */
+     , (39027,  16,     0.5) /* ArmorModVsCold */
+     , (39027,  17,   0.375) /* ArmorModVsFire */
+     , (39027,  18,   0.125) /* ArmorModVsAcid */
+     , (39027,  19,   0.125) /* ArmorModVsElectric */
+     , (39027, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (39027,   1, 'Armored Sclavus Mask') /* Name */
+     , (39027,  16, 'A mask made from one of the armored Sclavus followers of T''thuun.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (39027,   1,   33560681) /* Setup */
+     , (39027,   3,  536870932) /* SoundTable */
+     , (39027,   6,   67108990) /* PaletteBase */
+     , (39027,   7,  268437338) /* ClothingBase */
+     , (39027,   8,  100690292) /* Icon */
+     , (39027,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (39027,   2, 1343240388) /* Container */
+     , (39027,   3,          0) /* Wielder */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/39028 Armored Sclavus Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/39028 Armored Sclavus Mask.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 39028;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (39028, 'ace39028-armoredsclavusmask', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (39028,   1,          2) /* ItemType - Armor */
+     , (39028,   3,          4) /* PaletteTemplate - Brown */
+     , (39028,   4,      16384) /* ClothingPriority - Head */
+     , (39028,   5,        200) /* EncumbranceVal */
+     , (39028,   9,          1) /* ValidLocations - HeadWear */
+     , (39028,  10,          1) /* CurrentWieldedLocation - HeadWear */
+     , (39028,  19,        500) /* Value */
+     , (39028,  28,         10) /* ArmorLevel */
+     , (39028, 107,          0) /* ItemCurMana */
+     , (39028, 108,          0) /* ItemMaxMana */
+     , (39028, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (39028,  11, True ) /* IgnoreCollisions */
+     , (39028,  13, True ) /* Ethereal */
+     , (39028,  14, True ) /* GravityStatus */
+     , (39028,  19, True ) /* Attackable */
+     , (39028,  22, True ) /* Inscribable */
+     , (39028,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (39028,  13,     0.5) /* ArmorModVsSlash */
+     , (39028,  14,   0.375) /* ArmorModVsPierce */
+     , (39028,  15,    0.25) /* ArmorModVsBludgeon */
+     , (39028,  16,     0.5) /* ArmorModVsCold */
+     , (39028,  17,   0.375) /* ArmorModVsFire */
+     , (39028,  18,   0.125) /* ArmorModVsAcid */
+     , (39028,  19,   0.125) /* ArmorModVsElectric */
+     , (39028, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (39028,   1, 'Armored Sclavus Mask') /* Name */
+     , (39028,  16, 'A mask made from one of the armored Sclavus followers of T''thuun.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (39028,   1,   33560682) /* Setup */
+     , (39028,   3,  536870932) /* SoundTable */
+     , (39028,   6,   67108990) /* PaletteBase */
+     , (39028,   7,  268437339) /* ClothingBase */
+     , (39028,   8,  100690293) /* Icon */
+     , (39028,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (39028,   2, 1343240388) /* Container */
+     , (39028,   3,          0) /* Wielder */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/39029 Armored Sclavus Mask.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/39029 Armored Sclavus Mask.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 39029;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (39029, 'ace39029-armoredsclavusmask', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (39029,   1,          2) /* ItemType - Armor */
+     , (39029,   3,          4) /* PaletteTemplate - Brown */
+     , (39029,   4,      16384) /* ClothingPriority - Head */
+     , (39029,   5,        200) /* EncumbranceVal */
+     , (39029,   9,          1) /* ValidLocations - HeadWear */
+     , (39029,  10,          1) /* CurrentWieldedLocation - HeadWear */
+     , (39029,  19,        500) /* Value */
+     , (39029,  28,         10) /* ArmorLevel */
+     , (39029, 107,          0) /* ItemCurMana */
+     , (39029, 108,          0) /* ItemMaxMana */
+     , (39029, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (39029,  11, True ) /* IgnoreCollisions */
+     , (39029,  13, True ) /* Ethereal */
+     , (39029,  14, True ) /* GravityStatus */
+     , (39029,  19, True ) /* Attackable */
+     , (39029,  22, True ) /* Inscribable */
+     , (39029,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (39029,  13,     0.5) /* ArmorModVsSlash */
+     , (39029,  14,   0.375) /* ArmorModVsPierce */
+     , (39029,  15,    0.25) /* ArmorModVsBludgeon */
+     , (39029,  16,     0.5) /* ArmorModVsCold */
+     , (39029,  17,   0.375) /* ArmorModVsFire */
+     , (39029,  18,   0.125) /* ArmorModVsAcid */
+     , (39029,  19,   0.125) /* ArmorModVsElectric */
+     , (39029, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (39029,   1, 'Armored Sclavus Mask') /* Name */
+     , (39029,  16, 'A mask made from one of the armored Sclavus followers of T''thuun.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (39029,   1,   33560683) /* Setup */
+     , (39029,   3,  536870932) /* SoundTable */
+     , (39029,   6,   67108990) /* PaletteBase */
+     , (39029,   7,  268437340) /* ClothingBase */
+     , (39029,   8,  100690294) /* Icon */
+     , (39029,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (39029,   2, 1343240388) /* Container */
+     , (39029,   3,          0) /* Wielder */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70313 Corrupted Noble Sollerets.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70313 Corrupted Noble Sollerets.sql
@@ -1,0 +1,68 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70313;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70313, 'ace70313-corruptednoblesollerets', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70313,   1,          2) /* ItemType - Armor */
+     , (70313,   3,         21) /* PaletteTemplate - Gold */
+     , (70313,   4,      65536) /* ClothingPriority - Feet */
+     , (70313,   5,        450) /* EncumbranceVal */
+     , (70313,   8,        450) /* Mass */
+     , (70313,   9,        256) /* ValidLocations - FootWear */
+     , (70313,  16,          1) /* ItemUseable - No */
+     , (70313,  19,       8000) /* Value */
+     , (70313,  27,          2) /* ArmorType - Leather */
+     , (70313,  28,        400) /* ArmorLevel */
+     , (70313,  53,        101) /* PlacementPosition - Resting */
+     , (70313,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70313, 106,        400) /* ItemSpellcraft */
+     , (70313, 107,        800) /* ItemCurMana */
+     , (70313, 108,        800) /* ItemMaxMana */
+     , (70313, 109,        200) /* ItemDifficulty */
+     , (70313, 150,        103) /* HookPlacement - Hook */
+     , (70313, 151,          2) /* HookType - Wall */
+     , (70313, 158,          7) /* WieldRequirements - Level */
+     , (70313, 159,          1) /* WieldSkillType - Axe */
+     , (70313, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70313,  11, True ) /* IgnoreCollisions */
+     , (70313,  13, True ) /* Ethereal */
+     , (70313,  14, True ) /* GravityStatus */
+     , (70313,  19, True ) /* Attackable */
+     , (70313,  22, True ) /* Inscribable */
+     , (70313, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70313,   5, -0.0165999997407198) /* ManaRate */
+     , (70313,  12, 0.660000026226044) /* Shade */
+     , (70313,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70313,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70313,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70313,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70313,  17,       1) /* ArmorModVsFire */
+     , (70313,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70313,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70313, 110,       1) /* BulkMod */
+     , (70313, 111,       1) /* SizeMod */
+     , (70313, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70313,   1, 'Corrupted Noble Sollerets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70313,   1,   33554654) /* Setup */
+     , (70313,   3,  536870932) /* SoundTable */
+     , (70313,   6,   67108990) /* PaletteBase */
+     , (70313,   7,  268436876) /* ClothingBase */
+     , (70313,   8,  100667309) /* Icon */
+     , (70313,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70313,   244,      2)  /* Invulnerability Other VI */
+     , (70313,   255,      2)  /* Impregnability Other VI */
+     , (70313,   273,      2)  /* Magic Resistance Other VI */
+     , (70313,  2108,      2)  /* Brogard's Defiance */
+     , (70313,  3851,      2)  /* Corrupted Essence */
+     , (70313,  3852,      2)  /* Ravenous Armor */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70314 Noble Sollerets of Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70314 Noble Sollerets of Loyalty.sql
@@ -1,0 +1,68 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70314;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70314, 'ace70314-noblesolleretsofloyalty', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70314,   1,          2) /* ItemType - Armor */
+     , (70314,   3,         21) /* PaletteTemplate - Gold */
+     , (70314,   4,      65536) /* ClothingPriority - Feet */
+     , (70314,   5,        450) /* EncumbranceVal */
+     , (70314,   8,        450) /* Mass */
+     , (70314,   9,        256) /* ValidLocations - FootWear */
+     , (70314,  16,          1) /* ItemUseable - No */
+     , (70314,  19,       8000) /* Value */
+     , (70314,  27,          2) /* ArmorType - Leather */
+     , (70314,  28,        400) /* ArmorLevel */
+     , (70314,  53,        101) /* PlacementPosition - Resting */
+     , (70314,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70314, 106,        400) /* ItemSpellcraft */
+     , (70314, 107,        800) /* ItemCurMana */
+     , (70314, 108,        800) /* ItemMaxMana */
+     , (70314, 109,        200) /* ItemDifficulty */
+     , (70314, 150,        103) /* HookPlacement - Hook */
+     , (70314, 151,          2) /* HookType - Wall */
+     , (70314, 158,          7) /* WieldRequirements - Level */
+     , (70314, 159,          1) /* WieldSkillType - Axe */
+     , (70314, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70314,  11, True ) /* IgnoreCollisions */
+     , (70314,  13, True ) /* Ethereal */
+     , (70314,  14, True ) /* GravityStatus */
+     , (70314,  19, True ) /* Attackable */
+     , (70314,  22, True ) /* Inscribable */
+     , (70314, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70314,   5, -0.0165999997407198) /* ManaRate */
+     , (70314,  12, 0.660000026226044) /* Shade */
+     , (70314,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70314,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70314,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70314,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70314,  17,       1) /* ArmorModVsFire */
+     , (70314,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70314,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70314, 110,       1) /* BulkMod */
+     , (70314, 111,       1) /* SizeMod */
+     , (70314, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70314,   1, 'Noble Sollerets of Loyalty') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70314,   1,   33554654) /* Setup */
+     , (70314,   3,  536870932) /* SoundTable */
+     , (70314,   6,   67108990) /* PaletteBase */
+     , (70314,   7,  268436876) /* ClothingBase */
+     , (70314,   8,  100667309) /* Icon */
+     , (70314,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70314,   244,      2)  /* Invulnerability Other VI */
+     , (70314,   255,      2)  /* Impregnability Other VI */
+     , (70314,   273,      2)  /* Magic Resistance Other VI */
+     , (70314,  2108,      2)  /* Brogard's Defiance */
+     , (70314,  3853,      2)  /* Ardent Defense */
+     , (70314,  3854,      2)  /* True Loyalty */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70315 Corrupted Noble Leggings.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70315 Corrupted Noble Leggings.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70315;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70315, 'ace70315-corruptednobleleggings', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70315,   1,          2) /* ItemType - Armor */
+     , (70315,   3,         21) /* PaletteTemplate - Gold */
+     , (70315,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (70315,   5,       1150) /* EncumbranceVal */
+     , (70315,   8,       1150) /* Mass */
+     , (70315,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
+     , (70315,  16,          1) /* ItemUseable - No */
+     , (70315,  19,       8000) /* Value */
+     , (70315,  27,          2) /* ArmorType - Leather */
+     , (70315,  28,        400) /* ArmorLevel */
+     , (70315,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70315, 106,        400) /* ItemSpellcraft */
+     , (70315, 107,        800) /* ItemCurMana */
+     , (70315, 108,        800) /* ItemMaxMana */
+     , (70315, 109,        200) /* ItemDifficulty */
+     , (70315, 150,        103) /* HookPlacement - Hook */
+     , (70315, 151,          2) /* HookType - Wall */
+     , (70315, 158,          7) /* WieldRequirements - Level */
+     , (70315, 159,          1) /* WieldSkillType - Axe */
+     , (70315, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70315,  22, True ) /* Inscribable */
+     , (70315, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70315,   5, -0.0165999997407198) /* ManaRate */
+     , (70315,  12, 0.660000026226044) /* Shade */
+     , (70315,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70315,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70315,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70315,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70315,  17,       1) /* ArmorModVsFire */
+     , (70315,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70315,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70315, 110,       1) /* BulkMod */
+     , (70315, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70315,   1, 'Corrupted Noble Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70315,   1,   33554856) /* Setup */
+     , (70315,   3,  536870932) /* SoundTable */
+     , (70315,   6,   67108990) /* PaletteBase */
+     , (70315,   7,  268436878) /* ClothingBase */
+     , (70315,   8,  100675043) /* Icon */
+     , (70315,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70315,   568,      2)  /* Creature Enchantment Mastery Other VI */
+     , (70315,   592,      2)  /* Item Enchantment Mastery Other VI */
+     , (70315,   616,      2)  /* Life Magic Mastery Other VI */
+     , (70315,   640,      2)  /* War Magic Mastery Other VI */
+     , (70315,  2108,      2)  /* Brogard's Defiance */
+     , (70315,  3851,      2)  /* Corrupted Essence */
+     , (70315,  3852,      2)  /* Ravenous Armor */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70316 Noble Leggings of Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70316 Noble Leggings of Loyalty.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70316;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70316, 'ace70316-nobleleggingsofloyalty', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70316,   1,          2) /* ItemType - Armor */
+     , (70316,   3,         21) /* PaletteTemplate - Gold */
+     , (70316,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (70316,   5,       1150) /* EncumbranceVal */
+     , (70316,   8,       1150) /* Mass */
+     , (70316,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
+     , (70316,  16,          1) /* ItemUseable - No */
+     , (70316,  19,       8000) /* Value */
+     , (70316,  27,          2) /* ArmorType - Leather */
+     , (70316,  28,        400) /* ArmorLevel */
+     , (70316,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70316, 106,        400) /* ItemSpellcraft */
+     , (70316, 107,        800) /* ItemCurMana */
+     , (70316, 108,        800) /* ItemMaxMana */
+     , (70316, 109,        200) /* ItemDifficulty */
+     , (70316, 150,        103) /* HookPlacement - Hook */
+     , (70316, 151,          2) /* HookType - Wall */
+     , (70316, 158,          7) /* WieldRequirements - Level */
+     , (70316, 159,          1) /* WieldSkillType - Axe */
+     , (70316, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70316,  22, True ) /* Inscribable */
+     , (70316, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70316,   5, -0.0165999997407198) /* ManaRate */
+     , (70316,  12, 0.660000026226044) /* Shade */
+     , (70316,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70316,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70316,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70316,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70316,  17,       1) /* ArmorModVsFire */
+     , (70316,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70316,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70316, 110,       1) /* BulkMod */
+     , (70316, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70316,   1, 'Noble Leggings of Loyalty') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70316,   1,   33554856) /* Setup */
+     , (70316,   3,  536870932) /* SoundTable */
+     , (70316,   6,   67108990) /* PaletteBase */
+     , (70316,   7,  268436878) /* ClothingBase */
+     , (70316,   8,  100675043) /* Icon */
+     , (70316,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70316,   568,      2)  /* Creature Enchantment Mastery Other VI */
+     , (70316,   592,      2)  /* Item Enchantment Mastery Other VI */
+     , (70316,   616,      2)  /* Life Magic Mastery Other VI */
+     , (70316,   640,      2)  /* War Magic Mastery Other VI */
+     , (70316,  2108,      2)  /* Brogard's Defiance */
+     , (70316,  3853,      2)  /* Ardent Defense */
+     , (70316,  3854,      2)  /* True Loyalty */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70317 Corrupted Noble Gauntlets.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70317 Corrupted Noble Gauntlets.sql
@@ -1,0 +1,62 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70317;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70317, 'ace70317-corruptednoblegauntlets', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70317,   1,          2) /* ItemType - Armor */
+     , (70317,   3,         21) /* PaletteTemplate - Gold */
+     , (70317,   4,      32768) /* ClothingPriority - Hands */
+     , (70317,   5,        150) /* EncumbranceVal */
+     , (70317,   8,        150) /* Mass */
+     , (70317,   9,         32) /* ValidLocations - HandWear */
+     , (70317,  16,          1) /* ItemUseable - No */
+     , (70317,  19,       8000) /* Value */
+     , (70317,  27,          2) /* ArmorType - Leather */
+     , (70317,  28,        400) /* ArmorLevel */
+     , (70317,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70317, 106,        400) /* ItemSpellcraft */
+     , (70317, 107,        800) /* ItemCurMana */
+     , (70317, 108,        800) /* ItemMaxMana */
+     , (70317, 109,        200) /* ItemDifficulty */
+     , (70317, 150,        103) /* HookPlacement - Hook */
+     , (70317, 151,          2) /* HookType - Wall */
+     , (70317, 158,          7) /* WieldRequirements - Level */
+     , (70317, 159,          1) /* WieldSkillType - Axe */
+     , (70317, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70317,  22, True ) /* Inscribable */
+     , (70317,  69, False) /* IsSellable */
+     , (70317, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70317,   5, -0.0165999997407198) /* ManaRate */
+     , (70317,  12, 0.660000026226044) /* Shade */
+     , (70317,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70317,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70317,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70317,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70317,  17,       1) /* ArmorModVsFire */
+     , (70317,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70317,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70317, 110,       1) /* BulkMod */
+     , (70317, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70317,   1, 'Corrupted Noble Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70317,   1,   33554648) /* Setup */
+     , (70317,   3,  536870932) /* SoundTable */
+     , (70317,   6,   67108990) /* PaletteBase */
+     , (70317,   7,  268436875) /* ClothingBase */
+     , (70317,   8,  100674349) /* Icon */
+     , (70317,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70317,   321,      2)  /* Finesse Weapon Mastery Other VI */
+     , (70317,  2108,      2)  /* Brogard's Defiance */
+     , (70317,  3851,      2)  /* Corrupted Essence */
+     , (70317,  3852,      2)  /* Ravenous Armor */
+     , (70317,  5096,      2)  /* Two Handed Combat Mastery Other VI */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70318 Corrupted Noble Helm.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70318 Corrupted Noble Helm.sql
@@ -1,0 +1,66 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70318;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70318, 'ace70318-corruptednoblehelm', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70318,   1,          2) /* ItemType - Armor */
+     , (70318,   3,         21) /* PaletteTemplate - Gold */
+     , (70318,   4,      16384) /* ClothingPriority - Head */
+     , (70318,   5,        350) /* EncumbranceVal */
+     , (70318,   8,        350) /* Mass */
+     , (70318,   9,          1) /* ValidLocations - HeadWear */
+     , (70318,  16,          1) /* ItemUseable - No */
+     , (70318,  19,       8000) /* Value */
+     , (70318,  27,          2) /* ArmorType - Leather */
+     , (70318,  28,        400) /* ArmorLevel */
+     , (70318,  53,        101) /* PlacementPosition - Resting */
+     , (70318,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70318, 106,        400) /* ItemSpellcraft */
+     , (70318, 107,        800) /* ItemCurMana */
+     , (70318, 108,        800) /* ItemMaxMana */
+     , (70318, 109,        200) /* ItemDifficulty */
+     , (70318, 150,        103) /* HookPlacement - Hook */
+     , (70318, 151,          2) /* HookType - Wall */
+     , (70318, 158,          7) /* WieldRequirements - Level */
+     , (70318, 159,          1) /* WieldSkillType - Axe */
+     , (70318, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70318,  11, True ) /* IgnoreCollisions */
+     , (70318,  13, True ) /* Ethereal */
+     , (70318,  14, True ) /* GravityStatus */
+     , (70318,  19, True ) /* Attackable */
+     , (70318,  22, True ) /* Inscribable */
+     , (70318, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70318,   5, -0.0165999997407198) /* ManaRate */
+     , (70318,  12, 0.660000026226044) /* Shade */
+     , (70318,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70318,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70318,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70318,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70318,  17,       1) /* ArmorModVsFire */
+     , (70318,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70318,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70318, 110,       1) /* BulkMod */
+     , (70318, 111,       1) /* SizeMod */
+     , (70318, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70318,   1, 'Corrupted Noble Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70318,   1,   33559080) /* Setup */
+     , (70318,   3,  536870932) /* SoundTable */
+     , (70318,   6,   67108990) /* PaletteBase */
+     , (70318,   7,  268436879) /* ClothingBase */
+     , (70318,   8,  100674952) /* Icon */
+     , (70318,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70318,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (70318,  2108,      2)  /* Brogard's Defiance */
+     , (70318,  3851,      2)  /* Corrupted Essence */
+     , (70318,  3852,      2)  /* Ravenous Armor */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70319 Noble Helm of Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70319 Noble Helm of Loyalty.sql
@@ -1,0 +1,66 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70319;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70319, 'ace70319-noblehelmofloyalty', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70319,   1,          2) /* ItemType - Armor */
+     , (70319,   3,         21) /* PaletteTemplate - Gold */
+     , (70319,   4,      16384) /* ClothingPriority - Head */
+     , (70319,   5,        350) /* EncumbranceVal */
+     , (70319,   8,        350) /* Mass */
+     , (70319,   9,          1) /* ValidLocations - HeadWear */
+     , (70319,  16,          1) /* ItemUseable - No */
+     , (70319,  19,       8000) /* Value */
+     , (70319,  27,          2) /* ArmorType - Leather */
+     , (70319,  28,        400) /* ArmorLevel */
+     , (70319,  53,        101) /* PlacementPosition - Resting */
+     , (70319,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70319, 106,        400) /* ItemSpellcraft */
+     , (70319, 107,        800) /* ItemCurMana */
+     , (70319, 108,        800) /* ItemMaxMana */
+     , (70319, 109,        200) /* ItemDifficulty */
+     , (70319, 150,        103) /* HookPlacement - Hook */
+     , (70319, 151,          2) /* HookType - Wall */
+     , (70319, 158,          7) /* WieldRequirements - Level */
+     , (70319, 159,          1) /* WieldSkillType - Axe */
+     , (70319, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70319,  11, True ) /* IgnoreCollisions */
+     , (70319,  13, True ) /* Ethereal */
+     , (70319,  14, True ) /* GravityStatus */
+     , (70319,  19, True ) /* Attackable */
+     , (70319,  22, True ) /* Inscribable */
+     , (70319, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70319,   5, -0.0165999997407198) /* ManaRate */
+     , (70319,  12, 0.660000026226044) /* Shade */
+     , (70319,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70319,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70319,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70319,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70319,  17,       1) /* ArmorModVsFire */
+     , (70319,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70319,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70319, 110,       1) /* BulkMod */
+     , (70319, 111,       1) /* SizeMod */
+     , (70319, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70319,   1, 'Noble Helm of Loyalty') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70319,   1,   33559080) /* Setup */
+     , (70319,   3,  536870932) /* SoundTable */
+     , (70319,   6,   67108990) /* PaletteBase */
+     , (70319,   7,  268436879) /* ClothingBase */
+     , (70319,   8,  100674952) /* Icon */
+     , (70319,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70319,   466,      2)  /* Missile Weapon Mastery Other VI */
+     , (70319,  2108,      2)  /* Brogard's Defiance */
+     , (70319,  3853,      2)  /* Ardent Defense */
+     , (70319,  3854,      2)  /* True Loyalty */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70320 Corrupted Noble Coat.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70320 Corrupted Noble Coat.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70320;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70320, 'ace70320-corruptednoblecoat', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70320,   1,          2) /* ItemType - Armor */
+     , (70320,   3,         21) /* PaletteTemplate - Gold */
+     , (70320,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (70320,   5,       1250) /* EncumbranceVal */
+     , (70320,   8,       1250) /* Mass */
+     , (70320,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (70320,  16,          1) /* ItemUseable - No */
+     , (70320,  19,       8000) /* Value */
+     , (70320,  27,          2) /* ArmorType - Leather */
+     , (70320,  28,        400) /* ArmorLevel */
+     , (70320,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70320, 106,        400) /* ItemSpellcraft */
+     , (70320, 107,        800) /* ItemCurMana */
+     , (70320, 108,        800) /* ItemMaxMana */
+     , (70320, 109,        200) /* ItemDifficulty */
+     , (70320, 150,        103) /* HookPlacement - Hook */
+     , (70320, 151,          2) /* HookType - Wall */
+     , (70320, 158,          7) /* WieldRequirements - Level */
+     , (70320, 159,          1) /* WieldSkillType - Axe */
+     , (70320, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70320,  22, True ) /* Inscribable */
+     , (70320, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70320,   5, -0.0165999997407198) /* ManaRate */
+     , (70320,  12, 0.660000026226044) /* Shade */
+     , (70320,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70320,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70320,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70320,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70320,  17,       1) /* ArmorModVsFire */
+     , (70320,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70320,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70320, 110,       1) /* BulkMod */
+     , (70320, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70320,   1, 'Corrupted Noble Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70320,   1,   33554642) /* Setup */
+     , (70320,   3,  536870932) /* SoundTable */
+     , (70320,   6,   67108990) /* PaletteBase */
+     , (70320,   7,  268436877) /* ClothingBase */
+     , (70320,   8,  100675042) /* Icon */
+     , (70320,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70320,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (70320,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (70320,  2108,      2)  /* Brogard's Defiance */
+     , (70320,  3851,      2)  /* Corrupted Essence */
+     , (70320,  3852,      2)  /* Ravenous Armor */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70321 Noble Coat of Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Armor/70321 Noble Coat of Loyalty.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70321;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70321, 'ace70321-noblecoatofloyalty', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70321,   1,          2) /* ItemType - Armor */
+     , (70321,   3,         21) /* PaletteTemplate - Gold */
+     , (70321,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (70321,   5,       1250) /* EncumbranceVal */
+     , (70321,   8,       1250) /* Mass */
+     , (70321,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (70321,  16,          1) /* ItemUseable - No */
+     , (70321,  19,       8000) /* Value */
+     , (70321,  27,          2) /* ArmorType - Leather */
+     , (70321,  28,        400) /* ArmorLevel */
+     , (70321,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70321, 106,        400) /* ItemSpellcraft */
+     , (70321, 107,        800) /* ItemCurMana */
+     , (70321, 108,        800) /* ItemMaxMana */
+     , (70321, 109,        200) /* ItemDifficulty */
+     , (70321, 150,        103) /* HookPlacement - Hook */
+     , (70321, 151,          2) /* HookType - Wall */
+     , (70321, 158,          7) /* WieldRequirements - Level */
+     , (70321, 159,          1) /* WieldSkillType - Axe */
+     , (70321, 160,         60) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70321,  22, True ) /* Inscribable */
+     , (70321, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70321,   5, -0.0165999997407198) /* ManaRate */
+     , (70321,  12, 0.660000026226044) /* Shade */
+     , (70321,  13, 1.20000004768372) /* ArmorModVsSlash */
+     , (70321,  14, 1.20000004768372) /* ArmorModVsPierce */
+     , (70321,  15, 1.39999997615814) /* ArmorModVsBludgeon */
+     , (70321,  16, 1.39999997615814) /* ArmorModVsCold */
+     , (70321,  17,       1) /* ArmorModVsFire */
+     , (70321,  18, 0.800000011920929) /* ArmorModVsAcid */
+     , (70321,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (70321, 110,       1) /* BulkMod */
+     , (70321, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70321,   1, 'Noble Coat of Loyalty') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70321,   1,   33554642) /* Setup */
+     , (70321,   3,  536870932) /* SoundTable */
+     , (70321,   6,   67108990) /* PaletteBase */
+     , (70321,   7,  268436877) /* ClothingBase */
+     , (70321,   8,  100675042) /* Icon */
+     , (70321,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (70321,   297,      2)  /* Light Weapon Mastery Other VI */
+     , (70321,   417,      2)  /* Heavy Weapon Mastery Other VI */
+     , (70321,  2108,      2)  /* Brogard's Defiance */
+     , (70321,  3853,      2)  /* Ardent Defense */
+     , (70321,  3854,      2)  /* True Loyalty */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32152 Bathrobe of Ordinary Comfort.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32152 Bathrobe of Ordinary Comfort.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32152;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32152, 'ace32152-bathrobeofordinarycomfort', 2, '2019-09-13 04:06:21') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32152,   1,          4) /* ItemType - Clothing */
+     , (32152,   3,         39) /* PaletteTemplate - Black */
+     , (32152,   4,      16128) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (32152,   5,        200) /* EncumbranceVal */
+     , (32152,   9,      32512) /* ValidLocations - Armor */
+     , (32152,  16,          1) /* ItemUseable - No */
+     , (32152,  19,       1000) /* Value */
+     , (32152,  28,         50) /* ArmorLevel */
+     , (32152,  53,        101) /* PlacementPosition - Resting */
+     , (32152,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32152, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32152,  11, True ) /* IgnoreCollisions */
+     , (32152,  13, True ) /* Ethereal */
+     , (32152,  14, True ) /* GravityStatus */
+     , (32152,  19, True ) /* Attackable */
+     , (32152,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32152,  12,       0) /* Shade */
+     , (32152,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (32152,  14,     0.5) /* ArmorModVsPierce */
+     , (32152,  15,       1) /* ArmorModVsBludgeon */
+     , (32152,  16,     1.5) /* ArmorModVsCold */
+     , (32152,  17,       0) /* ArmorModVsFire */
+     , (32152,  18,       0) /* ArmorModVsAcid */
+     , (32152,  19, 0.300000011920929) /* ArmorModVsElectric */
+     , (32152, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32152,   1, 'Bathrobe of Ordinary Comfort') /* Name */
+     , (32152,  16, 'A plush and comfy bathrobe. A small label on the inside of the robe appears to have been removed.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32152,   1,   33554854) /* Setup */
+     , (32152,   3,  536870932) /* SoundTable */
+     , (32152,   6,   67108990) /* PaletteBase */
+     , (32152,   7,  268436794) /* ClothingBase */
+     , (32152,   8,  100688497) /* Icon */
+     , (32152,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32155 Ursuin Guise.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32155 Ursuin Guise.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32155;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32155, 'ace32155-ursuinguise', 2, '2019-09-15 00:18:36') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32155,   1,          4) /* ItemType - Clothing */
+     , (32155,   3,          4) /* PaletteTemplate - Brown */
+     , (32155,   4,     114432) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Hands, Feet */
+     , (32155,   5,       1400) /* EncumbranceVal */
+     , (32155,   9,      32544) /* ValidLocations - HandWear, Armor */
+     , (32155,  16,          1) /* ItemUseable - No */
+     , (32155,  19,       1000) /* Value */
+     , (32155,  28,         10) /* ArmorLevel */
+     , (32155,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32155, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32155,   1, False) /* Stuck */
+     , (32155,  11, True ) /* IgnoreCollisions */
+     , (32155,  13, True ) /* Ethereal */
+     , (32155,  14, True ) /* GravityStatus */
+     , (32155,  19, True ) /* Attackable */
+     , (32155,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32155,  12,       0) /* Shade */
+     , (32155,  13,     0.5) /* ArmorModVsSlash */
+     , (32155,  14,     0.5) /* ArmorModVsPierce */
+     , (32155,  15,    0.75) /* ArmorModVsBludgeon */
+     , (32155,  16, 0.649999976158142) /* ArmorModVsCold */
+     , (32155,  17, 0.550000011920929) /* ArmorModVsFire */
+     , (32155,  18, 0.550000011920929) /* ArmorModVsAcid */
+     , (32155,  19, 0.649999976158142) /* ArmorModVsElectric */
+     , (32155, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32155,   1, 'Ursuin Guise') /* Name */
+     , (32155,  16, 'An awkward Ursuin Guise. All you need is an Ursuin Mask to complete the look.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32155,   1,   33559782) /* Setup */
+     , (32155,   3,  536870932) /* SoundTable */
+     , (32155,   7,  268437085) /* ClothingBase */
+     , (32155,   8,  100688468) /* Icon */
+     , (32155,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32187 Festival Robe.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32187 Festival Robe.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32187;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32187, 'ace32187-festivalrobe', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32187,   1,          4) /* ItemType - Clothing */
+     , (32187,   3,         39) /* PaletteTemplate - Black */
+     , (32187,   4,      81664) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */
+     , (32187,   5,        200) /* EncumbranceVal */
+     , (32187,   9,      32512) /* ValidLocations - Armor */
+     , (32187,  16,          1) /* ItemUseable - No */
+     , (32187,  19,         42) /* Value */
+     , (32187,  28,          0) /* ArmorLevel */
+     , (32187,  53,        101) /* PlacementPosition - Resting */
+     , (32187,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32187,  11, True ) /* IgnoreCollisions */
+     , (32187,  13, True ) /* Ethereal */
+     , (32187,  14, True ) /* GravityStatus */
+     , (32187,  19, True ) /* Attackable */
+     , (32187,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32187,  12,       0) /* Shade */
+     , (32187,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (32187,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (32187,  15,       1) /* ArmorModVsBludgeon */
+     , (32187,  16, 0.200000002980232) /* ArmorModVsCold */
+     , (32187,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32187,  18, 0.100000001490116) /* ArmorModVsAcid */
+     , (32187,  19, 0.200000002980232) /* ArmorModVsElectric */
+     , (32187,  84,       0) /* Shade2 */
+     , (32187, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32187,   1, 'Festival Robe') /* Name */
+     , (32187,  16, 'A robe celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32187,   1,   33554854) /* Setup */
+     , (32187,   3,  536870932) /* SoundTable */
+     , (32187,   6,   67108990) /* PaletteBase */
+     , (32187,   7,  268437080) /* ClothingBase */
+     , (32187,   8,  100688495) /* Icon */
+     , (32187,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32188 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32188 Festival Shirt.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32188;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32188, 'ace32188-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32188,   1,          4) /* ItemType - Clothing */
+     , (32188,   3,         39) /* PaletteTemplate - Black */
+     , (32188,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32188,   5,         42) /* EncumbranceVal */
+     , (32188,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32188,  16,          1) /* ItemUseable - No */
+     , (32188,  19,          4) /* Value */
+     , (32188,  28,          0) /* ArmorLevel */
+     , (32188,  53,        101) /* PlacementPosition - Resting */
+     , (32188,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32188,  11, True ) /* IgnoreCollisions */
+     , (32188,  13, True ) /* Ethereal */
+     , (32188,  14, True ) /* GravityStatus */
+     , (32188,  19, True ) /* Attackable */
+     , (32188,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32188,  12,       0) /* Shade */
+     , (32188,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (32188,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (32188,  15,       1) /* ArmorModVsBludgeon */
+     , (32188,  16, 0.200000002980232) /* ArmorModVsCold */
+     , (32188,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (32188,  18, 0.100000001490116) /* ArmorModVsAcid */
+     , (32188,  19, 0.200000002980232) /* ArmorModVsElectric */
+     , (32188, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32188,   1, 'Festival Shirt') /* Name */
+     , (32188,   7, 'This IS my costume.') /* Inscription */
+     , (32188,   8, '-') /* ScribeName */
+     , (32188,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32188,   1,   33554883) /* Setup */
+     , (32188,   3,  536870932) /* SoundTable */
+     , (32188,   6,   67108990) /* PaletteBase */
+     , (32188,   7,  268437081) /* ClothingBase */
+     , (32188,   8,  100667377) /* Icon */
+     , (32188,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32189 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32189 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32189;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32189, 'ace32189-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32189,   1,          4) /* ItemType - Clothing */
+     , (32189,   3,         39) /* PaletteTemplate - Black */
+     , (32189,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32189,   5,         42) /* EncumbranceVal */
+     , (32189,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32189,  16,          1) /* ItemUseable - No */
+     , (32189,  19,         23) /* Value */
+     , (32189,  53,        101) /* PlacementPosition - Resting */
+     , (32189,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32189,  11, True ) /* IgnoreCollisions */
+     , (32189,  13, True ) /* Ethereal */
+     , (32189,  14, True ) /* GravityStatus */
+     , (32189,  19, True ) /* Attackable */
+     , (32189,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32189,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32189,   1, 'Festival Shirt') /* Name */
+     , (32189,   7, 'This shirt tastes orange') /* Inscription */
+     , (32189,   8, '-') /* ScribeName */
+     , (32189,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32189,   1,   33554883) /* Setup */
+     , (32189,   3,  536870932) /* SoundTable */
+     , (32189,   6,   67108990) /* PaletteBase */
+     , (32189,   7,  268437081) /* ClothingBase */
+     , (32189,   8,  100667377) /* Icon */
+     , (32189,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32190 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32190 Festival Shirt.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32190;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32190, 'ace32190-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32190,   1,          4) /* ItemType - Clothing */
+     , (32190,   3,         39) /* PaletteTemplate - Black */
+     , (32190,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32190,   5,         42) /* EncumbranceVal */
+     , (32190,   9,         14) /* ValidLocations - ChestWear, AbdomenWear, UpperArmWear */
+     , (32190,  16,          1) /* ItemUseable - No */
+     , (32190,  19,          8) /* Value */
+     , (32190,  53,        101) /* PlacementPosition - Resting */
+     , (32190,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32190,  11, True ) /* IgnoreCollisions */
+     , (32190,  13, True ) /* Ethereal */
+     , (32190,  14, True ) /* GravityStatus */
+     , (32190,  19, True ) /* Attackable */
+     , (32190,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32190,   1, 'Festival Shirt') /* Name */
+     , (32190,   7, 'BMF') /* Inscription */
+     , (32190,   8, ' Bad Moon Faden') /* ScribeName */
+     , (32190,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32190,   1,   33554883) /* Setup */
+     , (32190,   3,  536870932) /* SoundTable */
+     , (32190,   6,   67108990) /* PaletteBase */
+     , (32190,   7,  268437081) /* ClothingBase */
+     , (32190,   8,  100667377) /* Icon */
+     , (32190,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32191 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32191 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32191;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32191, 'ace32191-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32191,   1,          4) /* ItemType - Clothing */
+     , (32191,   3,         76) /* PaletteTemplate - Orange */
+     , (32191,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32191,   5,         42) /* EncumbranceVal */
+     , (32191,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32191,  16,          1) /* ItemUseable - No */
+     , (32191,  19,         15) /* Value */
+     , (32191,  53,        101) /* PlacementPosition - Resting */
+     , (32191,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32191,  11, True ) /* IgnoreCollisions */
+     , (32191,  13, True ) /* Ethereal */
+     , (32191,  14, True ) /* GravityStatus */
+     , (32191,  19, True ) /* Attackable */
+     , (32191,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32191,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32191,   1, 'Festival Shirt') /* Name */
+     , (32191,   7, 'Spooky, Creepy and full of candy') /* Inscription */
+     , (32191,   8, '-') /* ScribeName */
+     , (32191,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32191,   1,   33554883) /* Setup */
+     , (32191,   3,  536870932) /* SoundTable */
+     , (32191,   6,   67108990) /* PaletteBase */
+     , (32191,   7,  268437081) /* ClothingBase */
+     , (32191,   8,  100667379) /* Icon */
+     , (32191,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32192 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32192 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32192;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32192, 'ace32192-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32192,   1,          4) /* ItemType - Clothing */
+     , (32192,   3,         39) /* PaletteTemplate - Black */
+     , (32192,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32192,   5,         42) /* EncumbranceVal */
+     , (32192,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32192,  16,          1) /* ItemUseable - No */
+     , (32192,  19,         16) /* Value */
+     , (32192,  53,        101) /* PlacementPosition - Resting */
+     , (32192,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32192,  11, True ) /* IgnoreCollisions */
+     , (32192,  13, True ) /* Ethereal */
+     , (32192,  14, True ) /* GravityStatus */
+     , (32192,  19, True ) /* Attackable */
+     , (32192,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32192,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32192,   1, 'Festival Shirt') /* Name */
+     , (32192,   7, 'My other shirt is chainmail') /* Inscription */
+     , (32192,   8, ' Londigul Ellic the Armorer') /* ScribeName */
+     , (32192,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32192,   1,   33554883) /* Setup */
+     , (32192,   3,  536870932) /* SoundTable */
+     , (32192,   6,   67108990) /* PaletteBase */
+     , (32192,   7,  268437081) /* ClothingBase */
+     , (32192,   8,  100667377) /* Icon */
+     , (32192,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32193 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32193 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32193;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32193, 'ace32193-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32193,   1,          4) /* ItemType - Clothing */
+     , (32193,   3,         39) /* PaletteTemplate - Black */
+     , (32193,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32193,   5,         42) /* EncumbranceVal */
+     , (32193,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32193,  16,          1) /* ItemUseable - No */
+     , (32193,  19,         23) /* Value */
+     , (32193,  53,        101) /* PlacementPosition - Resting */
+     , (32193,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32193,  11, True ) /* IgnoreCollisions */
+     , (32193,  13, True ) /* Ethereal */
+     , (32193,  14, True ) /* GravityStatus */
+     , (32193,  19, True ) /* Attackable */
+     , (32193,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32193,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32193,   1, 'Festival Shirt') /* Name */
+     , (32193,   7, 'This shirt guaranteed to repel all insects') /* Inscription */
+     , (32193,   8, 'Telk the Addlepated') /* ScribeName */
+     , (32193,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32193,   1,   33554883) /* Setup */
+     , (32193,   3,  536870932) /* SoundTable */
+     , (32193,   6,   67108990) /* PaletteBase */
+     , (32193,   7,  268437081) /* ClothingBase */
+     , (32193,   8,  100667377) /* Icon */
+     , (32193,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32194 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32194 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32194;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32194, 'ace32194-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32194,   1,          4) /* ItemType - Clothing */
+     , (32194,   3,         39) /* PaletteTemplate - Black */
+     , (32194,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32194,   5,         42) /* EncumbranceVal */
+     , (32194,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32194,  16,          1) /* ItemUseable - No */
+     , (32194,  19,          4) /* Value */
+     , (32194,  53,        101) /* PlacementPosition - Resting */
+     , (32194,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32194,  11, True ) /* IgnoreCollisions */
+     , (32194,  13, True ) /* Ethereal */
+     , (32194,  14, True ) /* GravityStatus */
+     , (32194,  19, True ) /* Attackable */
+     , (32194,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32194,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32194,   1, 'Festival Shirt') /* Name */
+     , (32194,   7, 'WWUD') /* Inscription */
+     , (32194,   8, 'Ulgrim the Unpleasant') /* ScribeName */
+     , (32194,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32194,   1,   33554883) /* Setup */
+     , (32194,   3,  536870932) /* SoundTable */
+     , (32194,   6,   67108990) /* PaletteBase */
+     , (32194,   7,  268437081) /* ClothingBase */
+     , (32194,   8,  100667377) /* Icon */
+     , (32194,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32195 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32195 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32195;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32195, 'ace32195-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32195,   1,          4) /* ItemType - Clothing */
+     , (32195,   3,         39) /* PaletteTemplate - Black */
+     , (32195,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32195,   5,         42) /* EncumbranceVal */
+     , (32195,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32195,  16,          1) /* ItemUseable - No */
+     , (32195,  19,          8) /* Value */
+     , (32195,  53,        101) /* PlacementPosition - Resting */
+     , (32195,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32195,  11, True ) /* IgnoreCollisions */
+     , (32195,  13, True ) /* Ethereal */
+     , (32195,  14, True ) /* GravityStatus */
+     , (32195,  19, True ) /* Attackable */
+     , (32195,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32195,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32195,   1, 'Festival Shirt') /* Name */
+     , (32195,   7, 'Heightened levels of joy on your annual celebration of torpidity') /* Inscription */
+     , (32195,   8, 'Virind Leopold') /* ScribeName */
+     , (32195,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32195,   1,   33554883) /* Setup */
+     , (32195,   3,  536870932) /* SoundTable */
+     , (32195,   6,   67108990) /* PaletteBase */
+     , (32195,   7,  268437081) /* ClothingBase */
+     , (32195,   8,  100667377) /* Icon */
+     , (32195,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32196 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32196 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32196;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32196, 'ace32196-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32196,   1,          4) /* ItemType - Clothing */
+     , (32196,   3,         76) /* PaletteTemplate - Orange */
+     , (32196,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32196,   5,         42) /* EncumbranceVal */
+     , (32196,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32196,  16,          1) /* ItemUseable - No */
+     , (32196,  19,         15) /* Value */
+     , (32196,  28,          0) /* ArmorLevel */
+     , (32196,  53,        101) /* PlacementPosition - Resting */
+     , (32196,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32196,  11, True ) /* IgnoreCollisions */
+     , (32196,  13, True ) /* Ethereal */
+     , (32196,  14, True ) /* GravityStatus */
+     , (32196,  19, True ) /* Attackable */
+     , (32196,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32196,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32196,   1, 'Festival Shirt') /* Name */
+     , (32196,   7, 'By the pricking of my thumb, something wicked this way comes') /* Inscription */
+     , (32196,   8, '-') /* ScribeName */
+     , (32196,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32196,   1,   33554883) /* Setup */
+     , (32196,   3,  536870932) /* SoundTable */
+     , (32196,   6,   67108990) /* PaletteBase */
+     , (32196,   7,  268437081) /* ClothingBase */
+     , (32196,   8,  100667379) /* Icon */
+     , (32196,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32197 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/32197 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32197;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32197, 'ace32197-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32197,   1,          4) /* ItemType - Clothing */
+     , (32197,   3,         76) /* PaletteTemplate - Orange */
+     , (32197,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (32197,   5,         42) /* EncumbranceVal */
+     , (32197,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (32197,  16,          1) /* ItemUseable - No */
+     , (32197,  19,         16) /* Value */
+     , (32197,  53,        101) /* PlacementPosition - Resting */
+     , (32197,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32197,  11, True ) /* IgnoreCollisions */
+     , (32197,  13, True ) /* Ethereal */
+     , (32197,  14, True ) /* GravityStatus */
+     , (32197,  19, True ) /* Attackable */
+     , (32197,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32197,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32197,   1, 'Festival Shirt') /* Name */
+     , (32197,   7, 'Varicci stinks!') /* Inscription */
+     , (32197,   8, '-') /* ScribeName */
+     , (32197,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32197,   1,   33554883) /* Setup */
+     , (32197,   3,  536870932) /* SoundTable */
+     , (32197,   6,   67108990) /* PaletteBase */
+     , (32197,   7,  268437081) /* ClothingBase */
+     , (32197,   8,  100667379) /* Icon */
+     , (32197,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34105 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34105 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34105;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34105, 'ace34105-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34105,   1,          4) /* ItemType - Clothing */
+     , (34105,   3,         76) /* PaletteTemplate - Orange */
+     , (34105,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (34105,   5,         42) /* EncumbranceVal */
+     , (34105,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (34105,  16,          1) /* ItemUseable - No */
+     , (34105,  19,          8) /* Value */
+     , (34105,  28,          0) /* ArmorLevel */
+     , (34105,  53,        101) /* PlacementPosition - Resting */
+     , (34105,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34105,  11, True ) /* IgnoreCollisions */
+     , (34105,  13, True ) /* Ethereal */
+     , (34105,  14, True ) /* GravityStatus */
+     , (34105,  19, True ) /* Attackable */
+     , (34105,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34105,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34105,   1, 'Festival Shirt') /* Name */
+     , (34105,   7, 'I''m not wearing a costume! This is just a t-shirt you fool.') /* Inscription */
+     , (34105,   8, 'Ulgrim') /* ScribeName */
+     , (34105,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34105,   1,   33554883) /* Setup */
+     , (34105,   3,  536870932) /* SoundTable */
+     , (34105,   6,   67108990) /* PaletteBase */
+     , (34105,   7,  268437081) /* ClothingBase */
+     , (34105,   8,  100667379) /* Icon */
+     , (34105,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34106 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34106 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34106;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34106, 'ace34106-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34106,   1,          4) /* ItemType - Clothing */
+     , (34106,   3,         39) /* PaletteTemplate - Black */
+     , (34106,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (34106,   5,          4) /* EncumbranceVal */
+     , (34106,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (34106,  16,          1) /* ItemUseable - No */
+     , (34106,  19,         23) /* Value */
+     , (34106,  28,          0) /* ArmorLevel */
+     , (34106,  53,        101) /* PlacementPosition - Resting */
+     , (34106,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34106,  11, True ) /* IgnoreCollisions */
+     , (34106,  13, True ) /* Ethereal */
+     , (34106,  14, True ) /* GravityStatus */
+     , (34106,  19, True ) /* Attackable */
+     , (34106,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34106,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34106,   1, 'Festival Shirt') /* Name */
+     , (34106,   7, 'This shirt has absorbed stout from every bar in Dereth. Enjoy!') /* Inscription */
+     , (34106,   8, 'Ulgrim') /* ScribeName */
+     , (34106,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34106,   1,   33554883) /* Setup */
+     , (34106,   3,  536870932) /* SoundTable */
+     , (34106,   6,   67108990) /* PaletteBase */
+     , (34106,   7,  268437081) /* ClothingBase */
+     , (34106,   8,  100667377) /* Icon */
+     , (34106,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34107 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34107 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34107;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34107, 'ace34107-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34107,   1,          4) /* ItemType - Clothing */
+     , (34107,   3,         39) /* PaletteTemplate - Black */
+     , (34107,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (34107,   5,         42) /* EncumbranceVal */
+     , (34107,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (34107,  16,          1) /* ItemUseable - No */
+     , (34107,  19,         23) /* Value */
+     , (34107,  28,          0) /* ArmorLevel */
+     , (34107,  53,        101) /* PlacementPosition - Resting */
+     , (34107,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34107,  11, True ) /* IgnoreCollisions */
+     , (34107,  13, True ) /* Ethereal */
+     , (34107,  14, True ) /* GravityStatus */
+     , (34107,  19, True ) /* Attackable */
+     , (34107,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34107,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34107,   1, 'Festival Shirt') /* Name */
+     , (34107,   7, 'Please, wear this shirt. Its horrible arcane script in a dead language will surely not harm you or anyone around you. "Rybbo Vacdejym Caycuh!') /* Inscription */
+     , (34107,   8, 'Grael') /* ScribeName */
+     , (34107,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34107,   1,   33554883) /* Setup */
+     , (34107,   3,  536870932) /* SoundTable */
+     , (34107,   6,   67108990) /* PaletteBase */
+     , (34107,   7,  268437081) /* ClothingBase */
+     , (34107,   8,  100667377) /* Icon */
+     , (34107,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34108 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34108 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34108;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34108, 'ace34108-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34108,   1,          4) /* ItemType - Clothing */
+     , (34108,   3,         76) /* PaletteTemplate - Orange */
+     , (34108,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (34108,   5,         42) /* EncumbranceVal */
+     , (34108,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (34108,  16,          1) /* ItemUseable - No */
+     , (34108,  19,         15) /* Value */
+     , (34108,  28,          0) /* ArmorLevel */
+     , (34108,  53,        101) /* PlacementPosition - Resting */
+     , (34108,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34108,  11, True ) /* IgnoreCollisions */
+     , (34108,  13, True ) /* Ethereal */
+     , (34108,  14, True ) /* GravityStatus */
+     , (34108,  19, True ) /* Attackable */
+     , (34108,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34108,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34108,   1, 'Festival Shirt') /* Name */
+     , (34108,   7, 'At least I still have my crown') /* Inscription */
+     , (34108,   8, 'Dardante') /* ScribeName */
+     , (34108,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34108,   1,   33554883) /* Setup */
+     , (34108,   3,  536870932) /* SoundTable */
+     , (34108,   6,   67108990) /* PaletteBase */
+     , (34108,   7,  268437081) /* ClothingBase */
+     , (34108,   8,  100667379) /* Icon */
+     , (34108,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34109 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34109 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34109;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34109, 'ace34109-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34109,   1,          4) /* ItemType - Clothing */
+     , (34109,   3,         76) /* PaletteTemplate - Orange */
+     , (34109,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (34109,   5,         42) /* EncumbranceVal */
+     , (34109,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (34109,  16,          1) /* ItemUseable - No */
+     , (34109,  19,         16) /* Value */
+     , (34109,  28,          0) /* ArmorLevel */
+     , (34109,  53,        101) /* PlacementPosition - Resting */
+     , (34109,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34109,  11, True ) /* IgnoreCollisions */
+     , (34109,  13, True ) /* Ethereal */
+     , (34109,  14, True ) /* GravityStatus */
+     , (34109,  19, True ) /* Attackable */
+     , (34109,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34109,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34109,   1, 'Festival Shirt') /* Name */
+     , (34109,   7, 'I looted Nuhmidira''s Basement') /* Inscription */
+     , (34109,   8, '-') /* ScribeName */
+     , (34109,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34109,   1,   33554883) /* Setup */
+     , (34109,   3,  536870932) /* SoundTable */
+     , (34109,   6,   67108990) /* PaletteBase */
+     , (34109,   7,  268437081) /* ClothingBase */
+     , (34109,   8,  100667379) /* Icon */
+     , (34109,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34212 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/34212 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34212;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34212, 'ace34212-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34212,   1,          4) /* ItemType - Clothing */
+     , (34212,   3,         39) /* PaletteTemplate - Black */
+     , (34212,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (34212,   5,         42) /* EncumbranceVal */
+     , (34212,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (34212,  16,          1) /* ItemUseable - No */
+     , (34212,  19,         16) /* Value */
+     , (34212,  28,          0) /* ArmorLevel */
+     , (34212,  53,        101) /* PlacementPosition - Resting */
+     , (34212,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34212,  11, True ) /* IgnoreCollisions */
+     , (34212,  13, True ) /* Ethereal */
+     , (34212,  14, True ) /* GravityStatus */
+     , (34212,  19, True ) /* Attackable */
+     , (34212,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (34212,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34212,   1, 'Festival Shirt') /* Name */
+     , (34212,   7, 'Festival Season 06') /* Inscription */
+     , (34212,   8, '-') /* ScribeName */
+     , (34212,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34212,   1,   33554883) /* Setup */
+     , (34212,   3,  536870932) /* SoundTable */
+     , (34212,   6,   67108990) /* PaletteBase */
+     , (34212,   7,  268437081) /* ClothingBase */
+     , (34212,   8,  100667377) /* Icon */
+     , (34212,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36437 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36437 Festival Shirt.sql
@@ -1,0 +1,58 @@
+DELETE FROM `weenie` WHERE `class_Id` = 36437;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (36437, 'ace36437-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (36437,   1,          4) /* ItemType - Clothing */
+     , (36437,   3,         39) /* PaletteTemplate - Black */
+     , (36437,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (36437,   5,         42) /* EncumbranceVal */
+     , (36437,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (36437,  16,          1) /* ItemUseable - No */
+     , (36437,  19,         20) /* Value */
+     , (36437,  28,         50) /* ArmorLevel */
+     , (36437,  53,        101) /* PlacementPosition - Resting */
+     , (36437,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (36437, 106,        200) /* ItemSpellcraft */
+     , (36437, 107,        200) /* ItemCurMana */
+     , (36437, 108,        200) /* ItemMaxMana */
+     , (36437, 109,          0) /* ItemDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (36437,  11, True ) /* IgnoreCollisions */
+     , (36437,  13, True ) /* Ethereal */
+     , (36437,  14, True ) /* GravityStatus */
+     , (36437,  19, True ) /* Attackable */
+     , (36437,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (36437,   5, -0.0333000011742115) /* ManaRate */
+     , (36437,  12,       0) /* Shade */
+     , (36437,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (36437,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (36437,  15,       1) /* ArmorModVsBludgeon */
+     , (36437,  16, 0.200000002980232) /* ArmorModVsCold */
+     , (36437,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (36437,  18, 0.100000001490116) /* ArmorModVsAcid */
+     , (36437,  19, 0.200000002980232) /* ArmorModVsElectric */
+     , (36437, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (36437,   1, 'Festival Shirt') /* Name */
+     , (36437,   7, 'Festival Season 07') /* Inscription */
+     , (36437,   8, 'Crafters Guild') /* ScribeName */
+     , (36437,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (36437,   1,   33554883) /* Setup */
+     , (36437,   3,  536870932) /* SoundTable */
+     , (36437,   6,   67108990) /* PaletteBase */
+     , (36437,   7,  268437081) /* ClothingBase */
+     , (36437,   8,  100667377) /* Icon */
+     , (36437,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (36437,  2501,      0)  /* Major Alchemical Prowess */
+     , (36437,  2506,      0)  /* Major Cooking Prowess */
+     , (36437,  2512,      0)  /* Major Fletching Prowess */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36438 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36438 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 36438;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (36438, 'ace36438-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (36438,   1,          4) /* ItemType - Clothing */
+     , (36438,   3,         39) /* PaletteTemplate - Black */
+     , (36438,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (36438,   5,         42) /* EncumbranceVal */
+     , (36438,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (36438,  16,          1) /* ItemUseable - No */
+     , (36438,  19,         20) /* Value */
+     , (36438,  28,          0) /* ArmorLevel */
+     , (36438,  53,        101) /* PlacementPosition - Resting */
+     , (36438,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (36438,  11, True ) /* IgnoreCollisions */
+     , (36438,  13, True ) /* Ethereal */
+     , (36438,  14, True ) /* GravityStatus */
+     , (36438,  19, True ) /* Attackable */
+     , (36438,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (36438,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (36438,   1, 'Festival Shirt') /* Name */
+     , (36438,   7, 'If you are reading this, I should have carried more death items') /* Inscription */
+     , (36438,   8, 'Ardry') /* ScribeName */
+     , (36438,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (36438,   1,   33554883) /* Setup */
+     , (36438,   3,  536870932) /* SoundTable */
+     , (36438,   6,   67108990) /* PaletteBase */
+     , (36438,   7,  268437081) /* ClothingBase */
+     , (36438,   8,  100667377) /* Icon */
+     , (36438,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36439 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36439 Festival Shirt.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 36439;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (36439, 'ace36439-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (36439,   1,          4) /* ItemType - Clothing */
+     , (36439,   3,         39) /* PaletteTemplate - Black */
+     , (36439,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (36439,   5,         42) /* EncumbranceVal */
+     , (36439,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (36439,  16,          1) /* ItemUseable - No */
+     , (36439,  19,         20) /* Value */
+     , (36439,  28,          0) /* ArmorLevel */
+     , (36439,  53,        101) /* PlacementPosition - Resting */
+     , (36439,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (36439,  11, True ) /* IgnoreCollisions */
+     , (36439,  13, True ) /* Ethereal */
+     , (36439,  14, True ) /* GravityStatus */
+     , (36439,  19, True ) /* Attackable */
+     , (36439,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (36439,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (36439,   1, 'Festival Shirt') /* Name */
+     , (36439,   7, 'Nanjou Shou-jen are better than Undead Sailors') /* Inscription */
+     , (36439,   8, '-') /* ScribeName */
+     , (36439,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (36439,   1,   33554883) /* Setup */
+     , (36439,   3,  536870932) /* SoundTable */
+     , (36439,   6,   67108990) /* PaletteBase */
+     , (36439,   7,  268437081) /* ClothingBase */
+     , (36439,   8,  100667377) /* Icon */
+     , (36439,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36440 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36440 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 36440;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (36440, 'ace36440-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (36440,   1,          4) /* ItemType - Clothing */
+     , (36440,   3,         76) /* PaletteTemplate - Orange */
+     , (36440,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (36440,   5,         42) /* EncumbranceVal */
+     , (36440,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (36440,  16,          1) /* ItemUseable - No */
+     , (36440,  19,         20) /* Value */
+     , (36440,  53,        101) /* PlacementPosition - Resting */
+     , (36440,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (36440,  11, True ) /* IgnoreCollisions */
+     , (36440,  13, True ) /* Ethereal */
+     , (36440,  14, True ) /* GravityStatus */
+     , (36440,  19, True ) /* Attackable */
+     , (36440,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (36440,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (36440,   1, 'Festival Shirt') /* Name */
+     , (36440,   7, 'Undead Sailors are better than Nanjou Shou-jen') /* Inscription */
+     , (36440,   8, '-') /* ScribeName */
+     , (36440,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (36440,   1,   33554883) /* Setup */
+     , (36440,   3,  536870932) /* SoundTable */
+     , (36440,   6,   67108990) /* PaletteBase */
+     , (36440,   7,  268437081) /* ClothingBase */
+     , (36440,   8,  100667379) /* Icon */
+     , (36440,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36451 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/36451 Festival Shirt.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 36451;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (36451, 'ace36451-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (36451,   1,          4) /* ItemType - Clothing */
+     , (36451,   3,         39) /* PaletteTemplate - Black */
+     , (36451,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (36451,   5,         42) /* EncumbranceVal */
+     , (36451,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (36451,  16,          1) /* ItemUseable - No */
+     , (36451,  19,         20) /* Value */
+     , (36451,  53,        101) /* PlacementPosition - Resting */
+     , (36451,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (36451,  11, True ) /* IgnoreCollisions */
+     , (36451,  13, True ) /* Ethereal */
+     , (36451,  14, True ) /* GravityStatus */
+     , (36451,  19, True ) /* Attackable */
+     , (36451,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (36451,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (36451,   1, 'Festival Shirt') /* Name */
+     , (36451,   7, 'Nanjoe Shou-jen stink!') /* Inscription */
+     , (36451,   8, '-') /* ScribeName */
+     , (36451,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (36451,   1,   33554883) /* Setup */
+     , (36451,   3,  536870932) /* SoundTable */
+     , (36451,   6,   67108990) /* PaletteBase */
+     , (36451,   7,  268437081) /* ClothingBase */
+     , (36451,   8,  100667377) /* Icon */
+     , (36451,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/39112 Festival Shirt.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/39112 Festival Shirt.sql
@@ -1,0 +1,58 @@
+DELETE FROM `weenie` WHERE `class_Id` = 39112;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (39112, 'ace39112-festivalshirt', 2, '2019-09-27 11:34:19') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (39112,   1,          4) /* ItemType - Clothing */
+     , (39112,   3,         39) /* PaletteTemplate - Black */
+     , (39112,   4,         40) /* ClothingPriority - UnderwearChest, UnderwearUpperArms */
+     , (39112,   5,         42) /* EncumbranceVal */
+     , (39112,   9,         10) /* ValidLocations - ChestWear, UpperArmWear */
+     , (39112,  16,          1) /* ItemUseable - No */
+     , (39112,  19,         20) /* Value */
+     , (39112,  28,         50) /* ArmorLevel */
+     , (39112,  53,        101) /* PlacementPosition - Resting */
+     , (39112,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (39112, 106,        200) /* ItemSpellcraft */
+     , (39112, 107,        200) /* ItemCurMana */
+     , (39112, 108,        200) /* ItemMaxMana */
+     , (39112, 109,          0) /* ItemDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (39112,  11, True ) /* IgnoreCollisions */
+     , (39112,  13, True ) /* Ethereal */
+     , (39112,  14, True ) /* GravityStatus */
+     , (39112,  19, True ) /* Attackable */
+     , (39112,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (39112,   5, -0.0333000011742115) /* ManaRate */
+     , (39112,  12,       0) /* Shade */
+     , (39112,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (39112,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (39112,  15,       1) /* ArmorModVsBludgeon */
+     , (39112,  16, 0.200000002980232) /* ArmorModVsCold */
+     , (39112,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (39112,  18, 0.100000001490116) /* ArmorModVsAcid */
+     , (39112,  19, 0.200000002980232) /* ArmorModVsElectric */
+     , (39112, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (39112,   1, 'Festival Shirt') /* Name */
+     , (39112,   7, 'Festival Season 08') /* Inscription */
+     , (39112,   8, 'Crafters Guild') /* ScribeName */
+     , (39112,  16, 'A shirt celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (39112,   1,   33554883) /* Setup */
+     , (39112,   3,  536870932) /* SoundTable */
+     , (39112,   6,   67108990) /* PaletteBase */
+     , (39112,   7,  268437081) /* ClothingBase */
+     , (39112,   8,  100667377) /* Icon */
+     , (39112,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (39112,  2501,      2)  /* Major Alchemical Prowess */
+     , (39112,  2506,      2)  /* Major Cooking Prowess */
+     , (39112,  2512,      2)  /* Major Fletching Prowess */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/70269 Festival Robe.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Clothing/Clothing/70269 Festival Robe.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70269;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70269, 'ace70269-festivalrobe', 2, '2019-09-09 14:38:55') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70269,   1,          4) /* ItemType - Clothing */
+     , (70269,   3,         76) /* PaletteTemplate - Orange */
+     , (70269,   4,      81664) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */
+     , (70269,   5,        200) /* EncumbranceVal */
+     , (70269,   9,      32512) /* ValidLocations - Armor */
+     , (70269,  16,          1) /* ItemUseable - No */
+     , (70269,  19,         42) /* Value */
+     , (70269,  28,          0) /* ArmorLevel */
+     , (70269,  53,        101) /* PlacementPosition - Resting */
+     , (70269,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70269,  11, True ) /* IgnoreCollisions */
+     , (70269,  13, True ) /* Ethereal */
+     , (70269,  14, True ) /* GravityStatus */
+     , (70269,  19, True ) /* Attackable */
+     , (70269,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70269,  12,       0) /* Shade */
+     , (70269,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (70269,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (70269,  15,       1) /* ArmorModVsBludgeon */
+     , (70269,  16, 0.200000002980232) /* ArmorModVsCold */
+     , (70269,  17, 0.200000002980232) /* ArmorModVsFire */
+     , (70269,  18, 0.100000001490116) /* ArmorModVsAcid */
+     , (70269,  19, 0.200000002980232) /* ArmorModVsElectric */
+     , (70269,  84,       0) /* Shade2 */
+     , (70269, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70269,   1, 'Festival Robe') /* Name */
+     , (70269,  16, 'A robe celebrating the Festival Season.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70269,   1,   33554854) /* Setup */
+     , (70269,   3,  536870932) /* SoundTable */
+     , (70269,   6,   67108990) /* PaletteBase */
+     , (70269,   7,  268437080) /* ClothingBase */
+     , (70269,   8,  100688494) /* Icon */
+     , (70269,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Container/32198 Pumpkin Backpack.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Container/32198 Pumpkin Backpack.sql
@@ -1,0 +1,37 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32198;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32198, 'ace32198-pumpkinbackpack', 21, '2019-09-15 06:24:32') /* Container */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32198,   1,        512) /* ItemType - Container */
+     , (32198,   5,          1) /* EncumbranceVal */
+     , (32198,   6,         24) /* ItemsCapacity */
+     , (32198,  16,         56) /* ItemUseable - ContainedViewedRemote */
+     , (32198,  19,        250) /* Value */
+     , (32198,  53,        101) /* PlacementPosition - Resting */
+     , (32198,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32198,   1, False) /* Stuck */
+     , (32198,   2, True ) /* Open */
+     , (32198,  11, True ) /* IgnoreCollisions */
+     , (32198,  13, True ) /* Ethereal */
+     , (32198,  14, True ) /* GravityStatus */
+     , (32198,  19, True ) /* Attackable */
+     , (32198,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32198,  39, 1.29999995231628) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32198,   1, 'Pumpkin Backpack') /* Name */
+     , (32198,  14, 'Use this item to close it.') /* Use */
+     , (32198,  16, 'A hollowed out pumpkin with some straps so it can be used to carry things.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32198,   1,   33556809) /* Setup */
+     , (32198,   3,  536870932) /* SoundTable */
+     , (32198,   6,   67112968) /* PaletteBase */
+     , (32198,   8,  100671019) /* Icon */
+     , (32198,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Container/32199 Pumpkin Follower.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Container/32199 Pumpkin Follower.sql
@@ -1,0 +1,41 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32199;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32199, 'ace32199-pumpkinfollower', 21, '2019-09-13 02:41:34') /* Container */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32199,   1,        512) /* ItemType - Container */
+     , (32199,   5,       3010) /* EncumbranceVal */
+     , (32199,   6,        120) /* ItemsCapacity */
+     , (32199,   7,         10) /* ContainersCapacity */
+     , (32199,  16,         48) /* ItemUseable - ViewedRemote */
+     , (32199,  19,          0) /* Value */
+     , (32199,  81,          1) /* MaxGeneratedObjects */
+     , (32199,  82,          1) /* InitGeneratedObjects */
+     , (32199,  93,       1052) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity */
+     , (32199, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32199,   1, True ) /* Stuck */
+     , (32199,   2, False) /* Open */
+     , (32199,  11, True ) /* IgnoreCollisions */
+     , (32199,  12, True ) /* ReportCollisions */
+     , (32199,  13, True ) /* Ethereal */
+     , (32199,  14, True ) /* GravityStatus */
+     , (32199,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32199,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32199,   1, 'Pumpkin Follower') /* Name */
+     , (32199,  16, 'The corpse of a follower of the Majestic Pumpkin.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32199,   1,   33556617) /* Setup */
+     , (32199,   3,  536870932) /* SoundTable */
+     , (32199,   8,  100667504) /* Icon */
+     , (32199,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (32199, 1, 32200, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Blanket (32200) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/CraftTool/CraftCookingBase/32202 Golden Pumpkin.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/CraftTool/CraftCookingBase/32202 Golden Pumpkin.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32202;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32202, 'ace32202-goldenpumpkin', 1, '2019-09-15 06:24:32') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32202,   1,    4194304) /* ItemType - CraftCookingBase */
+     , (32202,   3,         21) /* PaletteTemplate - Gold */
+     , (32202,   5,         70) /* EncumbranceVal */
+     , (32202,  11,        100) /* MaxStackSize */
+     , (32202,  12,          1) /* StackSize */
+     , (32202,  16,          1) /* ItemUseable - No */
+     , (32202,  19,         10) /* Value */
+     , (32202,  53,        101) /* PlacementPosition - Resting */
+     , (32202,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32202, 151,         11) /* HookType - Floor, Wall, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32202,  11, True ) /* IgnoreCollisions */
+     , (32202,  13, True ) /* Ethereal */
+     , (32202,  14, True ) /* GravityStatus */
+     , (32202,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32202,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32202,   1, 'Golden Pumpkin') /* Name */
+     , (32202,  16, 'This item is used in Jack o'' Lantern crafting.
+
+A beautiful golden pumpkin.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32202,   1,   33556809) /* Setup */
+     , (32202,   3,  536870932) /* SoundTable */
+     , (32202,   6,   67112968) /* PaletteBase */
+     , (32202,   7,  268436043) /* ClothingBase */
+     , (32202,   8,  100688419) /* Icon */
+     , (32202,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/CraftTool/CraftCookingBase/70295 Uncooked Ginger Bread Pumpkin.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/CraftTool/CraftCookingBase/70295 Uncooked Ginger Bread Pumpkin.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70295;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70295, 'ace70295-uncookedgingerbreadpumpkin', 44, '2019-09-15 06:24:32') /* CraftTool */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70295,   1,    4194304) /* ItemType - CraftCookingBase */
+     , (70295,   5,         50) /* EncumbranceVal */
+     , (70295,   8,         25) /* Mass */
+     , (70295,  11,        100) /* MaxStackSize */
+     , (70295,  12,          1) /* StackSize */
+     , (70295,  13,         50) /* StackUnitEncumbrance */
+     , (70295,  14,         25) /* StackUnitMass */
+     , (70295,  15,          2) /* StackUnitValue */
+     , (70295,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (70295,  19,          2) /* Value */
+     , (70295,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70295,  94,    4194336) /* TargetType - Food, CraftCookingBase */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70295,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70295,   1, 'Uncooked Ginger Bread Pumpkin') /* Name */
+     , (70295,  14, 'This item is used in cooking.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70295,   1,   33559780) /* Setup */
+     , (70295,   3,  536870932) /* SoundTable */
+     , (70295,   8,  100688482) /* Icon */
+     , (70295,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/32200 Blue Blanket.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/32200 Blue Blanket.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32200;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32200, 'ace32200-blueblanket', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32200,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
+     , (32200,   5,         10) /* EncumbranceVal */
+     , (32200,  11,          1) /* MaxStackSize */
+     , (32200,  12,          1) /* StackSize */
+     , (32200,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (32200,  19,          0) /* Value */
+     , (32200,  53,        101) /* PlacementPosition - Resting */
+     , (32200,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32200,  94,       1024) /* TargetType - Useless */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32200,  11, True ) /* IgnoreCollisions */
+     , (32200,  13, True ) /* Ethereal */
+     , (32200,  14, True ) /* GravityStatus */
+     , (32200,  19, True ) /* Attackable */
+     , (32200,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32200,   1, 'Blue Blanket') /* Name */
+     , (32200,  16, 'A simple blue blanket.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32200,   1,   33555063) /* Setup */
+     , (32200,   3,  536870932) /* SoundTable */
+     , (32200,   8,  100688459) /* Icon */
+     , (32200,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32207 Candy Corn.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32207 Candy Corn.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32207;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32207, 'ace32207-candycorn', 18, '2019-09-13 02:41:34') /* Food */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32207,   1,         32) /* ItemType - Food */
+     , (32207,   5,          1) /* EncumbranceVal */
+     , (32207,  11,         10) /* MaxStackSize */
+     , (32207,  12,          1) /* StackSize */
+     , (32207,  16,          8) /* ItemUseable - Contained */
+     , (32207,  18,          1) /* UiEffects - Magical */
+     , (32207,  19,         10) /* Value */
+     , (32207,  53,        101) /* PlacementPosition - Resting */
+     , (32207,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32207,  94,         16) /* TargetType - Creature */
+     , (32207, 106,        300) /* ItemSpellcraft */
+     , (32207, 107,         50) /* ItemCurMana */
+     , (32207, 108,         50) /* ItemMaxMana */
+     , (32207, 109,          0) /* ItemDifficulty */
+     , (32207, 110,          0) /* ItemAllegianceRankLimit */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32207,  11, True ) /* IgnoreCollisions */
+     , (32207,  13, True ) /* Ethereal */
+     , (32207,  14, True ) /* GravityStatus */
+     , (32207,  19, True ) /* Attackable */
+     , (32207,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32207,  39,     0.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32207,   1, 'Candy Corn') /* Name */
+     , (32207,  14, 'Use this item to eat it.') /* Use */
+     , (32207,  16, 'A festival treat. Candy Corn is fabled to be the tears of a Great Pumpkin.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32207,   1,   33554817) /* Setup */
+     , (32207,   3,  536870932) /* SoundTable */
+     , (32207,   8,  100688413) /* Icon */
+     , (32207,  22,  872415275) /* PhysicsEffectTable */
+     , (32207,  28,       3860) /* Spell - Sweet Speed */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32208 Marshmallow Bat.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32208 Marshmallow Bat.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32208;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32208, 'ace32208-marshmallowbat', 18, '2019-09-13 02:41:34') /* Food */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32208,   1,         32) /* ItemType - Food */
+     , (32208,   3,         39) /* PaletteTemplate - Black */
+     , (32208,   5,          2) /* EncumbranceVal */
+     , (32208,  11,         10) /* MaxStackSize */
+     , (32208,  12,          1) /* StackSize */
+     , (32208,  16,          8) /* ItemUseable - Contained */
+     , (32208,  19,          1) /* Value */
+     , (32208,  53,        101) /* PlacementPosition - Resting */
+     , (32208,  89,          2) /* BoosterEnum - Health */
+     , (32208,  90,         40) /* BoostValue */
+     , (32208,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32208, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32208,  11, True ) /* IgnoreCollisions */
+     , (32208,  13, True ) /* Ethereal */
+     , (32208,  14, True ) /* GravityStatus */
+     , (32208,  19, True ) /* Attackable */
+     , (32208,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32208,  12,       0) /* Shade */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32208,   1, 'Marshmallow Bat') /* Name */
+     , (32208,  14, 'Use this item to eat it.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32208,   1,   33559793) /* Setup */
+     , (32208,   3,  536870932) /* SoundTable */
+     , (32208,   6,   67113158) /* PaletteBase */
+     , (32208,   7,  268437089) /* ClothingBase */
+     , (32208,   8,  100688454) /* Icon */
+     , (32208,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32209 Marshmallow Pumpkin.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32209 Marshmallow Pumpkin.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32209;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32209, 'ace32209-marshmallowpumpkin', 18, '2019-09-13 02:41:34') /* Food */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32209,   1,         32) /* ItemType - Food */
+     , (32209,   5,          2) /* EncumbranceVal */
+     , (32209,  11,         10) /* MaxStackSize */
+     , (32209,  12,          1) /* StackSize */
+     , (32209,  16,          8) /* ItemUseable - Contained */
+     , (32209,  19,          1) /* Value */
+     , (32209,  53,        101) /* PlacementPosition - Resting */
+     , (32209,  89,          4) /* BoosterEnum - Stamina */
+     , (32209,  90,         40) /* BoostValue */
+     , (32209,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32209, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32209,  11, True ) /* IgnoreCollisions */
+     , (32209,  13, True ) /* Ethereal */
+     , (32209,  14, True ) /* GravityStatus */
+     , (32209,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32209,   1, 'Marshmallow Pumpkin') /* Name */
+     , (32209,  14, 'Use this item to eat it.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32209,   1,   33559794) /* Setup */
+     , (32209,   3,  536870932) /* SoundTable */
+     , (32209,   8,  100688420) /* Icon */
+     , (32209,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32210 Ginger Bread Pumpkin.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Food/Food/32210 Ginger Bread Pumpkin.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32210;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32210, 'ace32210-gingerbreadpumpkin', 18, '2019-09-13 02:41:34') /* Food */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32210,   1,         32) /* ItemType - Food */
+     , (32210,   5,         15) /* EncumbranceVal */
+     , (32210,  11,        100) /* MaxStackSize */
+     , (32210,  12,          1) /* StackSize */
+     , (32210,  16,          8) /* ItemUseable - Contained */
+     , (32210,  19,         14) /* Value */
+     , (32210,  53,        101) /* PlacementPosition - Resting */
+     , (32210,  89,          4) /* BoosterEnum - Stamina */
+     , (32210,  90,         50) /* BoostValue */
+     , (32210,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32210, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32210,  11, True ) /* IgnoreCollisions */
+     , (32210,  13, True ) /* Ethereal */
+     , (32210,  14, True ) /* GravityStatus */
+     , (32210,  19, True ) /* Attackable */
+     , (32210,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32210,   1, 'Ginger Bread Pumpkin') /* Name */
+     , (32210,  14, 'Use this item to eat it.') /* Use */
+     , (32210,  16, 'A ginger bread cookie in the shape of a Pumpkin.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32210,   1,   33559780) /* Setup */
+     , (32210,   3,  536870932) /* SoundTable */
+     , (32210,   8,  100688421) /* Icon */
+     , (32210,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32206 Pack Pumpkin Lord.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32206 Pack Pumpkin Lord.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32206;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32206, 'ace32206-packpumpkinlord', 38, '2019-09-09 14:38:55') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32206,   1,       2048) /* ItemType - Gem */
+     , (32206,   5,         10) /* EncumbranceVal */
+     , (32206,  16,          1) /* ItemUseable - No */
+     , (32206,  19,         10) /* Value */
+     , (32206,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32206,  94,         16) /* TargetType - Creature */
+     , (32206, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32206,  11, True ) /* IgnoreCollisions */
+     , (32206,  13, True ) /* Ethereal */
+     , (32206,  14, True ) /* GravityStatus */
+     , (32206,  19, True ) /* Attackable */
+     , (32206,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32206,  39, 0.300000011920929) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32206,   1, 'Pack Pumpkin Lord') /* Name */
+     , (32206,  16, 'The vile and naughty Pumpkin Lord. He was grown from a bad seed.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32206,   1,   33559753) /* Setup */
+     , (32206,   2,  150995144) /* MotionTable */
+     , (32206,   8,  100688456) /* Icon */
+     , (32206,  22,  872415326) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32216 Pack Gold Remoran.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32216 Pack Gold Remoran.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32216;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32216, 'ace32216-packgoldremoran', 38, '2019-09-13 02:41:34') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32216,   1,       2048) /* ItemType - Gem */
+     , (32216,   5,         10) /* EncumbranceVal */
+     , (32216,  16,          1) /* ItemUseable - No */
+     , (32216,  19,         10) /* Value */
+     , (32216,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32216,  94,         16) /* TargetType - Creature */
+     , (32216, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32216,  11, True ) /* IgnoreCollisions */
+     , (32216,  13, True ) /* Ethereal */
+     , (32216,  14, True ) /* GravityStatus */
+     , (32216,  19, True ) /* Attackable */
+     , (32216,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32216,  39, 0.300000011920929) /* DefaultScale */
+     , (32216,  44,      -1) /* TimeToRot */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32216,   1, 'Pack Gold Remoran') /* Name */
+     , (32216,  16, 'A Gold Remoran with hover action. Look at all of it''s majesty.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32216,   1,   33559700) /* Setup */
+     , (32216,   2,  150995351) /* MotionTable */
+     , (32216,   6,   67116726) /* PaletteBase */
+     , (32216,   8,  100688455) /* Icon */
+     , (32216,  22,  872415414) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32254 Gem of Ardent Loyalty.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32254 Gem of Ardent Loyalty.sql
@@ -1,0 +1,38 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32254;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32254, 'ace32254-gemofardentloyalty', 38, '2019-09-27 11:34:19') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32254,   1,       2048) /* ItemType - Gem */
+     , (32254,   5,         10) /* EncumbranceVal */
+     , (32254,  11,          1) /* MaxStackSize */
+     , (32254,  12,          1) /* StackSize */
+     , (32254,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (32254,  19,          0) /* Value */
+     , (32254,  33,          1) /* Bonded - Bonded */
+     , (32254,  53,        101) /* PlacementPosition - Resting */
+     , (32254,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32254,  94,       2050) /* TargetType - Armor, Gem */
+     , (32254, 114,          1) /* Attuned - Attuned */
+     , (32254, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32254,  11, True ) /* IgnoreCollisions */
+     , (32254,  13, True ) /* Ethereal */
+     , (32254,  14, True ) /* GravityStatus */
+     , (32254,  19, True ) /* Attackable */
+     , (32254,  22, True ) /* Inscribable */
+     , (32254,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32254,   1, 'Gem of Ardent Loyalty') /* Name */
+     , (32254,  14, 'Combine with a piece of Noble armor to infuse the armor with the Ardent Defense and True Loyalty spells.') /* Use */
+     , (32254,  16, 'This gem can be placed into a piece of Noble Armor. If so, it will imbue the armor with very potent Melee Defense and Loyalty Spells that will affect the wearer. The armor will then only be wearable by the crafter.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32254,   1,   33554809) /* Setup */
+     , (32254,   3,  536870932) /* SoundTable */
+     , (32254,   6,   67111919) /* PaletteBase */
+     , (32254,   8,  100688417) /* Icon */
+     , (32254,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32255 Gem of Arcane Corruption.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Gem/32255 Gem of Arcane Corruption.sql
@@ -1,0 +1,38 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32255;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32255, 'ace32255-gemofarcanecorruption', 38, '2019-09-27 11:34:19') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32255,   1,       2048) /* ItemType - Gem */
+     , (32255,   5,         10) /* EncumbranceVal */
+     , (32255,  11,          1) /* MaxStackSize */
+     , (32255,  12,          1) /* StackSize */
+     , (32255,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (32255,  19,          0) /* Value */
+     , (32255,  33,          1) /* Bonded - Bonded */
+     , (32255,  53,        101) /* PlacementPosition - Resting */
+     , (32255,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32255,  94,       2050) /* TargetType - Armor, Gem */
+     , (32255, 114,          1) /* Attuned - Attuned */
+     , (32255, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32255,  11, True ) /* IgnoreCollisions */
+     , (32255,  13, True ) /* Ethereal */
+     , (32255,  14, True ) /* GravityStatus */
+     , (32255,  19, True ) /* Attackable */
+     , (32255,  22, True ) /* Inscribable */
+     , (32255,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32255,   1, 'Gem of Arcane Corruption') /* Name */
+     , (32255,  14, 'Combine with a piece of Noble armor to infuse the armor with the Corrupted Essence spell.') /* Use */
+     , (32255,  16, 'This gem can be placed into a piece of Noble Armor. If so, it will imbue the armor with a very potent Focus Spell that will affect the wearer, but in turn sap a small amount of the wearer''s health. The armor will then only be wearable by the crafter.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32255,   1,   33554809) /* Setup */
+     , (32255,   3,  536870932) /* SoundTable */
+     , (32255,   6,   67111919) /* PaletteBase */
+     , (32255,   8,  100688416) /* Icon */
+     , (32255,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/25559 Hollow Minion's Face.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/25559 Hollow Minion's Face.sql
@@ -1,0 +1,37 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25559;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25559, 'headhollowminion', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25559,   1,        128) /* ItemType - Misc */
+     , (25559,   5,         50) /* EncumbranceVal */
+     , (25559,   8,        600) /* Mass */
+     , (25559,   9,          0) /* ValidLocations - None */
+     , (25559,  16,          1) /* ItemUseable - No */
+     , (25559,  19,          0) /* Value */
+     , (25559,  53,        101) /* PlacementPosition - Resting */
+     , (25559,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (25559, 150,        103) /* HookPlacement - Hook */
+     , (25559, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25559,  11, True ) /* IgnoreCollisions */
+     , (25559,  13, True ) /* Ethereal */
+     , (25559,  14, True ) /* GravityStatus */
+     , (25559,  19, True ) /* Attackable */
+     , (25559,  22, True ) /* Inscribable */
+     , (25559,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25559,  39,     0.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25559,   1, 'Hollow Minion''s Face') /* Name */
+     , (25559,  16, 'A piece of tattered cloth and metal with a face cut into it.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25559,   1,   33559765) /* Setup */
+     , (25559,   3,  536870932) /* SoundTable */
+     , (25559,   8,  100688427) /* Icon */
+     , (25559,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32170 Ursuin Arm.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32170 Ursuin Arm.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32170;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32170, 'ace32170-ursuinarm', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32170,   1,        128) /* ItemType - Misc */
+     , (32170,   5,        200) /* EncumbranceVal */
+     , (32170,  11,          1) /* MaxStackSize */
+     , (32170,  12,          1) /* StackSize */
+     , (32170,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (32170,  19,          0) /* Value */
+     , (32170,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32170,  94,        128) /* TargetType - Misc */
+     , (32170, 151,          1) /* HookType - Floor */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32170,  11, True ) /* IgnoreCollisions */
+     , (32170,  13, True ) /* Ethereal */
+     , (32170,  14, True ) /* GravityStatus */
+     , (32170,  19, True ) /* Attackable */
+     , (32170,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32170,   1, 'Ursuin Arm') /* Name */
+     , (32170,  14, 'Use this on an Ursuin Torso with either one arm or an arm and two legs.') /* Use */
+     , (32170,  16, 'An Ursuin arm.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32170,   1,   33559784) /* Setup */
+     , (32170,   3,  536870932) /* SoundTable */
+     , (32170,   8,  100688469) /* Icon */
+     , (32170,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32171 Ursuin Legs.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32171 Ursuin Legs.sql
@@ -1,0 +1,34 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32171;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32171, 'ace32171-ursuinlegs', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32171,   1,        128) /* ItemType - Misc */
+     , (32171,   5,        200) /* EncumbranceVal */
+     , (32171,  11,          1) /* MaxStackSize */
+     , (32171,  12,          1) /* StackSize */
+     , (32171,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (32171,  19,          0) /* Value */
+     , (32171,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32171,  94,        128) /* TargetType - Misc */
+     , (32171, 151,          1) /* HookType - Floor */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32171,  11, True ) /* IgnoreCollisions */
+     , (32171,  13, True ) /* Ethereal */
+     , (32171,  14, True ) /* GravityStatus */
+     , (32171,  19, True ) /* Attackable */
+     , (32171,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32171,   1, 'Ursuin Legs') /* Name */
+     , (32171,  16, 'Use these legs on an Ursuin Torso fitted with either one or two arms.
+
+The lower trunk of an Ursuin, complete with legs.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32171,   1,   33559785) /* Setup */
+     , (32171,   3,  536870932) /* SoundTable */
+     , (32171,   8,  100688470) /* Icon */
+     , (32171,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32172 Ursuin Body with Two Arms.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32172 Ursuin Body with Two Arms.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32172;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32172, 'ace32172-ursuinbodywithtwoarms', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32172,   1,        128) /* ItemType - Misc */
+     , (32172,   5,        200) /* EncumbranceVal */
+     , (32172,  11,          1) /* MaxStackSize */
+     , (32172,  12,          1) /* StackSize */
+     , (32172,  16,          1) /* ItemUseable - No */
+     , (32172,  19,          0) /* Value */
+     , (32172,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32172, 151,          1) /* HookType - Floor */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32172,  11, True ) /* IgnoreCollisions */
+     , (32172,  13, True ) /* Ethereal */
+     , (32172,  14, True ) /* GravityStatus */
+     , (32172,  19, True ) /* Attackable */
+     , (32172,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32172,  39, 0.800000011920929) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32172,   1, 'Ursuin Body with Two Arms') /* Name */
+     , (32172,  16, 'Ursuin Legs can be added to this item.
+
+An Ursuin''s torso, with two arms attached.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32172,   1,   33559786) /* Setup */
+     , (32172,   3,  536870932) /* SoundTable */
+     , (32172,   8,  100688471) /* Icon */
+     , (32172,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32174 Ursuin Torso.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32174 Ursuin Torso.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32174;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32174, 'ace32174-ursuintorso', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32174,   1,        128) /* ItemType - Misc */
+     , (32174,   5,        200) /* EncumbranceVal */
+     , (32174,  11,          1) /* MaxStackSize */
+     , (32174,  12,          1) /* StackSize */
+     , (32174,  16,          1) /* ItemUseable - No */
+     , (32174,  19,          0) /* Value */
+     , (32174,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32174, 151,          1) /* HookType - Floor */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32174,  11, True ) /* IgnoreCollisions */
+     , (32174,  13, True ) /* Ethereal */
+     , (32174,  14, True ) /* GravityStatus */
+     , (32174,  19, True ) /* Attackable */
+     , (32174,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32174,  39, 0.800000011920929) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32174,   1, 'Ursuin Torso') /* Name */
+     , (32174,  16, 'Either Ursuin Legs or an Ursuin Arm can be added to this item.
+
+An Ursuin''s torso, with one arm still attached.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32174,   1,   33559787) /* Setup */
+     , (32174,   3,  536870932) /* SoundTable */
+     , (32174,   8,  100688473) /* Icon */
+     , (32174,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32179 Fiun Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32179 Fiun Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32179;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32179, 'ace32179-fiunhead', 1, '2019-09-15 06:24:32') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32179,   1,        128) /* ItemType - Misc */
+     , (32179,   5,        200) /* EncumbranceVal */
+     , (32179,  16,          1) /* ItemUseable - No */
+     , (32179,  19,          0) /* Value */
+     , (32179,  53,        101) /* PlacementPosition - Resting */
+     , (32179,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32179, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32179,  11, True ) /* IgnoreCollisions */
+     , (32179,  13, True ) /* Ethereal */
+     , (32179,  14, True ) /* GravityStatus */
+     , (32179,  19, True ) /* Attackable */
+     , (32179,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32179,   1, 'Fiun Head') /* Name */
+     , (32179,  16, 'The head of a Fiun, its crazed face drawn in madness.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32179,   1,   33559764) /* Setup */
+     , (32179,   3,  536870932) /* SoundTable */
+     , (32179,   8,  100688428) /* Icon */
+     , (32179,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32180 Ursuin Body.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32180 Ursuin Body.sql
@@ -1,0 +1,26 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32180;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32180, 'ace32180-ursuinbody', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32180,   1,        128) /* ItemType - Misc */
+     , (32180,   5,       1600) /* EncumbranceVal */
+     , (32180,  16,          1) /* ItemUseable - No */
+     , (32180,  19,          0) /* Value */
+     , (32180,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32180, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32180,  22, True ) /* Inscribable */
+     , (32180,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32180,   1, 'Ursuin Body') /* Name */
+     , (32180,  16, 'A complete ursuin body.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32180,   1,   33559782) /* Setup */
+     , (32180,   3,  536870932) /* SoundTable */
+     , (32180,   8,  100688475) /* Icon */
+     , (32180,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32184 Giant Snowman Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32184 Giant Snowman Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32184;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32184, 'ace32184-giantsnowmanhead', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32184,   1,        128) /* ItemType - Misc */
+     , (32184,   5,        200) /* EncumbranceVal */
+     , (32184,  16,          1) /* ItemUseable - No */
+     , (32184,  19,          0) /* Value */
+     , (32184,  53,        101) /* PlacementPosition - Resting */
+     , (32184,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32184, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32184,  11, True ) /* IgnoreCollisions */
+     , (32184,  13, True ) /* Ethereal */
+     , (32184,  14, True ) /* GravityStatus */
+     , (32184,  19, True ) /* Attackable */
+     , (32184,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32184,   1, 'Giant Snowman Head') /* Name */
+     , (32184,  16, 'The freezing head of a giant snowman.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32184,   1,   33559773) /* Setup */
+     , (32184,   3,  536870932) /* SoundTable */
+     , (32184,   8,  100688429) /* Icon */
+     , (32184,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32185 Two Headed Snowman Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32185 Two Headed Snowman Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32185;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32185, 'ace32185-twoheadedsnowmanhead', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32185,   1,        128) /* ItemType - Misc */
+     , (32185,   5,        200) /* EncumbranceVal */
+     , (32185,  16,          1) /* ItemUseable - No */
+     , (32185,  19,          0) /* Value */
+     , (32185,  53,        101) /* PlacementPosition - Resting */
+     , (32185,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32185, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32185,  11, True ) /* IgnoreCollisions */
+     , (32185,  13, True ) /* Ethereal */
+     , (32185,  14, True ) /* GravityStatus */
+     , (32185,  19, True ) /* Attackable */
+     , (32185,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32185,   1, 'Two Headed Snowman Head') /* Name */
+     , (32185,  15, 'Two snowman heads that seem frozen together.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32185,   1,   33559771) /* Setup */
+     , (32185,   3,  536870932) /* SoundTable */
+     , (32185,   8,  100688430) /* Icon */
+     , (32185,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32204 Seeds of Anger.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32204 Seeds of Anger.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32204;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32204, 'ace32204-seedsofanger', 1, '2019-09-13 04:59:39') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32204,   1,        128) /* ItemType - Misc */
+     , (32204,   5,          5) /* EncumbranceVal */
+     , (32204,  16,          1) /* ItemUseable - No */
+     , (32204,  19,          0) /* Value */
+     , (32204,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32204,  11, True ) /* IgnoreCollisions */
+     , (32204,  13, True ) /* Ethereal */
+     , (32204,  14, True ) /* GravityStatus */
+     , (32204,  19, True ) /* Attackable */
+     , (32204,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32204,   1, 'Seeds of Anger') /* Name */
+     , (32204,  16, 'A bunch of small pumpkin seeds. They look slightly burnt and twisted.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32204,   1,   33556678) /* Setup */
+     , (32204,   3,  536870932) /* SoundTable */
+     , (32204,   8,  100670851) /* Icon */
+     , (32204,  22,  872415275) /* PhysicsEffectTable */
+     , (32204,  52,  100667856) /* IconUnderlay */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32211 Festival Lights.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/32211 Festival Lights.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32211;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32211, 'ace32211-festivallights', 1, '2019-09-13 04:12:14') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32211,   1,        128) /* ItemType - Misc */
+     , (32211,   5,         50) /* EncumbranceVal */
+     , (32211,  16,          1) /* ItemUseable - No */
+     , (32211,  19,       5000) /* Value */
+     , (32211,  53,        101) /* PlacementPosition - Resting */
+     , (32211,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32211, 151,          6) /* HookType - Wall, Ceiling */
+     , (32211, 267,         30) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32211,  11, True ) /* IgnoreCollisions */
+     , (32211,  13, True ) /* Ethereal */
+     , (32211,  14, True ) /* GravityStatus */
+     , (32211,  19, True ) /* Attackable */
+     , (32211,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32211,  39, 0.300000011920929) /* DefaultScale */
+     , (32211,  76, 0.300000011920929) /* Translucency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32211,   1, 'Festival Lights') /* Name */
+     , (32211,  14, 'This item can be used on ceiling and wall hooks.') /* Use */
+     , (32211,  15, 'A small reflective pumpkin bauble with dancing colored lights around it. Don''t drop it unless you want to lose it. This item will quickly disappear if dropped on the ground -- it will even disappear from inside a pack, if that pack is dropped on the ground.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32211,   1,   33559751) /* Setup */
+     , (32211,   3,  536870932) /* SoundTable */
+     , (32211,   8,  100688463) /* Icon */
+     , (32211,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/34089 Floating Candle.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/34089 Floating Candle.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 34089;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (34089, 'ace34089-floatingcandle', 1, '2019-09-13 02:41:34') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (34089,   1,        128) /* ItemType - Misc */
+     , (34089,   5,          5) /* EncumbranceVal */
+     , (34089,  16,          1) /* ItemUseable - No */
+     , (34089,  19,         10) /* Value */
+     , (34089,  93,       1052) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity */
+     , (34089, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (34089,  11, True ) /* IgnoreCollisions */
+     , (34089,  12, True ) /* ReportCollisions */
+     , (34089,  13, True ) /* Ethereal */
+     , (34089,  14, True ) /* GravityStatus */
+     , (34089,  19, True ) /* Attackable */
+     , (34089,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (34089,   1, 'Floating Candle') /* Name */
+     , (34089,  14, 'This item can be used on floor and yard hooks.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (34089,   1,   33560114) /* Setup */
+     , (34089,   3,  536870932) /* SoundTable */
+     , (34089,   8,  100667477) /* Icon */
+     , (34089,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70259 Halmera's Encoded Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70259 Halmera's Encoded Notes.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70259;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70259, 'ace70259-halmerasencodednotes', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70259,   1,        128) /* ItemType - Misc */
+     , (70259,   5,        100) /* EncumbranceVal */
+     , (70259,  16,          1) /* ItemUseable - No */
+     , (70259,  19,          0) /* Value */
+     , (70259,  33,          1) /* Bonded - Bonded */
+     , (70259,  65,        101) /* Placement - Resting */
+     , (70259,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70259, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70259,   1, False) /* Stuck */
+     , (70259,  11, True ) /* IgnoreCollisions */
+     , (70259,  13, True ) /* Ethereal */
+     , (70259,  14, True ) /* GravityStatus */
+     , (70259,  19, True ) /* Attackable */
+     , (70259,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70259,   1, 'Halmera''s Encoded Notes') /* Name */
+     , (70259,  16, 'A set of notes written by Mistress Halmera in a strange, elaborate cipher.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70259,   1,   33554771) /* Setup */
+     , (70259,   3,  536870932) /* SoundTable */
+     , (70259,   8,  100668117) /* Icon */
+     , (70259,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70270 Vaserio's Encoded Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70270 Vaserio's Encoded Notes.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70270;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70270, 'ace70270-vaseriosencodednotes', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70270,   1,        128) /* ItemType - Misc */
+     , (70270,   5,        100) /* EncumbranceVal */
+     , (70270,  16,          1) /* ItemUseable - No */
+     , (70270,  19,          0) /* Value */
+     , (70270,  33,          1) /* Bonded - Bonded */
+     , (70270,  65,        101) /* Placement - Resting */
+     , (70270,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70270, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70270,   1, False) /* Stuck */
+     , (70270,  11, True ) /* IgnoreCollisions */
+     , (70270,  13, True ) /* Ethereal */
+     , (70270,  14, True ) /* GravityStatus */
+     , (70270,  19, True ) /* Attackable */
+     , (70270,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70270,   1, 'Vaserio''s Encoded Notes') /* Name */
+     , (70270,  16, 'A set of notes written by Master Vaserio in a strange, elaborate cipher.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70270,   1,   33554771) /* Setup */
+     , (70270,   3,  536870932) /* SoundTable */
+     , (70270,   8,  100668117) /* Icon */
+     , (70270,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70271 Alizari's Encoded Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70271 Alizari's Encoded Notes.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70271;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70271, 'ace70271-alizarisencodednotes', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70271,   1,        128) /* ItemType - Misc */
+     , (70271,   5,        100) /* EncumbranceVal */
+     , (70271,  16,          1) /* ItemUseable - No */
+     , (70271,  19,          0) /* Value */
+     , (70271,  33,          1) /* Bonded - Bonded */
+     , (70271,  65,        101) /* Placement - Resting */
+     , (70271,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70271, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70271,   1, False) /* Stuck */
+     , (70271,  11, True ) /* IgnoreCollisions */
+     , (70271,  13, True ) /* Ethereal */
+     , (70271,  14, True ) /* GravityStatus */
+     , (70271,  19, True ) /* Attackable */
+     , (70271,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70271,   1, 'Alizari''s Encoded Notes') /* Name */
+     , (70271,  16, 'A set of notes written by Master Alizari in a strange, elaborate cipher') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70271,   1,   33554771) /* Setup */
+     , (70271,   3,  536870932) /* SoundTable */
+     , (70271,   8,  100668117) /* Icon */
+     , (70271,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70273 Gabille's Encoded Notes.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70273 Gabille's Encoded Notes.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70273;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70273, 'ace70273-gabillesencodednotes', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70273,   1,        128) /* ItemType - Misc */
+     , (70273,   5,        100) /* EncumbranceVal */
+     , (70273,  16,          1) /* ItemUseable - No */
+     , (70273,  19,          0) /* Value */
+     , (70273,  33,          1) /* Bonded - Bonded */
+     , (70273,  65,        101) /* Placement - Resting */
+     , (70273,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70273, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70273,   1, False) /* Stuck */
+     , (70273,  11, True ) /* IgnoreCollisions */
+     , (70273,  13, True ) /* Ethereal */
+     , (70273,  14, True ) /* GravityStatus */
+     , (70273,  19, True ) /* Attackable */
+     , (70273,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70273,   1, 'Gabille''s Encoded Notes') /* Name */
+     , (70273,  16, 'A set of notes written by Mistress Gabille in a strange, elaborate cipher.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70273,   1,   33554771) /* Setup */
+     , (70273,   3,  536870932) /* SoundTable */
+     , (70273,   8,  100668117) /* Icon */
+     , (70273,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70275 Penguin Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70275 Penguin Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70275;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70275, 'ace70275-penguinhead', 1, '2019-09-13 04:59:39') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70275,   1,        128) /* ItemType - Misc */
+     , (70275,   5,        200) /* EncumbranceVal */
+     , (70275,  16,          1) /* ItemUseable - No */
+     , (70275,  19,          0) /* Value */
+     , (70275,  53,        101) /* PlacementPosition - Resting */
+     , (70275,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70275, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70275,  11, True ) /* IgnoreCollisions */
+     , (70275,  13, True ) /* Ethereal */
+     , (70275,  14, True ) /* GravityStatus */
+     , (70275,  19, True ) /* Attackable */
+     , (70275,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70275,   1, 'Penguin Head') /* Name */
+     , (70275,  16, 'The head of a Penguin.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70275,   1,   33559767) /* Setup */
+     , (70275,   3,  536870932) /* SoundTable */
+     , (70275,   8,  100688478) /* Icon */
+     , (70275,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70276 Ursuin Body with One Arm.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70276 Ursuin Body with One Arm.sql
@@ -1,0 +1,34 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70276;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70276, 'ace70276-ursuinbodywithonearm', 1, '2019-09-14 16:53:08') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70276,   1,        128) /* ItemType - Misc */
+     , (70276,   5,        200) /* EncumbranceVal */
+     , (70276,  11,          1) /* MaxStackSize */
+     , (70276,  12,          1) /* StackSize */
+     , (70276,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (70276,  19,          0) /* Value */
+     , (70276,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70276,  94,        128) /* TargetType - Misc */
+     , (70276, 151,          1) /* HookType - Floor */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70276,  11, True ) /* IgnoreCollisions */
+     , (70276,  13, True ) /* Ethereal */
+     , (70276,  14, True ) /* GravityStatus */
+     , (70276,  19, True ) /* Attackable */
+     , (70276,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70276,   1, 'Ursuin Body with One Arm') /* Name */
+     , (70276,  16, 'An Ursuin Arm can be added to this item.
+
+An Ursuin''s torso, with two legs and an arm attached.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70276,   1,   33559799) /* Setup */
+     , (70276,   3,  536870932) /* SoundTable */
+     , (70276,   8,  100688472) /* Icon */
+     , (70276,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70278 Uber Penguin Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70278 Uber Penguin Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70278;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70278, 'ace70278-uberpenguinhead', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70278,   1,        128) /* ItemType - Misc */
+     , (70278,   5,        200) /* EncumbranceVal */
+     , (70278,  16,          1) /* ItemUseable - No */
+     , (70278,  19,          0) /* Value */
+     , (70278,  53,        101) /* PlacementPosition - Resting */
+     , (70278,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70278, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70278,  11, True ) /* IgnoreCollisions */
+     , (70278,  13, True ) /* Ethereal */
+     , (70278,  14, True ) /* GravityStatus */
+     , (70278,  19, True ) /* Attackable */
+     , (70278,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70278,   1, 'Uber Penguin Head') /* Name */
+     , (70278,  16, 'A large penguin head with some odd devices embedded in its skull. The one mechanical eye still appears to follow movement') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70278,   1,   33559768) /* Setup */
+     , (70278,   3,  536870932) /* SoundTable */
+     , (70278,   8,  100688477) /* Icon */
+     , (70278,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70279 Ruschk Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70279 Ruschk Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70279;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70279, 'ace70279-ruschkhead', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70279,   1,        128) /* ItemType - Misc */
+     , (70279,   5,        200) /* EncumbranceVal */
+     , (70279,  16,          1) /* ItemUseable - No */
+     , (70279,  19,          0) /* Value */
+     , (70279,  53,        101) /* PlacementPosition - Resting */
+     , (70279,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70279, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70279,  11, True ) /* IgnoreCollisions */
+     , (70279,  13, True ) /* Ethereal */
+     , (70279,  14, True ) /* GravityStatus */
+     , (70279,  19, True ) /* Attackable */
+     , (70279,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70279,   1, 'Ruschk Head') /* Name */
+     , (70279,  16, 'The severed head of a Ruschk warrior.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70279,   1,   33559769) /* Setup */
+     , (70279,   3,  536870932) /* SoundTable */
+     , (70279,   8,  100688426) /* Icon */
+     , (70279,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70280 Snowman Head.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/70280 Snowman Head.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70280;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70280, 'ace70280-snowmanhead', 1, '2019-09-09 14:38:55') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70280,   1,        128) /* ItemType - Misc */
+     , (70280,   5,        200) /* EncumbranceVal */
+     , (70280,  16,          1) /* ItemUseable - No */
+     , (70280,  19,          0) /* Value */
+     , (70280,  53,        101) /* PlacementPosition - Resting */
+     , (70280,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (70280, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70280,  11, True ) /* IgnoreCollisions */
+     , (70280,  13, True ) /* Ethereal */
+     , (70280,  14, True ) /* GravityStatus */
+     , (70280,  19, True ) /* Attackable */
+     , (70280,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70280,   1, 'Snowman Head') /* Name */
+     , (70280,  15, 'The chilly head of a snowman.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70280,   1,   33559770) /* Setup */
+     , (70280,   3,  536870932) /* SoundTable */
+     , (70280,   8,  100688425) /* Icon */
+     , (70280,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/80021 Festival Vendor Generator.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Generic/80021 Festival Vendor Generator.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80021;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80021, 'ace80021-generatorfestivalvendor', 1, '2019-10-27 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80021,  81,          1) /* MaxGeneratedObjects */
+     , (80021,  82,          1) /* InitGeneratedObjects */
+     , (80021,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80021, 142,          3) /* GeneratorTimeType - Event */
+     , (80021, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80021,   1, True ) /* Stuck */
+     , (80021,  11, True ) /* IgnoreCollisions */
+     , (80021,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80021,  41,      30) /* RegenerationInterval */
+     , (80021,  43,       0) /* GeneratorRadius */
+     , (80021, 121,      10) /* GeneratorInitialDelay */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80021,   1, 'Festival Vendor Generator') /* Name */
+     , (80021,  34, 'EventFestivalVendor') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80021,   1,   33555051) /* Setup */
+     , (80021,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80021, -1, 70263, 10, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Festival Vendor (70263) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Vendor/70263 Festival Vendor.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Vendor/70263 Festival Vendor.sql
@@ -1,0 +1,213 @@
+DELETE FROM `weenie` WHERE `class_Id` = 70263;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (70263, 'ace70263-festivalvendor', 12, '2019-09-09 14:38:55') /* Vendor */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (70263,   1,         16) /* ItemType - Creature */
+     , (70263,   2,         31) /* CreatureType - Human */
+     , (70263,   6,         -1) /* ItemsCapacity */
+     , (70263,   7,         -1) /* ContainersCapacity */
+     , (70263,   8,        120) /* Mass */
+     , (70263,  16,         32) /* ItemUseable - Remote */
+     , (70263,  25,         42) /* Level */
+     , (70263,  27,          0) /* ArmorType - None */
+     , (70263,  74, 1208248231) /* MerchandiseItemTypes - VendorShopKeep */
+     , (70263,  75,          0) /* MerchandiseMinValue */
+     , (70263,  76,     100000) /* MerchandiseMaxValue */
+     , (70263,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (70263, 113,          2) /* Gender - Female */
+     , (70263, 126,        500) /* VendorHappyMean */
+     , (70263, 127,        500) /* VendorHappyVariance */
+     , (70263, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (70263, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (70263, 146,         90) /* XpOverride */
+     , (70263, 188,          3) /* HeritageGroup - Sho */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (70263,   1, True ) /* Stuck */
+     , (70263,  11, True ) /* IgnoreCollisions */
+     , (70263,  12, True ) /* ReportCollisions */
+     , (70263,  13, False) /* Ethereal */
+     , (70263,  14, True ) /* GravityStatus */
+     , (70263,  19, False) /* Attackable */
+     , (70263,  39, True ) /* DealMagicalItems */
+     , (70263,  41, True ) /* ReportCollisionsAsEnvironment */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (70263,   1,       5) /* HeartbeatInterval */
+     , (70263,   2,       0) /* HeartbeatTimestamp */
+     , (70263,   3, 0.159999996423721) /* HealthRate */
+     , (70263,   4,       5) /* StaminaRate */
+     , (70263,   5,       1) /* ManaRate */
+     , (70263,  11,     300) /* ResetInterval */
+     , (70263,  13, 0.899999976158142) /* ArmorModVsSlash */
+     , (70263,  14,       1) /* ArmorModVsPierce */
+     , (70263,  15, 1.10000002384186) /* ArmorModVsBludgeon */
+     , (70263,  16, 0.400000005960464) /* ArmorModVsCold */
+     , (70263,  17, 0.400000005960464) /* ArmorModVsFire */
+     , (70263,  18,       1) /* ArmorModVsAcid */
+     , (70263,  19, 0.600000023841858) /* ArmorModVsElectric */
+     , (70263,  37, 0.899999976158142) /* BuyPrice */
+     , (70263,  38,       1) /* SellPrice */
+     , (70263,  54,       3) /* UseRadius */
+     , (70263,  64,       1) /* ResistSlash */
+     , (70263,  65,       1) /* ResistPierce */
+     , (70263,  66,       1) /* ResistBludgeon */
+     , (70263,  67,       1) /* ResistFire */
+     , (70263,  68,       1) /* ResistCold */
+     , (70263,  69,       1) /* ResistAcid */
+     , (70263,  70,       1) /* ResistElectric */
+     , (70263,  71,       1) /* ResistHealthBoost */
+     , (70263,  72,       1) /* ResistStaminaDrain */
+     , (70263,  73,       1) /* ResistStaminaBoost */
+     , (70263,  74,       1) /* ResistManaDrain */
+     , (70263,  75,       1) /* ResistManaBoost */
+     , (70263, 104,      10) /* ObviousRadarRange */
+     , (70263, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (70263,   1, 'Festival Vendor') /* Name */
+     , (70263,   3, 'Female') /* Sex */
+     , (70263,   4, 'Sho') /* HeritageGroup */
+     , (70263,   5, 'Fesitval Vendor') /* Template */
+     , (70263,  24, 'Glenden Wood') /* TownName */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (70263,   1,   33554510) /* Setup */
+     , (70263,   2,  150994945) /* MotionTable */
+     , (70263,   3,  536870914) /* SoundTable */
+     , (70263,   4,  805306368) /* CombatTable */
+     , (70263,   6,   67108990) /* PaletteBase */
+     , (70263,   8,  100667446) /* Icon */
+     , (70263,   9,   83890277) /* EyesTexture */
+     , (70263,  10,   83890307) /* NoseTexture */
+     , (70263,  11,   83890345) /* MouthTexture */
+     , (70263,  15,   67116995) /* HairPalette */
+     , (70263,  16,   67109567) /* EyesPalette */
+     , (70263,  17,   67109560) /* SkinPalette */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (70263,   1,  40, 0, 0) /* Strength */
+     , (70263,   2,  40, 0, 0) /* Endurance */
+     , (70263,   3,  55, 0, 0) /* Quickness */
+     , (70263,   4,  60, 0, 0) /* Coordination */
+     , (70263,   5,  40, 0, 0) /* Focus */
+     , (70263,   6,  35, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (70263,   1,    45, 0, 0, 65) /* MaxHealth */
+     , (70263,   3,    50, 0, 0, 90) /* MaxStamina */
+     , (70263,   5,    15, 0, 0, 50) /* MaxMana */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (70263,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (70263,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (70263,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (70263,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (70263,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (70263,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (70263,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (70263,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (70263,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,    0.8, NULL, NULL, NULL, NULL, 3 /* Sell */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'I can certainly find a use for that.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,      1, NULL, NULL, NULL, NULL, 1 /* Open */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Happy Festival Season! I have many delicious and traditional festival treats for sale.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,      1, NULL, NULL, NULL, NULL, 2 /* Close */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Enjoy the Festival! I''ll be here all month.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,   0.25, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 318767229 /* BowDeep */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,    0.8, NULL, NULL, NULL, NULL, 4 /* Buy */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'I sell only the finest!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,    0.5, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 318767235 /* Nod */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,  0.125, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 318767239 /* Wave */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (70263,  2 /* Vendor */,  0.375, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 318767238 /* Shrug */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (70263, 2, 22018,  1, 44, 0, False) /* Create Mu-miyah Guise (22018) for Wield */
+     , (70263, 2, 25554,  1, 13, 0, False) /* Create Knath Head (25554) for Wield */
+     , (70263, 4, 32187, -1, 39, 0, False) /* Create Festival Robe (32187) for Shop */
+     , (70263, 4,   258, -1, 0, 0, False) /* Create Apple (258) for Shop */
+     , (70263, 4,  5670, -1, 0, 0, False) /* Create Tempting Apple (5670) for Shop */
+     , (70263, 4, 12227, -1, 0, 0, False) /* Create Candied Apple (12227) for Shop */
+     , (70263, 4, 14772, -1, 0, 0, False) /* Create Peppermint Monougat Chew (14772) for Shop */
+     , (70263, 4, 12233, -1, 0, 0, False) /* Create Dark Chocolate Candy Bar (12233) for Shop */
+     , (70263, 4, 12234, -1, 0, 0, False) /* Create Milk Chocolate Candy Bar (12234) for Shop */
+     , (70263, 4,  7830, -1, 0, 0, False) /* Create Bar of Dark Chocolate (7830) for Shop */
+     , (70263, 4,  7832, -1, 0, 0, False) /* Create Bar of Milk Chocolate (7832) for Shop */
+     , (70263, 4, 14758, -1, 0, 0, False) /* Create Peppermint Chocolate Bar (14758) for Shop */
+     , (70263, 4,  4721, -1, 0, 0, False) /* Create Cookie (4721) for Shop */
+     , (70263, 4, 14759, -1, 0, 0, False) /* Create Chocolate Cookie (14759) for Shop */
+     , (70263, 4, 14864, -1, 0, 0, False) /* Create Peppermint Chocolate Cookie (14864) for Shop */
+     , (70263, 4, 14763, -1, 0, 0, False) /* Create Peppermint Cookie (14763) for Shop */
+     , (70263, 4,  8248, -1, 0, 0, False) /* Create Pumpkin Pie (8248) for Shop */
+     , (70263, 4,  8249, -1, 0, 0, False) /* Create Pumpkin Soup (8249) for Shop */
+     , (70263, 4,  2453, -1, 0, 0, False) /* Create Cider (2453) for Shop */
+     , (70263, 4, 34088, -1, 0, 0, False) /* Create Scarecrow Stand (34088) for Shop */
+     , (70263, 4, 34094, -1, 0, 0, False) /* Create T-mon Backpack Straps (34094) for Shop */
+     , (70263, 4, 34195, -1, 0, 0, False) /* Create Red Anniversary Sparkler (34195) for Shop */
+     , (70263, 4, 34193, -1, 0, 0, False) /* Create Orange Anniversary Sparkler (34193) for Shop */
+     , (70263, 4, 34197, -1, 0, 0, False) /* Create Yellow Anniversary Sparkler (34197) for Shop */
+     , (70263, 4, 34192, -1, 0, 0, False) /* Create Green Anniversary Sparkler (34192) for Shop */
+     , (70263, 4, 34191, -1, 0, 0, False) /* Create Blue Anniversary Sparkler (34191) for Shop */
+     , (70263, 4, 34194, -1, 0, 0, False) /* Create Purple Anniversary Sparkler (34194) for Shop */
+     , (70263, 4, 34196, -1, 0, 0, False) /* Create White Anniversary Sparkler (34196) for Shop */
+     , (70263, 4, 13222, -1, 0, 0, False) /* Create Peppermint Stick (13222) for Shop */
+     , (70263, 4,  4757, -1, 0, 0, False) /* Create Carving Knife (4757) for Shop */
+     , (70263, 4,  4767, -1, 0, 0, False) /* Create Skewer (4767) for Shop */
+     , (70263, 4,  4762, -1, 0, 0, False) /* Create Frying Pan (4762) for Shop */
+     , (70263, 4,  4754, -1, 0, 0, False) /* Create Baking Pan (4754) for Shop */
+     , (70263, 4,  7824, -1, 0, 0, False) /* Create Metal Press (7824) for Shop */
+     , (70263, 4,   273, -1, 0, 0, False) /* Create Pyreal (273) for Shop */;

--- a/Database/Patches/2005-10-TricksAndTreats/B GameEventDefDB/EventFestivalVendor.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/B GameEventDefDB/EventFestivalVendor.sql
@@ -1,0 +1,4 @@
+DELETE FROM `event` WHERE `name` = 'EventFestivalVendor';
+
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('EventFestivalVendor', -1, -1, 3, '2019-10-27 00:00:00');


### PR DESCRIPTION
- Tricks and Treats patch items converted from LSD
- Added an event-based generator to spawn the Festival Vendor that currently activates by manually starting EventFestivalVendor, ie /event start EventFestivalVendor and /event stop EventFestivalVendor

