### PR TITLE
Swap a few mobs from WieldTreasure to Wield 

### DIFF
--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32221 Master Alizari.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32221 Master Alizari.sql
@@ -152,7 +152,7 @@ VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, N
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32221,  9, 70271,  0,  0,    1, False) /* Create Alizari's Encoded Notes (70271) for ContainTreasure */
-     , (32221, 10, 29966,  1,  0, 0.25, False) /* Create Quadrelle (29966) for WieldTreasure */
-     , (32221, 10, 29971,  1,  0, 0.25, False) /* Create Partizan (29971) for WieldTreasure */
-     , (32221, 10, 29976,  1,  0, 0.25, False) /* Create Spadone (29976) for WieldTreasure */
-     , (32221, 10, 29980, -1,  0, 0.25, False) /* Create Throwing Axe (29980) for WieldTreasure */;
+     , (32221,  2, 29966,  1,  0, 0.25, False) /* Create Quadrelle (29966) for Wield */
+     , (32221,  2, 29971,  1,  0, 0.25, False) /* Create Partizan (29971) for Wield */
+     , (32221,  2, 29976,  1,  0, 0.25, False) /* Create Spadone (29976) for Wield */
+     , (32221,  2, 29980, -1,  0, 0.25, False) /* Create Throwing Axe (29980) for Wield */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32224 Mistress Halmera.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32224 Mistress Halmera.sql
@@ -157,5 +157,5 @@ VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, N
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32224,  9, 70259,  0,  0, 1, False) /* Create Halmera's Encoded Notes (70259) for ContainTreasure */
-     , (32224, 10, 28614,  0, 13, 2, False) /* Create Vestiri Robe with Hood (28614) for WieldTreasure */
-     , (32224, 10, 30947,  1, 0, 1, False) /* Create Poniard (30947) for WieldTreasure */;
+     , (32224,  2, 28614,  0, 13, 2, False) /* Create Vestiri Robe with Hood (28614) for Wield */
+     , (32224,  2, 30947,  1, 0, 1, False) /* Create Poniard (30947) for Wield */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32227 Mistress Gabille.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32227 Mistress Gabille.sql
@@ -157,5 +157,5 @@ VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, N
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32227,  9, 70273,  0,  0, 1, False) /* Create Gabille's Encoded Notes (70273) for ContainTreasure */
-     , (32227, 10, 28614,  0, 13, 2, False) /* Create Vestiri Robe with Hood (28614) for WieldTreasure */
-     , (32227, 10, 30947,  1, 0, 1, False) /* Create Poniard (30947) for WieldTreasure */;
+     , (32227,  2, 28614,  0, 13, 2, False) /* Create Vestiri Robe with Hood (28614) for Wield */
+     , (32227,  2, 30947,  1, 0, 1, False) /* Create Poniard (30947) for Wield */;

--- a/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32230 Master Versario.sql
+++ b/Database/Patches/2005-10-TricksAndTreats/9 WeenieDefaults/Creature/ViamontianKnight/32230 Master Versario.sql
@@ -179,7 +179,7 @@ VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, N
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32230,  9, 70270,  0,  0,    1, False) /* Create Vaserio's Encoded Notes (70270) for ContainTreasure */
-     , (32230, 10, 29966,  1,  0, 0.25, False) /* Create Quadrelle (29966) for WieldTreasure */
-     , (32230, 10, 29971,  1,  0, 0.25, False) /* Create Partizan (29971) for WieldTreasure */
-     , (32230, 10, 29976,  1,  0, 0.25, False) /* Create Spadone (29976) for WieldTreasure */
-     , (32230, 10, 29980, -1,  0, 0.25, False) /* Create Throwing Axe (29980) for WieldTreasure */;
+     , (32230,  2, 29966,  1,  0, 0.25, False) /* Create Quadrelle (29966) for Wield */
+     , (32230,  2, 29971,  1,  0, 0.25, False) /* Create Partizan (29971) for Wield */
+     , (32230,  2, 29976,  1,  0, 0.25, False) /* Create Spadone (29976) for Wield */
+     , (32230,  2, 29980, -1,  0, 0.25, False) /* Create Throwing Axe (29980) for Wield */;


### PR DESCRIPTION
in ACE currently Wield does not drop on corpse, but WieldTreasure can drop, so just marking these differently to be clear.

Retail did handle some of this differently, but trying to not break the current ACE pattern atm