### PR TITLE
Armor reconcile

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00035 Chainmail Basinet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00035 Chainmail Basinet.sql
@@ -15,7 +15,7 @@ VALUES (35,   1,          2) /* ItemType - Armor */
      , (35,  27,         16) /* ArmorType - Chainmail */
      , (35,  28,        140) /* ArmorLevel */
      , (35,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (35, 124,          3) /* Version */
+     , (35, 124,          3) /* Version */
      , (35, 150,        103) /* HookPlacement - Hook */
      , (35, 151,          2) /* HookType - Wall */
      , (35, 169,  168429060) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00035 Chainmail Basinet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00035 Chainmail Basinet.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35, 'basinetchainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35,   1,          2) /* ItemType - Armor */
+     , (35,   3,         20) /* PaletteTemplate - Silver */
+     , (35,   4,      16384) /* ClothingPriority - Head */
+     , (35,   5,        320) /* EncumbranceVal */
+     , (35,   8,        160) /* Mass */
+     , (35,   9,          1) /* ValidLocations - HeadWear */
+     , (35,  16,          1) /* ItemUseable - No */
+     , (35,  19,       1400) /* Value */
+     , (35,  27,         16) /* ArmorType - Chainmail */
+     , (35,  28,        140) /* ArmorLevel */
+     , (35,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (35, 124,          3) /* Version */
+     , (35, 150,        103) /* HookPlacement - Hook */
+     , (35, 151,          2) /* HookType - Wall */
+     , (35, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35,  22, True ) /* Inscribable */
+     , (35, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35,  12,    0.66) /* Shade */
+     , (35,  13,     1.2) /* ArmorModVsSlash */
+     , (35,  14,       1) /* ArmorModVsPierce */
+     , (35,  15,     0.8) /* ArmorModVsBludgeon */
+     , (35,  16,     0.6) /* ArmorModVsCold */
+     , (35,  17,     0.6) /* ArmorModVsFire */
+     , (35,  18,     0.5) /* ArmorModVsAcid */
+     , (35,  19,     0.4) /* ArmorModVsElectric */
+     , (35, 110,     1.2) /* BulkMod */
+     , (35, 111,       1) /* SizeMod */
+     , (35, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35,   1, 'Chainmail Basinet') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35,   1,   33555048) /* Setup */
+     , (35,   3,  536870932) /* SoundTable */
+     , (35,   6,   67108990) /* PaletteBase */
+     , (35,   7,  268435514) /* ClothingBase */
+     , (35,   8,  100667343) /* Icon */
+     , (35,  22,  872415275) /* PhysicsEffectTable */
+     , (35,  36,  234881042) /* MutateFilter */
+     , (35,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00036 Leather Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00036 Leather Bracers.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 36;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36, 'bracersleather', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (36, 'bracersleather', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (36,   1,          2) /* ItemType - Armor */
@@ -11,30 +11,26 @@ VALUES (36,   1,          2) /* ItemType - Armor */
      , (36,   8,         90) /* Mass */
      , (36,   9,       4096) /* ValidLocations - LowerArmArmor */
      , (36,  16,          1) /* ItemUseable - No */
-     , (36,  19,         30) /* Value */
+     , (36,  19,       1100) /* Value */
      , (36,  27,          2) /* ArmorType - Leather */
-     , (36,  28,         20) /* ArmorLevel */
-     , (36,  53,        101) /* PlacementPosition */
+     , (36,  28,         90) /* ArmorLevel */
      , (36,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (36, 124,          3) /* Version */
      , (36, 169,  118162702) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (36,  11, True ) /* IgnoreCollisions */
-     , (36,  13, True ) /* Ethereal */
-     , (36,  14, True ) /* GravityStatus */
-     , (36,  19, True ) /* Attackable */
-     , (36,  22, True ) /* Inscribable */
+VALUES (36,  22, True ) /* Inscribable */
      , (36, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (36,  12, 0.660000026226044) /* Shade */
+VALUES (36,  12,    0.66) /* Shade */
      , (36,  13,       1) /* ArmorModVsSlash */
-     , (36,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (36,  14,     0.8) /* ArmorModVsPierce */
      , (36,  15,       1) /* ArmorModVsBludgeon */
      , (36,  16,     0.5) /* ArmorModVsCold */
      , (36,  17,     0.5) /* ArmorModVsFire */
-     , (36,  18, 0.300000011920929) /* ArmorModVsAcid */
-     , (36,  19, 0.600000023841858) /* ArmorModVsElectric */
+     , (36,  18,     0.3) /* ArmorModVsAcid */
+     , (36,  19,     0.6) /* ArmorModVsElectric */
      , (36, 165,       1) /* ArmorModVsNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00036 Leather Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00036 Leather Bracers.sql
@@ -15,7 +15,7 @@ VALUES (36,   1,          2) /* ItemType - Armor */
      , (36,  27,          2) /* ArmorType - Leather */
      , (36,  28,         90) /* ArmorLevel */
      , (36,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (36, 124,          3) /* Version */
+     , (36, 124,          3) /* Version */
      , (36, 169,  118162702) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00037 Scalemail Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00037 Scalemail Bracers.sql
@@ -15,7 +15,7 @@ VALUES (37,   1,          2) /* ItemType - Armor */
      , (37,  27,          8) /* ArmorType - Scalemail */
      , (37,  28,        100) /* ArmorLevel */
      , (37,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37, 124,          3) /* Version */
+     , (37, 124,          3) /* Version */
      , (37, 169,  118097156) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00037 Scalemail Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00037 Scalemail Bracers.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37, 'bracersscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37,   1,          2) /* ItemType - Armor */
+     , (37,   3,         20) /* PaletteTemplate - Silver */
+     , (37,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (37,   5,        320) /* EncumbranceVal */
+     , (37,   8,        160) /* Mass */
+     , (37,   9,       4096) /* ValidLocations - LowerArmArmor */
+     , (37,  16,          1) /* ItemUseable - No */
+     , (37,  19,        433) /* Value */
+     , (37,  27,          8) /* ArmorType - Scalemail */
+     , (37,  28,        100) /* ArmorLevel */
+     , (37,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (37, 124,          3) /* Version */
+     , (37, 169,  118097156) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37,  22, True ) /* Inscribable */
+     , (37, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37,  12,    0.66) /* Shade */
+     , (37,  13,       1) /* ArmorModVsSlash */
+     , (37,  14,     1.1) /* ArmorModVsPierce */
+     , (37,  15,       1) /* ArmorModVsBludgeon */
+     , (37,  16,     0.4) /* ArmorModVsCold */
+     , (37,  17,     0.4) /* ArmorModVsFire */
+     , (37,  18,     0.6) /* ArmorModVsAcid */
+     , (37,  19,     0.4) /* ArmorModVsElectric */
+     , (37, 110,     1.2) /* BulkMod */
+     , (37, 111,       1) /* SizeMod */
+     , (37, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37,   1, 'Scalemail Bracers') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37,   1,   33554641) /* Setup */
+     , (37,   3,  536870932) /* SoundTable */
+     , (37,   6,   67108990) /* PaletteBase */
+     , (37,   7,  268435470) /* ClothingBase */
+     , (37,   8,  100668181) /* Icon */
+     , (37,  22,  872415275) /* PhysicsEffectTable */
+     , (37,  36,  234881042) /* MutateFilter */
+     , (37,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00038 Studded Leather Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00038 Studded Leather Bracers.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 38;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (38, 'bracersstuddedleather', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (38, 'bracersstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (38,   1,          2) /* ItemType - Armor */
@@ -13,31 +13,24 @@ VALUES (38,   1,          2) /* ItemType - Armor */
      , (38,  16,          1) /* ItemUseable - No */
      , (38,  19,        110) /* Value */
      , (38,  27,          4) /* ArmorType - StuddedLeather */
-     , (38,  28,         30) /* ArmorLevel */
-     , (38,  53,        101) /* PlacementPosition */
+     , (38,  28,         90) /* ArmorLevel */
      , (38,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-     , (38, 105,          4) /* ItemWorkmanship */
-     , (38, 131,         52) /* MaterialType - Leather */
-     , (38, 169,  118162702) /* TsysMutationData */
-     , (38, 172,          1) /* AppraisalLongDescDecoration */;
+	 , (38, 124,          3) /* Version */
+     , (38, 169,  118162702) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (38,  11, True ) /* IgnoreCollisions */
-     , (38,  13, True ) /* Ethereal */
-     , (38,  14, True ) /* GravityStatus */
-     , (38,  19, True ) /* Attackable */
-     , (38,  22, True ) /* Inscribable */
+VALUES (38,  22, True ) /* Inscribable */
      , (38, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (38,  12, 0.660000026226044) /* Shade */
-     , (38,  13, 1.20000004768372) /* ArmorModVsSlash */
-     , (38,  14, 1.10000002384186) /* ArmorModVsPierce */
+VALUES (38,  12,    0.66) /* Shade */
+     , (38,  13,     1.2) /* ArmorModVsSlash */
+     , (38,  14,     1.1) /* ArmorModVsPierce */
      , (38,  15,       1) /* ArmorModVsBludgeon */
-     , (38,  16, 0.200000002980232) /* ArmorModVsCold */
-     , (38,  17, 0.200000002980232) /* ArmorModVsFire */
-     , (38,  18, 0.100000001490116) /* ArmorModVsAcid */
-     , (38,  19, 0.200000002980232) /* ArmorModVsElectric */
+     , (38,  16,     0.2) /* ArmorModVsCold */
+     , (38,  17,     0.2) /* ArmorModVsFire */
+     , (38,  18,     0.1) /* ArmorModVsAcid */
+     , (38,  19,     0.2) /* ArmorModVsElectric */
      , (38, 110,     1.5) /* BulkMod */
      , (38, 111,       1) /* SizeMod */
      , (38, 165,       1) /* ArmorModVsNether */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00038 Studded Leather Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00038 Studded Leather Bracers.sql
@@ -15,7 +15,7 @@ VALUES (38,   1,          2) /* ItemType - Armor */
      , (38,  27,          4) /* ArmorType - StuddedLeather */
      , (38,  28,         90) /* ArmorLevel */
      , (38,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (38, 124,          3) /* Version */
+     , (38, 124,          3) /* Version */
      , (38, 169,  118162702) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00039 Leather Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00039 Leather Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 39;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (39, 'breastplateleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (39,   1,          2) /* ItemType - Armor */
+     , (39,   3,          4) /* PaletteTemplate - Brown */
+     , (39,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (39,   5,        420) /* EncumbranceVal */
+     , (39,   8,        140) /* Mass */
+     , (39,   9,        512) /* ValidLocations - ChestArmor */
+     , (39,  16,          1) /* ItemUseable - No */
+     , (39,  19,       1400) /* Value */
+     , (39,  27,          2) /* ArmorType - Leather */
+     , (39,  28,         90) /* ArmorLevel */
+     , (39,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (39, 124,          3) /* Version */
+     , (39, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (39,  22, True ) /* Inscribable */
+     , (39, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (39,  12,    0.66) /* Shade */
+     , (39,  13,       1) /* ArmorModVsSlash */
+     , (39,  14,     0.8) /* ArmorModVsPierce */
+     , (39,  15,       1) /* ArmorModVsBludgeon */
+     , (39,  16,     0.5) /* ArmorModVsCold */
+     , (39,  17,     0.5) /* ArmorModVsFire */
+     , (39,  18,     0.3) /* ArmorModVsAcid */
+     , (39,  19,     0.6) /* ArmorModVsElectric */
+     , (39, 110,    1.67) /* BulkMod */
+     , (39, 111,     2.5) /* SizeMod */
+     , (39, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (39,   1, 'Leather Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (39,   1,   33554642) /* Setup */
+     , (39,   3,  536870932) /* SoundTable */
+     , (39,   6,   67108990) /* PaletteBase */
+     , (39,   7,  268435541) /* ClothingBase */
+     , (39,   8,  100667350) /* Icon */
+     , (39,  22,  872415275) /* PhysicsEffectTable */
+     , (39,  36,  234881042) /* MutateFilter */
+     , (39,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00039 Leather Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00039 Leather Breastplate.sql
@@ -15,7 +15,7 @@ VALUES (39,   1,          2) /* ItemType - Armor */
      , (39,  27,          2) /* ArmorType - Leather */
      , (39,  28,         90) /* ArmorLevel */
      , (39,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (39, 124,          3) /* Version */
+     , (39, 124,          3) /* Version */
      , (39, 169,  118163214) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00040 Platemail Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00040 Platemail Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40, 'breastplateplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40,   1,          2) /* ItemType - Armor */
+     , (40,   3,         20) /* PaletteTemplate - Silver */
+     , (40,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (40,   5,       2200) /* EncumbranceVal */
+     , (40,   8,       1100) /* Mass */
+     , (40,   9,        512) /* ValidLocations - ChestArmor */
+     , (40,  16,          1) /* ItemUseable - No */
+     , (40,  19,       1631) /* Value */
+     , (40,  27,         32) /* ArmorType - Metal */
+     , (40,  28,        100) /* ArmorLevel */
+     , (40,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (40, 124,          3) /* Version */
+     , (40, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40,  22, True ) /* Inscribable */
+     , (40, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40,  12,    0.33) /* Shade */
+     , (40,  13,     1.3) /* ArmorModVsSlash */
+     , (40,  14,       1) /* ArmorModVsPierce */
+     , (40,  15,       1) /* ArmorModVsBludgeon */
+     , (40,  16,     0.4) /* ArmorModVsCold */
+     , (40,  17,     0.4) /* ArmorModVsFire */
+     , (40,  18,     0.6) /* ArmorModVsAcid */
+     , (40,  19,     0.4) /* ArmorModVsElectric */
+     , (40, 110,       1) /* BulkMod */
+     , (40, 111,     1.3) /* SizeMod */
+     , (40, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40,   1, 'Platemail Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40,   1,   33554642) /* Setup */
+     , (40,   3,  536870932) /* SoundTable */
+     , (40,   6,   67108990) /* PaletteBase */
+     , (40,   7,  268435460) /* ClothingBase */
+     , (40,   8,  100667354) /* Icon */
+     , (40,  22,  872415275) /* PhysicsEffectTable */
+     , (40,  36,  234881042) /* MutateFilter */
+     , (40,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00040 Platemail Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00040 Platemail Breastplate.sql
@@ -15,7 +15,7 @@ VALUES (40,   1,          2) /* ItemType - Armor */
      , (40,  27,         32) /* ArmorType - Metal */
      , (40,  28,        100) /* ArmorLevel */
      , (40,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (40, 124,          3) /* Version */
+     , (40, 124,          3) /* Version */
      , (40, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00041 Scalemail Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00041 Scalemail Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 41;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (41, 'breastplatescalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (41,   1,          2) /* ItemType - Armor */
+     , (41,   3,         20) /* PaletteTemplate - Silver */
+     , (41,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (41,   5,       1215) /* EncumbranceVal */
+     , (41,   8,        730) /* Mass */
+     , (41,   9,        512) /* ValidLocations - ChestArmor */
+     , (41,  16,          1) /* ItemUseable - No */
+     , (41,  19,       1085) /* Value */
+     , (41,  27,          8) /* ArmorType - Scalemail */
+     , (41,  28,        100) /* ArmorLevel */
+     , (41,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (41, 124,          3) /* Version */
+     , (41, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (41,  22, True ) /* Inscribable */
+     , (41, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (41,  12,    0.33) /* Shade */
+     , (41,  13,       1) /* ArmorModVsSlash */
+     , (41,  14,     1.1) /* ArmorModVsPierce */
+     , (41,  15,       1) /* ArmorModVsBludgeon */
+     , (41,  16,     0.4) /* ArmorModVsCold */
+     , (41,  17,     0.4) /* ArmorModVsFire */
+     , (41,  18,     0.6) /* ArmorModVsAcid */
+     , (41,  19,     0.4) /* ArmorModVsElectric */
+     , (41, 110,     1.2) /* BulkMod */
+     , (41, 111,     1.3) /* SizeMod */
+     , (41, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (41,   1, 'Scalemail Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (41,   1,   33554642) /* Setup */
+     , (41,   3,  536870932) /* SoundTable */
+     , (41,   6,   67108990) /* PaletteBase */
+     , (41,   7,  268435495) /* ClothingBase */
+     , (41,   8,  100668140) /* Icon */
+     , (41,  22,  872415275) /* PhysicsEffectTable */
+     , (41,  36,  234881042) /* MutateFilter */
+     , (41,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00041 Scalemail Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00041 Scalemail Breastplate.sql
@@ -15,7 +15,7 @@ VALUES (41,   1,          2) /* ItemType - Armor */
      , (41,  27,          8) /* ArmorType - Scalemail */
      , (41,  28,        100) /* ArmorLevel */
      , (41,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (41, 124,          3) /* Version */
+     , (41, 124,          3) /* Version */
      , (41, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00042 Studded Leather Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00042 Studded Leather Breastplate.sql
@@ -15,7 +15,7 @@ VALUES (42,   1,          2) /* ItemType - Armor */
      , (42,  27,          4) /* ArmorType - StuddedLeather */
      , (42,  28,         90) /* ArmorLevel */
      , (42,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (42, 124,          3) /* Version */
+     , (42, 124,          3) /* Version */
      , (42, 169,  118163214) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00042 Studded Leather Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00042 Studded Leather Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 42;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (42, 'breastplatestuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (42,   1,          2) /* ItemType - Armor */
+     , (42,   3,         18) /* PaletteTemplate - YellowBrown */
+     , (42,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (42,   5,        675) /* EncumbranceVal */
+     , (42,   8,        270) /* Mass */
+     , (42,   9,        512) /* ValidLocations - ChestArmor */
+     , (42,  16,          1) /* ItemUseable - No */
+     , (42,  19,       1450) /* Value */
+     , (42,  27,          4) /* ArmorType - StuddedLeather */
+     , (42,  28,         90) /* ArmorLevel */
+     , (42,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42, 124,          3) /* Version */
+     , (42, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (42,  22, True ) /* Inscribable */
+     , (42, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (42,  12,    0.33) /* Shade */
+     , (42,  13,     1.2) /* ArmorModVsSlash */
+     , (42,  14,     1.1) /* ArmorModVsPierce */
+     , (42,  15,       1) /* ArmorModVsBludgeon */
+     , (42,  16,     0.4) /* ArmorModVsCold */
+     , (42,  17,     0.7) /* ArmorModVsFire */
+     , (42,  18,     0.3) /* ArmorModVsAcid */
+     , (42,  19,     0.4) /* ArmorModVsElectric */
+     , (42, 110,     1.5) /* BulkMod */
+     , (42, 111,     2.5) /* SizeMod */
+     , (42, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (42,   1, 'Studded Leather Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (42,   1,   33554642) /* Setup */
+     , (42,   3,  536870932) /* SoundTable */
+     , (42,   6,   67108990) /* PaletteBase */
+     , (42,   7,  268435496) /* ClothingBase */
+     , (42,   8,  100667930) /* Icon */
+     , (42,  22,  872415275) /* PhysicsEffectTable */
+     , (42,  36,  234881042) /* MutateFilter */
+     , (42,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00043 Yoroi Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00043 Yoroi Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43, 'breastplateyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43,   1,          2) /* ItemType - Armor */
+     , (43,   3,         20) /* PaletteTemplate - Silver */
+     , (43,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (43,   5,       1215) /* EncumbranceVal */
+     , (43,   8,        730) /* Mass */
+     , (43,   9,        512) /* ValidLocations - ChestArmor */
+     , (43,  16,          1) /* ItemUseable - No */
+     , (43,  19,       1500) /* Value */
+     , (43,  27,         32) /* ArmorType - Metal */
+     , (43,  28,        100) /* ArmorLevel */
+     , (43,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43, 124,          3) /* Version */
+     , (43, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43,  22, True ) /* Inscribable */
+     , (43, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43,  12,    0.33) /* Shade */
+     , (43,  13,     1.3) /* ArmorModVsSlash */
+     , (43,  14,       1) /* ArmorModVsPierce */
+     , (43,  15,       1) /* ArmorModVsBludgeon */
+     , (43,  16,     0.4) /* ArmorModVsCold */
+     , (43,  17,     0.4) /* ArmorModVsFire */
+     , (43,  18,     0.6) /* ArmorModVsAcid */
+     , (43,  19,     0.4) /* ArmorModVsElectric */
+     , (43, 110,    1.15) /* BulkMod */
+     , (43, 111,     1.3) /* SizeMod */
+     , (43, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43,   1, 'Yoroi Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43,   1,   33554642) /* Setup */
+     , (43,   3,  536870932) /* SoundTable */
+     , (43,   6,   67108990) /* PaletteBase */
+     , (43,   7,  268435493) /* ClothingBase */
+     , (43,   8,  100668147) /* Icon */
+     , (43,  22,  872415275) /* PhysicsEffectTable */
+     , (43,  36,  234881042) /* MutateFilter */
+     , (43,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00045 Leather Cap.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00045 Leather Cap.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 45;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (45, 'capleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (45,   1,          2) /* ItemType - Armor */
+     , (45,   3,          4) /* PaletteTemplate - Brown */
+     , (45,   4,      16384) /* ClothingPriority - Head */
+     , (45,   5,        100) /* EncumbranceVal */
+     , (45,   8,         45) /* Mass */
+     , (45,   9,          1) /* ValidLocations - HeadWear */
+     , (45,  16,          1) /* ItemUseable - No */
+     , (45,  19,       1100) /* Value */
+     , (45,  27,          2) /* ArmorType - Leather */
+     , (45,  28,        130) /* ArmorLevel */
+     , (45,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (45, 124,          3) /* Version */
+     , (45, 150,        103) /* HookPlacement - Hook */
+     , (45, 151,          2) /* HookType - Wall */
+     , (45, 169,  218826510) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (45,  22, True ) /* Inscribable */
+     , (45, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (45,  12,    0.66) /* Shade */
+     , (45,  13,     1.2) /* ArmorModVsSlash */
+     , (45,  14,     0.8) /* ArmorModVsPierce */
+     , (45,  15,       1) /* ArmorModVsBludgeon */
+     , (45,  16,     0.5) /* ArmorModVsCold */
+     , (45,  17,     0.5) /* ArmorModVsFire */
+     , (45,  18,     0.3) /* ArmorModVsAcid */
+     , (45,  19,     0.8) /* ArmorModVsElectric */
+     , (45, 110,    1.67) /* BulkMod */
+     , (45, 111,       1) /* SizeMod */
+     , (45, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (45,   1, 'Leather Cap') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (45,   1,   33554643) /* Setup */
+     , (45,   3,  536870932) /* SoundTable */
+     , (45,   6,   67108990) /* PaletteBase */
+     , (45,   7,  268435465) /* ClothingBase */
+     , (45,   8,  100667313) /* Icon */
+     , (45,  22,  872415275) /* PhysicsEffectTable */
+     , (45,  36,  234881042) /* MutateFilter */
+     , (45,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00046 Metal Cap.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00046 Metal Cap.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46, 'capmetal', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46,   1,          2) /* ItemType - Armor */
+     , (46,   3,         20) /* PaletteTemplate - Silver */
+     , (46,   4,      16384) /* ClothingPriority - Head */
+     , (46,   5,        120) /* EncumbranceVal */
+     , (46,   8,         90) /* Mass */
+     , (46,   9,          1) /* ValidLocations - HeadWear */
+     , (46,  16,          1) /* ItemUseable - No */
+     , (46,  19,         73) /* Value */
+     , (46,  27,         32) /* ArmorType - Metal */
+     , (46,  28,        140) /* ArmorLevel */
+     , (46,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (46, 124,          3) /* Version */
+     , (46, 150,        103) /* HookPlacement - Hook */
+     , (46, 151,          2) /* HookType - Wall */
+     , (46, 169,  218759684) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46,  22, True ) /* Inscribable */
+     , (46, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46,  12,    0.66) /* Shade */
+     , (46,  13,     1.3) /* ArmorModVsSlash */
+     , (46,  14,       1) /* ArmorModVsPierce */
+     , (46,  15,       1) /* ArmorModVsBludgeon */
+     , (46,  16,     0.4) /* ArmorModVsCold */
+     , (46,  17,     0.4) /* ArmorModVsFire */
+     , (46,  18,     0.6) /* ArmorModVsAcid */
+     , (46,  19,     0.4) /* ArmorModVsElectric */
+     , (46, 110,     1.5) /* BulkMod */
+     , (46, 111,       1) /* SizeMod */
+     , (46, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46,   1, 'Metal Cap') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46,   1,   33554643) /* Setup */
+     , (46,   3,  536870932) /* SoundTable */
+     , (46,   6,   67108990) /* PaletteBase */
+     , (46,   7,  268435520) /* ClothingBase */
+     , (46,   8,  100668166) /* Icon */
+     , (46,  22,  872415275) /* PhysicsEffectTable */
+     , (46,  36,  234881042) /* MutateFilter */
+     , (46,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00047 Leather Coat.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00047 Leather Coat.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 47;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (47, 'coatleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (47,   1,          2) /* ItemType - Armor */
+     , (47,   3,          4) /* PaletteTemplate - Brown */
+     , (47,   4,      15360) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (47,   5,        810) /* EncumbranceVal */
+     , (47,   8,        270) /* Mass */
+     , (47,   9,       7680) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor, LowerArmArmor */
+     , (47,  16,          1) /* ItemUseable - No */
+     , (47,  19,        150) /* Value */
+     , (47,  27,          2) /* ArmorType - Leather */
+     , (47,  28,         90) /* ArmorLevel */
+     , (47,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (47, 124,          3) /* Version */
+     , (47, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (47,  22, True ) /* Inscribable */
+     , (47, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (47,  12,    0.66) /* Shade */
+     , (47,  13,       1) /* ArmorModVsSlash */
+     , (47,  14,     0.8) /* ArmorModVsPierce */
+     , (47,  15,       1) /* ArmorModVsBludgeon */
+     , (47,  16,     0.5) /* ArmorModVsCold */
+     , (47,  17,     0.5) /* ArmorModVsFire */
+     , (47,  18,     0.3) /* ArmorModVsAcid */
+     , (47,  19,     0.6) /* ArmorModVsElectric */
+     , (47, 110,    1.67) /* BulkMod */
+     , (47, 111,     4.5) /* SizeMod */
+     , (47, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (47,   1, 'Leather Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (47,   1,   33554644) /* Setup */
+     , (47,   3,  536870932) /* SoundTable */
+     , (47,   6,   67108990) /* PaletteBase */
+     , (47,   7,  268435620) /* ClothingBase */
+     , (47,   8,  100667353) /* Icon */
+     , (47,  22,  872415275) /* PhysicsEffectTable */
+     , (47,  36,  234881042) /* MutateFilter */
+     , (47,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00048 Studded Leather Coat.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00048 Studded Leather Coat.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48, 'coatstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48,   1,          2) /* ItemType - Armor */
+     , (48,   3,          4) /* PaletteTemplate - Brown */
+     , (48,   4,      15360) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (48,   5,       1250) /* EncumbranceVal */
+     , (48,   8,        500) /* Mass */
+     , (48,   9,       7680) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor, LowerArmArmor */
+     , (48,  16,          1) /* ItemUseable - No */
+     , (48,  19,        470) /* Value */
+     , (48,  27,          4) /* ArmorType - StuddedLeather */
+     , (48,  28,         90) /* ArmorLevel */
+     , (48,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (48, 124,          3) /* Version */
+     , (48, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48,  22, True ) /* Inscribable */
+     , (48, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48,  12,    0.66) /* Shade */
+     , (48,  13,     1.2) /* ArmorModVsSlash */
+     , (48,  14,     1.1) /* ArmorModVsPierce */
+     , (48,  15,       1) /* ArmorModVsBludgeon */
+     , (48,  16,     0.2) /* ArmorModVsCold */
+     , (48,  17,     0.2) /* ArmorModVsFire */
+     , (48,  18,     0.1) /* ArmorModVsAcid */
+     , (48,  19,     0.2) /* ArmorModVsElectric */
+     , (48, 110,     1.5) /* BulkMod */
+     , (48, 111,     4.5) /* SizeMod */
+     , (48, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48,   1, 'Studded Leather Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48,   1,   33554644) /* Setup */
+     , (48,   3,  536870932) /* SoundTable */
+     , (48,   6,   67108990) /* PaletteBase */
+     , (48,   7,  268435623) /* ClothingBase */
+     , (48,   8,  100668413) /* Icon */
+     , (48,  22,  872415275) /* PhysicsEffectTable */
+     , (48,  36,  234881042) /* MutateFilter */
+     , (48,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00050 Leather Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00050 Leather Cuirass.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 50;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (50, 'cuirassleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (50,   1,          2) /* ItemType - Armor */
+     , (50,   3,          4) /* PaletteTemplate - Brown */
+     , (50,   4,       3072) /* ClothingPriority - OuterwearChest, OuterwearAbdomen */
+     , (50,   5,        540) /* EncumbranceVal */
+     , (50,   8,        180) /* Mass */
+     , (50,   9,       1536) /* ValidLocations - ChestArmor, AbdomenArmor */
+     , (50,  16,          1) /* ItemUseable - No */
+     , (50,  19,        120) /* Value */
+     , (50,  27,          2) /* ArmorType - Leather */
+     , (50,  28,         90) /* ArmorLevel */
+     , (50,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (50, 124,          3) /* Version */
+     , (50, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (50,  22, True ) /* Inscribable */
+     , (50, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (50,  12,    0.66) /* Shade */
+     , (50,  13,       1) /* ArmorModVsSlash */
+     , (50,  14,     0.8) /* ArmorModVsPierce */
+     , (50,  15,       1) /* ArmorModVsBludgeon */
+     , (50,  16,     0.5) /* ArmorModVsCold */
+     , (50,  17,     0.5) /* ArmorModVsFire */
+     , (50,  18,     0.3) /* ArmorModVsAcid */
+     , (50,  19,     0.6) /* ArmorModVsElectric */
+     , (50, 110,    1.67) /* BulkMod */
+     , (50, 111,     3.5) /* SizeMod */
+     , (50, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (50,   1, 'Leather Cuirass') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (50,   1,   33554854) /* Setup */
+     , (50,   3,  536870932) /* SoundTable */
+     , (50,   6,   67108990) /* PaletteBase */
+     , (50,   7,  268435615) /* ClothingBase */
+     , (50,   8,  100667351) /* Icon */
+     , (50,  22,  872415275) /* PhysicsEffectTable */
+     , (50,  36,  234881042) /* MutateFilter */
+     , (50,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00051 Platemail Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00051 Platemail Cuirass.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 51;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (51, 'cuirassplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (51,   1,          2) /* ItemType - Armor */
+     , (51,   3,         20) /* PaletteTemplate - Silver */
+     , (51,   4,       3072) /* ClothingPriority - OuterwearChest, OuterwearAbdomen */
+     , (51,   5,       2798) /* EncumbranceVal */
+     , (51,   8,       1400) /* Mass */
+     , (51,   9,       1536) /* ValidLocations - ChestArmor, AbdomenArmor */
+     , (51,  16,          1) /* ItemUseable - No */
+     , (51,  19,       2284) /* Value */
+     , (51,  27,         32) /* ArmorType - Metal */
+     , (51,  28,        110) /* ArmorLevel */
+     , (51,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (51, 124,          3) /* Version */
+     , (51, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (51,  22, True ) /* Inscribable */
+     , (51, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (51,  12,    0.66) /* Shade */
+     , (51,  13,     1.3) /* ArmorModVsSlash */
+     , (51,  14,       1) /* ArmorModVsPierce */
+     , (51,  15,       1) /* ArmorModVsBludgeon */
+     , (51,  16,     0.4) /* ArmorModVsCold */
+     , (51,  17,     0.4) /* ArmorModVsFire */
+     , (51,  18,     0.6) /* ArmorModVsAcid */
+     , (51,  19,     0.4) /* ArmorModVsElectric */
+     , (51, 110,       1) /* BulkMod */
+     , (51, 111,     1.4) /* SizeMod */
+     , (51, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (51,   1, 'Platemail Cuirass') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (51,   1,   33554854) /* Setup */
+     , (51,   3,  536870932) /* SoundTable */
+     , (51,   6,   67108990) /* PaletteBase */
+     , (51,   7,  268435616) /* ClothingBase */
+     , (51,   8,  100667355) /* Icon */
+     , (51,  22,  872415275) /* PhysicsEffectTable */
+     , (51,  36,  234881042) /* MutateFilter */
+     , (51,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00052 Scalemail Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00052 Scalemail Cuirass.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 52;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (52, 'cuirassscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (52,   1,          2) /* ItemType - Armor */
+     , (52,   3,         20) /* PaletteTemplate - Silver */
+     , (52,   4,       3072) /* ClothingPriority - OuterwearChest, OuterwearAbdomen */
+     , (52,   5,       2275) /* EncumbranceVal */
+     , (52,   8,        910) /* Mass */
+     , (52,   9,       1536) /* ValidLocations - ChestArmor, AbdomenArmor */
+     , (52,  16,          1) /* ItemUseable - No */
+     , (52,  19,       2280) /* Value */
+     , (52,  27,          8) /* ArmorType - Scalemail */
+     , (52,  28,        100) /* ArmorLevel */
+     , (52,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (52, 124,          3) /* Version */
+     , (52, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (52,  22, True ) /* Inscribable */
+     , (52, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (52,  12,    0.66) /* Shade */
+     , (52,  13,       1) /* ArmorModVsSlash */
+     , (52,  14,     1.1) /* ArmorModVsPierce */
+     , (52,  15,       1) /* ArmorModVsBludgeon */
+     , (52,  16,     0.4) /* ArmorModVsCold */
+     , (52,  17,     0.4) /* ArmorModVsFire */
+     , (52,  18,     0.6) /* ArmorModVsAcid */
+     , (52,  19,     0.4) /* ArmorModVsElectric */
+     , (52, 110,     1.2) /* BulkMod */
+     , (52, 111,     1.4) /* SizeMod */
+     , (52, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (52,   1, 'Scalemail Cuirass') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (52,   1,   33554854) /* Setup */
+     , (52,   3,  536870932) /* SoundTable */
+     , (52,   6,   67108990) /* PaletteBase */
+     , (52,   7,  268435617) /* ClothingBase */
+     , (52,   8,  100668140) /* Icon */
+     , (52,  22,  872415275) /* PhysicsEffectTable */
+     , (52,  36,  234881042) /* MutateFilter */
+     , (52,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00053 Studded Leather Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00053 Studded Leather Cuirass.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 53;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (53, 'cuirassstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (53,   1,          2) /* ItemType - Armor */
+     , (53,   3,          4) /* PaletteTemplate - Brown */
+     , (53,   4,       3072) /* ClothingPriority - OuterwearChest, OuterwearAbdomen */
+     , (53,   5,        900) /* EncumbranceVal */
+     , (53,   8,        360) /* Mass */
+     , (53,   9,       1536) /* ValidLocations - ChestArmor, AbdomenArmor */
+     , (53,  16,          1) /* ItemUseable - No */
+     , (53,  19,        900) /* Value */
+     , (53,  27,          4) /* ArmorType - StuddedLeather */
+     , (53,  28,         90) /* ArmorLevel */
+     , (53,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (53, 124,          3) /* Version */
+     , (53, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (53,  22, True ) /* Inscribable */
+     , (53, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (53,  12,    0.66) /* Shade */
+     , (53,  13,     1.2) /* ArmorModVsSlash */
+     , (53,  14,     1.1) /* ArmorModVsPierce */
+     , (53,  15,       1) /* ArmorModVsBludgeon */
+     , (53,  16,     0.2) /* ArmorModVsCold */
+     , (53,  17,     0.2) /* ArmorModVsFire */
+     , (53,  18,     0.1) /* ArmorModVsAcid */
+     , (53,  19,     0.2) /* ArmorModVsElectric */
+     , (53, 110,     1.5) /* BulkMod */
+     , (53, 111,     3.5) /* SizeMod */
+     , (53, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (53,   1, 'Studded Leather Cuirass') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (53,   1,   33554854) /* Setup */
+     , (53,   3,  536870932) /* SoundTable */
+     , (53,   6,   67108990) /* PaletteBase */
+     , (53,   7,  268435618) /* ClothingBase */
+     , (53,   8,  100668416) /* Icon */
+     , (53,  22,  872415275) /* PhysicsEffectTable */
+     , (53,  36,  234881042) /* MutateFilter */
+     , (53,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00054 Yoroi Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00054 Yoroi Cuirass.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 54;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (54, 'cuirassyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (54,   1,          2) /* ItemType - Armor */
+     , (54,   3,         20) /* PaletteTemplate - Silver */
+     , (54,   4,       3072) /* ClothingPriority - OuterwearChest, OuterwearAbdomen */
+     , (54,   5,       1515) /* EncumbranceVal */
+     , (54,   8,        910) /* Mass */
+     , (54,   9,       1536) /* ValidLocations - ChestArmor, AbdomenArmor */
+     , (54,  16,          1) /* ItemUseable - No */
+     , (54,  19,       1665) /* Value */
+     , (54,  27,         32) /* ArmorType - Metal */
+     , (54,  28,        100) /* ArmorLevel */
+     , (54,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (54, 124,          3) /* Version */
+     , (54, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (54,  22, True ) /* Inscribable */
+     , (54, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (54,  12,    0.66) /* Shade */
+     , (54,  13,     1.3) /* ArmorModVsSlash */
+     , (54,  14,       1) /* ArmorModVsPierce */
+     , (54,  15,       1) /* ArmorModVsBludgeon */
+     , (54,  16,     0.4) /* ArmorModVsCold */
+     , (54,  17,     0.4) /* ArmorModVsFire */
+     , (54,  18,     0.6) /* ArmorModVsAcid */
+     , (54,  19,     0.4) /* ArmorModVsElectric */
+     , (54, 110,    1.15) /* BulkMod */
+     , (54, 111,     1.4) /* SizeMod */
+     , (54, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (54,   1, 'Yoroi Cuirass') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (54,   1,   33554854) /* Setup */
+     , (54,   3,  536870932) /* SoundTable */
+     , (54,   6,   67108990) /* PaletteBase */
+     , (54,   7,  268435619) /* ClothingBase */
+     , (54,   8,  100668147) /* Icon */
+     , (54,  22,  872415275) /* PhysicsEffectTable */
+     , (54,  36,  234881042) /* MutateFilter */
+     , (54,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00055 Chainmail Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00055 Chainmail Gauntlets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 55;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (55, 'gauntletschainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (55,   1,          2) /* ItemType - Armor */
+     , (55,   3,         20) /* PaletteTemplate - Silver */
+     , (55,   4,      32768) /* ClothingPriority - Hands */
+     , (55,   5,        450) /* EncumbranceVal */
+     , (55,   8,        270) /* Mass */
+     , (55,   9,         32) /* ValidLocations - HandWear */
+     , (55,  16,          1) /* ItemUseable - No */
+     , (55,  19,       1210) /* Value */
+     , (55,  27,         16) /* ArmorType - Chainmail */
+     , (55,  28,        140) /* ArmorLevel */
+     , (55,  44,          2) /* Damage */
+     , (55,  45,          4) /* DamageType - Bludgeon */
+     , (55,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (55, 124,          3) /* Version */
+     , (55, 169,  151651588) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (55,  22, True ) /* Inscribable */
+     , (55, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (55,  12,    0.66) /* Shade */
+     , (55,  13,     1.2) /* ArmorModVsSlash */
+     , (55,  14,       1) /* ArmorModVsPierce */
+     , (55,  15,     0.8) /* ArmorModVsBludgeon */
+     , (55,  16,     0.6) /* ArmorModVsCold */
+     , (55,  17,     0.6) /* ArmorModVsFire */
+     , (55,  18,     0.5) /* ArmorModVsAcid */
+     , (55,  19,     0.4) /* ArmorModVsElectric */
+     , (55,  22,    0.75) /* DamageVariance */
+     , (55, 110,    1.33) /* BulkMod */
+     , (55, 111,       1) /* SizeMod */
+     , (55, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (55,   1, 'Chainmail Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (55,   1,   33554648) /* Setup */
+     , (55,   3,  536870932) /* SoundTable */
+     , (55,   6,   67108990) /* PaletteBase */
+     , (55,   7,  268435476) /* ClothingBase */
+     , (55,   8,  100667339) /* Icon */
+     , (55,  22,  872415275) /* PhysicsEffectTable */
+     , (55,  36,  234881042) /* MutateFilter */
+     , (55,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00056 Leather Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00056 Leather Gauntlets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 56;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (56, 'gauntletsleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (56,   1,          2) /* ItemType - Armor */
+     , (56,   3,          4) /* PaletteTemplate - Brown */
+     , (56,   4,      32768) /* ClothingPriority - Hands */
+     , (56,   5,        270) /* EncumbranceVal */
+     , (56,   8,         90) /* Mass */
+     , (56,   9,         32) /* ValidLocations - HandWear */
+     , (56,  16,          1) /* ItemUseable - No */
+     , (56,  19,       1100) /* Value */
+     , (56,  27,          2) /* ArmorType - Leather */
+     , (56,  28,        130) /* ArmorLevel */
+     , (56,  44,          0) /* Damage */
+     , (56,  45,          4) /* DamageType - Bludgeon */
+     , (56,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (56, 124,          3) /* Version */
+     , (56, 169,  151717134) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (56,  22, True ) /* Inscribable */
+     , (56, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (56,  12,    0.66) /* Shade */
+     , (56,  13,       1) /* ArmorModVsSlash */
+     , (56,  14,     0.8) /* ArmorModVsPierce */
+     , (56,  15,       1) /* ArmorModVsBludgeon */
+     , (56,  16,     0.5) /* ArmorModVsCold */
+     , (56,  17,     0.5) /* ArmorModVsFire */
+     , (56,  18,     0.3) /* ArmorModVsAcid */
+     , (56,  19,     0.6) /* ArmorModVsElectric */
+     , (56,  22,    0.75) /* DamageVariance */
+     , (56, 110,    1.67) /* BulkMod */
+     , (56, 111,       1) /* SizeMod */
+     , (56, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (56,   1, 'Leather Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (56,   1,   33554648) /* Setup */
+     , (56,   3,  536870932) /* SoundTable */
+     , (56,   6,   67108990) /* PaletteBase */
+     , (56,   7,  268435464) /* ClothingBase */
+     , (56,   8,  100667340) /* Icon */
+     , (56,  22,  872415275) /* PhysicsEffectTable */
+     , (56,  36,  234881042) /* MutateFilter */
+     , (56,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00057 Platemail Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00057 Platemail Gauntlets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 57;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (57, 'gauntletsplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (57,   1,          2) /* ItemType - Armor */
+     , (57,   3,         20) /* PaletteTemplate - Silver */
+     , (57,   4,      32768) /* ClothingPriority - Hands */
+     , (57,   5,        919) /* EncumbranceVal */
+     , (57,   8,        460) /* Mass */
+     , (57,   9,         32) /* ValidLocations - HandWear */
+     , (57,  16,          1) /* ItemUseable - No */
+     , (57,  19,       1600) /* Value */
+     , (57,  27,         32) /* ArmorType - Metal */
+     , (57,  28,        150) /* ArmorLevel */
+     , (57,  44,          3) /* Damage */
+     , (57,  45,          4) /* DamageType - Bludgeon */
+     , (57,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (57, 124,          3) /* Version */
+     , (57, 169,  151651588) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (57,  22, True ) /* Inscribable */
+     , (57, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (57,  12,    0.66) /* Shade */
+     , (57,  13,     1.3) /* ArmorModVsSlash */
+     , (57,  14,       1) /* ArmorModVsPierce */
+     , (57,  15,       1) /* ArmorModVsBludgeon */
+     , (57,  16,     0.4) /* ArmorModVsCold */
+     , (57,  17,     0.4) /* ArmorModVsFire */
+     , (57,  18,     0.6) /* ArmorModVsAcid */
+     , (57,  19,     0.4) /* ArmorModVsElectric */
+     , (57,  22,    0.75) /* DamageVariance */
+     , (57, 110,       1) /* BulkMod */
+     , (57, 111,       1) /* SizeMod */
+     , (57, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (57,   1, 'Platemail Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (57,   1,   33554648) /* Setup */
+     , (57,   3,  536870932) /* SoundTable */
+     , (57,   6,   67108990) /* PaletteBase */
+     , (57,   7,  268435473) /* ClothingBase */
+     , (57,   8,  100667341) /* Icon */
+     , (57,  22,  872415275) /* PhysicsEffectTable */
+     , (57,  36,  234881042) /* MutateFilter */
+     , (57,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00058 Scalemail Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00058 Scalemail Gauntlets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 58;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (58, 'gauntletsscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (58,   1,          2) /* ItemType - Armor */
+     , (58,   3,         20) /* PaletteTemplate - Silver */
+     , (58,   4,      32768) /* ClothingPriority - Hands */
+     , (58,   5,        300) /* EncumbranceVal */
+     , (58,   8,        360) /* Mass */
+     , (58,   9,         32) /* ValidLocations - HandWear */
+     , (58,  16,          1) /* ItemUseable - No */
+     , (58,  19,        433) /* Value */
+     , (58,  27,          8) /* ArmorType - Scalemail */
+     , (58,  28,        140) /* ArmorLevel */
+     , (58,  44,          2) /* Damage */
+     , (58,  45,          4) /* DamageType - Bludgeon */
+     , (58,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (58, 124,          3) /* Version */
+     , (58, 169,  151651588) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (58,  22, True ) /* Inscribable */
+     , (58, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (58,  12,    0.66) /* Shade */
+     , (58,  13,       1) /* ArmorModVsSlash */
+     , (58,  14,     1.1) /* ArmorModVsPierce */
+     , (58,  15,       1) /* ArmorModVsBludgeon */
+     , (58,  16,     0.4) /* ArmorModVsCold */
+     , (58,  17,     0.4) /* ArmorModVsFire */
+     , (58,  18,     0.6) /* ArmorModVsAcid */
+     , (58,  19,     0.4) /* ArmorModVsElectric */
+     , (58,  22,    0.75) /* DamageVariance */
+     , (58, 110,     1.2) /* BulkMod */
+     , (58, 111,       1) /* SizeMod */
+     , (58, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (58,   1, 'Scalemail Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (58,   1,   33554648) /* Setup */
+     , (58,   3,  536870932) /* SoundTable */
+     , (58,   6,   67108990) /* PaletteBase */
+     , (58,   7,  268435474) /* ClothingBase */
+     , (58,   8,  100669691) /* Icon */
+     , (58,  22,  872415275) /* PhysicsEffectTable */
+     , (58,  36,  234881042) /* MutateFilter */
+     , (58,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00059 Studded Leather Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00059 Studded Leather Gauntlets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 59;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (59, 'gauntletsstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (59,   1,          2) /* ItemType - Armor */
+     , (59,   3,          4) /* PaletteTemplate - Brown */
+     , (59,   4,      32768) /* ClothingPriority - Hands */
+     , (59,   5,        450) /* EncumbranceVal */
+     , (59,   8,        180) /* Mass */
+     , (59,   9,         32) /* ValidLocations - HandWear */
+     , (59,  16,          1) /* ItemUseable - No */
+     , (59,  19,       1100) /* Value */
+     , (59,  27,          4) /* ArmorType - StuddedLeather */
+     , (59,  28,        130) /* ArmorLevel */
+     , (59,  44,          2) /* Damage */
+     , (59,  45,          4) /* DamageType - Bludgeon */
+     , (59,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (59, 124,          3) /* Version */
+     , (59, 169,  151717134) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (59,  22, True ) /* Inscribable */
+     , (59, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (59,  12,    0.66) /* Shade */
+     , (59,  13,     1.2) /* ArmorModVsSlash */
+     , (59,  14,     1.1) /* ArmorModVsPierce */
+     , (59,  15,       1) /* ArmorModVsBludgeon */
+     , (59,  16,     0.4) /* ArmorModVsCold */
+     , (59,  17,     0.7) /* ArmorModVsFire */
+     , (59,  18,     0.3) /* ArmorModVsAcid */
+     , (59,  19,     0.4) /* ArmorModVsElectric */
+     , (59,  22,    0.75) /* DamageVariance */
+     , (59, 110,     1.5) /* BulkMod */
+     , (59, 111,       1) /* SizeMod */
+     , (59, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (59,   1, 'Studded Leather Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (59,   1,   33554648) /* Setup */
+     , (59,   3,  536870932) /* SoundTable */
+     , (59,   6,   67108990) /* PaletteBase */
+     , (59,   7,  268435475) /* ClothingBase */
+     , (59,   8,  100667342) /* Icon */
+     , (59,  22,  872415275) /* PhysicsEffectTable */
+     , (59,  36,  234881042) /* MutateFilter */
+     , (59,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00060 Leather Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00060 Leather Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 60;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (60, 'girthleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (60,   1,          2) /* ItemType - Armor */
+     , (60,   3,          4) /* PaletteTemplate - Brown */
+     , (60,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (60,   5,        270) /* EncumbranceVal */
+     , (60,   8,         90) /* Mass */
+     , (60,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (60,  16,          1) /* ItemUseable - No */
+     , (60,  19,       1350) /* Value */
+     , (60,  27,          2) /* ArmorType - Leather */
+     , (60,  28,         90) /* ArmorLevel */
+     , (60,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (60, 124,          3) /* Version */
+     , (60, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (60,  22, True ) /* Inscribable */
+     , (60, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (60,  12,    0.66) /* Shade */
+     , (60,  13,       1) /* ArmorModVsSlash */
+     , (60,  14,     0.8) /* ArmorModVsPierce */
+     , (60,  15,       1) /* ArmorModVsBludgeon */
+     , (60,  16,     0.5) /* ArmorModVsCold */
+     , (60,  17,     0.5) /* ArmorModVsFire */
+     , (60,  18,     0.3) /* ArmorModVsAcid */
+     , (60,  19,     0.6) /* ArmorModVsElectric */
+     , (60, 110,    1.67) /* BulkMod */
+     , (60, 111,     1.5) /* SizeMod */
+     , (60, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (60,   1, 'Leather Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (60,   1,   33554647) /* Setup */
+     , (60,   3,  536870932) /* SoundTable */
+     , (60,   6,   67108990) /* PaletteBase */
+     , (60,   7,  268435523) /* ClothingBase */
+     , (60,   8,  100668143) /* Icon */
+     , (60,  22,  872415275) /* PhysicsEffectTable */
+     , (60,  36,  234881042) /* MutateFilter */
+     , (60,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00061 Platemail Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00061 Platemail Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 61;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (61, 'girthplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (61,   1,          2) /* ItemType - Armor */
+     , (61,   3,         20) /* PaletteTemplate - Silver */
+     , (61,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (61,   5,       1099) /* EncumbranceVal */
+     , (61,   8,        550) /* Mass */
+     , (61,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (61,  16,          1) /* ItemUseable - No */
+     , (61,  19,        980) /* Value */
+     , (61,  27,         32) /* ArmorType - Metal */
+     , (61,  28,        110) /* ArmorLevel */
+     , (61,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (61, 124,          3) /* Version */
+     , (61, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (61,  22, True ) /* Inscribable */
+     , (61, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (61,  12,    0.33) /* Shade */
+     , (61,  13,     1.3) /* ArmorModVsSlash */
+     , (61,  14,       1) /* ArmorModVsPierce */
+     , (61,  15,       1) /* ArmorModVsBludgeon */
+     , (61,  16,     0.4) /* ArmorModVsCold */
+     , (61,  17,     0.4) /* ArmorModVsFire */
+     , (61,  18,     0.6) /* ArmorModVsAcid */
+     , (61,  19,     0.4) /* ArmorModVsElectric */
+     , (61, 110,       1) /* BulkMod */
+     , (61, 111,     1.5) /* SizeMod */
+     , (61, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (61,   1, 'Platemail Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (61,   1,   33554647) /* Setup */
+     , (61,   3,  536870932) /* SoundTable */
+     , (61,   6,   67108990) /* PaletteBase */
+     , (61,   7,  268435525) /* ClothingBase */
+     , (61,   8,  100668144) /* Icon */
+     , (61,  22,  872415275) /* PhysicsEffectTable */
+     , (61,  36,  234881042) /* MutateFilter */
+     , (61,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00062 Scalemail Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00062 Scalemail Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 62;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (62, 'girthscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (62,   1,          2) /* ItemType - Armor */
+     , (62,   3,         20) /* PaletteTemplate - Silver */
+     , (62,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (62,   5,        600) /* EncumbranceVal */
+     , (62,   8,        360) /* Mass */
+     , (62,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (62,  16,          1) /* ItemUseable - No */
+     , (62,  19,        653) /* Value */
+     , (62,  27,          8) /* ArmorType - Scalemail */
+     , (62,  28,        100) /* ArmorLevel */
+     , (62,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (62, 124,          3) /* Version */
+     , (62, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (62,  22, True ) /* Inscribable */
+     , (62, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (62,  12,    0.66) /* Shade */
+     , (62,  13,       1) /* ArmorModVsSlash */
+     , (62,  14,     1.1) /* ArmorModVsPierce */
+     , (62,  15,       1) /* ArmorModVsBludgeon */
+     , (62,  16,     0.4) /* ArmorModVsCold */
+     , (62,  17,     0.4) /* ArmorModVsFire */
+     , (62,  18,     0.6) /* ArmorModVsAcid */
+     , (62,  19,     0.4) /* ArmorModVsElectric */
+     , (62, 110,     1.2) /* BulkMod */
+     , (62, 111,     1.5) /* SizeMod */
+     , (62, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (62,   1, 'Scalemail Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (62,   1,   33554647) /* Setup */
+     , (62,   3,  536870932) /* SoundTable */
+     , (62,   6,   67108990) /* PaletteBase */
+     , (62,   7,  268435526) /* ClothingBase */
+     , (62,   8,  100668182) /* Icon */
+     , (62,  22,  872415275) /* PhysicsEffectTable */
+     , (62,  36,  234881042) /* MutateFilter */
+     , (62,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00063 Studded Leather Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00063 Studded Leather Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 63;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (63, 'girthstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (63,   1,          2) /* ItemType - Armor */
+     , (63,   3,          4) /* PaletteTemplate - Brown */
+     , (63,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (63,   5,        350) /* EncumbranceVal */
+     , (63,   8,        140) /* Mass */
+     , (63,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (63,  16,          1) /* ItemUseable - No */
+     , (63,  19,        160) /* Value */
+     , (63,  27,          4) /* ArmorType - StuddedLeather */
+     , (63,  28,         90) /* ArmorLevel */
+     , (63,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (63, 124,          3) /* Version */
+     , (63, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (63,  22, True ) /* Inscribable */
+     , (63, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (63,  12,    0.66) /* Shade */
+     , (63,  13,     1.2) /* ArmorModVsSlash */
+     , (63,  14,     1.1) /* ArmorModVsPierce */
+     , (63,  15,       1) /* ArmorModVsBludgeon */
+     , (63,  16,     0.2) /* ArmorModVsCold */
+     , (63,  17,     0.2) /* ArmorModVsFire */
+     , (63,  18,     0.1) /* ArmorModVsAcid */
+     , (63,  19,     0.2) /* ArmorModVsElectric */
+     , (63, 110,     1.5) /* BulkMod */
+     , (63, 111,     1.5) /* SizeMod */
+     , (63, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (63,   1, 'Studded Leather Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (63,   1,   33554647) /* Setup */
+     , (63,   3,  536870932) /* SoundTable */
+     , (63,   6,   67108990) /* PaletteBase */
+     , (63,   7,  268435528) /* ClothingBase */
+     , (63,   8,  100668145) /* Icon */
+     , (63,  22,  872415275) /* PhysicsEffectTable */
+     , (63,  36,  234881042) /* MutateFilter */
+     , (63,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00064 Yoroi Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00064 Yoroi Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 64;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (64, 'girthyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (64,   1,          2) /* ItemType - Armor */
+     , (64,   3,         20) /* PaletteTemplate - Silver */
+     , (64,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (64,   5,        600) /* EncumbranceVal */
+     , (64,   8,        360) /* Mass */
+     , (64,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (64,  16,          1) /* ItemUseable - No */
+     , (64,  19,       1700) /* Value */
+     , (64,  27,         32) /* ArmorType - Metal */
+     , (64,  28,        100) /* ArmorLevel */
+     , (64,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (64, 124,          3) /* Version */
+     , (64, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (64,  22, True ) /* Inscribable */
+     , (64, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (64,  12,    0.66) /* Shade */
+     , (64,  13,     1.3) /* ArmorModVsSlash */
+     , (64,  14,       1) /* ArmorModVsPierce */
+     , (64,  15,       1) /* ArmorModVsBludgeon */
+     , (64,  16,     0.4) /* ArmorModVsCold */
+     , (64,  17,     0.4) /* ArmorModVsFire */
+     , (64,  18,     0.6) /* ArmorModVsAcid */
+     , (64,  19,     0.4) /* ArmorModVsElectric */
+     , (64, 110,    1.15) /* BulkMod */
+     , (64, 111,     1.5) /* SizeMod */
+     , (64, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (64,   1, 'Yoroi Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (64,   1,   33554647) /* Setup */
+     , (64,   3,  536870932) /* SoundTable */
+     , (64,   6,   67108990) /* PaletteBase */
+     , (64,   7,  268435527) /* ClothingBase */
+     , (64,   8,  100668146) /* Icon */
+     , (64,  22,  872415275) /* PhysicsEffectTable */
+     , (64,  36,  234881042) /* MutateFilter */
+     , (64,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00065 Leather Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00065 Leather Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 65;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (65, 'greavesleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (65,   1,          2) /* ItemType - Armor */
+     , (65,   3,          4) /* PaletteTemplate - Brown */
+     , (65,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (65,   5,        420) /* EncumbranceVal */
+     , (65,   8,        140) /* Mass */
+     , (65,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (65,  16,          1) /* ItemUseable - No */
+     , (65,  19,       1200) /* Value */
+     , (65,  27,          2) /* ArmorType - Leather */
+     , (65,  28,         90) /* ArmorLevel */
+     , (65,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (65, 124,          3) /* Version */
+     , (65, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (65,  22, True ) /* Inscribable */
+     , (65, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (65,  12,    0.66) /* Shade */
+     , (65,  13,       1) /* ArmorModVsSlash */
+     , (65,  14,     0.8) /* ArmorModVsPierce */
+     , (65,  15,       1) /* ArmorModVsBludgeon */
+     , (65,  16,     0.5) /* ArmorModVsCold */
+     , (65,  17,     0.5) /* ArmorModVsFire */
+     , (65,  18,     0.3) /* ArmorModVsAcid */
+     , (65,  19,     0.6) /* ArmorModVsElectric */
+     , (65,  39,    1.33) /* DefaultScale */
+     , (65, 110,    1.67) /* BulkMod */
+     , (65, 111,       1) /* SizeMod */
+     , (65, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (65,   1, 'Leather Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (65,   1,   33554641) /* Setup */
+     , (65,   3,  536870932) /* SoundTable */
+     , (65,   6,   67108990) /* PaletteBase */
+     , (65,   7,  268435543) /* ClothingBase */
+     , (65,   8,  100668122) /* Icon */
+     , (65,  22,  872415275) /* PhysicsEffectTable */
+     , (65,  36,  234881042) /* MutateFilter */
+     , (65,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00066 Platemail Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00066 Platemail Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 66;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (66, 'greavesplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (66,   1,          2) /* ItemType - Armor */
+     , (66,   3,         20) /* PaletteTemplate - Silver */
+     , (66,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (66,   5,        919) /* EncumbranceVal */
+     , (66,   8,        460) /* Mass */
+     , (66,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (66,  16,          1) /* ItemUseable - No */
+     , (66,  19,       1600) /* Value */
+     , (66,  27,         32) /* ArmorType - Metal */
+     , (66,  28,        110) /* ArmorLevel */
+     , (66,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (66, 124,          3) /* Version */
+     , (66, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (66,  22, True ) /* Inscribable */
+     , (66, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (66,  12,    0.33) /* Shade */
+     , (66,  13,     1.3) /* ArmorModVsSlash */
+     , (66,  14,       1) /* ArmorModVsPierce */
+     , (66,  15,       1) /* ArmorModVsBludgeon */
+     , (66,  16,     0.4) /* ArmorModVsCold */
+     , (66,  17,     0.4) /* ArmorModVsFire */
+     , (66,  18,     0.6) /* ArmorModVsAcid */
+     , (66,  19,     0.4) /* ArmorModVsElectric */
+     , (66,  39,    1.33) /* DefaultScale */
+     , (66, 110,       1) /* BulkMod */
+     , (66, 111,       1) /* SizeMod */
+     , (66, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (66,   1, 'Platemail Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (66,   1,   33554641) /* Setup */
+     , (66,   3,  536870932) /* SoundTable */
+     , (66,   6,   67108990) /* PaletteBase */
+     , (66,   7,  268435529) /* ClothingBase */
+     , (66,   8,  100668167) /* Icon */
+     , (66,  22,  872415275) /* PhysicsEffectTable */
+     , (66,  36,  234881042) /* MutateFilter */
+     , (66,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00067 Scalemail Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00067 Scalemail Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 67;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (67, 'greavesscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (67,   1,          2) /* ItemType - Armor */
+     , (67,   3,         20) /* PaletteTemplate - Silver */
+     , (67,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (67,   5,        533) /* EncumbranceVal */
+     , (67,   8,        320) /* Mass */
+     , (67,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (67,  16,          1) /* ItemUseable - No */
+     , (67,  19,        433) /* Value */
+     , (67,  27,          8) /* ArmorType - Scalemail */
+     , (67,  28,        100) /* ArmorLevel */
+     , (67,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (67, 124,          3) /* Version */
+     , (67, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (67,  22, True ) /* Inscribable */
+     , (67, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (67,  12,    0.66) /* Shade */
+     , (67,  13,       1) /* ArmorModVsSlash */
+     , (67,  14,     1.1) /* ArmorModVsPierce */
+     , (67,  15,       1) /* ArmorModVsBludgeon */
+     , (67,  16,     0.4) /* ArmorModVsCold */
+     , (67,  17,     0.4) /* ArmorModVsFire */
+     , (67,  18,     0.6) /* ArmorModVsAcid */
+     , (67,  19,     0.4) /* ArmorModVsElectric */
+     , (67,  39,    1.33) /* DefaultScale */
+     , (67, 110,     1.2) /* BulkMod */
+     , (67, 111,       1) /* SizeMod */
+     , (67, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (67,   1, 'Scalemail Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (67,   1,   33554641) /* Setup */
+     , (67,   3,  536870932) /* SoundTable */
+     , (67,   6,   67108990) /* PaletteBase */
+     , (67,   7,  268435530) /* ClothingBase */
+     , (67,   8,  100667334) /* Icon */
+     , (67,  22,  872415275) /* PhysicsEffectTable */
+     , (67,  36,  234881042) /* MutateFilter */
+     , (67,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00068 Studded Leather Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00068 Studded Leather Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 68;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (68, 'greavesstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (68,   1,          2) /* ItemType - Armor */
+     , (68,   3,          4) /* PaletteTemplate - Brown */
+     , (68,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (68,   5,        450) /* EncumbranceVal */
+     , (68,   8,        180) /* Mass */
+     , (68,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (68,  16,          1) /* ItemUseable - No */
+     , (68,  19,        110) /* Value */
+     , (68,  27,          4) /* ArmorType - StuddedLeather */
+     , (68,  28,         90) /* ArmorLevel */
+     , (68,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (68, 124,          3) /* Version */
+     , (68, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (68,  22, True ) /* Inscribable */
+     , (68, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (68,  12,    0.66) /* Shade */
+     , (68,  13,     1.2) /* ArmorModVsSlash */
+     , (68,  14,     1.1) /* ArmorModVsPierce */
+     , (68,  15,       1) /* ArmorModVsBludgeon */
+     , (68,  16,     0.2) /* ArmorModVsCold */
+     , (68,  17,     0.2) /* ArmorModVsFire */
+     , (68,  18,     0.1) /* ArmorModVsAcid */
+     , (68,  19,     0.2) /* ArmorModVsElectric */
+     , (68,  39,    1.33) /* DefaultScale */
+     , (68, 110,     1.5) /* BulkMod */
+     , (68, 111,       1) /* SizeMod */
+     , (68, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (68,   1, 'Studded Leather Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (68,   1,   33554641) /* Setup */
+     , (68,   3,  536870932) /* SoundTable */
+     , (68,   6,   67108990) /* PaletteBase */
+     , (68,   7,  268435531) /* ClothingBase */
+     , (68,   8,  100668123) /* Icon */
+     , (68,  22,  872415275) /* PhysicsEffectTable */
+     , (68,  36,  234881042) /* MutateFilter */
+     , (68,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00069 Yoroi Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00069 Yoroi Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 69;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (69, 'greavesyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (69,   1,          2) /* ItemType - Armor */
+     , (69,   3,         20) /* PaletteTemplate - Silver */
+     , (69,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (69,   5,        450) /* EncumbranceVal */
+     , (69,   8,        270) /* Mass */
+     , (69,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (69,  16,          1) /* ItemUseable - No */
+     , (69,  19,       1700) /* Value */
+     , (69,  27,         32) /* ArmorType - Metal */
+     , (69,  28,        100) /* ArmorLevel */
+     , (69,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (69, 124,          3) /* Version */
+     , (69, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (69,  22, True ) /* Inscribable */
+     , (69, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (69,  12,    0.66) /* Shade */
+     , (69,  13,     1.3) /* ArmorModVsSlash */
+     , (69,  14,       1) /* ArmorModVsPierce */
+     , (69,  15,       1) /* ArmorModVsBludgeon */
+     , (69,  16,     0.4) /* ArmorModVsCold */
+     , (69,  17,     0.4) /* ArmorModVsFire */
+     , (69,  18,     0.6) /* ArmorModVsAcid */
+     , (69,  19,     0.4) /* ArmorModVsElectric */
+     , (69,  39,    1.33) /* DefaultScale */
+     , (69, 110,    1.15) /* BulkMod */
+     , (69, 111,       1) /* SizeMod */
+     , (69, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (69,   1, 'Yoroi Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (69,   1,   33554641) /* Setup */
+     , (69,   3,  536870932) /* SoundTable */
+     , (69,   6,   67108990) /* PaletteBase */
+     , (69,   7,  268435532) /* ClothingBase */
+     , (69,   8,  100668168) /* Icon */
+     , (69,  22,  872415275) /* PhysicsEffectTable */
+     , (69,  36,  234881042) /* MutateFilter */
+     , (69,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00071 Chainmail Hauberk.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00071 Chainmail Hauberk.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 71;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (71, 'hauberkchainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (71,   1,          2) /* ItemType - Armor */
+     , (71,   3,         20) /* PaletteTemplate - Silver */
+     , (71,   4,      15360) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (71,   5,       1515) /* EncumbranceVal */
+     , (71,   8,        910) /* Mass */
+     , (71,   9,       7680) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor, LowerArmArmor */
+     , (71,  16,          1) /* ItemUseable - No */
+     , (71,  19,        919) /* Value */
+     , (71,  27,         16) /* ArmorType - Chainmail */
+     , (71,  28,        100) /* ArmorLevel */
+     , (71,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (71, 124,          3) /* Version */
+     , (71, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (71,  22, True ) /* Inscribable */
+     , (71, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (71,  12,    0.66) /* Shade */
+     , (71,  13,     1.2) /* ArmorModVsSlash */
+     , (71,  14,       1) /* ArmorModVsPierce */
+     , (71,  15,     0.8) /* ArmorModVsBludgeon */
+     , (71,  16,     0.6) /* ArmorModVsCold */
+     , (71,  17,     0.6) /* ArmorModVsFire */
+     , (71,  18,     0.5) /* ArmorModVsAcid */
+     , (71,  19,     0.4) /* ArmorModVsElectric */
+     , (71, 110,    1.33) /* BulkMod */
+     , (71, 111,     4.5) /* SizeMod */
+     , (71, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (71,   1, 'Chainmail Hauberk') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (71,   1,   33554644) /* Setup */
+     , (71,   6,   67108990) /* PaletteBase */
+     , (71,   7,  268435462) /* ClothingBase */
+     , (71,   8,  100667335) /* Icon */
+     , (71,  22,  872415275) /* PhysicsEffectTable */
+     , (71,  36,  234881042) /* MutateFilter */
+     , (71,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00072 Platemail Hauberk.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00072 Platemail Hauberk.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72, 'hauberkplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72,   1,          2) /* ItemType - Armor */
+     , (72,   3,         20) /* PaletteTemplate - Silver */
+     , (72,   4,      15360) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (72,   5,       3596) /* EncumbranceVal */
+     , (72,   8,       1800) /* Mass */
+     , (72,   9,       7680) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor, LowerArmArmor */
+     , (72,  16,          1) /* ItemUseable - No */
+     , (72,  19,       2937) /* Value */
+     , (72,  27,         32) /* ArmorType - Metal */
+     , (72,  28,        110) /* ArmorLevel */
+     , (72,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (72, 124,          3) /* Version */
+     , (72, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72,  22, True ) /* Inscribable */
+     , (72, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72,  12,    0.66) /* Shade */
+     , (72,  13,     1.3) /* ArmorModVsSlash */
+     , (72,  14,       1) /* ArmorModVsPierce */
+     , (72,  15,       1) /* ArmorModVsBludgeon */
+     , (72,  16,     0.4) /* ArmorModVsCold */
+     , (72,  17,     0.4) /* ArmorModVsFire */
+     , (72,  18,     0.6) /* ArmorModVsAcid */
+     , (72,  19,     0.4) /* ArmorModVsElectric */
+     , (72, 110,       1) /* BulkMod */
+     , (72, 111,     1.5) /* SizeMod */
+     , (72, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72,   1, 'Platemail Hauberk') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72,   1,   33554644) /* Setup */
+     , (72,   3,  536870932) /* SoundTable */
+     , (72,   6,   67108990) /* PaletteBase */
+     , (72,   7,  268435621) /* ClothingBase */
+     , (72,   8,  100667357) /* Icon */
+     , (72,  22,  872415275) /* PhysicsEffectTable */
+     , (72,  36,  234881042) /* MutateFilter */
+     , (72,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00073 Scalemail Hauberk.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00073 Scalemail Hauberk.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73, 'hauberkscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73,   1,          2) /* ItemType - Armor */
+     , (73,   3,         20) /* PaletteTemplate - Silver */
+     , (73,   4,      15360) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (73,   5,       1831) /* EncumbranceVal */
+     , (73,   8,       1100) /* Mass */
+     , (73,   9,       7680) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor, LowerArmArmor */
+     , (73,  16,          1) /* ItemUseable - No */
+     , (73,  19,       1951) /* Value */
+     , (73,  27,          8) /* ArmorType - Scalemail */
+     , (73,  28,        100) /* ArmorLevel */
+     , (73,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (73, 124,          3) /* Version */
+     , (73, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73,  22, True ) /* Inscribable */
+     , (73, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73,  12,    0.66) /* Shade */
+     , (73,  13,       1) /* ArmorModVsSlash */
+     , (73,  14,     1.1) /* ArmorModVsPierce */
+     , (73,  15,       1) /* ArmorModVsBludgeon */
+     , (73,  16,     0.4) /* ArmorModVsCold */
+     , (73,  17,     0.4) /* ArmorModVsFire */
+     , (73,  18,     0.6) /* ArmorModVsAcid */
+     , (73,  19,     0.4) /* ArmorModVsElectric */
+     , (73, 110,     1.2) /* BulkMod */
+     , (73, 111,     1.5) /* SizeMod */
+     , (73, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73,   1, 'Scalemail Hauberk') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73,   1,   33554644) /* Setup */
+     , (73,   3,  536870932) /* SoundTable */
+     , (73,   6,   67108990) /* PaletteBase */
+     , (73,   7,  268435622) /* ClothingBase */
+     , (73,   8,  100669690) /* Icon */
+     , (73,  22,  872415275) /* PhysicsEffectTable */
+     , (73,  36,  234881042) /* MutateFilter */
+     , (73,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00074 Heaume.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00074 Heaume.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 74;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (74, 'heaume', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (74,   1,          2) /* ItemType - Armor */
+     , (74,   3,         20) /* PaletteTemplate - Silver */
+     , (74,   4,      16384) /* ClothingPriority - Head */
+     , (74,   5,        600) /* EncumbranceVal */
+     , (74,   8,        300) /* Mass */
+     , (74,   9,          1) /* ValidLocations - HeadWear */
+     , (74,  16,          1) /* ItemUseable - No */
+     , (74,  19,       1185) /* Value */
+     , (74,  27,         32) /* ArmorType - Metal */
+     , (74,  28,        150) /* ArmorLevel */
+     , (74,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (74, 124,          3) /* Version */
+     , (74, 150,        103) /* HookPlacement - Hook */
+     , (74, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (74,  22, True ) /* Inscribable */
+     , (74, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (74,  12,    0.66) /* Shade */
+     , (74,  13,     1.3) /* ArmorModVsSlash */
+     , (74,  14,       1) /* ArmorModVsPierce */
+     , (74,  15,       1) /* ArmorModVsBludgeon */
+     , (74,  16,     0.4) /* ArmorModVsCold */
+     , (74,  17,     0.4) /* ArmorModVsFire */
+     , (74,  18,     0.6) /* ArmorModVsAcid */
+     , (74,  19,     0.4) /* ArmorModVsElectric */
+     , (74, 110,     0.8) /* BulkMod */
+     , (74, 111,       1) /* SizeMod */
+     , (74, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (74,   1, 'Heaume') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (74,   1,   33555248) /* Setup */
+     , (74,   3,  536870932) /* SoundTable */
+     , (74,   6,   67108990) /* PaletteBase */
+     , (74,   7,  268435629) /* ClothingBase */
+     , (74,   8,  100667349) /* Icon */
+     , (74,  22,  872415275) /* PhysicsEffectTable */
+     , (74,  36,  234881042) /* MutateFilter */
+     , (74,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00075 Helmet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00075 Helmet.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 75;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (75, 'helmet', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (75,   1,          2) /* ItemType - Armor */
+     , (75,   3,         20) /* PaletteTemplate - Silver */
+     , (75,   4,      16384) /* ClothingPriority - Head */
+     , (75,   5,        533) /* EncumbranceVal */
+     , (75,   8,        200) /* Mass */
+     , (75,   9,          1) /* ValidLocations - HeadWear */
+     , (75,  16,          1) /* ItemUseable - No */
+     , (75,  19,       1700) /* Value */
+     , (75,  27,         32) /* ArmorType - Metal */
+     , (75,  28,        150) /* ArmorLevel */
+     , (75,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (75, 124,          3) /* Version */
+     , (75, 150,        103) /* HookPlacement - Hook */
+     , (75, 151,          2) /* HookType - Wall */
+     , (75, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (75,  22, True ) /* Inscribable */
+     , (75, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (75,  12,    0.66) /* Shade */
+     , (75,  13,     1.3) /* ArmorModVsSlash */
+     , (75,  14,       1) /* ArmorModVsPierce */
+     , (75,  15,       1) /* ArmorModVsBludgeon */
+     , (75,  16,     0.4) /* ArmorModVsCold */
+     , (75,  17,     0.4) /* ArmorModVsFire */
+     , (75,  18,     0.6) /* ArmorModVsAcid */
+     , (75,  19,     0.4) /* ArmorModVsElectric */
+     , (75, 110,       1) /* BulkMod */
+     , (75, 111,       1) /* SizeMod */
+     , (75, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (75,   1, 'Helmet') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (75,   1,   33554650) /* Setup */
+     , (75,   3,  536870932) /* SoundTable */
+     , (75,   6,   67108990) /* PaletteBase */
+     , (75,   7,  268435500) /* ClothingBase */
+     , (75,   8,  100667343) /* Icon */
+     , (75,  22,  872415275) /* PhysicsEffectTable */
+     , (75,  36,  234881042) /* MutateFilter */
+     , (75,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00076 Horned Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00076 Horned Helm.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 76;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (76, 'helmhorned', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (76,   1,          2) /* ItemType - Armor */
+     , (76,   3,         20) /* PaletteTemplate - Silver */
+     , (76,   4,      16384) /* ClothingPriority - Head */
+     , (76,   5,        666) /* EncumbranceVal */
+     , (76,   8,        250) /* Mass */
+     , (76,   9,          1) /* ValidLocations - HeadWear */
+     , (76,  16,          1) /* ItemUseable - No */
+     , (76,  19,        819) /* Value */
+     , (76,  27,         32) /* ArmorType - Metal */
+     , (76,  28,        150) /* ArmorLevel */
+     , (76,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (76, 124,          3) /* Version */
+     , (76, 150,        103) /* HookPlacement - Hook */
+     , (76, 151,          2) /* HookType - Wall */
+     , (76, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (76,  22, True ) /* Inscribable */
+     , (76, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (76,  12,    0.66) /* Shade */
+     , (76,  13,     1.3) /* ArmorModVsSlash */
+     , (76,  14,       1) /* ArmorModVsPierce */
+     , (76,  15,       1) /* ArmorModVsBludgeon */
+     , (76,  16,     0.4) /* ArmorModVsCold */
+     , (76,  17,     0.4) /* ArmorModVsFire */
+     , (76,  18,     0.6) /* ArmorModVsAcid */
+     , (76,  19,     0.4) /* ArmorModVsElectric */
+     , (76, 110,       1) /* BulkMod */
+     , (76, 111,    1.25) /* SizeMod */
+     , (76, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (76,   1, 'Horned Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (76,   1,   33554649) /* Setup */
+     , (76,   3,  536870932) /* SoundTable */
+     , (76,   6,   67108990) /* PaletteBase */
+     , (76,   7,  268435501) /* ClothingBase */
+     , (76,   8,  100667347) /* Icon */
+     , (76,  22,  872415275) /* PhysicsEffectTable */
+     , (76,  36,  234881042) /* MutateFilter */
+     , (76,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00077 Kabuton.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00077 Kabuton.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 77;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (77, 'kabuton', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (77,   1,          2) /* ItemType - Armor */
+     , (77,   3,         20) /* PaletteTemplate - Silver */
+     , (77,   4,      16384) /* ClothingPriority - Head */
+     , (77,   5,        533) /* EncumbranceVal */
+     , (77,   8,        200) /* Mass */
+     , (77,   9,          1) /* ValidLocations - HeadWear */
+     , (77,  16,          1) /* ItemUseable - No */
+     , (77,  19,       1700) /* Value */
+     , (77,  27,         32) /* ArmorType - Metal */
+     , (77,  28,        140) /* ArmorLevel */
+     , (77,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (77, 124,          3) /* Version */
+     , (77, 150,        103) /* HookPlacement - Hook */
+     , (77, 151,          2) /* HookType - Wall */
+     , (77, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (77,  22, True ) /* Inscribable */
+     , (77, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (77,  12,    0.33) /* Shade */
+     , (77,  13,     1.3) /* ArmorModVsSlash */
+     , (77,  14,       1) /* ArmorModVsPierce */
+     , (77,  15,       1) /* ArmorModVsBludgeon */
+     , (77,  16,     0.4) /* ArmorModVsCold */
+     , (77,  17,     0.4) /* ArmorModVsFire */
+     , (77,  18,     0.6) /* ArmorModVsAcid */
+     , (77,  19,     0.4) /* ArmorModVsElectric */
+     , (77, 110,       1) /* BulkMod */
+     , (77, 111,       1) /* SizeMod */
+     , (77, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (77,   1, 'Kabuton') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (77,   1,   33554652) /* Setup */
+     , (77,   3,  536870932) /* SoundTable */
+     , (77,   6,   67108990) /* PaletteBase */
+     , (77,   7,  268435490) /* ClothingBase */
+     , (77,   8,  100667944) /* Icon */
+     , (77,  22,  872415275) /* PhysicsEffectTable */
+     , (77,  36,  234881042) /* MutateFilter */
+     , (77,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00078 Kote.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00078 Kote.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 78;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (78, 'kote', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (78,   1,          2) /* ItemType - Armor */
+     , (78,   3,         20) /* PaletteTemplate - Silver */
+     , (78,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (78,   5,        360) /* EncumbranceVal */
+     , (78,   8,        180) /* Mass */
+     , (78,   9,       4096) /* ValidLocations - LowerArmArmor */
+     , (78,  16,          1) /* ItemUseable - No */
+     , (78,  19,       1500) /* Value */
+     , (78,  27,         32) /* ArmorType - Metal */
+     , (78,  28,        100) /* ArmorLevel */
+     , (78,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (78, 124,          3) /* Version */
+     , (78, 169,  118097156) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (78,  22, True ) /* Inscribable */
+     , (78, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (78,  12,    0.33) /* Shade */
+     , (78,  13,     1.3) /* ArmorModVsSlash */
+     , (78,  14,       1) /* ArmorModVsPierce */
+     , (78,  15,     0.8) /* ArmorModVsBludgeon */
+     , (78,  16,     0.4) /* ArmorModVsCold */
+     , (78,  17,     0.4) /* ArmorModVsFire */
+     , (78,  18,     0.6) /* ArmorModVsAcid */
+     , (78,  19,     0.4) /* ArmorModVsElectric */
+     , (78, 110,    1.15) /* BulkMod */
+     , (78, 111,       1) /* SizeMod */
+     , (78, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (78,   1, 'Kote') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (78,   1,   33554641) /* Setup */
+     , (78,   3,  536870932) /* SoundTable */
+     , (78,   6,   67108990) /* PaletteBase */
+     , (78,   7,  268435519) /* ClothingBase */
+     , (78,   8,  100667331) /* Icon */
+     , (78,  22,  872415275) /* PhysicsEffectTable */
+     , (78,  36,  234881042) /* MutateFilter */
+     , (78,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00080 Chainmail Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00080 Chainmail Leggings.sql
@@ -15,7 +15,7 @@ VALUES (80,   1,          2) /* ItemType - Armor */
      , (80,  27,         16) /* ArmorType - Chainmail */
      , (80,  28,        100) /* ArmorLevel */
      , (80,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (80, 124,          3) /* Version */
+     , (80, 124,          3) /* Version */
      , (80, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00080 Chainmail Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00080 Chainmail Leggings.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80, 'leggingschainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80,   1,          2) /* ItemType - Armor */
+     , (80,   3,         20) /* PaletteTemplate - Silver */
+     , (80,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (80,   5,       1515) /* EncumbranceVal */
+     , (80,   8,        910) /* Mass */
+     , (80,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (80,  16,          1) /* ItemUseable - No */
+     , (80,  19,       1850) /* Value */
+     , (80,  27,         16) /* ArmorType - Chainmail */
+     , (80,  28,        100) /* ArmorLevel */
+     , (80,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (80, 124,          3) /* Version */
+     , (80, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80,  22, True ) /* Inscribable */
+     , (80, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80,  12,    0.33) /* Shade */
+     , (80,  13,     1.2) /* ArmorModVsSlash */
+     , (80,  14,       1) /* ArmorModVsPierce */
+     , (80,  15,     0.8) /* ArmorModVsBludgeon */
+     , (80,  16,     0.6) /* ArmorModVsCold */
+     , (80,  17,     0.6) /* ArmorModVsFire */
+     , (80,  18,     0.5) /* ArmorModVsAcid */
+     , (80,  19,     0.4) /* ArmorModVsElectric */
+     , (80, 110,    1.33) /* BulkMod */
+     , (80, 111,       2) /* SizeMod */
+     , (80, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80,   1, 'Chainmail Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80,   1,   33554856) /* Setup */
+     , (80,   3,  536870932) /* SoundTable */
+     , (80,   6,   67108990) /* PaletteBase */
+     , (80,   7,  268435477) /* ClothingBase */
+     , (80,   8,  100667334) /* Icon */
+     , (80,  22,  872415275) /* PhysicsEffectTable */
+     , (80,  36,  234881042) /* MutateFilter */
+     , (80,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00081 Leather Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00081 Leather Leggings.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 81;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (81, 'leggingsleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (81,   1,          2) /* ItemType - Armor */
+     , (81,   3,          4) /* PaletteTemplate - Brown */
+     , (81,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (81,   5,        960) /* EncumbranceVal */
+     , (81,   8,        320) /* Mass */
+     , (81,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (81,  16,          1) /* ItemUseable - No */
+     , (81,  19,       2400) /* Value */
+     , (81,  27,          2) /* ArmorType - Leather */
+     , (81,  28,         90) /* ArmorLevel */
+     , (81,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (81, 124,          3) /* Version */
+     , (81, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (81,  22, True ) /* Inscribable */
+     , (81, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (81,  12,    0.66) /* Shade */
+     , (81,  13,       1) /* ArmorModVsSlash */
+     , (81,  14,     0.8) /* ArmorModVsPierce */
+     , (81,  15,       1) /* ArmorModVsBludgeon */
+     , (81,  16,     0.5) /* ArmorModVsCold */
+     , (81,  17,     0.5) /* ArmorModVsFire */
+     , (81,  18,     0.3) /* ArmorModVsAcid */
+     , (81,  19,     0.6) /* ArmorModVsElectric */
+     , (81, 110,    1.67) /* BulkMod */
+     , (81, 111,       2) /* SizeMod */
+     , (81, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (81,   1, 'Leather Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (81,   1,   33554856) /* Setup */
+     , (81,   3,  536870932) /* SoundTable */
+     , (81,   6,   67108990) /* PaletteBase */
+     , (81,   7,  268435533) /* ClothingBase */
+     , (81,   8,  100667352) /* Icon */
+     , (81,  22,  872415275) /* PhysicsEffectTable */
+     , (81,  36,  234881042) /* MutateFilter */
+     , (81,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00081 Leather Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00081 Leather Leggings.sql
@@ -15,7 +15,7 @@ VALUES (81,   1,          2) /* ItemType - Armor */
      , (81,  27,          2) /* ArmorType - Leather */
      , (81,  28,         90) /* ArmorLevel */
      , (81,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (81, 124,          3) /* Version */
+     , (81, 124,          3) /* Version */
      , (81, 169,  252379406) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00082 Platemail Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00082 Platemail Leggings.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 82;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (82, 'leggingsplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (82,   1,          2) /* ItemType - Armor */
+     , (82,   3,         20) /* PaletteTemplate - Silver */
+     , (82,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (82,   5,       2200) /* EncumbranceVal */
+     , (82,   8,       1100) /* Mass */
+     , (82,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (82,  16,          1) /* ItemUseable - No */
+     , (82,  19,       1305) /* Value */
+     , (82,  27,         32) /* ArmorType - Metal */
+     , (82,  28,        110) /* ArmorLevel */
+     , (82,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (82, 124,          3) /* Version */
+     , (82, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (82,  22, True ) /* Inscribable */
+     , (82, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (82,  12,    0.66) /* Shade */
+     , (82,  13,     1.3) /* ArmorModVsSlash */
+     , (82,  14,       1) /* ArmorModVsPierce */
+     , (82,  15,       1) /* ArmorModVsBludgeon */
+     , (82,  16,     0.4) /* ArmorModVsCold */
+     , (82,  17,     0.4) /* ArmorModVsFire */
+     , (82,  18,     0.6) /* ArmorModVsAcid */
+     , (82,  19,     0.4) /* ArmorModVsElectric */
+     , (82, 110,       1) /* BulkMod */
+     , (82, 111,     1.5) /* SizeMod */
+     , (82, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (82,   1, 'Platemail Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (82,   1,   33554856) /* Setup */
+     , (82,   3,  536870932) /* SoundTable */
+     , (82,   6,   67108990) /* PaletteBase */
+     , (82,   7,  268435478) /* ClothingBase */
+     , (82,   8,  100667356) /* Icon */
+     , (82,  22,  872415275) /* PhysicsEffectTable */
+     , (82,  36,  234881042) /* MutateFilter */
+     , (82,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00082 Platemail Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00082 Platemail Leggings.sql
@@ -15,7 +15,7 @@ VALUES (82,   1,          2) /* ItemType - Armor */
      , (82,  27,         32) /* ArmorType - Metal */
      , (82,  28,        110) /* ArmorLevel */
      , (82,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (82, 124,          3) /* Version */
+     , (82, 124,          3) /* Version */
      , (82, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00083 Scalemail Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00083 Scalemail Leggings.sql
@@ -15,7 +15,7 @@ VALUES (83,   1,          2) /* ItemType - Armor */
      , (83,  27,          8) /* ArmorType - Scalemail */
      , (83,  28,        100) /* ArmorLevel */
      , (83,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (83, 124,          3) /* Version */
+     , (83, 124,          3) /* Version */
      , (83, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00083 Scalemail Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00083 Scalemail Leggings.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 83;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (83, 'leggingsscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (83,   1,          2) /* ItemType - Armor */
+     , (83,   3,         20) /* PaletteTemplate - Silver */
+     , (83,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (83,   5,       1132) /* EncumbranceVal */
+     , (83,   8,        680) /* Mass */
+     , (83,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (83,  16,          1) /* ItemUseable - No */
+     , (83,  19,        865) /* Value */
+     , (83,  27,          8) /* ArmorType - Scalemail */
+     , (83,  28,        100) /* ArmorLevel */
+     , (83,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (83, 124,          3) /* Version */
+     , (83, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (83,  22, True ) /* Inscribable */
+     , (83, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (83,  12,    0.66) /* Shade */
+     , (83,  13,       1) /* ArmorModVsSlash */
+     , (83,  14,     1.1) /* ArmorModVsPierce */
+     , (83,  15,       1) /* ArmorModVsBludgeon */
+     , (83,  16,     0.4) /* ArmorModVsCold */
+     , (83,  17,     0.4) /* ArmorModVsFire */
+     , (83,  18,     0.6) /* ArmorModVsAcid */
+     , (83,  19,     0.4) /* ArmorModVsElectric */
+     , (83, 110,     1.2) /* BulkMod */
+     , (83, 111,     1.5) /* SizeMod */
+     , (83, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (83,   1, 'Scalemail Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (83,   1,   33554856) /* Setup */
+     , (83,   3,  536870932) /* SoundTable */
+     , (83,   6,   67108990) /* PaletteBase */
+     , (83,   7,  268435479) /* ClothingBase */
+     , (83,   8,  100668169) /* Icon */
+     , (83,  22,  872415275) /* PhysicsEffectTable */
+     , (83,  36,  234881042) /* MutateFilter */
+     , (83,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00084 Studded Leather Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00084 Studded Leather Leggings.sql
@@ -15,7 +15,7 @@ VALUES (84,   1,          2) /* ItemType - Armor */
      , (84,  27,          4) /* ArmorType - StuddedLeather */
      , (84,  28,         90) /* ArmorLevel */
      , (84,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (84, 124,          3) /* Version */
+     , (84, 124,          3) /* Version */
      , (84, 169,  252379406) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00084 Studded Leather Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00084 Studded Leather Leggings.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 84;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (84, 'leggingsstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (84,   1,          2) /* ItemType - Armor */
+     , (84,   3,         18) /* PaletteTemplate - YellowBrown */
+     , (84,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (84,   5,        900) /* EncumbranceVal */
+     , (84,   8,        360) /* Mass */
+     , (84,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (84,  16,          1) /* ItemUseable - No */
+     , (84,  19,        210) /* Value */
+     , (84,  27,          4) /* ArmorType - StuddedLeather */
+     , (84,  28,         90) /* ArmorLevel */
+     , (84,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (84, 124,          3) /* Version */
+     , (84, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (84,  22, True ) /* Inscribable */
+     , (84, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (84,  12,    0.66) /* Shade */
+     , (84,  13,     1.2) /* ArmorModVsSlash */
+     , (84,  14,     1.1) /* ArmorModVsPierce */
+     , (84,  15,       1) /* ArmorModVsBludgeon */
+     , (84,  16,     0.2) /* ArmorModVsCold */
+     , (84,  17,     0.2) /* ArmorModVsFire */
+     , (84,  18,     0.1) /* ArmorModVsAcid */
+     , (84,  19,     0.2) /* ArmorModVsElectric */
+     , (84, 110,       1) /* BulkMod */
+     , (84, 111,       1) /* SizeMod */
+     , (84, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (84,   1, 'Studded Leather Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (84,   1,   33554856) /* Setup */
+     , (84,   3,  536870932) /* SoundTable */
+     , (84,   6,   67108990) /* PaletteBase */
+     , (84,   7,  268435481) /* ClothingBase */
+     , (84,   8,  100667931) /* Icon */
+     , (84,  22,  872415275) /* PhysicsEffectTable */
+     , (84,  36,  234881042) /* MutateFilter */
+     , (84,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00085 Chainmail Coif.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00085 Chainmail Coif.sql
@@ -17,7 +17,7 @@ VALUES (85,   1,          2) /* ItemType - Armor */
      , (85,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (85, 150,        103) /* HookPlacement - Hook */
      , (85, 151,          2) /* HookType - Wall */
-	 , (85, 124,          3) /* Version */
+     , (85, 124,          3) /* Version */
      , (85, 169,  168427780) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00085 Chainmail Coif.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00085 Chainmail Coif.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 85;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (85, 'mailcoif', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (85,   1,          2) /* ItemType - Armor */
+     , (85,   3,         20) /* PaletteTemplate - Silver */
+     , (85,   4,      16384) /* ClothingPriority - Head */
+     , (85,   5,        140) /* EncumbranceVal */
+     , (85,   8,        140) /* Mass */
+     , (85,   9,          1) /* ValidLocations - HeadWear */
+     , (85,  16,          1) /* ItemUseable - No */
+     , (85,  19,       1200) /* Value */
+     , (85,  27,         16) /* ArmorType - Chainmail */
+     , (85,  28,        140) /* ArmorLevel */
+     , (85,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (85, 150,        103) /* HookPlacement - Hook */
+     , (85, 151,          2) /* HookType - Wall */
+	 , (85, 124,          3) /* Version */
+     , (85, 169,  168427780) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (85,  22, True ) /* Inscribable */
+     , (85, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (85,  12,    0.66) /* Shade */
+     , (85,  13,     1.2) /* ArmorModVsSlash */
+     , (85,  14,       1) /* ArmorModVsPierce */
+     , (85,  15,     0.8) /* ArmorModVsBludgeon */
+     , (85,  16,     0.6) /* ArmorModVsCold */
+     , (85,  17,     0.6) /* ArmorModVsFire */
+     , (85,  18,     0.5) /* ArmorModVsAcid */
+     , (85,  19,     0.4) /* ArmorModVsElectric */
+     , (85, 110,       1) /* BulkMod */
+     , (85, 111,       1) /* SizeMod */
+     , (85, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (85,   1, 'Chainmail Coif') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (85,   1,   33555048) /* Setup */
+     , (85,   3,  536870932) /* SoundTable */
+     , (85,   6,   67108990) /* PaletteBase */
+     , (85,   7,  268435508) /* ClothingBase */
+     , (85,   8,  100667338) /* Icon */
+     , (85,  22,  872415275) /* PhysicsEffectTable */
+     , (85,  36,  234881042) /* MutateFilter */
+     , (85,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00086 Leather Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00086 Leather Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 86;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (86, 'pauldronsleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (86,   1,          2) /* ItemType - Armor */
+     , (86,   3,          4) /* PaletteTemplate - Brown */
+     , (86,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (86,   5,        420) /* EncumbranceVal */
+     , (86,   8,        140) /* Mass */
+     , (86,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (86,  16,          1) /* ItemUseable - No */
+     , (86,  19,       1250) /* Value */
+     , (86,  27,          2) /* ArmorType - Leather */
+     , (86,  28,         90) /* ArmorLevel */
+     , (86,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (86, 124,          3) /* Version */
+     , (86, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (86,  22, True ) /* Inscribable */
+     , (86, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (86,  12,    0.66) /* Shade */
+     , (86,  13,       1) /* ArmorModVsSlash */
+     , (86,  14,     0.8) /* ArmorModVsPierce */
+     , (86,  15,       1) /* ArmorModVsBludgeon */
+     , (86,  16,     0.5) /* ArmorModVsCold */
+     , (86,  17,     0.5) /* ArmorModVsFire */
+     , (86,  18,     0.3) /* ArmorModVsAcid */
+     , (86,  19,     0.6) /* ArmorModVsElectric */
+     , (86,  39,     1.1) /* DefaultScale */
+     , (86, 110,    1.67) /* BulkMod */
+     , (86, 111,       1) /* SizeMod */
+     , (86, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (86,   1, 'Leather Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (86,   1,   33554641) /* Setup */
+     , (86,   3,  536870932) /* SoundTable */
+     , (86,   6,   67108990) /* PaletteBase */
+     , (86,   7,  268435535) /* ClothingBase */
+     , (86,   8,  100668171) /* Icon */
+     , (86,  22,  872415275) /* PhysicsEffectTable */
+     , (86,  36,  234881042) /* MutateFilter */
+     , (86,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00086 Leather Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00086 Leather Pauldrons.sql
@@ -15,7 +15,7 @@ VALUES (86,   1,          2) /* ItemType - Armor */
      , (86,  27,          2) /* ArmorType - Leather */
      , (86,  28,         90) /* ArmorLevel */
      , (86,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (86, 124,          3) /* Version */
+     , (86, 124,          3) /* Version */
      , (86, 169,  118161678) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00087 Platemail Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00087 Platemail Pauldrons.sql
@@ -15,7 +15,7 @@ VALUES (87,   1,          2) /* ItemType - Armor */
      , (87,  27,         32) /* ArmorType - Metal */
      , (87,  28,        110) /* ArmorLevel */
      , (87,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (87, 124,          3) /* Version */
+     , (87, 124,          3) /* Version */
      , (87, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00087 Platemail Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00087 Platemail Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 87;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (87, 'pauldronsplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (87,   1,          2) /* ItemType - Armor */
+     , (87,   3,         20) /* PaletteTemplate - Silver */
+     , (87,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (87,   5,        720) /* EncumbranceVal */
+     , (87,   8,        360) /* Mass */
+     , (87,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (87,  16,          1) /* ItemUseable - No */
+     , (87,  19,        653) /* Value */
+     , (87,  27,         32) /* ArmorType - Metal */
+     , (87,  28,        110) /* ArmorLevel */
+     , (87,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (87, 124,          3) /* Version */
+     , (87, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (87,  22, True ) /* Inscribable */
+     , (87, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (87,  12,    0.33) /* Shade */
+     , (87,  13,     1.3) /* ArmorModVsSlash */
+     , (87,  14,       1) /* ArmorModVsPierce */
+     , (87,  15,       1) /* ArmorModVsBludgeon */
+     , (87,  16,     0.4) /* ArmorModVsCold */
+     , (87,  17,     0.4) /* ArmorModVsFire */
+     , (87,  18,     0.6) /* ArmorModVsAcid */
+     , (87,  19,     0.4) /* ArmorModVsElectric */
+     , (87,  39,     1.1) /* DefaultScale */
+     , (87, 110,       1) /* BulkMod */
+     , (87, 111,       1) /* SizeMod */
+     , (87, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (87,   1, 'Platemail Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (87,   1,   33554641) /* Setup */
+     , (87,   3,  536870932) /* SoundTable */
+     , (87,   6,   67108990) /* PaletteBase */
+     , (87,   7,  268435536) /* ClothingBase */
+     , (87,   8,  100668172) /* Icon */
+     , (87,  22,  872415275) /* PhysicsEffectTable */
+     , (87,  36,  234881042) /* MutateFilter */
+     , (87,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00088 Scalemail Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00088 Scalemail Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 88;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (88, 'pauldronsscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (88,   1,          2) /* ItemType - Armor */
+     , (88,   3,         20) /* PaletteTemplate - Silver */
+     , (88,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (88,   5,        300) /* EncumbranceVal */
+     , (88,   8,        180) /* Mass */
+     , (88,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (88,  16,          1) /* ItemUseable - No */
+     , (88,  19,        433) /* Value */
+     , (88,  27,          8) /* ArmorType - Scalemail */
+     , (88,  28,        100) /* ArmorLevel */
+     , (88,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (88, 124,          3) /* Version */
+     , (88, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (88,  22, True ) /* Inscribable */
+     , (88, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (88,  12,    0.66) /* Shade */
+     , (88,  13,       1) /* ArmorModVsSlash */
+     , (88,  14,     1.1) /* ArmorModVsPierce */
+     , (88,  15,       1) /* ArmorModVsBludgeon */
+     , (88,  16,     0.4) /* ArmorModVsCold */
+     , (88,  17,     0.4) /* ArmorModVsFire */
+     , (88,  18,     0.6) /* ArmorModVsAcid */
+     , (88,  19,     0.4) /* ArmorModVsElectric */
+     , (88,  39,     1.1) /* DefaultScale */
+     , (88, 110,     1.2) /* BulkMod */
+     , (88, 111,       1) /* SizeMod */
+     , (88, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (88,   1, 'Scalemail Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (88,   1,   33554641) /* Setup */
+     , (88,   3,  536870932) /* SoundTable */
+     , (88,   6,   67108990) /* PaletteBase */
+     , (88,   7,  268435537) /* ClothingBase */
+     , (88,   8,  100668173) /* Icon */
+     , (88,  22,  872415275) /* PhysicsEffectTable */
+     , (88,  36,  234881042) /* MutateFilter */
+     , (88,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00088 Scalemail Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00088 Scalemail Pauldrons.sql
@@ -15,7 +15,7 @@ VALUES (88,   1,          2) /* ItemType - Armor */
      , (88,  27,          8) /* ArmorType - Scalemail */
      , (88,  28,        100) /* ArmorLevel */
      , (88,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (88, 124,          3) /* Version */
+     , (88, 124,          3) /* Version */
      , (88, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00089 Studded Leather Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00089 Studded Leather Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 89;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (89, 'pauldronsstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (89,   1,          2) /* ItemType - Armor */
+     , (89,   3,          4) /* PaletteTemplate - Brown */
+     , (89,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (89,   5,        350) /* EncumbranceVal */
+     , (89,   8,        140) /* Mass */
+     , (89,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (89,  16,          1) /* ItemUseable - No */
+     , (89,  19,        110) /* Value */
+     , (89,  27,          4) /* ArmorType - StuddedLeather */
+     , (89,  28,         90) /* ArmorLevel */
+     , (89,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (89, 124,          3) /* Version */
+     , (89, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (89,  22, True ) /* Inscribable */
+     , (89, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (89,  12,    0.66) /* Shade */
+     , (89,  13,     1.2) /* ArmorModVsSlash */
+     , (89,  14,     1.1) /* ArmorModVsPierce */
+     , (89,  15,       1) /* ArmorModVsBludgeon */
+     , (89,  16,     0.2) /* ArmorModVsCold */
+     , (89,  17,     0.2) /* ArmorModVsFire */
+     , (89,  18,     0.1) /* ArmorModVsAcid */
+     , (89,  19,     0.2) /* ArmorModVsElectric */
+     , (89,  39,     1.1) /* DefaultScale */
+     , (89, 110,     1.5) /* BulkMod */
+     , (89, 111,       1) /* SizeMod */
+     , (89, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (89,   1, 'Studded Leather Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (89,   1,   33554641) /* Setup */
+     , (89,   3,  536870932) /* SoundTable */
+     , (89,   6,   67108990) /* PaletteBase */
+     , (89,   7,  268435538) /* ClothingBase */
+     , (89,   8,  100668174) /* Icon */
+     , (89,  22,  872415275) /* PhysicsEffectTable */
+     , (89,  36,  234881042) /* MutateFilter */
+     , (89,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00089 Studded Leather Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00089 Studded Leather Pauldrons.sql
@@ -15,7 +15,7 @@ VALUES (89,   1,          2) /* ItemType - Armor */
      , (89,  27,          4) /* ArmorType - StuddedLeather */
      , (89,  28,         90) /* ArmorLevel */
      , (89,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (89, 124,          3) /* Version */
+     , (89, 124,          3) /* Version */
      , (89, 169,  118161678) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00090 Yoroi Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00090 Yoroi Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 90;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (90, 'pauldronsyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (90,   1,          2) /* ItemType - Armor */
+     , (90,   3,         20) /* PaletteTemplate - Silver */
+     , (90,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (90,   5,        383) /* EncumbranceVal */
+     , (90,   8,        230) /* Mass */
+     , (90,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (90,  16,          1) /* ItemUseable - No */
+     , (90,  19,       1500) /* Value */
+     , (90,  27,         32) /* ArmorType - Metal */
+     , (90,  28,        100) /* ArmorLevel */
+     , (90,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (90, 124,          3) /* Version */
+     , (90, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (90,  22, True ) /* Inscribable */
+     , (90, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (90,  12,    0.66) /* Shade */
+     , (90,  13,     1.3) /* ArmorModVsSlash */
+     , (90,  14,       1) /* ArmorModVsPierce */
+     , (90,  15,       1) /* ArmorModVsBludgeon */
+     , (90,  16,     0.4) /* ArmorModVsCold */
+     , (90,  17,     0.4) /* ArmorModVsFire */
+     , (90,  18,     0.6) /* ArmorModVsAcid */
+     , (90,  19,     0.4) /* ArmorModVsElectric */
+     , (90,  39,     1.1) /* DefaultScale */
+     , (90, 110,    1.15) /* BulkMod */
+     , (90, 111,       1) /* SizeMod */
+     , (90, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (90,   1, 'Yoroi Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (90,   1,   33554641) /* Setup */
+     , (90,   3,  536870932) /* SoundTable */
+     , (90,   6,   67108990) /* PaletteBase */
+     , (90,   7,  268435539) /* ClothingBase */
+     , (90,   8,  100667358) /* Icon */
+     , (90,  22,  872415275) /* PhysicsEffectTable */
+     , (90,  36,  234881042) /* MutateFilter */
+     , (90,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00090 Yoroi Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00090 Yoroi Pauldrons.sql
@@ -15,7 +15,7 @@ VALUES (90,   1,          2) /* ItemType - Armor */
      , (90,  27,         32) /* ArmorType - Metal */
      , (90,  28,        100) /* ArmorLevel */
      , (90,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (90, 124,          3) /* Version */
+     , (90, 124,          3) /* Version */
      , (90, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00096 Chainmail Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00096 Chainmail Shirt.sql
@@ -15,7 +15,7 @@ VALUES (96,   1,          2) /* ItemType - Armor */
      , (96,  27,         16) /* ArmorType - Chainmail */
      , (96,  28,        100) /* ArmorLevel */
      , (96,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (96, 124,          3) /* Version */
+     , (96, 124,          3) /* Version */
      , (96, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00096 Chainmail Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00096 Chainmail Shirt.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 96;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (96, 'shirtchainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (96,   1,          2) /* ItemType - Armor */
+     , (96,   3,         20) /* PaletteTemplate - Silver */
+     , (96,   4,       7168) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms */
+     , (96,   5,       1132) /* EncumbranceVal */
+     , (96,   8,        680) /* Mass */
+     , (96,   9,       3584) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor */
+     , (96,  16,          1) /* ItemUseable - No */
+     , (96,  19,       1875) /* Value */
+     , (96,  27,         16) /* ArmorType - Chainmail */
+     , (96,  28,        100) /* ArmorLevel */
+     , (96,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (96, 124,          3) /* Version */
+     , (96, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (96,  22, True ) /* Inscribable */
+     , (96, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (96,  12,       1) /* Shade */
+     , (96,  13,     1.2) /* ArmorModVsSlash */
+     , (96,  14,       1) /* ArmorModVsPierce */
+     , (96,  15,     0.8) /* ArmorModVsBludgeon */
+     , (96,  16,     0.6) /* ArmorModVsCold */
+     , (96,  17,     0.6) /* ArmorModVsFire */
+     , (96,  18,     0.5) /* ArmorModVsAcid */
+     , (96,  19,     0.4) /* ArmorModVsElectric */
+     , (96, 110,    1.33) /* BulkMod */
+     , (96, 111,       4) /* SizeMod */
+     , (96, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (96,   1, 'Chainmail Shirt') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (96,   1,   33554883) /* Setup */
+     , (96,   3,  536870932) /* SoundTable */
+     , (96,   6,   67108990) /* PaletteBase */
+     , (96,   7,  268435624) /* ClothingBase */
+     , (96,   8,  100667335) /* Icon */
+     , (96,  22,  872415275) /* PhysicsEffectTable */
+     , (96,  36,  234881042) /* MutateFilter */
+     , (96,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00097 Leather Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00097 Leather Shirt.sql
@@ -15,7 +15,7 @@ VALUES (97,   1,          2) /* ItemType - Armor */
      , (97,  27,          2) /* ArmorType - Leather */
      , (97,  28,         90) /* ArmorLevel */
      , (97,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (97, 124,          3) /* Version */
+     , (97, 124,          3) /* Version */
      , (97, 169,  118163214) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00097 Leather Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00097 Leather Shirt.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 97;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (97, 'shirtleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (97,   1,          2) /* ItemType - Armor */
+     , (97,   3,          4) /* PaletteTemplate - Brown */
+     , (97,   4,       7168) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms */
+     , (97,   5,        810) /* EncumbranceVal */
+     , (97,   8,        270) /* Mass */
+     , (97,   9,       3584) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor */
+     , (97,  16,          1) /* ItemUseable - No */
+     , (97,  19,        130) /* Value */
+     , (97,  27,          2) /* ArmorType - Leather */
+     , (97,  28,         90) /* ArmorLevel */
+     , (97,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (97, 124,          3) /* Version */
+     , (97, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (97,  22, True ) /* Inscribable */
+     , (97, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (97,  12,    0.66) /* Shade */
+     , (97,  13,       1) /* ArmorModVsSlash */
+     , (97,  14,     0.8) /* ArmorModVsPierce */
+     , (97,  15,       1) /* ArmorModVsBludgeon */
+     , (97,  16,     0.5) /* ArmorModVsCold */
+     , (97,  17,     0.5) /* ArmorModVsFire */
+     , (97,  18,     0.3) /* ArmorModVsAcid */
+     , (97,  19,     0.6) /* ArmorModVsElectric */
+     , (97, 110,    1.67) /* BulkMod */
+     , (97, 111,       4) /* SizeMod */
+     , (97, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (97,   1, 'Leather Shirt') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (97,   1,   33554883) /* Setup */
+     , (97,   3,  536870932) /* SoundTable */
+     , (97,   6,   67108990) /* PaletteBase */
+     , (97,   7,  268435625) /* ClothingBase */
+     , (97,   8,  100667353) /* Icon */
+     , (97,  22,  872415275) /* PhysicsEffectTable */
+     , (97,  36,  234881042) /* MutateFilter */
+     , (97,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00098 Scalemail Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00098 Scalemail Shirt.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 98;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (98, 'shirtscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (98,   1,          2) /* ItemType - Armor */
+     , (98,   3,         20) /* PaletteTemplate - Silver */
+     , (98,   4,       7168) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms */
+     , (98,   5,       1625) /* EncumbranceVal */
+     , (98,   8,       1000) /* Mass */
+     , (98,   9,       3584) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor */
+     , (98,  16,          1) /* ItemUseable - No */
+     , (98,  19,       1732) /* Value */
+     , (98,  27,          8) /* ArmorType - Scalemail */
+     , (98,  28,        100) /* ArmorLevel */
+     , (98,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (98, 124,          3) /* Version */
+     , (98, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (98,  22, True ) /* Inscribable */
+     , (98, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (98,  12,    0.66) /* Shade */
+     , (98,  13,       1) /* ArmorModVsSlash */
+     , (98,  14,     1.1) /* ArmorModVsPierce */
+     , (98,  15,       1) /* ArmorModVsBludgeon */
+     , (98,  16,     0.4) /* ArmorModVsCold */
+     , (98,  17,     0.4) /* ArmorModVsFire */
+     , (98,  18,     0.6) /* ArmorModVsAcid */
+     , (98,  19,     0.4) /* ArmorModVsElectric */
+     , (98, 110,     1.2) /* BulkMod */
+     , (98, 111,       4) /* SizeMod */
+     , (98, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (98,   1, 'Scalemail Shirt') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (98,   1,   33554883) /* Setup */
+     , (98,   3,  536870932) /* SoundTable */
+     , (98,   6,   67108990) /* PaletteBase */
+     , (98,   7,  268435627) /* ClothingBase */
+     , (98,   8,  100669692) /* Icon */
+     , (98,  22,  872415275) /* PhysicsEffectTable */
+     , (98,  36,  234881042) /* MutateFilter */
+     , (98,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00098 Scalemail Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00098 Scalemail Shirt.sql
@@ -15,7 +15,7 @@ VALUES (98,   1,          2) /* ItemType - Armor */
      , (98,  27,          8) /* ArmorType - Scalemail */
      , (98,  28,        100) /* ArmorLevel */
      , (98,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (98, 124,          3) /* Version */
+     , (98, 124,          3) /* Version */
      , (98, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00099 Studded Leather Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00099 Studded Leather Shirt.sql
@@ -15,7 +15,7 @@ VALUES (99,   1,          2) /* ItemType - Armor */
      , (99,  27,          4) /* ArmorType - StuddedLeather */
      , (99,  28,         90) /* ArmorLevel */
      , (99,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (99, 124,          3) /* Version */
+     , (99, 124,          3) /* Version */
      , (99, 169,  118163214) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00099 Studded Leather Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00099 Studded Leather Shirt.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 99;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (99, 'shirtstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (99,   1,          2) /* ItemType - Armor */
+     , (99,   3,          4) /* PaletteTemplate - Brown */
+     , (99,   4,       7168) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms */
+     , (99,   5,       1000) /* EncumbranceVal */
+     , (99,   8,        400) /* Mass */
+     , (99,   9,       3584) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor */
+     , (99,  16,          1) /* ItemUseable - No */
+     , (99,  19,        420) /* Value */
+     , (99,  27,          4) /* ArmorType - StuddedLeather */
+     , (99,  28,         90) /* ArmorLevel */
+     , (99,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (99, 124,          3) /* Version */
+     , (99, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (99,  22, True ) /* Inscribable */
+     , (99, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (99,  12,    0.66) /* Shade */
+     , (99,  13,     1.2) /* ArmorModVsSlash */
+     , (99,  14,     1.1) /* ArmorModVsPierce */
+     , (99,  15,       1) /* ArmorModVsBludgeon */
+     , (99,  16,     0.2) /* ArmorModVsCold */
+     , (99,  17,     0.2) /* ArmorModVsFire */
+     , (99,  18,     0.1) /* ArmorModVsAcid */
+     , (99,  19,     0.2) /* ArmorModVsElectric */
+     , (99, 110,     1.5) /* BulkMod */
+     , (99, 111,       4) /* SizeMod */
+     , (99, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (99,   1, 'Studded Leather Shirt') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (99,   1,   33554883) /* Setup */
+     , (99,   3,  536870932) /* SoundTable */
+     , (99,   6,   67108990) /* PaletteBase */
+     , (99,   7,  268435628) /* ClothingBase */
+     , (99,   8,  100667353) /* Icon */
+     , (99,  22,  872415275) /* PhysicsEffectTable */
+     , (99,  36,  234881042) /* MutateFilter */
+     , (99,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00101 Chainmail Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00101 Chainmail Sleeves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 101;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (101, 'sleeveschainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (101,   1,          2) /* ItemType - Armor */
+     , (101,   3,         20) /* PaletteTemplate - Silver */
+     , (101,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (101,   5,        600) /* EncumbranceVal */
+     , (101,   8,        360) /* Mass */
+     , (101,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (101,  16,          1) /* ItemUseable - No */
+     , (101,  19,        360) /* Value */
+     , (101,  27,         16) /* ArmorType - Chainmail */
+     , (101,  28,        100) /* ArmorLevel */
+     , (101,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (101, 124,          3) /* Version */
+     , (101, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (101,  22, True ) /* Inscribable */
+     , (101, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (101,  12,    0.66) /* Shade */
+     , (101,  13,     1.2) /* ArmorModVsSlash */
+     , (101,  14,       1) /* ArmorModVsPierce */
+     , (101,  15,     0.8) /* ArmorModVsBludgeon */
+     , (101,  16,     0.6) /* ArmorModVsCold */
+     , (101,  17,     0.6) /* ArmorModVsFire */
+     , (101,  18,     0.5) /* ArmorModVsAcid */
+     , (101,  19,     0.4) /* ArmorModVsElectric */
+     , (101, 110,    1.33) /* BulkMod */
+     , (101, 111,    1.75) /* SizeMod */
+     , (101, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (101,   1, 'Chainmail Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (101,   1,   33554655) /* Setup */
+     , (101,   3,  536870932) /* SoundTable */
+     , (101,   6,   67108990) /* PaletteBase */
+     , (101,   7,  268435504) /* ClothingBase */
+     , (101,   8,  100668802) /* Icon */
+     , (101,  22,  872415275) /* PhysicsEffectTable */
+     , (101,  36,  234881042) /* MutateFilter */
+     , (101,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00101 Chainmail Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00101 Chainmail Sleeves.sql
@@ -15,7 +15,7 @@ VALUES (101,   1,          2) /* ItemType - Armor */
      , (101,  27,         16) /* ArmorType - Chainmail */
      , (101,  28,        100) /* ArmorLevel */
      , (101,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (101, 124,          3) /* Version */
+     , (101, 124,          3) /* Version */
      , (101, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00102 Leather Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00102 Leather Sleeves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 102;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (102, 'sleevesleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (102,   1,          2) /* ItemType - Armor */
+     , (102,   3,          4) /* PaletteTemplate - Brown */
+     , (102,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (102,   5,        540) /* EncumbranceVal */
+     , (102,   8,        180) /* Mass */
+     , (102,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (102,  16,          1) /* ItemUseable - No */
+     , (102,  19,         60) /* Value */
+     , (102,  27,          2) /* ArmorType - Leather */
+     , (102,  28,         90) /* ArmorLevel */
+     , (102,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (102, 124,          3) /* Version */
+     , (102, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (102,  22, True ) /* Inscribable */
+     , (102, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (102,  12,    0.66) /* Shade */
+     , (102,  13,       1) /* ArmorModVsSlash */
+     , (102,  14,     0.8) /* ArmorModVsPierce */
+     , (102,  15,       1) /* ArmorModVsBludgeon */
+     , (102,  16,     0.5) /* ArmorModVsCold */
+     , (102,  17,     0.5) /* ArmorModVsFire */
+     , (102,  18,     0.3) /* ArmorModVsAcid */
+     , (102,  19,     0.6) /* ArmorModVsElectric */
+     , (102, 110,    1.67) /* BulkMod */
+     , (102, 111,    1.75) /* SizeMod */
+     , (102, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (102,   1, 'Leather Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (102,   1,   33554655) /* Setup */
+     , (102,   3,  536870932) /* SoundTable */
+     , (102,   6,   67108990) /* PaletteBase */
+     , (102,   7,  268435502) /* ClothingBase */
+     , (102,   8,  100668412) /* Icon */
+     , (102,  22,  872415275) /* PhysicsEffectTable */
+     , (102,  36,  234881042) /* MutateFilter */
+     , (102,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00102 Leather Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00102 Leather Sleeves.sql
@@ -15,7 +15,7 @@ VALUES (102,   1,          2) /* ItemType - Armor */
      , (102,  27,          2) /* ArmorType - Leather */
      , (102,  28,         90) /* ArmorLevel */
      , (102,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (102, 124,          3) /* Version */
+     , (102, 124,          3) /* Version */
      , (102, 169,  118161678) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00103 Platemail Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00103 Platemail Sleeves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 103;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (103, 'sleevesplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (103,   1,          2) /* ItemType - Armor */
+     , (103,   3,         20) /* PaletteTemplate - Silver */
+     , (103,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (103,   5,       1099) /* EncumbranceVal */
+     , (103,   8,        550) /* Mass */
+     , (103,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (103,  16,          1) /* ItemUseable - No */
+     , (103,  19,       1145) /* Value */
+     , (103,  27,         32) /* ArmorType - Metal */
+     , (103,  28,        110) /* ArmorLevel */
+     , (103,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (103, 124,          3) /* Version */
+     , (103, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (103,  22, True ) /* Inscribable */
+     , (103, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (103,  12,    0.66) /* Shade */
+     , (103,  13,     1.3) /* ArmorModVsSlash */
+     , (103,  14,       1) /* ArmorModVsPierce */
+     , (103,  15,       1) /* ArmorModVsBludgeon */
+     , (103,  16,     0.4) /* ArmorModVsCold */
+     , (103,  17,     0.4) /* ArmorModVsFire */
+     , (103,  18,     0.6) /* ArmorModVsAcid */
+     , (103,  19,     0.4) /* ArmorModVsElectric */
+     , (103, 110,       1) /* BulkMod */
+     , (103, 111,     1.2) /* SizeMod */
+     , (103, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (103,   1, 'Platemail Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (103,   1,   33554655) /* Setup */
+     , (103,   3,  536870932) /* SoundTable */
+     , (103,   6,   67108990) /* PaletteBase */
+     , (103,   7,  268435506) /* ClothingBase */
+     , (103,   8,  100668410) /* Icon */
+     , (103,  22,  872415275) /* PhysicsEffectTable */
+     , (103,  36,  234881042) /* MutateFilter */
+     , (103,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00103 Platemail Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00103 Platemail Sleeves.sql
@@ -15,7 +15,7 @@ VALUES (103,   1,          2) /* ItemType - Armor */
      , (103,  27,         32) /* ArmorType - Metal */
      , (103,  28,        110) /* ArmorLevel */
      , (103,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (103, 124,          3) /* Version */
+     , (103, 124,          3) /* Version */
      , (103, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00104 Scalemail Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00104 Scalemail Sleeves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 104;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (104, 'sleevesscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (104,   1,          2) /* ItemType - Armor */
+     , (104,   3,         20) /* PaletteTemplate - Silver */
+     , (104,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (104,   5,        533) /* EncumbranceVal */
+     , (104,   8,        320) /* Mass */
+     , (104,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (104,  16,          1) /* ItemUseable - No */
+     , (104,  19,        760) /* Value */
+     , (104,  27,          8) /* ArmorType - Scalemail */
+     , (104,  28,        100) /* ArmorLevel */
+     , (104,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (104, 124,          3) /* Version */
+     , (104, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (104,  22, True ) /* Inscribable */
+     , (104, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (104,  12,    0.66) /* Shade */
+     , (104,  13,       1) /* ArmorModVsSlash */
+     , (104,  14,     1.1) /* ArmorModVsPierce */
+     , (104,  15,       1) /* ArmorModVsBludgeon */
+     , (104,  16,     0.4) /* ArmorModVsCold */
+     , (104,  17,     0.4) /* ArmorModVsFire */
+     , (104,  18,     0.6) /* ArmorModVsAcid */
+     , (104,  19,     0.4) /* ArmorModVsElectric */
+     , (104, 110,     1.2) /* BulkMod */
+     , (104, 111,     1.2) /* SizeMod */
+     , (104, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (104,   1, 'Scalemail Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (104,   1,   33554655) /* Setup */
+     , (104,   3,  536870932) /* SoundTable */
+     , (104,   6,   67108990) /* PaletteBase */
+     , (104,   7,  268435505) /* ClothingBase */
+     , (104,   8,  100668803) /* Icon */
+     , (104,  22,  872415275) /* PhysicsEffectTable */
+     , (104,  36,  234881042) /* MutateFilter */
+     , (104,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00104 Scalemail Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00104 Scalemail Sleeves.sql
@@ -15,7 +15,7 @@ VALUES (104,   1,          2) /* ItemType - Armor */
      , (104,  27,          8) /* ArmorType - Scalemail */
      , (104,  28,        100) /* ArmorLevel */
      , (104,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (104, 124,          3) /* Version */
+     , (104, 124,          3) /* Version */
      , (104, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00105 Studded Leather Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00105 Studded Leather Sleeves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 105;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (105, 'sleevesstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (105,   1,          2) /* ItemType - Armor */
+     , (105,   3,          4) /* PaletteTemplate - Brown */
+     , (105,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (105,   5,        575) /* EncumbranceVal */
+     , (105,   8,        230) /* Mass */
+     , (105,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (105,  16,          1) /* ItemUseable - No */
+     , (105,  19,        180) /* Value */
+     , (105,  27,          4) /* ArmorType - StuddedLeather */
+     , (105,  28,         90) /* ArmorLevel */
+     , (105,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (105, 124,          3) /* Version */
+     , (105, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (105,  22, True ) /* Inscribable */
+     , (105, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (105,  12,    0.66) /* Shade */
+     , (105,  13,     1.2) /* ArmorModVsSlash */
+     , (105,  14,     1.1) /* ArmorModVsPierce */
+     , (105,  15,       1) /* ArmorModVsBludgeon */
+     , (105,  16,     0.2) /* ArmorModVsCold */
+     , (105,  17,     0.2) /* ArmorModVsFire */
+     , (105,  18,     0.1) /* ArmorModVsAcid */
+     , (105,  19,     0.2) /* ArmorModVsElectric */
+     , (105, 110,     1.5) /* BulkMod */
+     , (105, 111,    1.75) /* SizeMod */
+     , (105, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (105,   1, 'Studded Leather Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (105,   1,   33554655) /* Setup */
+     , (105,   3,  536870932) /* SoundTable */
+     , (105,   6,   67108990) /* PaletteBase */
+     , (105,   7,  268435503) /* ClothingBase */
+     , (105,   8,  100668414) /* Icon */
+     , (105,  22,  872415275) /* PhysicsEffectTable */
+     , (105,  36,  234881042) /* MutateFilter */
+     , (105,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00105 Studded Leather Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00105 Studded Leather Sleeves.sql
@@ -15,7 +15,7 @@ VALUES (105,   1,          2) /* ItemType - Armor */
      , (105,  27,          4) /* ArmorType - StuddedLeather */
      , (105,  28,         90) /* ArmorLevel */
      , (105,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (105, 124,          3) /* Version */
+     , (105, 124,          3) /* Version */
      , (105, 169,  118161678) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00106 Yoroi Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00106 Yoroi Sleeves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 106;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (106, 'sleevesyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (106,   1,          2) /* ItemType - Armor */
+     , (106,   3,         20) /* PaletteTemplate - Silver */
+     , (106,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (106,   5,        600) /* EncumbranceVal */
+     , (106,   8,        360) /* Mass */
+     , (106,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (106,  16,          1) /* ItemUseable - No */
+     , (106,  19,        833) /* Value */
+     , (106,  27,         32) /* ArmorType - Metal */
+     , (106,  28,        100) /* ArmorLevel */
+     , (106,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (106, 124,          3) /* Version */
+     , (106, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (106,  22, True ) /* Inscribable */
+     , (106, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (106,  12,    0.66) /* Shade */
+     , (106,  13,     1.3) /* ArmorModVsSlash */
+     , (106,  14,       1) /* ArmorModVsPierce */
+     , (106,  15,       1) /* ArmorModVsBludgeon */
+     , (106,  16,     0.4) /* ArmorModVsCold */
+     , (106,  17,     0.4) /* ArmorModVsFire */
+     , (106,  18,     0.6) /* ArmorModVsAcid */
+     , (106,  19,     0.4) /* ArmorModVsElectric */
+     , (106, 110,    1.15) /* BulkMod */
+     , (106, 111,     1.2) /* SizeMod */
+     , (106, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (106,   1, 'Yoroi Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (106,   1,   33554655) /* Setup */
+     , (106,   3,  536870932) /* SoundTable */
+     , (106,   6,   67108990) /* PaletteBase */
+     , (106,   7,  268435507) /* ClothingBase */
+     , (106,   8,  100668411) /* Icon */
+     , (106,  22,  872415275) /* PhysicsEffectTable */
+     , (106,  36,  234881042) /* MutateFilter */
+     , (106,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00106 Yoroi Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00106 Yoroi Sleeves.sql
@@ -15,7 +15,7 @@ VALUES (106,   1,          2) /* ItemType - Armor */
      , (106,  27,         32) /* ArmorType - Metal */
      , (106,  28,        100) /* ArmorLevel */
      , (106,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (106, 124,          3) /* Version */
+     , (106, 124,          3) /* Version */
      , (106, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00107 Sollerets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00107 Sollerets.sql
@@ -17,7 +17,7 @@ VALUES (107,   1,          2) /* ItemType - Armor */
      , (107,  44,          3) /* Damage */
      , (107,  45,          4) /* DamageType - Bludgeon */
      , (107,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (107, 124,          3) /* Version */
+     , (107, 124,          3) /* Version */
      , (107, 169,  151650564) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00107 Sollerets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00107 Sollerets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 107;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (107, 'sollerets', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (107,   1,          2) /* ItemType - Armor */
+     , (107,   3,         20) /* PaletteTemplate - Silver */
+     , (107,   4,      65536) /* ClothingPriority - Feet */
+     , (107,   5,        540) /* EncumbranceVal */
+     , (107,   8,        360) /* Mass */
+     , (107,   9,        256) /* ValidLocations - FootWear */
+     , (107,  16,          1) /* ItemUseable - No */
+     , (107,  19,        653) /* Value */
+     , (107,  27,         32) /* ArmorType - Metal */
+     , (107,  28,        150) /* ArmorLevel */
+     , (107,  44,          3) /* Damage */
+     , (107,  45,          4) /* DamageType - Bludgeon */
+     , (107,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (107, 124,          3) /* Version */
+     , (107, 169,  151650564) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (107,  22, True ) /* Inscribable */
+     , (107, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (107,  12,    0.66) /* Shade */
+     , (107,  13,     1.3) /* ArmorModVsSlash */
+     , (107,  14,       1) /* ArmorModVsPierce */
+     , (107,  15,       1) /* ArmorModVsBludgeon */
+     , (107,  16,     0.4) /* ArmorModVsCold */
+     , (107,  17,     0.4) /* ArmorModVsFire */
+     , (107,  18,     0.6) /* ArmorModVsAcid */
+     , (107,  19,     0.4) /* ArmorModVsElectric */
+     , (107,  22,    0.75) /* DamageVariance */
+     , (107, 110,       1) /* BulkMod */
+     , (107, 111,       1) /* SizeMod */
+     , (107, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (107,   1, 'Sollerets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (107,   1,   33554654) /* Setup */
+     , (107,   3,  536870932) /* SoundTable */
+     , (107,   6,   67108990) /* PaletteBase */
+     , (107,   7,  268435540) /* ClothingBase */
+     , (107,   8,  100667309) /* Icon */
+     , (107,  22,  872415275) /* PhysicsEffectTable */
+     , (107,  36,  234881042) /* MutateFilter */
+     , (107,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00108 Chainmail Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00108 Chainmail Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 108;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (108, 'tassetschainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (108,   1,          2) /* ItemType - Armor */
+     , (108,   3,         20) /* PaletteTemplate - Silver */
+     , (108,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (108,   5,        280) /* EncumbranceVal */
+     , (108,   8,        260) /* Mass */
+     , (108,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (108,  16,          1) /* ItemUseable - No */
+     , (108,  19,       1275) /* Value */
+     , (108,  27,         16) /* ArmorType - Chainmail */
+     , (108,  28,        100) /* ArmorLevel */
+     , (108,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (108, 124,          3) /* Version */
+     , (108, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (108,  22, True ) /* Inscribable */
+     , (108, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (108,  12,    0.66) /* Shade */
+     , (108,  13,     1.2) /* ArmorModVsSlash */
+     , (108,  14,       1) /* ArmorModVsPierce */
+     , (108,  15,     0.8) /* ArmorModVsBludgeon */
+     , (108,  16,     0.6) /* ArmorModVsCold */
+     , (108,  17,     0.6) /* ArmorModVsFire */
+     , (108,  18,     0.5) /* ArmorModVsAcid */
+     , (108,  19,     0.4) /* ArmorModVsElectric */
+     , (108,  39,    1.33) /* DefaultScale */
+     , (108, 110,    1.33) /* BulkMod */
+     , (108, 111,       1) /* SizeMod */
+     , (108, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (108,   1, 'Chainmail Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (108,   1,   33554656) /* Setup */
+     , (108,   3,  536870932) /* SoundTable */
+     , (108,   6,   67108990) /* PaletteBase */
+     , (108,   7,  268436439) /* ClothingBase */
+     , (108,   8,  100673328) /* Icon */
+     , (108,  22,  872415275) /* PhysicsEffectTable */
+     , (108,  36,  234881042) /* MutateFilter */
+     , (108,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00108 Chainmail Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00108 Chainmail Tassets.sql
@@ -15,7 +15,7 @@ VALUES (108,   1,          2) /* ItemType - Armor */
      , (108,  27,         16) /* ArmorType - Chainmail */
      , (108,  28,        100) /* ArmorLevel */
      , (108,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (108, 124,          3) /* Version */
+     , (108, 124,          3) /* Version */
      , (108, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00109 Leather Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00109 Leather Tassets.sql
@@ -15,7 +15,7 @@ VALUES (109,   1,          2) /* ItemType - Armor */
      , (109,  27,          2) /* ArmorType - Leather */
      , (109,  28,         90) /* ArmorLevel */
      , (109,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (109, 124,          3) /* Version */
+     , (109, 124,          3) /* Version */
      , (109, 169,  252379406) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00109 Leather Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00109 Leather Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 109;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (109, 'tassetsleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (109,   1,          2) /* ItemType - Armor */
+     , (109,   3,          4) /* PaletteTemplate - Brown */
+     , (109,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (109,   5,        420) /* EncumbranceVal */
+     , (109,   8,        140) /* Mass */
+     , (109,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (109,  16,          1) /* ItemUseable - No */
+     , (109,  19,       1100) /* Value */
+     , (109,  27,          2) /* ArmorType - Leather */
+     , (109,  28,         90) /* ArmorLevel */
+     , (109,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (109, 124,          3) /* Version */
+     , (109, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (109,  22, True ) /* Inscribable */
+     , (109, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (109,  12,    0.66) /* Shade */
+     , (109,  13,       1) /* ArmorModVsSlash */
+     , (109,  14,     0.8) /* ArmorModVsPierce */
+     , (109,  15,       1) /* ArmorModVsBludgeon */
+     , (109,  16,     0.5) /* ArmorModVsCold */
+     , (109,  17,     0.5) /* ArmorModVsFire */
+     , (109,  18,     0.3) /* ArmorModVsAcid */
+     , (109,  19,     0.6) /* ArmorModVsElectric */
+     , (109,  39,    1.33) /* DefaultScale */
+     , (109, 110,    1.67) /* BulkMod */
+     , (109, 111,       1) /* SizeMod */
+     , (109, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (109,   1, 'Leather Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (109,   1,   33554656) /* Setup */
+     , (109,   3,  536870932) /* SoundTable */
+     , (109,   6,   67108990) /* PaletteBase */
+     , (109,   7,  268436436) /* ClothingBase */
+     , (109,   8,  100673335) /* Icon */
+     , (109,  22,  872415275) /* PhysicsEffectTable */
+     , (109,  36,  234881042) /* MutateFilter */
+     , (109,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00110 Platemail Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00110 Platemail Tassets.sql
@@ -15,7 +15,7 @@ VALUES (110,   1,          2) /* ItemType - Armor */
      , (110,  27,         32) /* ArmorType - Metal */
      , (110,  28,        110) /* ArmorLevel */
      , (110,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (110, 124,          3) /* Version */
+     , (110, 124,          3) /* Version */
      , (110, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00110 Platemail Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00110 Platemail Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 110;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (110, 'tassetsplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (110,   1,          2) /* ItemType - Armor */
+     , (110,   3,         20) /* PaletteTemplate - Silver */
+     , (110,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (110,   5,        919) /* EncumbranceVal */
+     , (110,   8,        460) /* Mass */
+     , (110,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (110,  16,          1) /* ItemUseable - No */
+     , (110,  19,        653) /* Value */
+     , (110,  27,         32) /* ArmorType - Metal */
+     , (110,  28,        110) /* ArmorLevel */
+     , (110,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (110, 124,          3) /* Version */
+     , (110, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (110,  22, True ) /* Inscribable */
+     , (110, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (110,  12,    0.33) /* Shade */
+     , (110,  13,     1.3) /* ArmorModVsSlash */
+     , (110,  14,       1) /* ArmorModVsPierce */
+     , (110,  15,       1) /* ArmorModVsBludgeon */
+     , (110,  16,     0.4) /* ArmorModVsCold */
+     , (110,  17,     0.4) /* ArmorModVsFire */
+     , (110,  18,     0.6) /* ArmorModVsAcid */
+     , (110,  19,     0.4) /* ArmorModVsElectric */
+     , (110,  39,    1.33) /* DefaultScale */
+     , (110, 110,       1) /* BulkMod */
+     , (110, 111,       1) /* SizeMod */
+     , (110, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (110,   1, 'Platemail Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (110,   1,   33554656) /* Setup */
+     , (110,   3,  536870932) /* SoundTable */
+     , (110,   6,   67108990) /* PaletteBase */
+     , (110,   7,  268436437) /* ClothingBase */
+     , (110,   8,  100673371) /* Icon */
+     , (110,  22,  872415275) /* PhysicsEffectTable */
+     , (110,  36,  234881042) /* MutateFilter */
+     , (110,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00111 Scalemail Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00111 Scalemail Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 111;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (111, 'tassetsscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (111,   1,          2) /* ItemType - Armor */
+     , (111,   3,         20) /* PaletteTemplate - Silver */
+     , (111,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (111,   5,        533) /* EncumbranceVal */
+     , (111,   8,        320) /* Mass */
+     , (111,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (111,  16,          1) /* ItemUseable - No */
+     , (111,  19,        433) /* Value */
+     , (111,  27,          8) /* ArmorType - Scalemail */
+     , (111,  28,        100) /* ArmorLevel */
+     , (111,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (111, 124,          3) /* Version */
+     , (111, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (111,  22, True ) /* Inscribable */
+     , (111, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (111,  12,    0.66) /* Shade */
+     , (111,  13,       1) /* ArmorModVsSlash */
+     , (111,  14,     1.1) /* ArmorModVsPierce */
+     , (111,  15,       1) /* ArmorModVsBludgeon */
+     , (111,  16,     0.4) /* ArmorModVsCold */
+     , (111,  17,     0.4) /* ArmorModVsFire */
+     , (111,  18,     0.6) /* ArmorModVsAcid */
+     , (111,  19,     0.4) /* ArmorModVsElectric */
+     , (111,  39,    1.33) /* DefaultScale */
+     , (111, 110,     1.2) /* BulkMod */
+     , (111, 111,       1) /* SizeMod */
+     , (111, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (111,   1, 'Scalemail Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (111,   1,   33554656) /* Setup */
+     , (111,   3,  536870932) /* SoundTable */
+     , (111,   6,   67108990) /* PaletteBase */
+     , (111,   7,  268436435) /* ClothingBase */
+     , (111,   8,  100673349) /* Icon */
+     , (111,  22,  872415275) /* PhysicsEffectTable */
+     , (111,  36,  234881042) /* MutateFilter */
+     , (111,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00111 Scalemail Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00111 Scalemail Tassets.sql
@@ -15,7 +15,7 @@ VALUES (111,   1,          2) /* ItemType - Armor */
      , (111,  27,          8) /* ArmorType - Scalemail */
      , (111,  28,        100) /* ArmorLevel */
      , (111,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (111, 124,          3) /* Version */
+     , (111, 124,          3) /* Version */
      , (111, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00112 Studded Leather Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00112 Studded Leather Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 112;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (112, 'tassetsstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (112,   1,          2) /* ItemType - Armor */
+     , (112,   3,          4) /* PaletteTemplate - Brown */
+     , (112,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (112,   5,        450) /* EncumbranceVal */
+     , (112,   8,        180) /* Mass */
+     , (112,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (112,  16,          1) /* ItemUseable - No */
+     , (112,  19,        110) /* Value */
+     , (112,  27,          4) /* ArmorType - StuddedLeather */
+     , (112,  28,         90) /* ArmorLevel */
+     , (112,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (112, 124,          3) /* Version */
+     , (112, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (112,  22, True ) /* Inscribable */
+     , (112, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (112,  12,    0.66) /* Shade */
+     , (112,  13,     1.2) /* ArmorModVsSlash */
+     , (112,  14,     1.1) /* ArmorModVsPierce */
+     , (112,  15,       1) /* ArmorModVsBludgeon */
+     , (112,  16,     0.2) /* ArmorModVsCold */
+     , (112,  17,     0.2) /* ArmorModVsFire */
+     , (112,  18,     0.1) /* ArmorModVsAcid */
+     , (112,  19,     0.2) /* ArmorModVsElectric */
+     , (112,  39,    1.33) /* DefaultScale */
+     , (112, 110,     1.5) /* BulkMod */
+     , (112, 111,       1) /* SizeMod */
+     , (112, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (112,   1, 'Studded Leather Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (112,   1,   33554656) /* Setup */
+     , (112,   3,  536870932) /* SoundTable */
+     , (112,   6,   67108990) /* PaletteBase */
+     , (112,   7,  268436440) /* ClothingBase */
+     , (112,   8,  100673352) /* Icon */
+     , (112,  22,  872415275) /* PhysicsEffectTable */
+     , (112,  36,  234881042) /* MutateFilter */
+     , (112,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00112 Studded Leather Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00112 Studded Leather Tassets.sql
@@ -15,7 +15,7 @@ VALUES (112,   1,          2) /* ItemType - Armor */
      , (112,  27,          4) /* ArmorType - StuddedLeather */
      , (112,  28,         90) /* ArmorLevel */
      , (112,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (112, 124,          3) /* Version */
+     , (112, 124,          3) /* Version */
      , (112, 169,  252379406) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00113 Yoroi Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00113 Yoroi Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 113;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (113, 'tassetsyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (113,   1,          2) /* ItemType - Armor */
+     , (113,   3,         20) /* PaletteTemplate - Silver */
+     , (113,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (113,   5,        450) /* EncumbranceVal */
+     , (113,   8,        270) /* Mass */
+     , (113,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (113,  16,          1) /* ItemUseable - No */
+     , (113,  19,        472) /* Value */
+     , (113,  27,         32) /* ArmorType - Metal */
+     , (113,  28,        100) /* ArmorLevel */
+     , (113,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (113, 124,          3) /* Version */
+     , (113, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (113,  22, True ) /* Inscribable */
+     , (113, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (113,  12,    0.66) /* Shade */
+     , (113,  13,     1.3) /* ArmorModVsSlash */
+     , (113,  14,       1) /* ArmorModVsPierce */
+     , (113,  15,       1) /* ArmorModVsBludgeon */
+     , (113,  16,     0.4) /* ArmorModVsCold */
+     , (113,  17,     0.4) /* ArmorModVsFire */
+     , (113,  18,     0.6) /* ArmorModVsAcid */
+     , (113,  19,     0.4) /* ArmorModVsElectric */
+     , (113,  39,    1.33) /* DefaultScale */
+     , (113, 110,    1.15) /* BulkMod */
+     , (113, 111,       1) /* SizeMod */
+     , (113, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (113,   1, 'Yoroi Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (113,   1,   33554656) /* Setup */
+     , (113,   3,  536870932) /* SoundTable */
+     , (113,   6,   67108990) /* PaletteBase */
+     , (113,   7,  268436438) /* ClothingBase */
+     , (113,   8,  100673372) /* Icon */
+     , (113,  22,  872415275) /* PhysicsEffectTable */
+     , (113,  36,  234881042) /* MutateFilter */
+     , (113,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00113 Yoroi Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00113 Yoroi Tassets.sql
@@ -15,7 +15,7 @@ VALUES (113,   1,          2) /* ItemType - Armor */
      , (113,  27,         32) /* ArmorType - Metal */
      , (113,  28,        100) /* ArmorLevel */
      , (113,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (113, 124,          3) /* Version */
+     , (113, 124,          3) /* Version */
      , (113, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00114 Platemail Vambraces.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00114 Platemail Vambraces.sql
@@ -15,7 +15,7 @@ VALUES (114,   1,          2) /* ItemType - Armor */
      , (114,  27,         32) /* ArmorType - Metal */
      , (114,  28,        110) /* ArmorLevel */
      , (114,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (114, 124,          3) /* Version */
+     , (114, 124,          3) /* Version */
      , (114, 169,  118097156) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00114 Platemail Vambraces.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00114 Platemail Vambraces.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 114;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (114, 'vambracesplatemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (114,   1,          2) /* ItemType - Armor */
+     , (114,   3,         20) /* PaletteTemplate - Silver */
+     , (114,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (114,   5,        540) /* EncumbranceVal */
+     , (114,   8,        270) /* Mass */
+     , (114,   9,       4096) /* ValidLocations - LowerArmArmor */
+     , (114,  16,          1) /* ItemUseable - No */
+     , (114,  19,        653) /* Value */
+     , (114,  27,         32) /* ArmorType - Metal */
+     , (114,  28,        110) /* ArmorLevel */
+     , (114,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (114, 124,          3) /* Version */
+     , (114, 169,  118097156) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (114,  22, True ) /* Inscribable */
+     , (114, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (114,  12,    0.33) /* Shade */
+     , (114,  13,     1.3) /* ArmorModVsSlash */
+     , (114,  14,       1) /* ArmorModVsPierce */
+     , (114,  15,       1) /* ArmorModVsBludgeon */
+     , (114,  16,     0.4) /* ArmorModVsCold */
+     , (114,  17,     0.4) /* ArmorModVsFire */
+     , (114,  18,     0.6) /* ArmorModVsAcid */
+     , (114,  19,     0.4) /* ArmorModVsElectric */
+     , (114, 110,       1) /* BulkMod */
+     , (114, 111,       1) /* SizeMod */
+     , (114, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (114,   1, 'Platemail Vambraces') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (114,   1,   33554641) /* Setup */
+     , (114,   3,  536870932) /* SoundTable */
+     , (114,   6,   67108990) /* PaletteBase */
+     , (114,   7,  268435469) /* ClothingBase */
+     , (114,   8,  100667331) /* Icon */
+     , (114,  22,  872415275) /* PhysicsEffectTable */
+     , (114,  36,  234881042) /* MutateFilter */
+     , (114,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00115 Leather Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00115 Leather Boots.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 115;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (115, 'bootsleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (115,   1,          2) /* ItemType - Armor */
+     , (115,   3,          4) /* PaletteTemplate - Brown */
+     , (115,   4,      65536) /* ClothingPriority - Feet */
+     , (115,   5,        420) /* EncumbranceVal */
+     , (115,   8,        140) /* Mass */
+     , (115,   9,        384) /* ValidLocations - LowerLegWear, FootWear */
+     , (115,  16,          1) /* ItemUseable - No */
+     , (115,  19,       1100) /* Value */
+     , (115,  27,          2) /* ArmorType - Leather */
+     , (115,  28,        130) /* ArmorLevel */
+     , (115,  44,          1) /* Damage */
+     , (115,  45,          4) /* DamageType - Bludgeon */
+     , (115,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (115, 124,          3) /* Version */
+     , (115, 169,  185271566) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (115,  22, True ) /* Inscribable */
+     , (115, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (115,  12,     0.1) /* Shade */
+     , (115,  13,       1) /* ArmorModVsSlash */
+     , (115,  14,     0.8) /* ArmorModVsPierce */
+     , (115,  15,       1) /* ArmorModVsBludgeon */
+     , (115,  16,     0.5) /* ArmorModVsCold */
+     , (115,  17,     0.5) /* ArmorModVsFire */
+     , (115,  18,     0.3) /* ArmorModVsAcid */
+     , (115,  19,     0.6) /* ArmorModVsElectric */
+     , (115,  22,    0.75) /* DamageVariance */
+     , (115, 110,    1.67) /* BulkMod */
+     , (115, 111,       2) /* SizeMod */
+     , (115, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (115,   1, 'Leather Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (115,   1,   33554640) /* Setup */
+     , (115,   3,  536870932) /* SoundTable */
+     , (115,   6,   67108990) /* PaletteBase */
+     , (115,   7,  268435463) /* ClothingBase */
+     , (115,   8,  100667310) /* Icon */
+     , (115,  22,  872415275) /* PhysicsEffectTable */
+     , (115,  36,  234881042) /* MutateFilter */
+     , (115,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00115 Leather Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00115 Leather Boots.sql
@@ -17,7 +17,7 @@ VALUES (115,   1,          2) /* ItemType - Armor */
      , (115,  44,          1) /* Damage */
      , (115,  45,          4) /* DamageType - Bludgeon */
      , (115,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (115, 124,          3) /* Version */
+     , (115, 124,          3) /* Version */
      , (115, 169,  185271566) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00116 Studded Leather Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00116 Studded Leather Boots.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 116;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (116, 'bootsreinforcedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (116,   1,          2) /* ItemType - Armor */
+     , (116,   3,          4) /* PaletteTemplate - Brown */
+     , (116,   4,      65536) /* ClothingPriority - Feet */
+     , (116,   5,        690) /* EncumbranceVal */
+     , (116,   8,        230) /* Mass */
+     , (116,   9,        384) /* ValidLocations - LowerLegWear, FootWear */
+     , (116,  16,          1) /* ItemUseable - No */
+     , (116,  19,       1250) /* Value */
+     , (116,  27,          4) /* ArmorType - StuddedLeather */
+     , (116,  28,        130) /* ArmorLevel */
+     , (116,  44,          2) /* Damage */
+     , (116,  45,          4) /* DamageType - Bludgeon */
+     , (116,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (116, 124,          3) /* Version */
+     , (116, 169,  185271566) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (116,  22, True ) /* Inscribable */
+     , (116, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (116,  12,     0.1) /* Shade */
+     , (116,  13,     1.2) /* ArmorModVsSlash */
+     , (116,  14,     1.1) /* ArmorModVsPierce */
+     , (116,  15,       1) /* ArmorModVsBludgeon */
+     , (116,  16,     0.4) /* ArmorModVsCold */
+     , (116,  17,     0.7) /* ArmorModVsFire */
+     , (116,  18,     0.3) /* ArmorModVsAcid */
+     , (116,  19,     0.4) /* ArmorModVsElectric */
+     , (116,  22,    0.75) /* DamageVariance */
+     , (116, 110,     1.5) /* BulkMod */
+     , (116, 111,       2) /* SizeMod */
+     , (116, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (116,   1, 'Studded Leather Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (116,   1,   33554640) /* Setup */
+     , (116,   3,  536870932) /* SoundTable */
+     , (116,   6,   67108990) /* PaletteBase */
+     , (116,   7,  268435542) /* ClothingBase */
+     , (116,   8,  100668177) /* Icon */
+     , (116,  22,  872415275) /* PhysicsEffectTable */
+     , (116,  36,  234881042) /* MutateFilter */
+     , (116,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00116 Studded Leather Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00116 Studded Leather Boots.sql
@@ -17,7 +17,7 @@ VALUES (116,   1,          2) /* ItemType - Armor */
      , (116,  44,          2) /* Damage */
      , (116,  45,          4) /* DamageType - Bludgeon */
      , (116,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (116, 124,          3) /* Version */
+     , (116, 124,          3) /* Version */
      , (116, 169,  185271566) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00413 Chainmail Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00413 Chainmail Bracers.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 413;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (413, 'bracerschainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (413,   1,          2) /* ItemType - Armor */
+     , (413,   3,         20) /* PaletteTemplate - Silver */
+     , (413,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (413,   5,        300) /* EncumbranceVal */
+     , (413,   8,        180) /* Mass */
+     , (413,   9,       4096) /* ValidLocations - LowerArmArmor */
+     , (413,  16,          1) /* ItemUseable - No */
+     , (413,  19,       1280) /* Value */
+     , (413,  27,         16) /* ArmorType - Chainmail */
+     , (413,  28,        100) /* ArmorLevel */
+     , (413,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (413, 124,          3) /* Version */
+     , (413, 169,  118097156) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (413,  22, True ) /* Inscribable */
+     , (413, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (413,  12,    0.66) /* Shade */
+     , (413,  13,     1.2) /* ArmorModVsSlash */
+     , (413,  14,       1) /* ArmorModVsPierce */
+     , (413,  15,     0.8) /* ArmorModVsBludgeon */
+     , (413,  16,     0.6) /* ArmorModVsCold */
+     , (413,  17,     0.6) /* ArmorModVsFire */
+     , (413,  18,     0.5) /* ArmorModVsAcid */
+     , (413,  19,     0.4) /* ArmorModVsElectric */
+     , (413, 110,    1.33) /* BulkMod */
+     , (413, 111,       1) /* SizeMod */
+     , (413, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (413,   1, 'Chainmail Bracers') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (413,   1,   33554641) /* Setup */
+     , (413,   3,  536870932) /* SoundTable */
+     , (413,   6,   67108990) /* PaletteBase */
+     , (413,   7,  268435518) /* ClothingBase */
+     , (413,   8,  100668139) /* Icon */
+     , (413,  22,  872415275) /* PhysicsEffectTable */
+     , (413,  36,  234881042) /* MutateFilter */
+     , (413,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00414 Chainmail Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00414 Chainmail Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 414;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (414, 'breastplatechainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (414,   1,          2) /* ItemType - Armor */
+     , (414,   3,         20) /* PaletteTemplate - Silver */
+     , (414,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (414,   5,        932) /* EncumbranceVal */
+     , (414,   8,        560) /* Mass */
+     , (414,   9,        512) /* ValidLocations - ChestArmor */
+     , (414,  16,          1) /* ItemUseable - No */
+     , (414,  19,       1500) /* Value */
+     , (414,  27,         16) /* ArmorType - Chainmail */
+     , (414,  28,        100) /* ArmorLevel */
+     , (414,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (414, 124,          3) /* Version */
+     , (414, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (414,  22, True ) /* Inscribable */
+     , (414, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (414,  12,    0.66) /* Shade */
+     , (414,  13,     1.2) /* ArmorModVsSlash */
+     , (414,  14,       1) /* ArmorModVsPierce */
+     , (414,  15,     0.8) /* ArmorModVsBludgeon */
+     , (414,  16,     0.6) /* ArmorModVsCold */
+     , (414,  17,     0.6) /* ArmorModVsFire */
+     , (414,  18,     0.5) /* ArmorModVsAcid */
+     , (414,  19,     0.4) /* ArmorModVsElectric */
+     , (414, 110,    1.33) /* BulkMod */
+     , (414, 111,     2.5) /* SizeMod */
+     , (414, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (414,   1, 'Chainmail Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (414,   1,   33554642) /* Setup */
+     , (414,   3,  536870932) /* SoundTable */
+     , (414,   6,   67108990) /* PaletteBase */
+     , (414,   7,  268435494) /* ClothingBase */
+     , (414,   8,  100670263) /* Icon */
+     , (414,  22,  872415275) /* PhysicsEffectTable */
+     , (414,  36,  234881042) /* MutateFilter */
+     , (414,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00415 Chainmail Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00415 Chainmail Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 415;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (415, 'girthchainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (415,   1,          2) /* ItemType - Armor */
+     , (415,   3,         20) /* PaletteTemplate - Silver */
+     , (415,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (415,   5,        466) /* EncumbranceVal */
+     , (415,   8,        280) /* Mass */
+     , (415,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (415,  16,          1) /* ItemUseable - No */
+     , (415,  19,       1350) /* Value */
+     , (415,  27,         16) /* ArmorType - Chainmail */
+     , (415,  28,        100) /* ArmorLevel */
+     , (415,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (415, 124,          3) /* Version */
+     , (415, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (415,  22, True ) /* Inscribable */
+     , (415, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (415,  12,    0.66) /* Shade */
+     , (415,  13,     1.2) /* ArmorModVsSlash */
+     , (415,  14,       1) /* ArmorModVsPierce */
+     , (415,  15,     0.8) /* ArmorModVsBludgeon */
+     , (415,  16,     0.6) /* ArmorModVsCold */
+     , (415,  17,     0.6) /* ArmorModVsFire */
+     , (415,  18,     0.5) /* ArmorModVsAcid */
+     , (415,  19,     0.4) /* ArmorModVsElectric */
+     , (415, 110,    1.33) /* BulkMod */
+     , (415, 111,     1.5) /* SizeMod */
+     , (415, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (415,   1, 'Chainmail Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (415,   1,   33554647) /* Setup */
+     , (415,   3,  536870932) /* SoundTable */
+     , (415,   6,   67108990) /* PaletteBase */
+     , (415,   7,  268435521) /* ClothingBase */
+     , (415,   8,  100668142) /* Icon */
+     , (415,  22,  872415275) /* PhysicsEffectTable */
+     , (415,  36,  234881042) /* MutateFilter */
+     , (415,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00416 Chainmail Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00416 Chainmail Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 416;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (416, 'pauldronschainmail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (416,   1,          2) /* ItemType - Armor */
+     , (416,   3,         20) /* PaletteTemplate - Silver */
+     , (416,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (416,   5,        400) /* EncumbranceVal */
+     , (416,   8,        240) /* Mass */
+     , (416,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (416,  16,          1) /* ItemUseable - No */
+     , (416,  19,       1200) /* Value */
+     , (416,  27,         16) /* ArmorType - Chainmail */
+     , (416,  28,        100) /* ArmorLevel */
+     , (416,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (416, 124,          3) /* Version */
+     , (416, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (416,  22, True ) /* Inscribable */
+     , (416, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (416,  12,    0.66) /* Shade */
+     , (416,  13,     1.2) /* ArmorModVsSlash */
+     , (416,  14,       1) /* ArmorModVsPierce */
+     , (416,  15,     0.8) /* ArmorModVsBludgeon */
+     , (416,  16,     0.6) /* ArmorModVsCold */
+     , (416,  17,     0.6) /* ArmorModVsFire */
+     , (416,  18,     0.5) /* ArmorModVsAcid */
+     , (416,  19,     0.4) /* ArmorModVsElectric */
+     , (416,  39,     1.1) /* DefaultScale */
+     , (416, 110,    1.33) /* BulkMod */
+     , (416, 111,       1) /* SizeMod */
+     , (416, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (416,   1, 'Chainmail Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (416,   1,   33554641) /* Setup */
+     , (416,   3,  536870932) /* SoundTable */
+     , (416,   6,   67108990) /* PaletteBase */
+     , (416,   7,  268435534) /* ClothingBase */
+     , (416,   8,  100668170) /* Icon */
+     , (416,  22,  872415275) /* PhysicsEffectTable */
+     , (416,  36,  234881042) /* MutateFilter */
+     , (416,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00458 Leather Cowl.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00458 Leather Cowl.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 458;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (458, 'cowlleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (458,   1,          2) /* ItemType - Armor */
+     , (458,   3,          4) /* PaletteTemplate - Brown */
+     , (458,   4,      16384) /* ClothingPriority - Head */
+     , (458,   5,        188) /* EncumbranceVal */
+     , (458,   8,         75) /* Mass */
+     , (458,   9,          1) /* ValidLocations - HeadWear */
+     , (458,  16,          1) /* ItemUseable - No */
+     , (458,  19,       1100) /* Value */
+     , (458,  27,          2) /* ArmorType - Leather */
+     , (458,  28,        130) /* ArmorLevel */
+     , (458,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (458, 124,          3) /* Version */
+     , (458, 150,        103) /* HookPlacement - Hook */
+     , (458, 151,          2) /* HookType - Wall */
+     , (458, 169,  168493326) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (458,  22, True ) /* Inscribable */
+     , (458, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (458,  12,    0.66) /* Shade */
+     , (458,  13,       1) /* ArmorModVsSlash */
+     , (458,  14,     0.8) /* ArmorModVsPierce */
+     , (458,  15,       1) /* ArmorModVsBludgeon */
+     , (458,  16,     0.5) /* ArmorModVsCold */
+     , (458,  17,     0.5) /* ArmorModVsFire */
+     , (458,  18,     0.3) /* ArmorModVsAcid */
+     , (458,  19,     0.6) /* ArmorModVsElectric */
+     , (458, 110,    1.67) /* BulkMod */
+     , (458, 111,       1) /* SizeMod */
+     , (458, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (458,   1, 'Leather Cowl') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (458,   1,   33555048) /* Setup */
+     , (458,   3,  536870932) /* SoundTable */
+     , (458,   6,   67108990) /* PaletteBase */
+     , (458,   7,  268435466) /* ClothingBase */
+     , (458,   8,  100667323) /* Icon */
+     , (458,  22,  872415275) /* PhysicsEffectTable */
+     , (458,  36,  234881042) /* MutateFilter */
+     , (458,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00550 Baigha.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00550 Baigha.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 550;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (550, 'baigha', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (550,   1,          2) /* ItemType - Armor */
+     , (550,   3,         20) /* PaletteTemplate - Silver */
+     , (550,   4,      16384) /* ClothingPriority - Head */
+     , (550,   5,        533) /* EncumbranceVal */
+     , (550,   8,        200) /* Mass */
+     , (550,   9,          1) /* ValidLocations - HeadWear */
+     , (550,  16,          1) /* ItemUseable - No */
+     , (550,  19,       1600) /* Value */
+     , (550,  27,         32) /* ArmorType - Metal */
+     , (550,  28,        140) /* ArmorLevel */
+     , (550,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (550, 124,          3) /* Version */
+     , (550, 150,        103) /* HookPlacement - Hook */
+     , (550, 151,          2) /* HookType - Wall */
+     , (550, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (550,  22, True ) /* Inscribable */
+     , (550, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (550,  12,    0.66) /* Shade */
+     , (550,  13,       1) /* ArmorModVsSlash */
+     , (550,  14,     1.3) /* ArmorModVsPierce */
+     , (550,  15,       1) /* ArmorModVsBludgeon */
+     , (550,  16,     0.4) /* ArmorModVsCold */
+     , (550,  17,     0.4) /* ArmorModVsFire */
+     , (550,  18,     0.6) /* ArmorModVsAcid */
+     , (550,  19,     0.4) /* ArmorModVsElectric */
+     , (550, 110,       1) /* BulkMod */
+     , (550, 111,       1) /* SizeMod */
+     , (550, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (550,   1, 'Baigha') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (550,   1,   33555048) /* Setup */
+     , (550,   3,  536870932) /* SoundTable */
+     , (550,   6,   67108990) /* PaletteBase */
+     , (550,   7,  268435630) /* ClothingBase */
+     , (550,   8,  100668240) /* Icon */
+     , (550,  22,  872415275) /* PhysicsEffectTable */
+     , (550,  36,  234881042) /* MutateFilter */
+     , (550,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00551 Leather Basinet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00551 Leather Basinet.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 551;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (551, 'basinetleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (551,   1,          2) /* ItemType - Armor */
+     , (551,   3,          4) /* PaletteTemplate - Brown */
+     , (551,   4,      16384) /* ClothingPriority - Head */
+     , (551,   5,        330) /* EncumbranceVal */
+     , (551,   8,        110) /* Mass */
+     , (551,   9,          1) /* ValidLocations - HeadWear */
+     , (551,  16,          1) /* ItemUseable - No */
+     , (551,  19,       1200) /* Value */
+     , (551,  27,          2) /* ArmorType - Leather */
+     , (551,  28,        130) /* ArmorLevel */
+     , (551,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (551, 124,          3) /* Version */
+     , (551, 150,        103) /* HookPlacement - Hook */
+     , (551, 151,          2) /* HookType - Wall */
+     , (551, 169,  168494606) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (551,  22, True ) /* Inscribable */
+     , (551, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (551,  12,    0.66) /* Shade */
+     , (551,  13,       1) /* ArmorModVsSlash */
+     , (551,  14,     0.8) /* ArmorModVsPierce */
+     , (551,  15,       1) /* ArmorModVsBludgeon */
+     , (551,  16,     0.5) /* ArmorModVsCold */
+     , (551,  17,     0.5) /* ArmorModVsFire */
+     , (551,  18,     0.3) /* ArmorModVsAcid */
+     , (551,  19,     0.6) /* ArmorModVsElectric */
+     , (551, 110,    1.25) /* BulkMod */
+     , (551, 111,       1) /* SizeMod */
+     , (551, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (551,   1, 'Leather Basinet') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (551,   1,   33555048) /* Setup */
+     , (551,   3,  536870932) /* SoundTable */
+     , (551,   6,   67108990) /* PaletteBase */
+     , (551,   7,  268435512) /* ClothingBase */
+     , (551,   8,  100668241) /* Icon */
+     , (551,  22,  872415275) /* PhysicsEffectTable */
+     , (551,  36,  234881042) /* MutateFilter */
+     , (551,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00552 Scalemail Basinet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00552 Scalemail Basinet.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 552;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (552, 'basinetscalemail', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (552,   1,          2) /* ItemType - Armor */
+     , (552,   3,         20) /* PaletteTemplate - Silver */
+     , (552,   4,      16384) /* ClothingPriority - Head */
+     , (552,   5,        360) /* EncumbranceVal */
+     , (552,   8,        180) /* Mass */
+     , (552,   9,          1) /* ValidLocations - HeadWear */
+     , (552,  16,          1) /* ItemUseable - No */
+     , (552,  19,        553) /* Value */
+     , (552,  27,          8) /* ArmorType - Scalemail */
+     , (552,  28,        140) /* ArmorLevel */
+     , (552,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (552, 124,          3) /* Version */
+     , (552, 150,        103) /* HookPlacement - Hook */
+     , (552, 151,          2) /* HookType - Wall */
+     , (552, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (552,  22, True ) /* Inscribable */
+     , (552, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (552,  12,    0.66) /* Shade */
+     , (552,  13,       1) /* ArmorModVsSlash */
+     , (552,  14,     1.1) /* ArmorModVsPierce */
+     , (552,  15,       1) /* ArmorModVsBludgeon */
+     , (552,  16,     0.4) /* ArmorModVsCold */
+     , (552,  17,     0.4) /* ArmorModVsFire */
+     , (552,  18,     0.6) /* ArmorModVsAcid */
+     , (552,  19,     0.4) /* ArmorModVsElectric */
+     , (552, 110,     1.1) /* BulkMod */
+     , (552, 111,       1) /* SizeMod */
+     , (552, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (552,   1, 'Scalemail Basinet') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (552,   1,   33555048) /* Setup */
+     , (552,   3,  536870932) /* SoundTable */
+     , (552,   6,   67108990) /* PaletteBase */
+     , (552,   7,  268435515) /* ClothingBase */
+     , (552,   8,  100668242) /* Icon */
+     , (552,  22,  872415275) /* PhysicsEffectTable */
+     , (552,  36,  234881042) /* MutateFilter */
+     , (552,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00554 Studded Leather Basinet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00554 Studded Leather Basinet.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 554;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (554, 'basinetstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (554,   1,          2) /* ItemType - Armor */
+     , (554,   3,          4) /* PaletteTemplate - Brown */
+     , (554,   4,      16384) /* ClothingPriority - Head */
+     , (554,   5,        375) /* EncumbranceVal */
+     , (554,   8,        125) /* Mass */
+     , (554,   9,          1) /* ValidLocations - HeadWear */
+     , (554,  16,          1) /* ItemUseable - No */
+     , (554,  19,       1300) /* Value */
+     , (554,  27,          4) /* ArmorType - StuddedLeather */
+     , (554,  28,        130) /* ArmorLevel */
+     , (554,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (554, 124,          3) /* Version */
+     , (554, 150,        103) /* HookPlacement - Hook */
+     , (554, 151,          2) /* HookType - Wall */
+     , (554, 169,  168494606) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (554,  22, True ) /* Inscribable */
+     , (554, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (554,  12,     0.5) /* Shade */
+     , (554,  13,     1.2) /* ArmorModVsSlash */
+     , (554,  14,     1.1) /* ArmorModVsPierce */
+     , (554,  15,       1) /* ArmorModVsBludgeon */
+     , (554,  16,     0.4) /* ArmorModVsCold */
+     , (554,  17,     0.7) /* ArmorModVsFire */
+     , (554,  18,     0.3) /* ArmorModVsAcid */
+     , (554,  19,     0.4) /* ArmorModVsElectric */
+     , (554, 110,    1.33) /* BulkMod */
+     , (554, 111,       1) /* SizeMod */
+     , (554, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (554,   1, 'Studded Leather Basinet') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (554,   1,   33555048) /* Setup */
+     , (554,   3,  536870932) /* SoundTable */
+     , (554,   6,   67108990) /* PaletteBase */
+     , (554,   7,  268435513) /* ClothingBase */
+     , (554,   8,  100668243) /* Icon */
+     , (554,  22,  872415275) /* PhysicsEffectTable */
+     , (554,  36,  234881042) /* MutateFilter */
+     , (554,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00723 Studded Leather Cowl.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00723 Studded Leather Cowl.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 723;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (723, 'cowlstuddedleather', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (723,   1,          2) /* ItemType - Armor */
+     , (723,   3,          4) /* PaletteTemplate - Brown */
+     , (723,   4,      16384) /* ClothingPriority - Head */
+     , (723,   5,        255) /* EncumbranceVal */
+     , (723,   8,         90) /* Mass */
+     , (723,   9,          1) /* ValidLocations - HeadWear */
+     , (723,  16,          1) /* ItemUseable - No */
+     , (723,  19,        110) /* Value */
+     , (723,  27,          2) /* ArmorType - Leather */
+     , (723,  28,        130) /* ArmorLevel */
+     , (723,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (723, 124,          3) /* Version */
+     , (723, 150,        103) /* HookPlacement - Hook */
+     , (723, 151,          2) /* HookType - Wall */
+     , (723, 169,  168493326) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (723,  22, True ) /* Inscribable */
+     , (723, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (723,  12,    0.66) /* Shade */
+     , (723,  13,     1.2) /* ArmorModVsSlash */
+     , (723,  14,     1.1) /* ArmorModVsPierce */
+     , (723,  15,       1) /* ArmorModVsBludgeon */
+     , (723,  16,     0.2) /* ArmorModVsCold */
+     , (723,  17,     0.2) /* ArmorModVsFire */
+     , (723,  18,     0.1) /* ArmorModVsAcid */
+     , (723,  19,     0.2) /* ArmorModVsElectric */
+     , (723, 110,     1.5) /* BulkMod */
+     , (723, 111,       1) /* SizeMod */
+     , (723, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (723,   1, 'Studded Leather Cowl') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (723,   1,   33555048) /* Setup */
+     , (723,   3,  536870932) /* SoundTable */
+     , (723,   6,   67108990) /* PaletteBase */
+     , (723,   7,  268435466) /* ClothingBase */
+     , (723,   8,  100667323) /* Icon */
+     , (723,  22,  872415275) /* PhysicsEffectTable */
+     , (723,  36,  234881042) /* MutateFilter */
+     , (723,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00793 Scalemail Coif.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/00793 Scalemail Coif.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 793;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (793, 'coifscale', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (793,   1,          2) /* ItemType - Armor */
+     , (793,   3,         20) /* PaletteTemplate - Silver */
+     , (793,   4,      16384) /* ClothingPriority - Head */
+     , (793,   5,        266) /* EncumbranceVal */
+     , (793,   8,        160) /* Mass */
+     , (793,   9,          1) /* ValidLocations - HeadWear */
+     , (793,  16,          1) /* ItemUseable - No */
+     , (793,  19,        433) /* Value */
+     , (793,  27,         16) /* ArmorType - Chainmail */
+     , (793,  28,        140) /* ArmorLevel */
+     , (793,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (793, 124,          3) /* Version */
+     , (793, 150,        103) /* HookPlacement - Hook */
+     , (793, 151,          2) /* HookType - Wall */
+     , (793, 169,  168427780) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (793,  22, True ) /* Inscribable */
+     , (793, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (793,  12,    0.66) /* Shade */
+     , (793,  13,       1) /* ArmorModVsSlash */
+     , (793,  14,     1.1) /* ArmorModVsPierce */
+     , (793,  15,       1) /* ArmorModVsBludgeon */
+     , (793,  16,     0.4) /* ArmorModVsCold */
+     , (793,  17,     0.4) /* ArmorModVsFire */
+     , (793,  18,     0.6) /* ArmorModVsAcid */
+     , (793,  19,     0.4) /* ArmorModVsElectric */
+     , (793, 110,     1.2) /* BulkMod */
+     , (793, 111,       1) /* SizeMod */
+     , (793, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (793,   1, 'Scalemail Coif') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (793,   1,   33555048) /* Setup */
+     , (793,   3,  536870932) /* SoundTable */
+     , (793,   6,   67108990) /* PaletteBase */
+     , (793,   7,  268435613) /* ClothingBase */
+     , (793,   8,  100667338) /* Icon */
+     , (793,  22,  872415275) /* PhysicsEffectTable */
+     , (793,  36,  234881042) /* MutateFilter */
+     , (793,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/02437 Yoroi Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/02437 Yoroi Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 2437;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (2437, 'leggingsyoroi', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (2437,   1,          2) /* ItemType - Armor */
+     , (2437,   3,         20) /* PaletteTemplate - Silver */
+     , (2437,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (2437,   5,       1099) /* EncumbranceVal */
+     , (2437,   8,        660) /* Mass */
+     , (2437,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (2437,  16,          1) /* ItemUseable - No */
+     , (2437,  19,       2000) /* Value */
+     , (2437,  27,         32) /* ArmorType - Metal */
+     , (2437,  28,        100) /* ArmorLevel */
+     , (2437,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (2437, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (2437,  22, True ) /* Inscribable */
+     , (2437, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (2437,  12,    0.66) /* Shade */
+     , (2437,  13,     1.3) /* ArmorModVsSlash */
+     , (2437,  14,       1) /* ArmorModVsPierce */
+     , (2437,  15,       1) /* ArmorModVsBludgeon */
+     , (2437,  16,     0.4) /* ArmorModVsCold */
+     , (2437,  17,     0.4) /* ArmorModVsFire */
+     , (2437,  18,     0.6) /* ArmorModVsAcid */
+     , (2437,  19,     0.4) /* ArmorModVsElectric */
+     , (2437, 110,     1.5) /* BulkMod */
+     , (2437, 111,     1.5) /* SizeMod */
+     , (2437, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (2437,   1, 'Yoroi Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (2437,   1,   33554856) /* Setup */
+     , (2437,   3,  536870932) /* SoundTable */
+     , (2437,   6,   67108990) /* PaletteBase */
+     , (2437,   7,  268435697) /* ClothingBase */
+     , (2437,   8,  100668169) /* Icon */
+     , (2437,  22,  872415275) /* PhysicsEffectTable */
+     , (2437,  36,  234881042) /* MutateFilter */
+     , (2437,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/02437 Yoroi Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/02437 Yoroi Leggings.sql
@@ -15,6 +15,7 @@ VALUES (2437,   1,          2) /* ItemType - Armor */
      , (2437,  27,         32) /* ArmorType - Metal */
      , (2437,  28,        100) /* ArmorLevel */
      , (2437,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (2437, 124,          3) /* Version */
      , (2437, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/02605 Chainmail Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/02605 Chainmail Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 2605;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (2605, 'greaveschainmail', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (2605,   1,          2) /* ItemType - Armor */
+     , (2605,   3,         20) /* PaletteTemplate - Silver */
+     , (2605,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (2605,   5,        280) /* EncumbranceVal */
+     , (2605,   8,        260) /* Mass */
+     , (2605,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (2605,  16,          1) /* ItemUseable - No */
+     , (2605,  19,       1400) /* Value */
+     , (2605,  27,         16) /* ArmorType - Chainmail */
+     , (2605,  28,        100) /* ArmorLevel */
+     , (2605,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (2605, 124,          3) /* Version */
+     , (2605, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (2605,  22, True ) /* Inscribable */
+     , (2605, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (2605,  12,    0.66) /* Shade */
+     , (2605,  13,     1.2) /* ArmorModVsSlash */
+     , (2605,  14,       1) /* ArmorModVsPierce */
+     , (2605,  15,     0.8) /* ArmorModVsBludgeon */
+     , (2605,  16,     0.6) /* ArmorModVsCold */
+     , (2605,  17,     0.6) /* ArmorModVsFire */
+     , (2605,  18,     0.5) /* ArmorModVsAcid */
+     , (2605,  19,     0.4) /* ArmorModVsElectric */
+     , (2605,  39,    1.33) /* DefaultScale */
+     , (2605, 110,    1.33) /* BulkMod */
+     , (2605, 111,       1) /* SizeMod */
+     , (2605, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (2605,   1, 'Chainmail Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (2605,   1,   33554641) /* Setup */
+     , (2605,   3,  536870932) /* SoundTable */
+     , (2605,   6,   67108990) /* PaletteBase */
+     , (2605,   7,  268435696) /* ClothingBase */
+     , (2605,   8,  100668804) /* Icon */
+     , (2605,  22,  872415275) /* PhysicsEffectTable */
+     , (2605,  36,  234881042) /* MutateFilter */
+     , (2605,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06003 Koujia Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06003 Koujia Breastplate.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6003;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6003, 'breastplatekoujia', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6003,   1,          2) /* ItemType - Armor */
+     , (6003,   3,         20) /* PaletteTemplate - Silver */
+     , (6003,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (6003,   5,       1415) /* EncumbranceVal */
+     , (6003,   8,        850) /* Mass */
+     , (6003,   9,        512) /* ValidLocations - ChestArmor */
+     , (6003,  16,          1) /* ItemUseable - No */
+     , (6003,  19,       1545) /* Value */
+     , (6003,  27,         32) /* ArmorType - Metal */
+     , (6003,  28,        100) /* ArmorLevel */
+     , (6003,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6003, 124,          3) /* Version */
+     , (6003, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6003,  22, True ) /* Inscribable */
+     , (6003, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6003,  12,    0.33) /* Shade */
+     , (6003,  13,     1.3) /* ArmorModVsSlash */
+     , (6003,  14,       1) /* ArmorModVsPierce */
+     , (6003,  15,       1) /* ArmorModVsBludgeon */
+     , (6003,  16,     0.4) /* ArmorModVsCold */
+     , (6003,  17,     0.4) /* ArmorModVsFire */
+     , (6003,  18,     0.6) /* ArmorModVsAcid */
+     , (6003,  19,     0.4) /* ArmorModVsElectric */
+     , (6003, 110,    1.05) /* BulkMod */
+     , (6003, 111,     1.3) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6003,   1, 'Koujia Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6003,   1,   33554642) /* Setup */
+     , (6003,   3,  536870932) /* SoundTable */
+     , (6003,   6,   67108990) /* PaletteBase */
+     , (6003,   7,  268435852) /* ClothingBase */
+     , (6003,   8,  100670451) /* Icon */
+     , (6003,  22,  872415275) /* PhysicsEffectTable */
+     , (6003,  36,  234881042) /* MutateFilter */
+     , (6003,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06004 Koujia Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06004 Koujia Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6004;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6004, 'leggingskoujia', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6004,   1,          2) /* ItemType - Armor */
+     , (6004,   3,         20) /* PaletteTemplate - Silver */
+     , (6004,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (6004,   5,       2247) /* EncumbranceVal */
+     , (6004,   8,       1350) /* Mass */
+     , (6004,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
+     , (6004,  16,          1) /* ItemUseable - No */
+     , (6004,  19,       2157) /* Value */
+     , (6004,  27,         32) /* ArmorType - Metal */
+     , (6004,  28,        100) /* ArmorLevel */
+     , (6004,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6004, 124,          3) /* Version */
+     , (6004, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6004,  22, True ) /* Inscribable */
+     , (6004, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6004,  12,    0.66) /* Shade */
+     , (6004,  13,     1.3) /* ArmorModVsSlash */
+     , (6004,  14,       1) /* ArmorModVsPierce */
+     , (6004,  15,       1) /* ArmorModVsBludgeon */
+     , (6004,  16,     0.4) /* ArmorModVsCold */
+     , (6004,  17,     0.4) /* ArmorModVsFire */
+     , (6004,  18,     0.6) /* ArmorModVsAcid */
+     , (6004,  19,     0.4) /* ArmorModVsElectric */
+     , (6004, 110,    1.05) /* BulkMod */
+     , (6004, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6004,   1, 'Koujia Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6004,   1,   33554856) /* Setup */
+     , (6004,   3,  536870932) /* SoundTable */
+     , (6004,   6,   67108990) /* PaletteBase */
+     , (6004,   7,  268435849) /* ClothingBase */
+     , (6004,   8,  100670459) /* Icon */
+     , (6004,  22,  872415275) /* PhysicsEffectTable */
+     , (6004,  36,  234881042) /* MutateFilter */
+     , (6004,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06005 Koujia Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06005 Koujia Sleeves.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6005;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6005, 'sleeveskoujia', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6005,   1,          2) /* ItemType - Armor */
+     , (6005,   3,          9) /* PaletteTemplate - Grey */
+     , (6005,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (6005,   5,       1375) /* EncumbranceVal */
+     , (6005,   8,        550) /* Mass */
+     , (6005,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (6005,  16,          1) /* ItemUseable - No */
+     , (6005,  19,       1620) /* Value */
+     , (6005,  27,          2) /* ArmorType - Leather */
+     , (6005,  28,         90) /* ArmorLevel */
+     , (6005,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6005, 124,          3) /* Version */
+     , (6005, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6005,  22, True ) /* Inscribable */
+     , (6005, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6005,  12,    0.66) /* Shade */
+     , (6005,  13,       1) /* ArmorModVsSlash */
+     , (6005,  14,     0.8) /* ArmorModVsPierce */
+     , (6005,  15,       1) /* ArmorModVsBludgeon */
+     , (6005,  16,     0.5) /* ArmorModVsCold */
+     , (6005,  17,     0.5) /* ArmorModVsFire */
+     , (6005,  18,     0.3) /* ArmorModVsAcid */
+     , (6005,  19,     0.6) /* ArmorModVsElectric */
+     , (6005, 110,    1.05) /* BulkMod */
+     , (6005, 111,     1.2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6005,   1, 'Koujia Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6005,   1,   33554655) /* Setup */
+     , (6005,   3,  536870932) /* SoundTable */
+     , (6005,   6,   67108990) /* PaletteBase */
+     , (6005,   7,  268435851) /* ClothingBase */
+     , (6005,   8,  100670467) /* Icon */
+     , (6005,  22,  872415275) /* PhysicsEffectTable */
+     , (6005,  36,  234881042) /* MutateFilter */
+     , (6005,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06043 Celdon Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06043 Celdon Girth.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6043;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6043, 'girthceldon', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6043,   1,          2) /* ItemType - Armor */
+     , (6043,   3,         20) /* PaletteTemplate - Silver */
+     , (6043,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (6043,   5,       1248) /* EncumbranceVal */
+     , (6043,   8,        625) /* Mass */
+     , (6043,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (6043,  16,          1) /* ItemUseable - No */
+     , (6043,  19,       1072) /* Value */
+     , (6043,  27,         32) /* ArmorType - Metal */
+     , (6043,  28,        110) /* ArmorLevel */
+     , (6043,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6043, 124,          3) /* Version */
+     , (6043, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6043,  22, True ) /* Inscribable */
+     , (6043, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6043,  12,    0.33) /* Shade */
+     , (6043,  13,     1.3) /* ArmorModVsSlash */
+     , (6043,  14,       1) /* ArmorModVsPierce */
+     , (6043,  15,       1) /* ArmorModVsBludgeon */
+     , (6043,  16,     0.4) /* ArmorModVsCold */
+     , (6043,  17,     0.4) /* ArmorModVsFire */
+     , (6043,  18,     0.6) /* ArmorModVsAcid */
+     , (6043,  19,     0.4) /* ArmorModVsElectric */
+     , (6043, 110,     0.9) /* BulkMod */
+     , (6043, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6043,   1, 'Celdon Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6043,   1,   33554647) /* Setup */
+     , (6043,   3,  536870932) /* SoundTable */
+     , (6043,   6,   67108990) /* PaletteBase */
+     , (6043,   7,  268435843) /* ClothingBase */
+     , (6043,   8,  100670411) /* Icon */
+     , (6043,  22,  872415275) /* PhysicsEffectTable */
+     , (6043,  36,  234881042) /* MutateFilter */
+     , (6043,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06044 Celdon Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06044 Celdon Breastplate.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6044;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6044, 'breastplateceldon', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6044,   1,          2) /* ItemType - Armor */
+     , (6044,   3,         20) /* PaletteTemplate - Silver */
+     , (6044,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (6044,   5,       2400) /* EncumbranceVal */
+     , (6044,   8,       1200) /* Mass */
+     , (6044,   9,        512) /* ValidLocations - ChestArmor */
+     , (6044,  16,          1) /* ItemUseable - No */
+     , (6044,  19,       1785) /* Value */
+     , (6044,  27,         32) /* ArmorType - Metal */
+     , (6044,  28,        110) /* ArmorLevel */
+     , (6044,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6044, 124,          3) /* Version */
+     , (6044, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6044,  22, True ) /* Inscribable */
+     , (6044, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6044,  12,    0.33) /* Shade */
+     , (6044,  13,     1.3) /* ArmorModVsSlash */
+     , (6044,  14,       1) /* ArmorModVsPierce */
+     , (6044,  15,       1) /* ArmorModVsBludgeon */
+     , (6044,  16,     0.4) /* ArmorModVsCold */
+     , (6044,  17,     0.4) /* ArmorModVsFire */
+     , (6044,  18,     0.6) /* ArmorModVsAcid */
+     , (6044,  19,     0.4) /* ArmorModVsElectric */
+     , (6044, 110,     0.9) /* BulkMod */
+     , (6044, 111,     1.3) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6044,   1, 'Celdon Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6044,   1,   33554642) /* Setup */
+     , (6044,   3,  536870932) /* SoundTable */
+     , (6044,   6,   67108990) /* PaletteBase */
+     , (6044,   7,  268435848) /* ClothingBase */
+     , (6044,   8,  100670403) /* Icon */
+     , (6044,  22,  872415275) /* PhysicsEffectTable */
+     , (6044,  36,  234881042) /* MutateFilter */
+     , (6044,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06045 Celdon Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06045 Celdon Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6045;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6045, 'leggingsceldon', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6045,   1,          2) /* ItemType - Armor */
+     , (6045,   3,         20) /* PaletteTemplate - Silver */
+     , (6045,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (6045,   5,       2400) /* EncumbranceVal */
+     , (6045,   8,       1200) /* Mass */
+     , (6045,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (6045,  16,          1) /* ItemUseable - No */
+     , (6045,  19,       1425) /* Value */
+     , (6045,  27,         32) /* ArmorType - Metal */
+     , (6045,  28,        110) /* ArmorLevel */
+     , (6045,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6045, 124,          3) /* Version */
+     , (6045, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6045,  22, True ) /* Inscribable */
+     , (6045, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6045,  12,    0.66) /* Shade */
+     , (6045,  13,     1.3) /* ArmorModVsSlash */
+     , (6045,  14,       1) /* ArmorModVsPierce */
+     , (6045,  15,       1) /* ArmorModVsBludgeon */
+     , (6045,  16,     0.4) /* ArmorModVsCold */
+     , (6045,  17,     0.4) /* ArmorModVsFire */
+     , (6045,  18,     0.6) /* ArmorModVsAcid */
+     , (6045,  19,     0.4) /* ArmorModVsElectric */
+     , (6045, 110,     0.9) /* BulkMod */
+     , (6045, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6045,   1, 'Celdon Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6045,   1,   33554856) /* Setup */
+     , (6045,   3,  536870932) /* SoundTable */
+     , (6045,   6,   67108990) /* PaletteBase */
+     , (6045,   7,  268435844) /* ClothingBase */
+     , (6045,   8,  100670419) /* Icon */
+     , (6045,  22,  872415275) /* PhysicsEffectTable */
+     , (6045,  36,  234881042) /* MutateFilter */
+     , (6045,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06046 Amuli Coat.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06046 Amuli Coat.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6046;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6046, 'coatamullian', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6046,   1,          2) /* ItemType - Armor */
+     , (6046,   3,         20) /* PaletteTemplate - Silver */
+     , (6046,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (6046,   5,       1665) /* EncumbranceVal */
+     , (6046,   8,       1000) /* Mass */
+     , (6046,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (6046,  16,          1) /* ItemUseable - No */
+     , (6046,  19,       1738) /* Value */
+     , (6046,  27,          8) /* ArmorType - Scalemail */
+     , (6046,  28,        100) /* ArmorLevel */
+     , (6046,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6046, 124,          3) /* Version */
+     , (6046, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6046,  22, True ) /* Inscribable */
+     , (6046, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6046,  12,    0.66) /* Shade */
+     , (6046,  13,       1) /* ArmorModVsSlash */
+     , (6046,  14,     1.1) /* ArmorModVsPierce */
+     , (6046,  15,       1) /* ArmorModVsBludgeon */
+     , (6046,  16,     0.4) /* ArmorModVsCold */
+     , (6046,  17,     0.4) /* ArmorModVsFire */
+     , (6046,  18,     0.6) /* ArmorModVsAcid */
+     , (6046,  19,     0.4) /* ArmorModVsElectric */
+     , (6046, 110,     1.1) /* BulkMod */
+     , (6046, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6046,   1, 'Amuli Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6046,   1,   33554854) /* Setup */
+     , (6046,   3,  536870932) /* SoundTable */
+     , (6046,   6,   67108990) /* PaletteBase */
+     , (6046,   7,  268435873) /* ClothingBase */
+     , (6046,   8,  100670435) /* Icon */
+     , (6046,  22,  872415275) /* PhysicsEffectTable */
+     , (6046,  36,  234881042) /* MutateFilter */
+     , (6046,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06047 Amuli Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06047 Amuli Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6047;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6047, 'leggingsamullian', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6047,   1,          2) /* ItemType - Armor */
+     , (6047,   3,          9) /* PaletteTemplate - Grey */
+     , (6047,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (6047,   5,       3188) /* EncumbranceVal */
+     , (6047,   8,       1275) /* Mass */
+     , (6047,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
+     , (6047,  16,          1) /* ItemUseable - No */
+     , (6047,  19,       3040) /* Value */
+     , (6047,  27,          2) /* ArmorType - Leather */
+     , (6047,  28,        100) /* ArmorLevel */
+     , (6047,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6047, 124,          3) /* Version */
+     , (6047, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6047,  22, True ) /* Inscribable */
+     , (6047, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6047,  12,     0.5) /* Shade */
+     , (6047,  13,       1) /* ArmorModVsSlash */
+     , (6047,  14,     0.8) /* ArmorModVsPierce */
+     , (6047,  15,       1) /* ArmorModVsBludgeon */
+     , (6047,  16,     0.5) /* ArmorModVsCold */
+     , (6047,  17,     0.5) /* ArmorModVsFire */
+     , (6047,  18,     0.3) /* ArmorModVsAcid */
+     , (6047,  19,     0.6) /* ArmorModVsElectric */
+     , (6047, 110,     1.1) /* BulkMod */
+     , (6047, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6047,   1, 'Amuli Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6047,   1,   33554856) /* Setup */
+     , (6047,   3,  536870932) /* SoundTable */
+     , (6047,   6,   67108990) /* PaletteBase */
+     , (6047,   7,  268435872) /* ClothingBase */
+     , (6047,   8,  100670443) /* Icon */
+     , (6047,  22,  872415275) /* PhysicsEffectTable */
+     , (6047,  36,  234881042) /* MutateFilter */
+     , (6047,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06048 Celdon Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/06048 Celdon Sleeves.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6048;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6048, 'sleevesceldon', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6048,   1,          2) /* ItemType - Armor */
+     , (6048,   3,         20) /* PaletteTemplate - Silver */
+     , (6048,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (6048,   5,       1400) /* EncumbranceVal */
+     , (6048,   8,        700) /* Mass */
+     , (6048,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (6048,  16,          1) /* ItemUseable - No */
+     , (6048,  19,       1247) /* Value */
+     , (6048,  27,         32) /* ArmorType - Metal */
+     , (6048,  28,        110) /* ArmorLevel */
+     , (6048,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (6048, 124,          3) /* Version */
+     , (6048, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6048,  22, True ) /* Inscribable */
+     , (6048, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6048,  12,    0.66) /* Shade */
+     , (6048,  13,     1.3) /* ArmorModVsSlash */
+     , (6048,  14,       1) /* ArmorModVsPierce */
+     , (6048,  15,       1) /* ArmorModVsBludgeon */
+     , (6048,  16,     0.4) /* ArmorModVsCold */
+     , (6048,  17,     0.4) /* ArmorModVsFire */
+     , (6048,  18,     0.6) /* ArmorModVsAcid */
+     , (6048,  19,     0.4) /* ArmorModVsElectric */
+     , (6048, 110,     0.9) /* BulkMod */
+     , (6048, 111,     1.2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6048,   1, 'Celdon Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6048,   1,   33554655) /* Setup */
+     , (6048,   3,  536870932) /* SoundTable */
+     , (6048,   6,   67108990) /* PaletteBase */
+     , (6048,   7,  268435847) /* ClothingBase */
+     , (6048,   8,  100670427) /* Icon */
+     , (6048,  22,  872415275) /* PhysicsEffectTable */
+     , (6048,  36,  234881042) /* MutateFilter */
+     , (6048,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/07897 Steel Toed Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/07897 Steel Toed Boots.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 7897;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (7897, 'bootssteeltoe', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (7897,   1,          2) /* ItemType - Armor */
+     , (7897,   3,          4) /* PaletteTemplate - Brown */
+     , (7897,   4,      65536) /* ClothingPriority - Feet */
+     , (7897,   5,        750) /* EncumbranceVal */
+     , (7897,   8,        230) /* Mass */
+     , (7897,   9,        384) /* ValidLocations - LowerLegWear, FootWear */
+     , (7897,  16,          1) /* ItemUseable - No */
+     , (7897,  19,        210) /* Value */
+     , (7897,  27,          4) /* ArmorType - StuddedLeather */
+     , (7897,  28,        130) /* ArmorLevel */
+     , (7897,  44,          3) /* Damage */
+     , (7897,  45,          4) /* DamageType - Bludgeon */
+     , (7897,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (7897, 124,          3) /* Version */
+     , (7897, 169,  185271566) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (7897,  22, True ) /* Inscribable */
+     , (7897, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (7897,  12,     0.1) /* Shade */
+     , (7897,  13,     1.2) /* ArmorModVsSlash */
+     , (7897,  14,     1.1) /* ArmorModVsPierce */
+     , (7897,  15,       1) /* ArmorModVsBludgeon */
+     , (7897,  16,     0.4) /* ArmorModVsCold */
+     , (7897,  17,     0.4) /* ArmorModVsFire */
+     , (7897,  18,     0.2) /* ArmorModVsAcid */
+     , (7897,  19,     0.4) /* ArmorModVsElectric */
+     , (7897,  22,    0.75) /* DamageVariance */
+     , (7897, 110,     1.5) /* BulkMod */
+     , (7897, 111,       2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (7897,   1, 'Steel Toed Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (7897,   1,   33556683) /* Setup */
+     , (7897,   3,  536870932) /* SoundTable */
+     , (7897,   6,   67108990) /* PaletteBase */
+     , (7897,   7,  268436025) /* ClothingBase */
+     , (7897,   8,  100668177) /* Icon */
+     , (7897,  22,  872415275) /* PhysicsEffectTable */
+     , (7897,  36,  234881042) /* MutateFilter */
+     , (7897,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/08396 Heaume.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/08396 Heaume.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 8396;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (8396, 'heaumeold', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (8396, 'heaumeold', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (8396,   1,          2) /* ItemType - Armor */
@@ -11,10 +11,11 @@ VALUES (8396,   1,          2) /* ItemType - Armor */
      , (8396,   8,        300) /* Mass */
      , (8396,   9,          1) /* ValidLocations - HeadWear */
      , (8396,  16,          1) /* ItemUseable - No */
-     , (8396,  19,       1185) /* Value */
+     , (8396,  19,       2200) /* Value */
      , (8396,  27,         32) /* ArmorType - Metal */
      , (8396,  28,        150) /* ArmorLevel */
      , (8396,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (8396, 124,          3) /* Version */
      , (8396, 150,        103) /* HookPlacement - Hook */
      , (8396, 151,          2) /* HookType - Wall */
      , (8396, 169,  168429060) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/08488 Armet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/08488 Armet.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8488;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8488, 'armet', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8488,   1,          2) /* ItemType - Armor */
+     , (8488,   3,         20) /* PaletteTemplate - Silver */
+     , (8488,   4,      16384) /* ClothingPriority - Head */
+     , (8488,   5,        600) /* EncumbranceVal */
+     , (8488,   8,        300) /* Mass */
+     , (8488,   9,          1) /* ValidLocations - HeadWear */
+     , (8488,  16,          1) /* ItemUseable - No */
+     , (8488,  19,       2100) /* Value */
+     , (8488,  27,         32) /* ArmorType - Metal */
+     , (8488,  28,        150) /* ArmorLevel */
+     , (8488,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (8488, 124,          3) /* Version */
+     , (8488, 150,        103) /* HookPlacement - Hook */
+     , (8488, 151,          2) /* HookType - Wall */
+     , (8488, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8488,  22, True ) /* Inscribable */
+     , (8488, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8488,  12,    0.66) /* Shade */
+     , (8488,  13,     1.3) /* ArmorModVsSlash */
+     , (8488,  14,       1) /* ArmorModVsPierce */
+     , (8488,  15,       1) /* ArmorModVsBludgeon */
+     , (8488,  16,     0.4) /* ArmorModVsCold */
+     , (8488,  17,     0.4) /* ArmorModVsFire */
+     , (8488,  18,     0.6) /* ArmorModVsAcid */
+     , (8488,  19,     0.4) /* ArmorModVsElectric */
+     , (8488, 110,     0.8) /* BulkMod */
+     , (8488, 111,       1) /* SizeMod */
+     , (8488, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8488,   1, 'Armet') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8488,   1,   33556856) /* Setup */
+     , (8488,   3,  536870932) /* SoundTable */
+     , (8488,   6,   67108990) /* PaletteBase */
+     , (8488,   7,  268436075) /* ClothingBase */
+     , (8488,   8,  100667343) /* Icon */
+     , (8488,  22,  872415275) /* PhysicsEffectTable */
+     , (8488,  36,  234881042) /* MutateFilter */
+     , (8488,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/08489 Heaume.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/08489 Heaume.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8489;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8489, 'heaumenew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8489,   1,          2) /* ItemType - Armor */
+     , (8489,   3,         20) /* PaletteTemplate - Silver */
+     , (8489,   4,      16384) /* ClothingPriority - Head */
+     , (8489,   5,        600) /* EncumbranceVal */
+     , (8489,   8,        300) /* Mass */
+     , (8489,   9,          1) /* ValidLocations - HeadWear */
+     , (8489,  16,          1) /* ItemUseable - No */
+     , (8489,  19,       2200) /* Value */
+     , (8489,  27,         32) /* ArmorType - Metal */
+     , (8489,  28,        150) /* ArmorLevel */
+     , (8489,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (8489, 124,          3) /* Version */
+     , (8489, 150,        103) /* HookPlacement - Hook */
+     , (8489, 151,          2) /* HookType - Wall */
+     , (8489, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8489,  22, True ) /* Inscribable */
+     , (8489, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8489,  12,    0.66) /* Shade */
+     , (8489,  13,     1.3) /* ArmorModVsSlash */
+     , (8489,  14,       1) /* ArmorModVsPierce */
+     , (8489,  15,       1) /* ArmorModVsBludgeon */
+     , (8489,  16,     0.4) /* ArmorModVsCold */
+     , (8489,  17,     0.4) /* ArmorModVsFire */
+     , (8489,  18,     0.6) /* ArmorModVsAcid */
+     , (8489,  19,     0.4) /* ArmorModVsElectric */
+     , (8489, 110,     0.8) /* BulkMod */
+     , (8489, 111,       1) /* SizeMod */
+     , (8489, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8489,   1, 'Heaume') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8489,   1,   33556883) /* Setup */
+     , (8489,   3,  536870932) /* SoundTable */
+     , (8489,   6,   67108990) /* PaletteBase */
+     , (8489,   7,  268436088) /* ClothingBase */
+     , (8489,   8,  100667349) /* Icon */
+     , (8489,  22,  872415275) /* PhysicsEffectTable */
+     , (8489,  36,  234881042) /* MutateFilter */
+     , (8489,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21150 Covenant Sollerets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21150 Covenant Sollerets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21150;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21150, 'bootscovenant', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21150,   1,          2) /* ItemType - Armor */
+     , (21150,   3,         20) /* PaletteTemplate - Silver */
+     , (21150,   4,      65536) /* ClothingPriority - Feet */
+     , (21150,   5,        540) /* EncumbranceVal */
+     , (21150,   8,        360) /* Mass */
+     , (21150,   9,        256) /* ValidLocations - FootWear */
+     , (21150,  16,          1) /* ItemUseable - No */
+     , (21150,  19,        653) /* Value */
+     , (21150,  27,         32) /* ArmorType - Metal */
+     , (21150,  28,        200) /* ArmorLevel */
+     , (21150,  36,       9999) /* ResistMagic */
+     , (21150,  44,          3) /* Damage */
+     , (21150,  45,          4) /* DamageType - Bludgeon */
+     , (21150,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21150, 124,          3) /* Version */
+     , (21150, 169,  185204996) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21150,  22, True ) /* Inscribable */
+     , (21150, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21150,  12,    0.66) /* Shade */
+     , (21150,  13,     1.3) /* ArmorModVsSlash */
+     , (21150,  14,     1.3) /* ArmorModVsPierce */
+     , (21150,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21150,  16,     0.6) /* ArmorModVsCold */
+     , (21150,  17,     0.6) /* ArmorModVsFire */
+     , (21150,  18,     0.6) /* ArmorModVsAcid */
+     , (21150,  19,     0.6) /* ArmorModVsElectric */
+     , (21150,  22,    0.75) /* DamageVariance */
+     , (21150, 110,       1) /* BulkMod */
+     , (21150, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21150,   1, 'Covenant Sollerets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21150,   1,   33554654) /* Setup */
+     , (21150,   3,  536870932) /* SoundTable */
+     , (21150,   6,   67108990) /* PaletteBase */
+     , (21150,   7,  268436450) /* ClothingBase */
+     , (21150,   8,  100667309) /* Icon */
+     , (21150,  22,  872415275) /* PhysicsEffectTable */
+     , (21150,  36,  234881046) /* MutateFilter */
+     , (21150,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21151 Covenant Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21151 Covenant Bracers.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21151;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21151, 'bracerscovenant', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21151,   1,          2) /* ItemType - Armor */
+     , (21151,   3,         20) /* PaletteTemplate - Silver */
+     , (21151,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (21151,   5,        540) /* EncumbranceVal */
+     , (21151,   8,        270) /* Mass */
+     , (21151,   9,       4096) /* ValidLocations - LowerArmArmor */
+     , (21151,  16,          1) /* ItemUseable - No */
+     , (21151,  19,        653) /* Value */
+     , (21151,  27,         32) /* ArmorType - Metal */
+     , (21151,  28,        200) /* ArmorLevel */
+     , (21151,  36,       9999) /* ResistMagic */
+     , (21151,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21151, 124,          3) /* Version */
+     , (21151, 169,  118097156) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21151,  22, True ) /* Inscribable */
+     , (21151, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21151,  12,    0.33) /* Shade */
+     , (21151,  13,     1.3) /* ArmorModVsSlash */
+     , (21151,  14,     1.3) /* ArmorModVsPierce */
+     , (21151,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21151,  16,     0.6) /* ArmorModVsCold */
+     , (21151,  17,     0.6) /* ArmorModVsFire */
+     , (21151,  18,     0.6) /* ArmorModVsAcid */
+     , (21151,  19,     0.6) /* ArmorModVsElectric */
+     , (21151, 110,       1) /* BulkMod */
+     , (21151, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21151,   1, 'Covenant Bracers') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21151,   1,   33554641) /* Setup */
+     , (21151,   3,  536870932) /* SoundTable */
+     , (21151,   6,   67108990) /* PaletteBase */
+     , (21151,   7,  268436444) /* ClothingBase */
+     , (21151,   8,  100667331) /* Icon */
+     , (21151,  22,  872415275) /* PhysicsEffectTable */
+     , (21151,  36,  234881046) /* MutateFilter */
+     , (21151,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21152 Covenant Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21152 Covenant Breastplate.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21152;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21152, 'breastplatecovenant', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21152,   1,          2) /* ItemType - Armor */
+     , (21152,   3,         20) /* PaletteTemplate - Silver */
+     , (21152,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (21152,   5,       2200) /* EncumbranceVal */
+     , (21152,   8,       1100) /* Mass */
+     , (21152,   9,        512) /* ValidLocations - ChestArmor */
+     , (21152,  16,          1) /* ItemUseable - No */
+     , (21152,  19,       1631) /* Value */
+     , (21152,  27,         32) /* ArmorType - Metal */
+     , (21152,  28,        200) /* ArmorLevel */
+     , (21152,  36,       9999) /* ResistMagic */
+     , (21152,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21152, 124,          3) /* Version */
+     , (21152, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21152,  22, True ) /* Inscribable */
+     , (21152, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21152,  12,    0.33) /* Shade */
+     , (21152,  13,     1.3) /* ArmorModVsSlash */
+     , (21152,  14,     1.3) /* ArmorModVsPierce */
+     , (21152,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21152,  16,     0.6) /* ArmorModVsCold */
+     , (21152,  17,     0.6) /* ArmorModVsFire */
+     , (21152,  18,     0.6) /* ArmorModVsAcid */
+     , (21152,  19,     0.6) /* ArmorModVsElectric */
+     , (21152, 110,       1) /* BulkMod */
+     , (21152, 111,     2.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21152,   1, 'Covenant Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21152,   1,   33554642) /* Setup */
+     , (21152,   3,  536870932) /* SoundTable */
+     , (21152,   6,   67108990) /* PaletteBase */
+     , (21152,   7,  268436452) /* ClothingBase */
+     , (21152,   8,  100667354) /* Icon */
+     , (21152,  22,  872415275) /* PhysicsEffectTable */
+     , (21152,  36,  234881046) /* MutateFilter */
+     , (21152,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21153 Covenant Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21153 Covenant Gauntlets.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21153;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21153, 'gauntletscovenant', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21153,   1,          2) /* ItemType - Armor */
+     , (21153,   3,         20) /* PaletteTemplate - Silver */
+     , (21153,   4,      32768) /* ClothingPriority - Hands */
+     , (21153,   5,        919) /* EncumbranceVal */
+     , (21153,   8,        460) /* Mass */
+     , (21153,   9,         32) /* ValidLocations - HandWear */
+     , (21153,  16,          1) /* ItemUseable - No */
+     , (21153,  19,        653) /* Value */
+     , (21153,  27,         32) /* ArmorType - Metal */
+     , (21153,  28,        200) /* ArmorLevel */
+     , (21153,  36,       9999) /* ResistMagic */
+     , (21153,  44,          3) /* Damage */
+     , (21153,  45,          4) /* DamageType - Bludgeon */
+     , (21153,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21153, 124,          3) /* Version */
+     , (21153, 169,  151651588) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21153,  22, True ) /* Inscribable */
+     , (21153, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21153,  12,    0.66) /* Shade */
+     , (21153,  13,     1.3) /* ArmorModVsSlash */
+     , (21153,  14,     1.3) /* ArmorModVsPierce */
+     , (21153,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21153,  16,     0.6) /* ArmorModVsCold */
+     , (21153,  17,     0.6) /* ArmorModVsFire */
+     , (21153,  18,     0.6) /* ArmorModVsAcid */
+     , (21153,  19,     0.6) /* ArmorModVsElectric */
+     , (21153,  22,    0.75) /* DamageVariance */
+     , (21153, 110,       1) /* BulkMod */
+     , (21153, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21153,   1, 'Covenant Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21153,   1,   33554648) /* Setup */
+     , (21153,   3,  536870932) /* SoundTable */
+     , (21153,   6,   67108990) /* PaletteBase */
+     , (21153,   7,  268436445) /* ClothingBase */
+     , (21153,   8,  100667341) /* Icon */
+     , (21153,  22,  872415275) /* PhysicsEffectTable */
+     , (21153,  36,  234881046) /* MutateFilter */
+     , (21153,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21154 Covenant Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21154 Covenant Girth.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21154;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21154, 'girthcovenant', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21154,   1,          2) /* ItemType - Armor */
+     , (21154,   3,         20) /* PaletteTemplate - Silver */
+     , (21154,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (21154,   5,       1099) /* EncumbranceVal */
+     , (21154,   8,        550) /* Mass */
+     , (21154,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (21154,  16,          1) /* ItemUseable - No */
+     , (21154,  19,        980) /* Value */
+     , (21154,  27,         32) /* ArmorType - Metal */
+     , (21154,  28,        200) /* ArmorLevel */
+     , (21154,  36,       9999) /* ResistMagic */
+     , (21154,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21154, 124,          3) /* Version */
+     , (21154, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21154,  22, True ) /* Inscribable */
+     , (21154, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21154,  12,    0.33) /* Shade */
+     , (21154,  13,     1.3) /* ArmorModVsSlash */
+     , (21154,  14,     1.3) /* ArmorModVsPierce */
+     , (21154,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21154,  16,     0.6) /* ArmorModVsCold */
+     , (21154,  17,     0.6) /* ArmorModVsFire */
+     , (21154,  18,     0.6) /* ArmorModVsAcid */
+     , (21154,  19,     0.6) /* ArmorModVsElectric */
+     , (21154, 110,       1) /* BulkMod */
+     , (21154, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21154,   1, 'Covenant Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21154,   1,   33554647) /* Setup */
+     , (21154,   3,  536870932) /* SoundTable */
+     , (21154,   6,   67108990) /* PaletteBase */
+     , (21154,   7,  268436446) /* ClothingBase */
+     , (21154,   8,  100668144) /* Icon */
+     , (21154,  22,  872415275) /* PhysicsEffectTable */
+     , (21154,  36,  234881046) /* MutateFilter */
+     , (21154,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21155 Covenant Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21155 Covenant Greaves.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21155;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21155, 'greavescovenant', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21155,   1,          2) /* ItemType - Armor */
+     , (21155,   3,         20) /* PaletteTemplate - Silver */
+     , (21155,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (21155,   5,        919) /* EncumbranceVal */
+     , (21155,   8,        460) /* Mass */
+     , (21155,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (21155,  16,          1) /* ItemUseable - No */
+     , (21155,  19,        653) /* Value */
+     , (21155,  27,         32) /* ArmorType - Metal */
+     , (21155,  28,        200) /* ArmorLevel */
+     , (21155,  36,       9999) /* ResistMagic */
+     , (21155,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21155, 124,          3) /* Version */
+     , (21155, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21155,  22, True ) /* Inscribable */
+     , (21155, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21155,  12,    0.33) /* Shade */
+     , (21155,  13,     1.3) /* ArmorModVsSlash */
+     , (21155,  14,     1.3) /* ArmorModVsPierce */
+     , (21155,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21155,  16,     0.6) /* ArmorModVsCold */
+     , (21155,  17,     0.6) /* ArmorModVsFire */
+     , (21155,  18,     0.6) /* ArmorModVsAcid */
+     , (21155,  19,     0.6) /* ArmorModVsElectric */
+     , (21155,  39,    1.33) /* DefaultScale */
+     , (21155, 110,       1) /* BulkMod */
+     , (21155, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21155,   1, 'Covenant Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21155,   1,   33554641) /* Setup */
+     , (21155,   3,  536870932) /* SoundTable */
+     , (21155,   6,   67108990) /* PaletteBase */
+     , (21155,   7,  268436447) /* ClothingBase */
+     , (21155,   8,  100668167) /* Icon */
+     , (21155,  22,  872415275) /* PhysicsEffectTable */
+     , (21155,  36,  234881046) /* MutateFilter */
+     , (21155,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21156 Covenant Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21156 Covenant Helm.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21156;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21156, 'helmcovenant', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21156,   1,          2) /* ItemType - Armor */
+     , (21156,   3,         20) /* PaletteTemplate - Silver */
+     , (21156,   4,      16384) /* ClothingPriority - Head */
+     , (21156,   5,        600) /* EncumbranceVal */
+     , (21156,   8,        300) /* Mass */
+     , (21156,   9,          1) /* ValidLocations - HeadWear */
+     , (21156,  16,          1) /* ItemUseable - No */
+     , (21156,  19,       1187) /* Value */
+     , (21156,  27,         32) /* ArmorType - Metal */
+     , (21156,  28,        200) /* ArmorLevel */
+     , (21156,  36,       9999) /* ResistMagic */
+     , (21156,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (21156, 150,        103) /* HookPlacement - Hook */
+     , (21156, 151,          2) /* HookType - Wall */
+     , (21156, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21156,  22, True ) /* Inscribable */
+     , (21156, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21156,  12,    0.66) /* Shade */
+     , (21156,  13,     1.3) /* ArmorModVsSlash */
+     , (21156,  14,     1.3) /* ArmorModVsPierce */
+     , (21156,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21156,  16,     0.6) /* ArmorModVsCold */
+     , (21156,  17,     0.6) /* ArmorModVsFire */
+     , (21156,  18,     0.6) /* ArmorModVsAcid */
+     , (21156,  19,     0.6) /* ArmorModVsElectric */
+     , (21156, 110,     0.8) /* BulkMod */
+     , (21156, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21156,   1, 'Covenant Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21156,   1,   33557884) /* Setup */
+     , (21156,   3,  536870932) /* SoundTable */
+     , (21156,   6,   67108990) /* PaletteBase */
+     , (21156,   7,  268436448) /* ClothingBase */
+     , (21156,   8,  100667343) /* Icon */
+     , (21156,  22,  872415275) /* PhysicsEffectTable */
+     , (21156,  36,  234881046) /* MutateFilter */
+     , (21156,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21156 Covenant Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21156 Covenant Helm.sql
@@ -16,6 +16,7 @@ VALUES (21156,   1,          2) /* ItemType - Armor */
      , (21156,  28,        200) /* ArmorLevel */
      , (21156,  36,       9999) /* ResistMagic */
      , (21156,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21156, 124,          3) /* Version */
      , (21156, 150,        103) /* HookPlacement - Hook */
      , (21156, 151,          2) /* HookType - Wall */
      , (21156, 169,  168429060) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21157 Covenant Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21157 Covenant Pauldrons.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21157;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21157, 'pauldronscovenant', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21157,   1,          2) /* ItemType - Armor */
+     , (21157,   3,         20) /* PaletteTemplate - Silver */
+     , (21157,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (21157,   5,        720) /* EncumbranceVal */
+     , (21157,   8,        360) /* Mass */
+     , (21157,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (21157,  16,          1) /* ItemUseable - No */
+     , (21157,  19,        653) /* Value */
+     , (21157,  27,         32) /* ArmorType - Metal */
+     , (21157,  28,        200) /* ArmorLevel */
+     , (21157,  36,       9999) /* ResistMagic */
+     , (21157,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21157, 124,          3) /* Version */
+     , (21157, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21157,  22, True ) /* Inscribable */
+     , (21157, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21157,  12,    0.33) /* Shade */
+     , (21157,  13,     1.3) /* ArmorModVsSlash */
+     , (21157,  14,     1.3) /* ArmorModVsPierce */
+     , (21157,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21157,  16,     0.6) /* ArmorModVsCold */
+     , (21157,  17,     0.6) /* ArmorModVsFire */
+     , (21157,  18,     0.6) /* ArmorModVsAcid */
+     , (21157,  19,     0.6) /* ArmorModVsElectric */
+     , (21157,  39,     1.1) /* DefaultScale */
+     , (21157, 110,       1) /* BulkMod */
+     , (21157, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21157,   1, 'Covenant Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21157,   1,   33554641) /* Setup */
+     , (21157,   3,  536870932) /* SoundTable */
+     , (21157,   6,   67108990) /* PaletteBase */
+     , (21157,   7,  268436449) /* ClothingBase */
+     , (21157,   8,  100668172) /* Icon */
+     , (21157,  22,  872415275) /* PhysicsEffectTable */
+     , (21157,  36,  234881046) /* MutateFilter */
+     , (21157,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21159 Covenant Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/21159 Covenant Tassets.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21159;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21159, 'tassetscovenant', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21159,   1,          2) /* ItemType - Armor */
+     , (21159,   3,         20) /* PaletteTemplate - Silver */
+     , (21159,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (21159,   5,        919) /* EncumbranceVal */
+     , (21159,   8,        460) /* Mass */
+     , (21159,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (21159,  16,          1) /* ItemUseable - No */
+     , (21159,  19,        653) /* Value */
+     , (21159,  27,         32) /* ArmorType - Metal */
+     , (21159,  28,        200) /* ArmorLevel */
+     , (21159,  36,       9999) /* ResistMagic */
+     , (21159,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21159, 124,          3) /* Version */
+     , (21159, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21159,  22, True ) /* Inscribable */
+     , (21159, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21159,  12,    0.33) /* Shade */
+     , (21159,  13,     1.3) /* ArmorModVsSlash */
+     , (21159,  14,     1.3) /* ArmorModVsPierce */
+     , (21159,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21159,  16,     0.6) /* ArmorModVsCold */
+     , (21159,  17,     0.6) /* ArmorModVsFire */
+     , (21159,  18,     0.6) /* ArmorModVsAcid */
+     , (21159,  19,     0.6) /* ArmorModVsElectric */
+     , (21159,  39,    1.33) /* DefaultScale */
+     , (21159, 110,       1) /* BulkMod */
+     , (21159, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21159,   1, 'Covenant Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21159,   1,   33554656) /* Setup */
+     , (21159,   3,  536870932) /* SoundTable */
+     , (21159,   6,   67108990) /* PaletteBase */
+     , (21159,   7,  268436451) /* ClothingBase */
+     , (21159,   8,  100673372) /* Icon */
+     , (21159,  22,  872415275) /* PhysicsEffectTable */
+     , (21159,  36,  234881046) /* MutateFilter */
+     , (21159,  46,  939524130) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25636 Leather Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25636 Leather Helm.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25636;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25636, 'basinetleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25636,   1,          2) /* ItemType - Armor */
+     , (25636,   3,          4) /* PaletteTemplate - Brown */
+     , (25636,   4,      16384) /* ClothingPriority - Head */
+     , (25636,   5,        330) /* EncumbranceVal */
+     , (25636,   8,        110) /* Mass */
+     , (25636,   9,          1) /* ValidLocations - HeadWear */
+     , (25636,  16,          1) /* ItemUseable - No */
+     , (25636,  19,        180) /* Value */
+     , (25636,  27,          2) /* ArmorType - Leather */
+     , (25636,  28,        130) /* ArmorLevel */
+     , (25636,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25636, 124,          3) /* Version */
+     , (25636, 150,        103) /* HookPlacement - Hook */
+     , (25636, 151,          2) /* HookType - Wall */
+     , (25636, 169,  168494606) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25636,  22, True ) /* Inscribable */
+     , (25636, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25636,  12,    0.66) /* Shade */
+     , (25636,  13,       1) /* ArmorModVsSlash */
+     , (25636,  14,     0.8) /* ArmorModVsPierce */
+     , (25636,  15,       1) /* ArmorModVsBludgeon */
+     , (25636,  16,     0.5) /* ArmorModVsCold */
+     , (25636,  17,     0.5) /* ArmorModVsFire */
+     , (25636,  18,     0.3) /* ArmorModVsAcid */
+     , (25636,  19,     0.6) /* ArmorModVsElectric */
+     , (25636, 110,    1.25) /* BulkMod */
+     , (25636, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25636,   1, 'Leather Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25636,   1,   33555048) /* Setup */
+     , (25636,   3,  536870932) /* SoundTable */
+     , (25636,   6,   67108990) /* PaletteBase */
+     , (25636,   7,  268436711) /* ClothingBase */
+     , (25636,   8,  100675169) /* Icon */
+     , (25636,  22,  872415275) /* PhysicsEffectTable */
+     , (25636,  36,  234881042) /* MutateFilter */
+     , (25636,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25637 Leather Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25637 Leather Bracers.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 25637;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (25637, 'bracersleathernew', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (25637, 'bracersleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (25637,   1,          2) /* ItemType - Armor */
@@ -13,9 +13,10 @@ VALUES (25637,   1,          2) /* ItemType - Armor */
      , (25637,  16,          1) /* ItemUseable - No */
      , (25637,  19,         30) /* Value */
      , (25637,  27,          2) /* ArmorType - Leather */
-     , (25637,  28,         20) /* ArmorLevel */
+     , (25637,  28,         90) /* ArmorLevel */
      , (25637,  53,        101) /* PlacementPosition */
      , (25637,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25637, 124,          3) /* Version */
      , (25637, 169,  118162702) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25638 Leather Vest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25638 Leather Vest.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25638;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25638, 'breastplateleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25638,   1,          2) /* ItemType - Armor */
+     , (25638,   3,          4) /* PaletteTemplate - Brown */
+     , (25638,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (25638,   5,        420) /* EncumbranceVal */
+     , (25638,   8,        140) /* Mass */
+     , (25638,   9,        512) /* ValidLocations - ChestArmor */
+     , (25638,  16,          1) /* ItemUseable - No */
+     , (25638,  19,         80) /* Value */
+     , (25638,  27,          2) /* ArmorType - Leather */
+     , (25638,  28,         90) /* ArmorLevel */
+     , (25638,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25638, 124,          3) /* Version */
+     , (25638, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25638,  22, True ) /* Inscribable */
+     , (25638, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25638,  12,    0.66) /* Shade */
+     , (25638,  13,       1) /* ArmorModVsSlash */
+     , (25638,  14,     0.8) /* ArmorModVsPierce */
+     , (25638,  15,       1) /* ArmorModVsBludgeon */
+     , (25638,  16,     0.5) /* ArmorModVsCold */
+     , (25638,  17,     0.5) /* ArmorModVsFire */
+     , (25638,  18,     0.3) /* ArmorModVsAcid */
+     , (25638,  19,     0.6) /* ArmorModVsElectric */
+     , (25638, 110,    1.67) /* BulkMod */
+     , (25638, 111,     2.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25638,   1, 'Leather Vest') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25638,   1,   33554642) /* Setup */
+     , (25638,   3,  536870932) /* SoundTable */
+     , (25638,   6,   67108990) /* PaletteBase */
+     , (25638,   7,  268436716) /* ClothingBase */
+     , (25638,   8,  100675123) /* Icon */
+     , (25638,  22,  872415275) /* PhysicsEffectTable */
+     , (25638,  36,  234881042) /* MutateFilter */
+     , (25638,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25639 Leather Jerkin.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25639 Leather Jerkin.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25639;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25639, 'coatleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25639,   1,          2) /* ItemType - Armor */
+     , (25639,   3,          4) /* PaletteTemplate - Brown */
+     , (25639,   4,      15360) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms */
+     , (25639,   5,        810) /* EncumbranceVal */
+     , (25639,   8,        270) /* Mass */
+     , (25639,   9,       7680) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor, LowerArmArmor */
+     , (25639,  16,          1) /* ItemUseable - No */
+     , (25639,  19,        150) /* Value */
+     , (25639,  27,          2) /* ArmorType - Leather */
+     , (25639,  28,         90) /* ArmorLevel */
+     , (25639,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25639, 124,          3) /* Version */
+     , (25639, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25639,  22, True ) /* Inscribable */
+     , (25639, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25639,  12,    0.66) /* Shade */
+     , (25639,  13,       1) /* ArmorModVsSlash */
+     , (25639,  14,     0.8) /* ArmorModVsPierce */
+     , (25639,  15,       1) /* ArmorModVsBludgeon */
+     , (25639,  16,     0.5) /* ArmorModVsCold */
+     , (25639,  17,     0.5) /* ArmorModVsFire */
+     , (25639,  18,     0.3) /* ArmorModVsAcid */
+     , (25639,  19,     0.6) /* ArmorModVsElectric */
+     , (25639, 110,    1.67) /* BulkMod */
+     , (25639, 111,     4.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25639,   1, 'Leather Jerkin') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25639,   1,   33554644) /* Setup */
+     , (25639,   3,  536870932) /* SoundTable */
+     , (25639,   6,   67108990) /* PaletteBase */
+     , (25639,   7,  268436705) /* ClothingBase */
+     , (25639,   8,  100675128) /* Icon */
+     , (25639,  22,  872415275) /* PhysicsEffectTable */
+     , (25639,  36,  234881042) /* MutateFilter */
+     , (25639,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25640 Leather Cowl.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25640 Leather Cowl.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25640;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25640, 'cowlleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25640,   1,          2) /* ItemType - Armor */
+     , (25640,   3,          4) /* PaletteTemplate - Brown */
+     , (25640,   4,      16384) /* ClothingPriority - Head */
+     , (25640,   5,        188) /* EncumbranceVal */
+     , (25640,   8,         75) /* Mass */
+     , (25640,   9,          1) /* ValidLocations - HeadWear */
+     , (25640,  16,          1) /* ItemUseable - No */
+     , (25640,  19,         30) /* Value */
+     , (25640,  27,          2) /* ArmorType - Leather */
+     , (25640,  28,        130) /* ArmorLevel */
+     , (25640,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (25640, 150,        103) /* HookPlacement - Hook */
+     , (25640, 151,          2) /* HookType - Wall */
+	 , (25640, 124,          3) /* Version */
+     , (25640, 169,  168493326) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25640,  22, True ) /* Inscribable */
+     , (25640, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25640,  12,    0.66) /* Shade */
+     , (25640,  13,       1) /* ArmorModVsSlash */
+     , (25640,  14,     0.8) /* ArmorModVsPierce */
+     , (25640,  15,       1) /* ArmorModVsBludgeon */
+     , (25640,  16,     0.5) /* ArmorModVsCold */
+     , (25640,  17,     0.5) /* ArmorModVsFire */
+     , (25640,  18,     0.3) /* ArmorModVsAcid */
+     , (25640,  19,     0.6) /* ArmorModVsElectric */
+     , (25640, 110,    1.67) /* BulkMod */
+     , (25640, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25640,   1, 'Leather Cowl') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25640,   1,   33555048) /* Setup */
+     , (25640,   3,  536870932) /* SoundTable */
+     , (25640,   6,   67108990) /* PaletteBase */
+     , (25640,   7,  268436712) /* ClothingBase */
+     , (25640,   8,  100675169) /* Icon */
+     , (25640,  22,  872415275) /* PhysicsEffectTable */
+     , (25640,  36,  234881042) /* MutateFilter */
+     , (25640,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25641 Leather Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25641 Leather Cuirass.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25641;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25641, 'cuirassleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25641,   1,          2) /* ItemType - Armor */
+     , (25641,   3,          4) /* PaletteTemplate - Brown */
+     , (25641,   4,       3072) /* ClothingPriority - OuterwearChest, OuterwearAbdomen */
+     , (25641,   5,        540) /* EncumbranceVal */
+     , (25641,   8,        180) /* Mass */
+     , (25641,   9,       1536) /* ValidLocations - ChestArmor, AbdomenArmor */
+     , (25641,  16,          1) /* ItemUseable - No */
+     , (25641,  19,        120) /* Value */
+     , (25641,  27,          2) /* ArmorType - Leather */
+     , (25641,  28,         90) /* ArmorLevel */
+     , (25641,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25641, 124,          3) /* Version */
+     , (25641, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25641,  22, True ) /* Inscribable */
+     , (25641, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25641,  12,    0.66) /* Shade */
+     , (25641,  13,       1) /* ArmorModVsSlash */
+     , (25641,  14,     0.8) /* ArmorModVsPierce */
+     , (25641,  15,       1) /* ArmorModVsBludgeon */
+     , (25641,  16,     0.5) /* ArmorModVsCold */
+     , (25641,  17,     0.5) /* ArmorModVsFire */
+     , (25641,  18,     0.3) /* ArmorModVsAcid */
+     , (25641,  19,     0.6) /* ArmorModVsElectric */
+     , (25641, 110,    1.67) /* BulkMod */
+     , (25641, 111,     3.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25641,   1, 'Leather Cuirass') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25641,   1,   33554854) /* Setup */
+     , (25641,   3,  536870932) /* SoundTable */
+     , (25641,   6,   67108990) /* PaletteBase */
+     , (25641,   7,  268436707) /* ClothingBase */
+     , (25641,   8,  100675193) /* Icon */
+     , (25641,  22,  872415275) /* PhysicsEffectTable */
+     , (25641,  36,  234881042) /* MutateFilter */
+     , (25641,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25642 Leather Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25642 Leather Gauntlets.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25642;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25642, 'gauntletsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25642,   1,          2) /* ItemType - Armor */
+     , (25642,   3,          4) /* PaletteTemplate - Brown */
+     , (25642,   4,      32768) /* ClothingPriority - Hands */
+     , (25642,   5,        270) /* EncumbranceVal */
+     , (25642,   8,         90) /* Mass */
+     , (25642,   9,         32) /* ValidLocations - HandWear */
+     , (25642,  16,          1) /* ItemUseable - No */
+     , (25642,  19,         30) /* Value */
+     , (25642,  27,          2) /* ArmorType - Leather */
+     , (25642,  28,        130) /* ArmorLevel */
+     , (25642,  44,          0) /* Damage */
+     , (25642,  45,          4) /* DamageType - Bludgeon */
+     , (25642,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25642, 124,          3) /* Version */
+     , (25642, 169,  151717134) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25642,  22, True ) /* Inscribable */
+     , (25642, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25642,  12,    0.66) /* Shade */
+     , (25642,  13,       1) /* ArmorModVsSlash */
+     , (25642,  14,     0.8) /* ArmorModVsPierce */
+     , (25642,  15,       1) /* ArmorModVsBludgeon */
+     , (25642,  16,     0.5) /* ArmorModVsCold */
+     , (25642,  17,     0.5) /* ArmorModVsFire */
+     , (25642,  18,     0.3) /* ArmorModVsAcid */
+     , (25642,  19,     0.6) /* ArmorModVsElectric */
+     , (25642,  22,    0.75) /* DamageVariance */
+     , (25642, 110,    1.67) /* BulkMod */
+     , (25642, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25642,   1, 'Leather Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25642,   1,   33554648) /* Setup */
+     , (25642,   3,  536870932) /* SoundTable */
+     , (25642,   6,   67108990) /* PaletteBase */
+     , (25642,   7,  268436708) /* ClothingBase */
+     , (25642,   8,  100675217) /* Icon */
+     , (25642,  22,  872415275) /* PhysicsEffectTable */
+     , (25642,  36,  234881042) /* MutateFilter */
+     , (25642,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25643 Leather Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25643 Leather Girth.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25643;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25643, 'girthleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25643,   1,          2) /* ItemType - Armor */
+     , (25643,   3,          4) /* PaletteTemplate - Brown */
+     , (25643,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (25643,   5,        270) /* EncumbranceVal */
+     , (25643,   8,         90) /* Mass */
+     , (25643,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (25643,  16,          1) /* ItemUseable - No */
+     , (25643,  19,         50) /* Value */
+     , (25643,  27,          2) /* ArmorType - Leather */
+     , (25643,  28,         90) /* ArmorLevel */
+     , (25643,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25643, 124,          3) /* Version */
+     , (25643, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25643,  22, True ) /* Inscribable */
+     , (25643, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25643,  12,    0.66) /* Shade */
+     , (25643,  13,       1) /* ArmorModVsSlash */
+     , (25643,  14,     0.8) /* ArmorModVsPierce */
+     , (25643,  15,       1) /* ArmorModVsBludgeon */
+     , (25643,  16,     0.5) /* ArmorModVsCold */
+     , (25643,  17,     0.5) /* ArmorModVsFire */
+     , (25643,  18,     0.3) /* ArmorModVsAcid */
+     , (25643,  19,     0.6) /* ArmorModVsElectric */
+     , (25643, 110,    1.67) /* BulkMod */
+     , (25643, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25643,   1, 'Leather Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25643,   1,   33554647) /* Setup */
+     , (25643,   3,  536870932) /* SoundTable */
+     , (25643,   6,   67108990) /* PaletteBase */
+     , (25643,   7,  268436714) /* ClothingBase */
+     , (25643,   8,  100675222) /* Icon */
+     , (25643,  22,  872415275) /* PhysicsEffectTable */
+     , (25643,  36,  234881042) /* MutateFilter */
+     , (25643,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25644 Leather Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25644 Leather Greaves.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25644;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25644, 'greavesleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25644,   1,          2) /* ItemType - Armor */
+     , (25644,   3,          4) /* PaletteTemplate - Brown */
+     , (25644,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (25644,   5,        420) /* EncumbranceVal */
+     , (25644,   8,        140) /* Mass */
+     , (25644,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (25644,  16,          1) /* ItemUseable - No */
+     , (25644,  19,         30) /* Value */
+     , (25644,  27,          2) /* ArmorType - Leather */
+     , (25644,  28,         90) /* ArmorLevel */
+     , (25644,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25644, 124,          3) /* Version */
+     , (25644, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25644,  22, True ) /* Inscribable */
+     , (25644, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25644,  12,    0.66) /* Shade */
+     , (25644,  13,       1) /* ArmorModVsSlash */
+     , (25644,  14,     0.8) /* ArmorModVsPierce */
+     , (25644,  15,       1) /* ArmorModVsBludgeon */
+     , (25644,  16,     0.5) /* ArmorModVsCold */
+     , (25644,  17,     0.5) /* ArmorModVsFire */
+     , (25644,  18,     0.3) /* ArmorModVsAcid */
+     , (25644,  19,     0.6) /* ArmorModVsElectric */
+     , (25644,  39,    1.33) /* DefaultScale */
+     , (25644, 110,    1.67) /* BulkMod */
+     , (25644, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25644,   1, 'Leather Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25644,   1,   33554641) /* Setup */
+     , (25644,   3,  536870932) /* SoundTable */
+     , (25644,   6,   67108990) /* PaletteBase */
+     , (25644,   7,  268436703) /* ClothingBase */
+     , (25644,   8,  100675264) /* Icon */
+     , (25644,  22,  872415275) /* PhysicsEffectTable */
+     , (25644,  36,  234881042) /* MutateFilter */
+     , (25644,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25645 Leather Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25645 Leather Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25645;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25645, 'leggingsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25645,   1,          2) /* ItemType - Armor */
+     , (25645,   3,          4) /* PaletteTemplate - Brown */
+     , (25645,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (25645,   5,        960) /* EncumbranceVal */
+     , (25645,   8,        320) /* Mass */
+     , (25645,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (25645,  16,          1) /* ItemUseable - No */
+     , (25645,  19,         70) /* Value */
+     , (25645,  27,          2) /* ArmorType - Leather */
+     , (25645,  28,         90) /* ArmorLevel */
+     , (25645,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25645, 124,          3) /* Version */
+     , (25645, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25645,  22, True ) /* Inscribable */
+     , (25645, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25645,  12,    0.66) /* Shade */
+     , (25645,  13,       1) /* ArmorModVsSlash */
+     , (25645,  14,     0.8) /* ArmorModVsPierce */
+     , (25645,  15,       1) /* ArmorModVsBludgeon */
+     , (25645,  16,     0.5) /* ArmorModVsCold */
+     , (25645,  17,     0.5) /* ArmorModVsFire */
+     , (25645,  18,     0.3) /* ArmorModVsAcid */
+     , (25645,  19,     0.6) /* ArmorModVsElectric */
+     , (25645, 110,    1.67) /* BulkMod */
+     , (25645, 111,       2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25645,   1, 'Leather Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25645,   1,   33554856) /* Setup */
+     , (25645,   3,  536870932) /* SoundTable */
+     , (25645,   6,   67108990) /* PaletteBase */
+     , (25645,   7,  268436702) /* ClothingBase */
+     , (25645,   8,  100675312) /* Icon */
+     , (25645,  22,  872415275) /* PhysicsEffectTable */
+     , (25645,  36,  234881042) /* MutateFilter */
+     , (25645,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25646 Long Leather Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25646 Long Leather Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 25646;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (25646, 'longgauntletsleathernew', 2, '2019-04-29 19:32:42') /* Clothing */;
+VALUES (25646, 'longgauntletsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (25646,   1,          2) /* ItemType - Armor */
@@ -13,11 +13,12 @@ VALUES (25646,   1,          2) /* ItemType - Armor */
      , (25646,  16,          1) /* ItemUseable - No */
      , (25646,  19,         30) /* Value */
      , (25646,  27,          2) /* ArmorType - Leather */
-     , (25646,  28,         20) /* ArmorLevel */
+     , (25646,  28,         90) /* ArmorLevel */
      , (25646,  44,          0) /* Damage */
      , (25646,  45,          4) /* DamageType - Bludgeon */
      , (25646,  53,        101) /* PlacementPosition - Resting */
      , (25646,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25646, 124,          3) /* Version */
      , (25646, 169,  151717134) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25647 Leather Pants.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25647 Leather Pants.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25647;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25647, 'pantsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25647,   1,          2) /* ItemType - Armor */
+     , (25647,   3,          4) /* PaletteTemplate - Brown */
+     , (25647,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (25647,   5,        960) /* EncumbranceVal */
+     , (25647,   8,        320) /* Mass */
+     , (25647,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
+     , (25647,  16,          1) /* ItemUseable - No */
+     , (25647,  19,         70) /* Value */
+     , (25647,  27,          2) /* ArmorType - Leather */
+     , (25647,  28,         90) /* ArmorLevel */
+     , (25647,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25647, 124,          3) /* Version */
+     , (25647, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25647,  22, True ) /* Inscribable */
+     , (25647, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25647,  12,    0.66) /* Shade */
+     , (25647,  13,       1) /* ArmorModVsSlash */
+     , (25647,  14,     0.8) /* ArmorModVsPierce */
+     , (25647,  15,       1) /* ArmorModVsBludgeon */
+     , (25647,  16,     0.5) /* ArmorModVsCold */
+     , (25647,  17,     0.5) /* ArmorModVsFire */
+     , (25647,  18,     0.3) /* ArmorModVsAcid */
+     , (25647,  19,     0.6) /* ArmorModVsElectric */
+     , (25647, 110,    1.67) /* BulkMod */
+     , (25647, 111,       2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25647,   1, 'Leather Pants') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25647,   1,   33554856) /* Setup */
+     , (25647,   3,  536870932) /* SoundTable */
+     , (25647,   6,   67108990) /* PaletteBase */
+     , (25647,   7,  268436717) /* ClothingBase */
+     , (25647,   8,  100675312) /* Icon */
+     , (25647,  22,  872415275) /* PhysicsEffectTable */
+     , (25647,  36,  234881042) /* MutateFilter */
+     , (25647,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25648 Leather Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25648 Leather Pauldrons.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25648;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25648, 'pauldronsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25648,   1,          2) /* ItemType - Armor */
+     , (25648,   3,          4) /* PaletteTemplate - Brown */
+     , (25648,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (25648,   5,        420) /* EncumbranceVal */
+     , (25648,   8,        140) /* Mass */
+     , (25648,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (25648,  16,          1) /* ItemUseable - No */
+     , (25648,  19,         30) /* Value */
+     , (25648,  27,          2) /* ArmorType - Leather */
+     , (25648,  28,         90) /* ArmorLevel */
+     , (25648,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25648, 124,          3) /* Version */
+     , (25648, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25648,  22, True ) /* Inscribable */
+     , (25648, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25648,  12,    0.66) /* Shade */
+     , (25648,  13,       1) /* ArmorModVsSlash */
+     , (25648,  14,     0.8) /* ArmorModVsPierce */
+     , (25648,  15,       1) /* ArmorModVsBludgeon */
+     , (25648,  16,     0.5) /* ArmorModVsCold */
+     , (25648,  17,     0.5) /* ArmorModVsFire */
+     , (25648,  18,     0.3) /* ArmorModVsAcid */
+     , (25648,  19,     0.6) /* ArmorModVsElectric */
+     , (25648,  39,     1.1) /* DefaultScale */
+     , (25648, 110,    1.67) /* BulkMod */
+     , (25648, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25648,   1, 'Leather Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25648,   1,   33554641) /* Setup */
+     , (25648,   3,  536870932) /* SoundTable */
+     , (25648,   6,   67108990) /* PaletteBase */
+     , (25648,   7,  268436715) /* ClothingBase */
+     , (25648,   8,  100675341) /* Icon */
+     , (25648,  22,  872415275) /* PhysicsEffectTable */
+     , (25648,  36,  234881042) /* MutateFilter */
+     , (25648,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25649 Leather Shirt.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25649 Leather Shirt.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25649;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25649, 'shirtleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25649,   1,          2) /* ItemType - Armor */
+     , (25649,   3,          4) /* PaletteTemplate - Brown */
+     , (25649,   4,       7168) /* ClothingPriority - OuterwearChest, OuterwearAbdomen, OuterwearUpperArms */
+     , (25649,   5,        810) /* EncumbranceVal */
+     , (25649,   8,        270) /* Mass */
+     , (25649,   9,       3584) /* ValidLocations - ChestArmor, AbdomenArmor, UpperArmArmor */
+     , (25649,  16,          1) /* ItemUseable - No */
+     , (25649,  19,        130) /* Value */
+     , (25649,  27,          2) /* ArmorType - Leather */
+     , (25649,  28,         90) /* ArmorLevel */
+     , (25649,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25649, 124,          3) /* Version */
+     , (25649, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25649,  22, True ) /* Inscribable */
+     , (25649, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25649,  12,    0.66) /* Shade */
+     , (25649,  13,       1) /* ArmorModVsSlash */
+     , (25649,  14,     0.8) /* ArmorModVsPierce */
+     , (25649,  15,       1) /* ArmorModVsBludgeon */
+     , (25649,  16,     0.5) /* ArmorModVsCold */
+     , (25649,  17,     0.5) /* ArmorModVsFire */
+     , (25649,  18,     0.3) /* ArmorModVsAcid */
+     , (25649,  19,     0.6) /* ArmorModVsElectric */
+     , (25649, 110,    1.67) /* BulkMod */
+     , (25649, 111,       4) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25649,   1, 'Leather Shirt') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25649,   1,   33554883) /* Setup */
+     , (25649,   3,  536870932) /* SoundTable */
+     , (25649,   6,   67108990) /* PaletteBase */
+     , (25649,   7,  268436700) /* ClothingBase */
+     , (25649,   8,  100675384) /* Icon */
+     , (25649,  22,  872415275) /* PhysicsEffectTable */
+     , (25649,  36,  234881042) /* MutateFilter */
+     , (25649,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25650 Leather Shorts.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25650 Leather Shorts.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25650;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25650, 'shortsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25650,   1,          2) /* ItemType - Armor */
+     , (25650,   3,          4) /* PaletteTemplate - Brown */
+     , (25650,   4,       2304) /* ClothingPriority - OuterwearUpperLegs, OuterwearAbdomen */
+     , (25650,   5,        270) /* EncumbranceVal */
+     , (25650,   8,         90) /* Mass */
+     , (25650,   9,       9216) /* ValidLocations - AbdomenArmor, UpperLegArmor */
+     , (25650,  16,          1) /* ItemUseable - No */
+     , (25650,  19,         50) /* Value */
+     , (25650,  27,          2) /* ArmorType - Leather */
+     , (25650,  28,         90) /* ArmorLevel */
+     , (25650,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25650, 124,          3) /* Version */
+     , (25650, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25650,  22, True ) /* Inscribable */
+     , (25650, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25650,  12,    0.66) /* Shade */
+     , (25650,  13,       1) /* ArmorModVsSlash */
+     , (25650,  14,     0.8) /* ArmorModVsPierce */
+     , (25650,  15,       1) /* ArmorModVsBludgeon */
+     , (25650,  16,     0.5) /* ArmorModVsCold */
+     , (25650,  17,     0.5) /* ArmorModVsFire */
+     , (25650,  18,     0.3) /* ArmorModVsAcid */
+     , (25650,  19,     0.6) /* ArmorModVsElectric */
+     , (25650, 110,    1.67) /* BulkMod */
+     , (25650, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25650,   1, 'Leather Shorts') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25650,   1,   33554647) /* Setup */
+     , (25650,   3,  536870932) /* SoundTable */
+     , (25650,   6,   67108990) /* PaletteBase */
+     , (25650,   7,  268436701) /* ClothingBase */
+     , (25650,   8,  100675408) /* Icon */
+     , (25650,  22,  872415275) /* PhysicsEffectTable */
+     , (25650,  36,  234881042) /* MutateFilter */
+     , (25650,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25651 Leather Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25651 Leather Sleeves.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25651;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25651, 'sleevesleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25651,   1,          2) /* ItemType - Armor */
+     , (25651,   3,          4) /* PaletteTemplate - Brown */
+     , (25651,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (25651,   5,        540) /* EncumbranceVal */
+     , (25651,   8,        180) /* Mass */
+     , (25651,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (25651,  16,          1) /* ItemUseable - No */
+     , (25651,  19,         60) /* Value */
+     , (25651,  27,          2) /* ArmorType - Leather */
+     , (25651,  28,         90) /* ArmorLevel */
+     , (25651,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25651, 124,          3) /* Version */
+     , (25651, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25651,  22, True ) /* Inscribable */
+     , (25651, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25651,  12,    0.66) /* Shade */
+     , (25651,  13,       1) /* ArmorModVsSlash */
+     , (25651,  14,     0.8) /* ArmorModVsPierce */
+     , (25651,  15,       1) /* ArmorModVsBludgeon */
+     , (25651,  16,     0.5) /* ArmorModVsCold */
+     , (25651,  17,     0.5) /* ArmorModVsFire */
+     , (25651,  18,     0.3) /* ArmorModVsAcid */
+     , (25651,  19,     0.6) /* ArmorModVsElectric */
+     , (25651, 110,    1.67) /* BulkMod */
+     , (25651, 111,    1.75) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25651,   1, 'Leather Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25651,   1,   33554655) /* Setup */
+     , (25651,   3,  536870932) /* SoundTable */
+     , (25651,   6,   67108990) /* PaletteBase */
+     , (25651,   7,  268436704) /* ClothingBase */
+     , (25651,   8,  100675432) /* Icon */
+     , (25651,  22,  872415275) /* PhysicsEffectTable */
+     , (25651,  36,  234881042) /* MutateFilter */
+     , (25651,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25652 Leather Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25652 Leather Tassets.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25652;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25652, 'tassetsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25652,   1,          2) /* ItemType - Armor */
+     , (25652,   3,          4) /* PaletteTemplate - Brown */
+     , (25652,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (25652,   5,        420) /* EncumbranceVal */
+     , (25652,   8,        140) /* Mass */
+     , (25652,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (25652,  16,          1) /* ItemUseable - No */
+     , (25652,  19,         30) /* Value */
+     , (25652,  27,          2) /* ArmorType - Leather */
+     , (25652,  28,         90) /* ArmorLevel */
+     , (25652,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25652, 124,          3) /* Version */
+     , (25652, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25652,  22, True ) /* Inscribable */
+     , (25652, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25652,  12,    0.66) /* Shade */
+     , (25652,  13,       1) /* ArmorModVsSlash */
+     , (25652,  14,     0.8) /* ArmorModVsPierce */
+     , (25652,  15,       1) /* ArmorModVsBludgeon */
+     , (25652,  16,     0.5) /* ArmorModVsCold */
+     , (25652,  17,     0.5) /* ArmorModVsFire */
+     , (25652,  18,     0.3) /* ArmorModVsAcid */
+     , (25652,  19,     0.6) /* ArmorModVsElectric */
+     , (25652,  39,    1.33) /* DefaultScale */
+     , (25652, 110,    1.67) /* BulkMod */
+     , (25652, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25652,   1, 'Leather Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25652,   1,   33554656) /* Setup */
+     , (25652,   3,  536870932) /* SoundTable */
+     , (25652,   6,   67108990) /* PaletteBase */
+     , (25652,   7,  268436713) /* ClothingBase */
+     , (25652,   8,  100675456) /* Icon */
+     , (25652,  22,  872415275) /* PhysicsEffectTable */
+     , (25652,  36,  234881042) /* MutateFilter */
+     , (25652,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25661 Leather Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/25661 Leather Boots.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25661;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25661, 'bootsleathernew', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25661,   1,          2) /* ItemType - Armor */
+     , (25661,   3,          4) /* PaletteTemplate - Brown */
+     , (25661,   4,      65536) /* ClothingPriority - Feet */
+     , (25661,   5,        420) /* EncumbranceVal */
+     , (25661,   8,        140) /* Mass */
+     , (25661,   9,        384) /* ValidLocations - LowerLegWear, FootWear */
+     , (25661,  16,          1) /* ItemUseable - No */
+     , (25661,  19,         70) /* Value */
+     , (25661,  27,          2) /* ArmorType - Leather */
+     , (25661,  28,         90) /* ArmorLevel */
+     , (25661,  44,          1) /* Damage */
+     , (25661,  45,          4) /* DamageType - Bludgeon */
+     , (25661,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (25661, 124,          3) /* Version */
+     , (25661, 169,  185271566) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25661,  22, True ) /* Inscribable */
+     , (25661, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25661,  12,     0.1) /* Shade */
+     , (25661,  13,       1) /* ArmorModVsSlash */
+     , (25661,  14,     0.8) /* ArmorModVsPierce */
+     , (25661,  15,       1) /* ArmorModVsBludgeon */
+     , (25661,  16,     0.5) /* ArmorModVsCold */
+     , (25661,  17,     0.5) /* ArmorModVsFire */
+     , (25661,  18,     0.3) /* ArmorModVsAcid */
+     , (25661,  19,     0.6) /* ArmorModVsElectric */
+     , (25661,  22,    0.75) /* DamageVariance */
+     , (25661, 110,    1.67) /* BulkMod */
+     , (25661, 111,       2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25661,   1, 'Leather Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25661,   1,   33556683) /* Setup */
+     , (25661,   3,  536870932) /* SoundTable */
+     , (25661,   6,   67108990) /* PaletteBase */
+     , (25661,   7,  268436710) /* ClothingBase */
+     , (25661,   8,  100667310) /* Icon */
+     , (25661,  22,  872415275) /* PhysicsEffectTable */
+     , (25661,  36,  234881042) /* MutateFilter */
+     , (25661,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27215 Chiran Coat.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27215 Chiran Coat.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27215;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27215, 'coatchiran', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27215,   1,          2) /* ItemType - Armor */
+     , (27215,   3,         20) /* PaletteTemplate - Silver */
+     , (27215,   4,      13312) /* ClothingPriority - OuterwearChest, OuterwearUpperArms, OuterwearLowerArms */
+     , (27215,   5,       1665) /* EncumbranceVal */
+     , (27215,   8,       1000) /* Mass */
+     , (27215,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
+     , (27215,  16,          1) /* ItemUseable - No */
+     , (27215,  19,       1738) /* Value */
+     , (27215,  27,          8) /* ArmorType - Scalemail */
+     , (27215,  28,         90) /* ArmorLevel */
+     , (27215,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27215, 124,          3) /* Version */
+     , (27215, 169,  118097680) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27215,  22, True ) /* Inscribable */
+     , (27215, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27215,  12,    0.66) /* Shade */
+     , (27215,  13,       1) /* ArmorModVsSlash */
+     , (27215,  14,     1.1) /* ArmorModVsPierce */
+     , (27215,  15,       1) /* ArmorModVsBludgeon */
+     , (27215,  16,     0.4) /* ArmorModVsCold */
+     , (27215,  17,     0.4) /* ArmorModVsFire */
+     , (27215,  18,     0.6) /* ArmorModVsAcid */
+     , (27215,  19,     0.4) /* ArmorModVsElectric */
+     , (27215, 110,     1.1) /* BulkMod */
+     , (27215, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27215,   1, 'Chiran Coat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27215,   1,   33554854) /* Setup */
+     , (27215,   3,  536870932) /* SoundTable */
+     , (27215,   6,   67108990) /* PaletteBase */
+     , (27215,   7,  268436797) /* ClothingBase */
+     , (27215,   8,  100676006) /* Icon */
+     , (27215,  22,  872415275) /* PhysicsEffectTable */
+     , (27215,  36,  234881042) /* MutateFilter */
+     , (27215,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27216 Chiran Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27216 Chiran Gauntlets.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27216;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27216, 'gauntletschiran', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27216,   1,          2) /* ItemType - Armor */
+     , (27216,   3,         20) /* PaletteTemplate - Silver */
+     , (27216,   4,      32768) /* ClothingPriority - Hands */
+     , (27216,   5,        919) /* EncumbranceVal */
+     , (27216,   8,        460) /* Mass */
+     , (27216,   9,         32) /* ValidLocations - HandWear */
+     , (27216,  16,          1) /* ItemUseable - No */
+     , (27216,  19,        653) /* Value */
+     , (27216,  27,         32) /* ArmorType - Metal */
+     , (27216,  28,        140) /* ArmorLevel */
+     , (27216,  44,          3) /* Damage */
+     , (27216,  45,          4) /* DamageType - Bludgeon */
+     , (27216,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27216, 124,          3) /* Version */
+     , (27216, 169,  151651600) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27216,  22, True ) /* Inscribable */
+     , (27216, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27216,  12,    0.66) /* Shade */
+     , (27216,  13,     1.3) /* ArmorModVsSlash */
+     , (27216,  14,       1) /* ArmorModVsPierce */
+     , (27216,  15,       1) /* ArmorModVsBludgeon */
+     , (27216,  16,     0.4) /* ArmorModVsCold */
+     , (27216,  17,     0.4) /* ArmorModVsFire */
+     , (27216,  18,     0.6) /* ArmorModVsAcid */
+     , (27216,  19,     0.4) /* ArmorModVsElectric */
+     , (27216,  22,    0.75) /* DamageVariance */
+     , (27216, 110,       1) /* BulkMod */
+     , (27216, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27216,   1, 'Chiran Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27216,   1,   33554648) /* Setup */
+     , (27216,   3,  536870932) /* SoundTable */
+     , (27216,   6,   67108990) /* PaletteBase */
+     , (27216,   7,  268436799) /* ClothingBase */
+     , (27216,   8,  100675987) /* Icon */
+     , (27216,  22,  872415275) /* PhysicsEffectTable */
+     , (27216,  36,  234881042) /* MutateFilter */
+     , (27216,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27217 Chiran Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27217 Chiran Helm.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27217;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27217, 'helmchiran', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27217,   1,          2) /* ItemType - Armor */
+     , (27217,   3,         20) /* PaletteTemplate - Silver */
+     , (27217,   4,      16384) /* ClothingPriority - Head */
+     , (27217,   5,        533) /* EncumbranceVal */
+     , (27217,   8,        200) /* Mass */
+     , (27217,   9,          1) /* ValidLocations - HeadWear */
+     , (27217,  16,          1) /* ItemUseable - No */
+     , (27217,  19,        653) /* Value */
+     , (27217,  27,         32) /* ArmorType - Metal */
+     , (27217,  28,        140) /* ArmorLevel */
+     , (27217,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (27217, 150,        103) /* HookPlacement - Hook */
+     , (27217, 151,          2) /* HookType - Wall */
+	 , (27217, 124,          3) /* Version */
+     , (27217, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27217,  22, True ) /* Inscribable */
+     , (27217, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27217,  12,    0.33) /* Shade */
+     , (27217,  13,     1.3) /* ArmorModVsSlash */
+     , (27217,  14,       1) /* ArmorModVsPierce */
+     , (27217,  15,       1) /* ArmorModVsBludgeon */
+     , (27217,  16,     0.4) /* ArmorModVsCold */
+     , (27217,  17,     0.4) /* ArmorModVsFire */
+     , (27217,  18,     0.6) /* ArmorModVsAcid */
+     , (27217,  19,     0.4) /* ArmorModVsElectric */
+     , (27217, 110,       1) /* BulkMod */
+     , (27217, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27217,   1, 'Chiran Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27217,   1,   33555248) /* Setup */
+     , (27217,   3,  536870932) /* SoundTable */
+     , (27217,   6,   67108990) /* PaletteBase */
+     , (27217,   7,  268436801) /* ClothingBase */
+     , (27217,   8,  100675948) /* Icon */
+     , (27217,  22,  872415275) /* PhysicsEffectTable */
+     , (27217,  36,  234881042) /* MutateFilter */
+     , (27217,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27218 Chiran Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27218 Chiran Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 27218;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (27218, 'leggingschiran', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (27218, 'leggingschiran', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (27218,   1,          2) /* ItemType - Armor */
@@ -16,8 +16,8 @@ VALUES (27218,   1,          2) /* ItemType - Armor */
      , (27218,  28,         90) /* ArmorLevel */
      , (27218,  53,        101) /* PlacementPosition */
      , (27218,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-     , (27218, 169,  252313872) /* TsysMutationData */
-     , (27218, 172,          1) /* AppraisalLongDescDecoration */;
+	 , (27218, 124,          3) /* Version */
+     , (27218, 169,  252313872) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (27218,  11, True ) /* IgnoreCollisions */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27219 Chiran Sandals.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27219 Chiran Sandals.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27219;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27219, 'sandalschiran', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27219,   1,          2) /* ItemType - Armor */
+     , (27219,   3,         20) /* PaletteTemplate - Silver */
+     , (27219,   4,      65536) /* ClothingPriority - Feet */
+     , (27219,   5,        540) /* EncumbranceVal */
+     , (27219,   8,        360) /* Mass */
+     , (27219,   9,        256) /* ValidLocations - FootWear */
+     , (27219,  16,          1) /* ItemUseable - No */
+     , (27219,  19,        653) /* Value */
+     , (27219,  27,         32) /* ArmorType - Metal */
+     , (27219,  28,        140) /* ArmorLevel */
+     , (27219,  44,          3) /* Damage */
+     , (27219,  45,          4) /* DamageType - Bludgeon */
+     , (27219,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27219, 124,          3) /* Version */
+     , (27219, 169,  151650576) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27219,  22, True ) /* Inscribable */
+     , (27219, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27219,  12,    0.66) /* Shade */
+     , (27219,  13,     1.3) /* ArmorModVsSlash */
+     , (27219,  14,       1) /* ArmorModVsPierce */
+     , (27219,  15,       1) /* ArmorModVsBludgeon */
+     , (27219,  16,     0.4) /* ArmorModVsCold */
+     , (27219,  17,     0.4) /* ArmorModVsFire */
+     , (27219,  18,     0.6) /* ArmorModVsAcid */
+     , (27219,  19,     0.4) /* ArmorModVsElectric */
+     , (27219,  22,    0.75) /* DamageVariance */
+     , (27219, 110,       1) /* BulkMod */
+     , (27219, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27219,   1, 'Chiran Sandals') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27219,   1,   33554654) /* Setup */
+     , (27219,   3,  536870932) /* SoundTable */
+     , (27219,   6,   67108990) /* PaletteBase */
+     , (27219,   7,  268436798) /* ClothingBase */
+     , (27219,   8,  100676025) /* Icon */
+     , (27219,  22,  872415275) /* PhysicsEffectTable */
+     , (27219,  36,  234881042) /* MutateFilter */
+     , (27219,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27220 Lorica Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27220 Lorica Boots.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27220;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27220, 'bootslorica', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27220,   1,          2) /* ItemType - Armor */
+     , (27220,   3,         20) /* PaletteTemplate - Silver */
+     , (27220,   4,      65536) /* ClothingPriority - Feet */
+     , (27220,   5,        540) /* EncumbranceVal */
+     , (27220,   8,        360) /* Mass */
+     , (27220,   9,        256) /* ValidLocations - FootWear */
+     , (27220,  16,          1) /* ItemUseable - No */
+     , (27220,  19,        653) /* Value */
+     , (27220,  27,         32) /* ArmorType - Metal */
+     , (27220,  28,        140) /* ArmorLevel */
+     , (27220,  44,          3) /* Damage */
+     , (27220,  45,          4) /* DamageType - Bludgeon */
+     , (27220,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27220, 124,          3) /* Version */
+     , (27220, 169,  151650564) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27220,  22, True ) /* Inscribable */
+     , (27220, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27220,  12,    0.66) /* Shade */
+     , (27220,  13,     1.3) /* ArmorModVsSlash */
+     , (27220,  14,       1) /* ArmorModVsPierce */
+     , (27220,  15,       1) /* ArmorModVsBludgeon */
+     , (27220,  16,     0.4) /* ArmorModVsCold */
+     , (27220,  17,     0.4) /* ArmorModVsFire */
+     , (27220,  18,     0.6) /* ArmorModVsAcid */
+     , (27220,  19,     0.4) /* ArmorModVsElectric */
+     , (27220,  22,    0.75) /* DamageVariance */
+     , (27220, 110,       1) /* BulkMod */
+     , (27220, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27220,   1, 'Lorica Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27220,   1,   33554654) /* Setup */
+     , (27220,   3,  536870932) /* SoundTable */
+     , (27220,   6,   67108990) /* PaletteBase */
+     , (27220,   7,  268436802) /* ClothingBase */
+     , (27220,   8,  100676063) /* Icon */
+     , (27220,  22,  872415275) /* PhysicsEffectTable */
+     , (27220,  36,  234881042) /* MutateFilter */
+     , (27220,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27221 Lorica Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27221 Lorica Breastplate.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27221;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27221, 'breastplatelorica', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27221,   1,          2) /* ItemType - Armor */
+     , (27221,   3,         20) /* PaletteTemplate - Silver */
+     , (27221,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (27221,   5,       1415) /* EncumbranceVal */
+     , (27221,   8,        850) /* Mass */
+     , (27221,   9,        512) /* ValidLocations - ChestArmor */
+     , (27221,  16,          1) /* ItemUseable - No */
+     , (27221,  19,       1545) /* Value */
+     , (27221,  27,         32) /* ArmorType - Metal */
+     , (27221,  28,         95) /* ArmorLevel */
+     , (27221,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27221, 124,          3) /* Version */
+     , (27221, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27221,  22, True ) /* Inscribable */
+     , (27221, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27221,  12,    0.33) /* Shade */
+     , (27221,  13,     1.3) /* ArmorModVsSlash */
+     , (27221,  14,       1) /* ArmorModVsPierce */
+     , (27221,  15,       1) /* ArmorModVsBludgeon */
+     , (27221,  16,     0.4) /* ArmorModVsCold */
+     , (27221,  17,     0.4) /* ArmorModVsFire */
+     , (27221,  18,     0.6) /* ArmorModVsAcid */
+     , (27221,  19,     0.4) /* ArmorModVsElectric */
+     , (27221, 110,    1.05) /* BulkMod */
+     , (27221, 111,     1.3) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27221,   1, 'Lorica Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27221,   1,   33554642) /* Setup */
+     , (27221,   3,  536870932) /* SoundTable */
+     , (27221,   6,   67108990) /* PaletteBase */
+     , (27221,   7,  268436807) /* ClothingBase */
+     , (27221,   8,  100676043) /* Icon */
+     , (27221,  22,  872415275) /* PhysicsEffectTable */
+     , (27221,  36,  234881042) /* MutateFilter */
+     , (27221,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27222 Lorica Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27222 Lorica Gauntlets.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27222;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27222, 'gauntletslorica', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27222,   1,          2) /* ItemType - Armor */
+     , (27222,   3,         20) /* PaletteTemplate - Silver */
+     , (27222,   4,      32768) /* ClothingPriority - Hands */
+     , (27222,   5,        919) /* EncumbranceVal */
+     , (27222,   8,        460) /* Mass */
+     , (27222,   9,         32) /* ValidLocations - HandWear */
+     , (27222,  16,          1) /* ItemUseable - No */
+     , (27222,  19,        653) /* Value */
+     , (27222,  27,         32) /* ArmorType - Metal */
+     , (27222,  28,        140) /* ArmorLevel */
+     , (27222,  44,          3) /* Damage */
+     , (27222,  45,          4) /* DamageType - Bludgeon */
+     , (27222,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27222, 124,          3) /* Version */
+     , (27222, 169,  151651588) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27222,  22, True ) /* Inscribable */
+     , (27222, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27222,  12,    0.66) /* Shade */
+     , (27222,  13,     1.3) /* ArmorModVsSlash */
+     , (27222,  14,       1) /* ArmorModVsPierce */
+     , (27222,  15,       1) /* ArmorModVsBludgeon */
+     , (27222,  16,     0.4) /* ArmorModVsCold */
+     , (27222,  17,     0.4) /* ArmorModVsFire */
+     , (27222,  18,     0.6) /* ArmorModVsAcid */
+     , (27222,  19,     0.4) /* ArmorModVsElectric */
+     , (27222,  22,    0.75) /* DamageVariance */
+     , (27222, 110,       1) /* BulkMod */
+     , (27222, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27222,   1, 'Lorica Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27222,   1,   33554648) /* Setup */
+     , (27222,   3,  536870932) /* SoundTable */
+     , (27222,   6,   67108990) /* PaletteBase */
+     , (27222,   7,  268436803) /* ClothingBase */
+     , (27222,   8,  100676120) /* Icon */
+     , (27222,  22,  872415275) /* PhysicsEffectTable */
+     , (27222,  36,  234881042) /* MutateFilter */
+     , (27222,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27223 Lorica Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27223 Lorica Helm.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27223;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27223, 'helmlorica', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27223,   1,          2) /* ItemType - Armor */
+     , (27223,   3,         20) /* PaletteTemplate - Silver */
+     , (27223,   4,      16384) /* ClothingPriority - Head */
+     , (27223,   5,        533) /* EncumbranceVal */
+     , (27223,   8,        200) /* Mass */
+     , (27223,   9,          1) /* ValidLocations - HeadWear */
+     , (27223,  16,          1) /* ItemUseable - No */
+     , (27223,  19,        653) /* Value */
+     , (27223,  27,         32) /* ArmorType - Metal */
+     , (27223,  28,        140) /* ArmorLevel */
+     , (27223,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (27223, 150,        103) /* HookPlacement - Hook */
+     , (27223, 151,          2) /* HookType - Wall */
+	 , (27223, 124,          3) /* Version */
+     , (27223, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27223,  22, True ) /* Inscribable */
+     , (27223, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27223,  12,    0.33) /* Shade */
+     , (27223,  13,     1.3) /* ArmorModVsSlash */
+     , (27223,  14,       1) /* ArmorModVsPierce */
+     , (27223,  15,       1) /* ArmorModVsBludgeon */
+     , (27223,  16,     0.4) /* ArmorModVsCold */
+     , (27223,  17,     0.4) /* ArmorModVsFire */
+     , (27223,  18,     0.6) /* ArmorModVsAcid */
+     , (27223,  19,     0.4) /* ArmorModVsElectric */
+     , (27223, 110,       1) /* BulkMod */
+     , (27223, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27223,   1, 'Lorica Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27223,   1,   33555248) /* Setup */
+     , (27223,   3,  536870932) /* SoundTable */
+     , (27223,   6,   67108990) /* PaletteBase */
+     , (27223,   7,  268436804) /* ClothingBase */
+     , (27223,   8,  100676101) /* Icon */
+     , (27223,  22,  872415275) /* PhysicsEffectTable */
+     , (27223,  36,  234881042) /* MutateFilter */
+     , (27223,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27224 Lorica Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27224 Lorica Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27224;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27224, 'leggingslorica', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27224,   1,          2) /* ItemType - Armor */
+     , (27224,   3,         20) /* PaletteTemplate - Silver */
+     , (27224,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
+     , (27224,   5,       2247) /* EncumbranceVal */
+     , (27224,   8,       1350) /* Mass */
+     , (27224,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
+     , (27224,  16,          1) /* ItemUseable - No */
+     , (27224,  19,       2157) /* Value */
+     , (27224,  27,         32) /* ArmorType - Metal */
+     , (27224,  28,         95) /* ArmorLevel */
+     , (27224,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27224, 124,          3) /* Version */
+     , (27224, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27224,  22, True ) /* Inscribable */
+     , (27224, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27224,  12,    0.66) /* Shade */
+     , (27224,  13,     1.3) /* ArmorModVsSlash */
+     , (27224,  14,       1) /* ArmorModVsPierce */
+     , (27224,  15,       1) /* ArmorModVsBludgeon */
+     , (27224,  16,     0.4) /* ArmorModVsCold */
+     , (27224,  17,     0.4) /* ArmorModVsFire */
+     , (27224,  18,     0.6) /* ArmorModVsAcid */
+     , (27224,  19,     0.4) /* ArmorModVsElectric */
+     , (27224, 110,    1.05) /* BulkMod */
+     , (27224, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27224,   1, 'Lorica Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27224,   1,   33554856) /* Setup */
+     , (27224,   3,  536870932) /* SoundTable */
+     , (27224,   6,   67108990) /* PaletteBase */
+     , (27224,   7,  268436805) /* ClothingBase */
+     , (27224,   8,  100676082) /* Icon */
+     , (27224,  22,  872415275) /* PhysicsEffectTable */
+     , (27224,  36,  234881042) /* MutateFilter */
+     , (27224,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27225 Lorica Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27225 Lorica Sleeves.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27225;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27225, 'sleeveslorica', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27225,   1,          2) /* ItemType - Armor */
+     , (27225,   3,         20) /* PaletteTemplate - Silver */
+     , (27225,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (27225,   5,       1375) /* EncumbranceVal */
+     , (27225,   8,        550) /* Mass */
+     , (27225,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (27225,  16,          1) /* ItemUseable - No */
+     , (27225,  19,       1620) /* Value */
+     , (27225,  27,          2) /* ArmorType - Leather */
+     , (27225,  28,         95) /* ArmorLevel */
+     , (27225,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27225, 124,          3) /* Version */
+     , (27225, 169,  118096142) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27225,  22, True ) /* Inscribable */
+     , (27225, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27225,  12,    0.66) /* Shade */
+     , (27225,  13,       1) /* ArmorModVsSlash */
+     , (27225,  14,     0.8) /* ArmorModVsPierce */
+     , (27225,  15,       1) /* ArmorModVsBludgeon */
+     , (27225,  16,     0.5) /* ArmorModVsCold */
+     , (27225,  17,     0.5) /* ArmorModVsFire */
+     , (27225,  18,     0.3) /* ArmorModVsAcid */
+     , (27225,  19,     0.6) /* ArmorModVsElectric */
+     , (27225, 110,    1.05) /* BulkMod */
+     , (27225, 111,     1.2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27225,   1, 'Lorica Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27225,   1,   33554655) /* Setup */
+     , (27225,   3,  536870932) /* SoundTable */
+     , (27225,   6,   67108990) /* PaletteBase */
+     , (27225,   7,  268436806) /* ClothingBase */
+     , (27225,   8,  100676139) /* Icon */
+     , (27225,  22,  872415275) /* PhysicsEffectTable */
+     , (27225,  36,  234881042) /* MutateFilter */
+     , (27225,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27226 Nariyid Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27226 Nariyid Boots.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27226;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27226, 'bootsnariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27226,   1,          2) /* ItemType - Armor */
+     , (27226,   3,         20) /* PaletteTemplate - Silver */
+     , (27226,   4,      65536) /* ClothingPriority - Feet */
+     , (27226,   5,        540) /* EncumbranceVal */
+     , (27226,   8,        360) /* Mass */
+     , (27226,   9,        256) /* ValidLocations - FootWear */
+     , (27226,  16,          1) /* ItemUseable - No */
+     , (27226,  19,        653) /* Value */
+     , (27226,  27,         32) /* ArmorType - Metal */
+     , (27226,  28,        140) /* ArmorLevel */
+     , (27226,  44,          3) /* Damage */
+     , (27226,  45,          4) /* DamageType - Bludgeon */
+     , (27226,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27226, 124,          3) /* Version */
+     , (27226, 169,  151650564) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27226,  22, True ) /* Inscribable */
+     , (27226, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27226,  12,    0.66) /* Shade */
+     , (27226,  13,     1.3) /* ArmorModVsSlash */
+     , (27226,  14,       1) /* ArmorModVsPierce */
+     , (27226,  15,       1) /* ArmorModVsBludgeon */
+     , (27226,  16,     0.4) /* ArmorModVsCold */
+     , (27226,  17,     0.4) /* ArmorModVsFire */
+     , (27226,  18,     0.6) /* ArmorModVsAcid */
+     , (27226,  19,     0.4) /* ArmorModVsElectric */
+     , (27226,  22,    0.75) /* DamageVariance */
+     , (27226, 110,       1) /* BulkMod */
+     , (27226, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27226,   1, 'Nariyid Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27226,   1,   33554654) /* Setup */
+     , (27226,   3,  536870932) /* SoundTable */
+     , (27226,   6,   67108990) /* PaletteBase */
+     , (27226,   7,  268436812) /* ClothingBase */
+     , (27226,   8,  100676176) /* Icon */
+     , (27226,  22,  872415275) /* PhysicsEffectTable */
+     , (27226,  36,  234881042) /* MutateFilter */
+     , (27226,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27227 Nariyid Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27227 Nariyid Breastplate.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27227;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27227, 'breastplatenariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27227,   1,          2) /* ItemType - Armor */
+     , (27227,   3,         20) /* PaletteTemplate - Silver */
+     , (27227,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (27227,   5,       2400) /* EncumbranceVal */
+     , (27227,   8,       1200) /* Mass */
+     , (27227,   9,        512) /* ValidLocations - ChestArmor */
+     , (27227,  16,          1) /* ItemUseable - No */
+     , (27227,  19,       1785) /* Value */
+     , (27227,  27,         32) /* ArmorType - Metal */
+     , (27227,  28,        110) /* ArmorLevel */
+     , (27227,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27227, 124,          3) /* Version */
+     , (27227, 169,  118097668) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27227,  22, True ) /* Inscribable */
+     , (27227, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27227,  12,    0.33) /* Shade */
+     , (27227,  13,     1.3) /* ArmorModVsSlash */
+     , (27227,  14,       1) /* ArmorModVsPierce */
+     , (27227,  15,       1) /* ArmorModVsBludgeon */
+     , (27227,  16,     0.4) /* ArmorModVsCold */
+     , (27227,  17,     0.4) /* ArmorModVsFire */
+     , (27227,  18,     0.6) /* ArmorModVsAcid */
+     , (27227,  19,     0.4) /* ArmorModVsElectric */
+     , (27227, 110,     0.9) /* BulkMod */
+     , (27227, 111,     1.3) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27227,   1, 'Nariyid Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27227,   1,   33554642) /* Setup */
+     , (27227,   3,  536870932) /* SoundTable */
+     , (27227,   6,   67108990) /* PaletteBase */
+     , (27227,   7,  268436811) /* ClothingBase */
+     , (27227,   8,  100676156) /* Icon */
+     , (27227,  22,  872415275) /* PhysicsEffectTable */
+     , (27227,  36,  234881042) /* MutateFilter */
+     , (27227,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27228 Nariyid Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27228 Nariyid Gauntlets.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27228;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27228, 'gauntletsnariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27228,   1,          2) /* ItemType - Armor */
+     , (27228,   3,         20) /* PaletteTemplate - Silver */
+     , (27228,   4,      32768) /* ClothingPriority - Hands */
+     , (27228,   5,        919) /* EncumbranceVal */
+     , (27228,   8,        460) /* Mass */
+     , (27228,   9,         32) /* ValidLocations - HandWear */
+     , (27228,  16,          1) /* ItemUseable - No */
+     , (27228,  19,        653) /* Value */
+     , (27228,  27,         32) /* ArmorType - Metal */
+     , (27228,  28,        140) /* ArmorLevel */
+     , (27228,  44,          3) /* Damage */
+     , (27228,  45,          4) /* DamageType - Bludgeon */
+     , (27228,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27228, 124,          3) /* Version */
+     , (27228, 169,  151651588) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27228,  22, True ) /* Inscribable */
+     , (27228, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27228,  12,    0.66) /* Shade */
+     , (27228,  13,     1.3) /* ArmorModVsSlash */
+     , (27228,  14,       1) /* ArmorModVsPierce */
+     , (27228,  15,       1) /* ArmorModVsBludgeon */
+     , (27228,  16,     0.4) /* ArmorModVsCold */
+     , (27228,  17,     0.4) /* ArmorModVsFire */
+     , (27228,  18,     0.6) /* ArmorModVsAcid */
+     , (27228,  19,     0.4) /* ArmorModVsElectric */
+     , (27228,  22,    0.75) /* DamageVariance */
+     , (27228, 110,       1) /* BulkMod */
+     , (27228, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27228,   1, 'Nariyid Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27228,   1,   33554648) /* Setup */
+     , (27228,   3,  536870932) /* SoundTable */
+     , (27228,   6,   67108990) /* PaletteBase */
+     , (27228,   7,  268436814) /* ClothingBase */
+     , (27228,   8,  100676252) /* Icon */
+     , (27228,  22,  872415275) /* PhysicsEffectTable */
+     , (27228,  36,  234881042) /* MutateFilter */
+     , (27228,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27229 Nariyid Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27229 Nariyid Girth.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27229;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27229, 'girthnariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27229,   1,          2) /* ItemType - Armor */
+     , (27229,   3,         20) /* PaletteTemplate - Silver */
+     , (27229,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
+     , (27229,   5,       1248) /* EncumbranceVal */
+     , (27229,   8,        625) /* Mass */
+     , (27229,   9,       1024) /* ValidLocations - AbdomenArmor */
+     , (27229,  16,          1) /* ItemUseable - No */
+     , (27229,  19,       1072) /* Value */
+     , (27229,  27,         32) /* ArmorType - Metal */
+     , (27229,  28,        110) /* ArmorLevel */
+     , (27229,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27229, 124,          3) /* Version */
+     , (27229, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27229,  22, True ) /* Inscribable */
+     , (27229, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27229,  12,    0.33) /* Shade */
+     , (27229,  13,     1.3) /* ArmorModVsSlash */
+     , (27229,  14,       1) /* ArmorModVsPierce */
+     , (27229,  15,       1) /* ArmorModVsBludgeon */
+     , (27229,  16,     0.4) /* ArmorModVsCold */
+     , (27229,  17,     0.4) /* ArmorModVsFire */
+     , (27229,  18,     0.6) /* ArmorModVsAcid */
+     , (27229,  19,     0.4) /* ArmorModVsElectric */
+     , (27229, 110,     0.9) /* BulkMod */
+     , (27229, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27229,   1, 'Nariyid Girth') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27229,   1,   33554647) /* Setup */
+     , (27229,   3,  536870932) /* SoundTable */
+     , (27229,   6,   67108990) /* PaletteBase */
+     , (27229,   7,  268436808) /* ClothingBase */
+     , (27229,   8,  100676233) /* Icon */
+     , (27229,  22,  872415275) /* PhysicsEffectTable */
+     , (27229,  36,  234881042) /* MutateFilter */
+     , (27229,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27230 Nariyid Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27230 Nariyid Helm.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27230;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27230, 'helmnariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27230,   1,          2) /* ItemType - Armor */
+     , (27230,   3,         20) /* PaletteTemplate - Silver */
+     , (27230,   4,      16384) /* ClothingPriority - Head */
+     , (27230,   5,        533) /* EncumbranceVal */
+     , (27230,   8,        200) /* Mass */
+     , (27230,   9,          1) /* ValidLocations - HeadWear */
+     , (27230,  16,          1) /* ItemUseable - No */
+     , (27230,  19,        653) /* Value */
+     , (27230,  27,         32) /* ArmorType - Metal */
+     , (27230,  28,        140) /* ArmorLevel */
+     , (27230,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (27230, 150,        103) /* HookPlacement - Hook */
+     , (27230, 151,          2) /* HookType - Wall */
+	 , (27230, 124,          3) /* Version */
+     , (27230, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27230,  22, True ) /* Inscribable */
+     , (27230, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27230,  12,    0.33) /* Shade */
+     , (27230,  13,     1.3) /* ArmorModVsSlash */
+     , (27230,  14,       1) /* ArmorModVsPierce */
+     , (27230,  15,       1) /* ArmorModVsBludgeon */
+     , (27230,  16,     0.4) /* ArmorModVsCold */
+     , (27230,  17,     0.4) /* ArmorModVsFire */
+     , (27230,  18,     0.6) /* ArmorModVsAcid */
+     , (27230,  19,     0.4) /* ArmorModVsElectric */
+     , (27230, 110,       1) /* BulkMod */
+     , (27230, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27230,   1, 'Nariyid Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27230,   1,   33555248) /* Setup */
+     , (27230,   3,  536870932) /* SoundTable */
+     , (27230,   6,   67108990) /* PaletteBase */
+     , (27230,   7,  268436813) /* ClothingBase */
+     , (27230,   8,  100676214) /* Icon */
+     , (27230,  22,  872415275) /* PhysicsEffectTable */
+     , (27230,  36,  234881042) /* MutateFilter */
+     , (27230,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27231 Nariyid Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27231 Nariyid Leggings.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27231;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27231, 'leggingsnariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27231,   1,          2) /* ItemType - Armor */
+     , (27231,   3,         20) /* PaletteTemplate - Silver */
+     , (27231,   4,        768) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs */
+     , (27231,   5,       2400) /* EncumbranceVal */
+     , (27231,   8,       1200) /* Mass */
+     , (27231,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
+     , (27231,  16,          1) /* ItemUseable - No */
+     , (27231,  19,       1425) /* Value */
+     , (27231,  27,         32) /* ArmorType - Metal */
+     , (27231,  28,        110) /* ArmorLevel */
+     , (27231,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27231, 124,          3) /* Version */
+     , (27231, 169,  252313860) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27231,  22, True ) /* Inscribable */
+     , (27231, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27231,  12,    0.66) /* Shade */
+     , (27231,  13,     1.3) /* ArmorModVsSlash */
+     , (27231,  14,       1) /* ArmorModVsPierce */
+     , (27231,  15,       1) /* ArmorModVsBludgeon */
+     , (27231,  16,     0.4) /* ArmorModVsCold */
+     , (27231,  17,     0.4) /* ArmorModVsFire */
+     , (27231,  18,     0.6) /* ArmorModVsAcid */
+     , (27231,  19,     0.4) /* ArmorModVsElectric */
+     , (27231, 110,     0.9) /* BulkMod */
+     , (27231, 111,     1.5) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27231,   1, 'Nariyid Leggings') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27231,   1,   33554856) /* Setup */
+     , (27231,   3,  536870932) /* SoundTable */
+     , (27231,   6,   67108990) /* PaletteBase */
+     , (27231,   7,  268436810) /* ClothingBase */
+     , (27231,   8,  100676195) /* Icon */
+     , (27231,  22,  872415275) /* PhysicsEffectTable */
+     , (27231,  36,  234881042) /* MutateFilter */
+     , (27231,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27232 Nariyid Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/27232 Nariyid Sleeves.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27232;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27232, 'sleevesnariyid', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27232,   1,          2) /* ItemType - Armor */
+     , (27232,   3,         20) /* PaletteTemplate - Silver */
+     , (27232,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (27232,   5,       1400) /* EncumbranceVal */
+     , (27232,   8,        700) /* Mass */
+     , (27232,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (27232,  16,          1) /* ItemUseable - No */
+     , (27232,  19,       1247) /* Value */
+     , (27232,  27,         32) /* ArmorType - Metal */
+     , (27232,  28,        110) /* ArmorLevel */
+     , (27232,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (27232, 124,          3) /* Version */
+     , (27232, 169,  118096132) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27232,  22, True ) /* Inscribable */
+     , (27232, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27232,  12,    0.66) /* Shade */
+     , (27232,  13,     1.3) /* ArmorModVsSlash */
+     , (27232,  14,       1) /* ArmorModVsPierce */
+     , (27232,  15,       1) /* ArmorModVsBludgeon */
+     , (27232,  16,     0.4) /* ArmorModVsCold */
+     , (27232,  17,     0.4) /* ArmorModVsFire */
+     , (27232,  18,     0.6) /* ArmorModVsAcid */
+     , (27232,  19,     0.4) /* ArmorModVsElectric */
+     , (27232, 110,     0.9) /* BulkMod */
+     , (27232, 111,     1.2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27232,   1, 'Nariyid Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27232,   1,   33554655) /* Setup */
+     , (27232,   3,  536870932) /* SoundTable */
+     , (27232,   6,   67108990) /* PaletteBase */
+     , (27232,   7,  268436809) /* ClothingBase */
+     , (27232,   8,  100676271) /* Icon */
+     , (27232,  22,  872415275) /* PhysicsEffectTable */
+     , (27232,  36,  234881042) /* MutateFilter */
+     , (27232,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28611 Viamontian Laced Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28611 Viamontian Laced Boots.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28611;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28611, 'bootsviamont', 2, '2019-08-16 14:09:58') /* Clothing */;
+VALUES (28611, 'bootsviamont', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28611,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (28611,   1,          2) /* ItemType - Armor */
      , (28611,  28,         20) /* ArmorLevel */
      , (28611,  53,        101) /* PlacementPosition - Resting */
      , (28611,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28611, 124,          3) /* Version */
      , (28611, 169,  185271566) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28617 Alduressa Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28617 Alduressa Helm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28617;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28617, 'helmalduressa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28617, 'helmalduressa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28617,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (28617,   1,          2) /* ItemType - Armor */
      , (28617,  27,         32) /* ArmorType - Metal */
      , (28617,  28,        110) /* ArmorLevel */
      , (28617,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28617, 124,          3) /* Version */
      , (28617, 150,        103) /* HookPlacement - Hook */
      , (28617, 151,          2) /* HookType - Wall */
 	 , (28617, 169,  168429060) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28618 Diforsa Helm.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28618 Diforsa Helm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28618;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28618, 'helmdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28618, 'helmdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28618,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28618,   1,          2) /* ItemType - Armor */
      , (28618,  27,         32) /* ArmorType - Metal */
      , (28618,  28,        150) /* ArmorLevel */
      , (28618,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28618, 124,          3) /* Version */
      , (28618, 150,        103) /* HookPlacement - Hook */
      , (28618, 151,          2) /* HookType - Wall */
      , (28618, 169,  118096132) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28620 Alduressa Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28620 Alduressa Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28620;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28620, 'leggingsalduressa', 2, '2019-05-18 23:01:22') /* Clothing */;
+VALUES (28620, 'leggingsalduressa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28620,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (28620,   1,          2) /* ItemType - Armor */
      , (28620,  27,          2) /* ArmorType - Leather */
      , (28620,  28,        110) /* ArmorLevel */
      , (28620,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28620, 124,          3) /* Version */
      , (28620, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28621 Diforsa Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28621 Diforsa Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28621;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28621, 'leggingsdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28621, 'leggingsdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28621,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28621,   1,          2) /* ItemType - Armor */
      , (28621,  27,         32) /* ArmorType - Metal */
      , (28621,  28,        110) /* ArmorLevel */
      , (28621,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28621, 124,          3) /* Version */
      , (28621, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28622 Tenassa Leggings.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28622 Tenassa Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28622;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28622, 'leggingstenassa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28622, 'leggingstenassa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28622,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28622,   1,          2) /* ItemType - Armor */
      , (28622,  27,         32) /* ArmorType - Metal */
      , (28622,  28,        100) /* ArmorLevel */
      , (28622,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28622, 124,          3) /* Version */
      , (28622, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28623 Diforsa Pauldrons.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28623 Diforsa Pauldrons.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28623;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28623, 'pauldronsdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28623, 'pauldronsdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28623,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28623,   1,          2) /* ItemType - Armor */
      , (28623,  27,         32) /* ArmorType - Metal */
      , (28623,  28,        110) /* ArmorLevel */
      , (28623,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28623, 124,          3) /* Version */
      , (28623, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28624 Tenassa Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28624 Tenassa Sleeves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28624;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28624, 'sleevestenassa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28624, 'sleevestenassa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28624,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28624,   1,          2) /* ItemType - Armor */
      , (28624,  27,         32) /* ArmorType - Metal */
      , (28624,  28,        100) /* ArmorLevel */
      , (28624,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28624, 124,          3) /* Version */
      , (28624, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28625 Diforsa Sollerets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28625 Diforsa Sollerets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28625;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28625, 'solleretsdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28625, 'solleretsdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28625,   1,          2) /* ItemType - Armor */
@@ -16,6 +16,7 @@ VALUES (28625,   1,          2) /* ItemType - Armor */
      , (28625,  44,          3) /* Damage */
      , (28625,  45,          4) /* DamageType - Bludgeon */
      , (28625,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28625, 124,          3) /* Version */
      , (28625, 169,  151650564) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28626 Diforsa Tassets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28626 Diforsa Tassets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28626;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28626, 'tassetsdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28626, 'tassetsdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28626,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28626,   1,          2) /* ItemType - Armor */
      , (28626,  27,         32) /* ArmorType - Metal */
      , (28626,  28,        110) /* ArmorLevel */
      , (28626,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28626, 124,          3) /* Version */
      , (28626, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28627 Diforsa Bracers.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28627 Diforsa Bracers.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28627;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28627, 'bracersdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28627, 'bracersdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28627,   1,          2) /* ItemType - Armor */
@@ -14,8 +14,8 @@ VALUES (28627,   1,          2) /* ItemType - Armor */
      , (28627,  19,        653) /* Value */
      , (28627,  27,         16) /* ArmorType - Chainmail */
      , (28627,  28,        110) /* ArmorLevel */
-     , (28627,  53,        101) /* PlacementPosition */
      , (28627,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (28627, 124,          3) /* Version */
      , (28627, 150,        103) /* HookPlacement - Hook */
      , (28627, 151,          2) /* HookType - Wall */
      , (28627, 169,  118097668) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28628 Diforsa Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28628 Diforsa Breastplate.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28628;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28628, 'breastplatediforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28628, 'breastplatediforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28628,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28628,   1,          2) /* ItemType - Armor */
      , (28628,  27,         32) /* ArmorType - Metal */
      , (28628,  28,        110) /* ArmorLevel */
      , (28628,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28628, 124,          3) /* Version */
      , (28628, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28629 Alduressa Coat.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28629 Alduressa Coat.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28629;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28629, 'coatalduressa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28629, 'coatalduressa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28629,   1,          2) /* ItemType - Armor */
@@ -14,8 +14,8 @@ VALUES (28629,   1,          2) /* ItemType - Armor */
      , (28629,  19,       1738) /* Value */
      , (28629,  27,          8) /* ArmorType - Scalemail */
      , (28629,  28,        110) /* ArmorLevel */
-     , (28629,  53,        101) /* PlacementPosition */
      , (28629,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28629, 124,          3) /* Version */
      , (28629, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28630 Diforsa Cuirass.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28630 Diforsa Cuirass.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28630;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28630, 'cuirassdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28630, 'cuirassdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28630,   1,          2) /* ItemType - Armor */
@@ -13,8 +13,8 @@ VALUES (28630,   1,          2) /* ItemType - Armor */
      , (28630,  19,       2284) /* Value */
      , (28630,  27,         32) /* ArmorType - Metal */
      , (28630,  28,        110) /* ArmorLevel */
-     , (28630,  53,        101) /* PlacementPosition */
      , (28630,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28630, 124,          3) /* Version */
      , (28630, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28632 Diforsa Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28632 Diforsa Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28632;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28632, 'gauntletsdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28632, 'gauntletsdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28632,   1,          2) /* ItemType - Armor */
@@ -16,6 +16,7 @@ VALUES (28632,   1,          2) /* ItemType - Armor */
      , (28632,  44,          3) /* Damage */
      , (28632,  45,          4) /* DamageType - Bludgeon */
      , (28632,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28632, 124,          3) /* Version */
      , (28632, 169,  151651588) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28633 Diforsa Girth.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28633 Diforsa Girth.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28633;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28633, 'girthdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28633, 'girthdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28633,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (28633,   1,          2) /* ItemType - Armor */
      , (28633,  27,         32) /* ArmorType - Metal */
      , (28633,  28,        110) /* ArmorLevel */
      , (28633,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28633, 124,          3) /* Version */
      , (28633, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28634 Diforsa Greaves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/28634 Diforsa Greaves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28634;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28634, 'greavesdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (28634, 'greavesdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28634,   1,          2) /* ItemType - Armor */
@@ -13,8 +13,8 @@ VALUES (28634,   1,          2) /* ItemType - Armor */
      , (28634,  19,        653) /* Value */
      , (28634,  27,         32) /* ArmorType - Metal */
      , (28634,  28,        110) /* ArmorLevel */
-     , (28634,  53,        101) /* PlacementPosition */
      , (28634,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (28634, 124,          3) /* Version */
      , (28634, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30948 Diforsa Hauberk.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30948 Diforsa Hauberk.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 30948;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (30948, 'hauberkdiforsa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (30948, 'hauberkdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (30948,   1,          2) /* ItemType - Armor */
@@ -13,8 +13,8 @@ VALUES (30948,   1,          2) /* ItemType - Armor */
      , (30948,  19,       2937) /* Value */
      , (30948,  27,         32) /* ArmorType - Metal */
      , (30948,  28,        110) /* ArmorLevel */
-     , (30948,  53,        101) /* PlacementPosition */
      , (30948,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (30948, 124,          3) /* Version */
      , (30948, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30949 Diforsa Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30949 Diforsa Sleeves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 30949;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (30949, 'sleevesdiforsa', 2, '2019-05-18 23:01:22') /* Clothing */;
+VALUES (30949, 'sleevesdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (30949,   1,          2) /* ItemType - Armor */
@@ -13,8 +13,8 @@ VALUES (30949,   1,          2) /* ItemType - Armor */
      , (30949,  19,       1145) /* Value */
      , (30949,  27,         32) /* ArmorType - Metal */
      , (30949,  28,        110) /* ArmorLevel */
-     , (30949,  53,        101) /* PlacementPosition - Resting */
      , (30949,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (30949, 124,          3) /* Version */
      , (30949, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30949 Leather Sleeves.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30949 Leather Sleeves.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30949;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30949, 'sleevesdiforsa', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30949,   1,          2) /* ItemType - Armor */
+     , (30949,   3,          4) /* PaletteTemplate - Brown */
+     , (30949,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
+     , (30949,   5,        540) /* EncumbranceVal */
+     , (30949,   8,        180) /* Mass */
+     , (30949,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
+     , (30949,  16,          1) /* ItemUseable - No */
+     , (30949,  19,         60) /* Value */
+     , (30949,  27,          2) /* ArmorType - Leather */
+     , (30949,  28,         90) /* ArmorLevel */
+     , (30949,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (30949, 124,          3) /* Version */
+     , (30949, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30949,  22, True ) /* Inscribable */
+     , (30949, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30949,  12,    0.66) /* Shade */
+     , (30949,  13,       1) /* ArmorModVsSlash */
+     , (30949,  14,     0.8) /* ArmorModVsPierce */
+     , (30949,  15,       1) /* ArmorModVsBludgeon */
+     , (30949,  16,     0.5) /* ArmorModVsCold */
+     , (30949,  17,     0.5) /* ArmorModVsFire */
+     , (30949,  18,     0.3) /* ArmorModVsAcid */
+     , (30949,  19,     0.6) /* ArmorModVsElectric */
+     , (30949, 110,    1.67) /* BulkMod */
+     , (30949, 111,    1.75) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30949,   1, 'Leather Sleeves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30949,   1,   33554655) /* Setup */
+     , (30949,   3,  536870932) /* SoundTable */
+     , (30949,   6,   67108990) /* PaletteBase */
+     , (30949,   7,  268435502) /* ClothingBase */
+     , (30949,   8,  100668412) /* Icon */
+     , (30949,  22,  872415275) /* PhysicsEffectTable */
+     , (30949,  36,  234881042) /* MutateFilter */
+     , (30949,  46,  939524146) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30950 Alduressa Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30950 Alduressa Boots.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 30950;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (30950, 'bootsalduressa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (30950, 'bootsalduressa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (30950,   1,          2) /* ItemType - Armor */
@@ -13,10 +13,11 @@ VALUES (30950,   1,          2) /* ItemType - Armor */
      , (30950,  16,          1) /* ItemUseable - No */
      , (30950,  19,         70) /* Value */
      , (30950,  27,          2) /* ArmorType - Leather */
-     , (30950,  28,         20) /* ArmorLevel */
+     , (30950,  28,        130) /* ArmorLevel */
      , (30950,  44,          1) /* Damage */
      , (30950,  45,          4) /* DamageType - Bludgeon */
      , (30950,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (30950, 124,          3) /* Version */
      , (30950, 169,  185271566) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30951 Alduressa Gauntlets.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/30951 Alduressa Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 30951;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (30951, 'gauntletsalduressa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (30951, 'gauntletsalduressa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (30951,   1,          2) /* ItemType - Armor */
@@ -13,10 +13,11 @@ VALUES (30951,   1,          2) /* ItemType - Armor */
      , (30951,  16,          1) /* ItemUseable - No */
      , (30951,  19,         30) /* Value */
      , (30951,  27,          2) /* ArmorType - Leather */
-     , (30951,  28,         20) /* ArmorLevel */
+     , (30951,  28,        130) /* ArmorLevel */
      , (30951,  44,          0) /* Damage */
      , (30951,  45,          4) /* DamageType - Bludgeon */
      , (30951,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (30951, 124,          3) /* Version */
      , (30951, 169,  151717134) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31026 Tenassa Breastplate.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31026 Tenassa Breastplate.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 31026;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (31026, 'breastplatetenassa', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (31026, 'breastplatetenassa', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (31026,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (31026,   1,          2) /* ItemType - Armor */
      , (31026,  27,         32) /* ArmorType - Metal */
      , (31026,  28,        100) /* ArmorLevel */
      , (31026,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31026, 124,          3) /* Version */
      , (31026, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31249 Viamontian Laced Boots.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31249 Viamontian Laced Boots.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 31249;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (31249, 'ace31249-viamontianlacedboots', 2, '2019-08-16 14:09:58') /* Clothing */;
+VALUES (31249, 'ace31249-viamontianlacedboots', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (31249,   1,          2) /* ItemType - Armor */
@@ -17,6 +17,7 @@ VALUES (31249,   1,          2) /* ItemType - Armor */
      , (31249,  45,          4) /* DamageType - Bludgeon */
      , (31249,  53,        101) /* PlacementPosition - Resting */
      , (31249,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31249, 124,          3) /* Version */
      , (31249, 169,  185271566) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31864 Teardrop Crown.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31864 Teardrop Crown.sql
@@ -15,6 +15,7 @@ VALUES (31864,   1,          2) /* ItemType - Armor */
      , (31864,  27,         32) /* ArmorType - Metal */
      , (31864,  28,         30) /* ArmorLevel */
      , (31864,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31864, 124,          3) /* Version */
      , (31864, 150,        103) /* HookPlacement - Hook */
      , (31864, 151,          2) /* HookType - Wall */
      , (31864, 169,   51054852) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31865 Circlet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31865 Circlet.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 31865;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (31865, 'ace31865-circlet', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (31865, 'ace31865-circlet', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (31865,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (31865,   1,          2) /* ItemType - Armor */
      , (31865,  27,         32) /* ArmorType - Metal */
      , (31865,  28,         30) /* ArmorLevel */
      , (31865,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31865, 124,          3) /* Version */
      , (31865, 150,        103) /* HookPlacement - Hook */
      , (31865, 151,          2) /* HookType - Wall */
      , (31865, 169,   51054852) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31866 Coronet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31866 Coronet.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 31866;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (31866, 'ace31866-coronet', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (31866, 'ace31866-coronet', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (31866,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (31866,   1,          2) /* ItemType - Armor */
      , (31866,  27,         32) /* ArmorType - Metal */
      , (31866,  28,         30) /* ArmorLevel */
      , (31866,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31866, 124,          3) /* Version */
      , (31866, 150,        103) /* HookPlacement - Hook */
      , (31866, 151,          2) /* HookType - Wall */
      , (31866, 169,   51054852) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31867 Diadem.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31867 Diadem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 31867;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (31867, 'ace31867-diadem', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (31867, 'ace31867-diadem', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (31867,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (31867,   1,          2) /* ItemType - Armor */
      , (31867,  27,         32) /* ArmorType - Metal */
      , (31867,  28,         30) /* ArmorLevel */
      , (31867,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31867, 124,          3) /* Version */
      , (31867, 150,        103) /* HookPlacement - Hook */
      , (31867, 151,          2) /* HookType - Wall */
      , (31867, 169,   51054852) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31868 Signet Crown.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Armor/31868 Signet Crown.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 31868;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (31868, 'ace31868-signetcrown', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (31868, 'ace31868-signetcrown', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (31868,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (31868,   1,          2) /* ItemType - Armor */
      , (31868,  27,         32) /* ArmorType - Metal */
      , (31868,  28,         30) /* ArmorLevel */
      , (31868,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (31868, 124,          3) /* Version */
      , (31868, 150,        103) /* HookPlacement - Hook */
      , (31868, 151,          2) /* HookType - Wall */
      , (31868, 169,   51054852) /* TsysMutationData */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00118 Cap.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00118 Cap.sql
@@ -11,33 +11,28 @@ VALUES (118,   1,          4) /* ItemType - Clothing */
      , (118,   8,         15) /* Mass */
      , (118,   9,          1) /* ValidLocations - HeadWear */
      , (118,  16,          1) /* ItemUseable - No */
-     , (118,  19,          5) /* Value */
+     , (118,  19,       1010) /* Value */
      , (118,  27,          1) /* ArmorType - Cloth */
      , (118,  28,         20) /* ArmorLevel */
-     , (118,  53,        101) /* PlacementPosition */
      , (118,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (118, 150,        103) /* HookPlacement - Hook */
      , (118, 151,          2) /* HookType - Wall */
      , (118, 169,  218104336) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (118,  11, True ) /* IgnoreCollisions */
-     , (118,  13, True ) /* Ethereal */
-     , (118,  14, True ) /* GravityStatus */
-     , (118,  19, True ) /* Attackable */
-     , (118,  22, True ) /* Inscribable */
+VALUES (118,  22, True ) /* Inscribable */
      , (118, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (118,  12, 0.660000026226044) /* Shade */
-     , (118,  13, 0.800000011920929) /* ArmorModVsSlash */
-     , (118,  14, 0.800000011920929) /* ArmorModVsPierce */
-     , (118,  15,       1) /* ArmorModVsBludgeon */
-     , (118,  16, 0.200000002980232) /* ArmorModVsCold */
-     , (118,  17, 0.200000002980232) /* ArmorModVsFire */
-     , (118,  18, 0.100000001490116) /* ArmorModVsAcid */
-     , (118,  19, 0.200000002980232) /* ArmorModVsElectric */
-     , (118, 165,       1) /* ArmorModVsNether */;
+VALUES (118,  12, 0.66) /* Shade */
+     , (118,  13,  1.2) /* ArmorModVsSlash */
+     , (118,  14,  0.8) /* ArmorModVsPierce */
+     , (118,  15,    1) /* ArmorModVsBludgeon */
+     , (118,  16,  0.5) /* ArmorModVsCold */
+     , (118,  17,  0.5) /* ArmorModVsFire */
+     , (118,  18,  0.3) /* ArmorModVsAcid */
+     , (118,  19,  0.8) /* ArmorModVsElectric */
+     , (118, 165,    1) /* ArmorModVsNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (118,   1, 'Cap') /* Name */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00119 Cowl.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00119 Cowl.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 119;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (119, 'cowlcloth', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (119, 'cowlcloth', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (119,   1,          4) /* ItemType - Clothing */
@@ -14,30 +14,25 @@ VALUES (119,   1,          4) /* ItemType - Clothing */
      , (119,  19,          5) /* Value */
      , (119,  27,          1) /* ArmorType - Cloth */
      , (119,  28,         20) /* ArmorLevel */
-     , (119,  53,        101) /* PlacementPosition */
      , (119,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (119, 150,        103) /* HookPlacement - Hook */
      , (119, 151,          2) /* HookType - Wall */
      , (119, 169,  218104080) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (119,  11, True ) /* IgnoreCollisions */
-     , (119,  13, True ) /* Ethereal */
-     , (119,  14, True ) /* GravityStatus */
-     , (119,  19, True ) /* Attackable */
-     , (119,  22, True ) /* Inscribable */
+VALUES (119,  22, True ) /* Inscribable */
      , (119, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (119,  12, 0.660000026226044) /* Shade */
-     , (119,  13, 0.800000011920929) /* ArmorModVsSlash */
-     , (119,  14, 0.800000011920929) /* ArmorModVsPierce */
-     , (119,  15,       1) /* ArmorModVsBludgeon */
-     , (119,  16, 0.200000002980232) /* ArmorModVsCold */
-     , (119,  17, 0.200000002980232) /* ArmorModVsFire */
-     , (119,  18, 0.100000001490116) /* ArmorModVsAcid */
-     , (119,  19, 0.200000002980232) /* ArmorModVsElectric */
-     , (119, 165,       1) /* ArmorModVsNether */;
+VALUES (119,  12, 0.66) /* Shade */
+     , (119,  13,  1.2) /* ArmorModVsSlash */
+     , (119,  14,  0.8) /* ArmorModVsPierce */
+     , (119,  15,    1) /* ArmorModVsBludgeon */
+     , (119,  16,  0.5) /* ArmorModVsCold */
+     , (119,  17,  0.5) /* ArmorModVsFire */
+     , (119,  18,  0.3) /* ArmorModVsAcid */
+     , (119,  19,  0.8) /* ArmorModVsElectric */
+     , (119, 165,    1) /* ArmorModVsNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (119,   1, 'Cowl') /* Name */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00128 Qafiya.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00128 Qafiya.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 128;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (128, 'qafiya', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (128, 'qafiya', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (128,   1,          4) /* ItemType - Clothing */
@@ -11,33 +11,28 @@ VALUES (128,   1,          4) /* ItemType - Clothing */
      , (128,   8,         15) /* Mass */
      , (128,   9,          1) /* ValidLocations - HeadWear */
      , (128,  16,          1) /* ItemUseable - No */
-     , (128,  19,          5) /* Value */
+     , (128,  19,       1020) /* Value */
      , (128,  27,          1) /* ArmorType - Cloth */
      , (128,  28,         20) /* ArmorLevel */
-     , (128,  53,        101) /* PlacementPosition */
      , (128,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (128, 150,        103) /* HookPlacement - Hook */
      , (128, 151,          2) /* HookType - Wall */
      , (128, 169,  218104336) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (128,  11, True ) /* IgnoreCollisions */
-     , (128,  13, True ) /* Ethereal */
-     , (128,  14, True ) /* GravityStatus */
-     , (128,  19, True ) /* Attackable */
-     , (128,  22, True ) /* Inscribable */
+VALUES (128,  22, True ) /* Inscribable */
      , (128, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (128,  12, 0.600000023841858) /* Shade */
-     , (128,  13, 0.800000011920929) /* ArmorModVsSlash */
-     , (128,  14, 0.800000011920929) /* ArmorModVsPierce */
-     , (128,  15,       1) /* ArmorModVsBludgeon */
-     , (128,  16, 0.200000002980232) /* ArmorModVsCold */
-     , (128,  17, 0.200000002980232) /* ArmorModVsFire */
-     , (128,  18, 0.100000001490116) /* ArmorModVsAcid */
-     , (128,  19, 0.200000002980232) /* ArmorModVsElectric */
-     , (128, 165,       1) /* ArmorModVsNether */;
+VALUES (128,  12, 0.6) /* Shade */
+     , (128,  13, 1.2) /* ArmorModVsSlash */
+     , (128,  14, 0.8) /* ArmorModVsPierce */
+     , (128,  15,   1) /* ArmorModVsBludgeon */
+     , (128,  16, 0.5) /* ArmorModVsCold */
+     , (128,  17, 0.5) /* ArmorModVsFire */
+     , (128,  18, 0.3) /* ArmorModVsAcid */
+     , (128,  19, 0.8) /* ArmorModVsElectric */
+     , (128, 165,   1) /* ArmorModVsNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (128,   1, 'Qafiya') /* Name */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00129 Sandals.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00129 Sandals.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 129;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (129, 'sandals', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (129,   1,          4) /* ItemType - Clothing */
+     , (129,   3,          4) /* PaletteTemplate - Brown */
+     , (129,   4,      65536) /* ClothingPriority - Feet */
+     , (129,   5,         90) /* EncumbranceVal */
+     , (129,   8,         45) /* Mass */
+     , (129,   9,        256) /* ValidLocations - FootWear */
+     , (129,  16,          1) /* ItemUseable - No */
+     , (129,  19,       1040) /* Value */
+     , (129,  27,          2) /* ArmorType - Leather */
+     , (129,  28,         20) /* ArmorLevel */
+     , (129,  44,          1) /* Damage */
+     , (129,  45,          4) /* DamageType - Bludgeon */
+     , (129,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (129, 124,          3) /* Version */
+     , (129, 169,  184550670) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (129,  22, True ) /* Inscribable */
+     , (129, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (129,  12,     0.2) /* Shade */
+     , (129,  13,     1.2) /* ArmorModVsSlash */
+     , (129,  14,     0.8) /* ArmorModVsPierce */
+     , (129,  15,       1) /* ArmorModVsBludgeon */
+     , (129,  16,     0.5) /* ArmorModVsCold */
+     , (129,  17,     0.5) /* ArmorModVsFire */
+     , (129,  18,     0.3) /* ArmorModVsAcid */
+     , (129,  19,     0.8) /* ArmorModVsElectric */
+     , (129,  22,    0.75) /* DamageVariance */
+     , (129, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (129,   1, 'Sandals') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (129,   1,   33554654) /* Setup */
+     , (129,   3,  536870932) /* SoundTable */
+     , (129,   6,   67108990) /* PaletteBase */
+     , (129,   7,  268435716) /* ClothingBase */
+     , (129,   8,  100667324) /* Icon */
+     , (129,  22,  872415275) /* PhysicsEffectTable */
+     , (129,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00132 Shoes.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00132 Shoes.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 132;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (132, 'shoes', 2, '2019-11-05 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (132,   1,          4) /* ItemType - Clothing */
+     , (132,   3,          4) /* PaletteTemplate - Brown */
+     , (132,   4,      65536) /* ClothingPriority - Feet */
+     , (132,   5,         90) /* EncumbranceVal */
+     , (132,   8,         45) /* Mass */
+     , (132,   9,        256) /* ValidLocations - FootWear */
+     , (132,  16,          1) /* ItemUseable - No */
+     , (132,  19,       1040) /* Value */
+     , (132,  27,          1) /* ArmorType - Cloth */
+     , (132,  28,         20) /* ArmorLevel */
+     , (132,  44,          1) /* Damage */
+     , (132,  45,          4) /* DamageType - Bludgeon */
+     , (132,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (132, 169,  184550670) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (132,  22, True ) /* Inscribable */
+     , (132, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (132,  12,     0.6) /* Shade */
+     , (132,  13,     1.2) /* ArmorModVsSlash */
+     , (132,  14,     0.8) /* ArmorModVsPierce */
+     , (132,  15,       1) /* ArmorModVsBludgeon */
+     , (132,  16,     0.5) /* ArmorModVsCold */
+     , (132,  17,     0.5) /* ArmorModVsFire */
+     , (132,  18,     0.3) /* ArmorModVsAcid */
+     , (132,  19,     0.8) /* ArmorModVsElectric */
+     , (132,  22,    0.75) /* DamageVariance */
+     , (132, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (132,   1, 'Shoes') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (132,   1,   33554654) /* Setup */
+     , (132,   3,  536870932) /* SoundTable */
+     , (132,   6,   67108990) /* PaletteBase */
+     , (132,   7,  268435487) /* ClothingBase */
+     , (132,   8,  100667325) /* Icon */
+     , (132,  22,  872415275) /* PhysicsEffectTable */
+     , (132,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00135 Turban.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Clothing/00135 Turban.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 135;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (135, 'turban', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (135, 'turban', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (135,   1,          4) /* ItemType - Clothing */
@@ -11,33 +11,28 @@ VALUES (135,   1,          4) /* ItemType - Clothing */
      , (135,   8,         15) /* Mass */
      , (135,   9,          1) /* ValidLocations - HeadWear */
      , (135,  16,          1) /* ItemUseable - No */
-     , (135,  19,          5) /* Value */
+     , (135,  19,       1008) /* Value */
      , (135,  27,          1) /* ArmorType - Cloth */
      , (135,  28,         20) /* ArmorLevel */
-     , (135,  53,        101) /* PlacementPosition */
      , (135,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (135, 150,        103) /* HookPlacement - Hook */
      , (135, 151,          2) /* HookType - Wall */
      , (135, 169,  218105360) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (135,  11, True ) /* IgnoreCollisions */
-     , (135,  13, True ) /* Ethereal */
-     , (135,  14, True ) /* GravityStatus */
-     , (135,  19, True ) /* Attackable */
-     , (135,  22, True ) /* Inscribable */
+VALUES (135,  22, True ) /* Inscribable */
      , (135, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (135,  12, 0.800000011920929) /* Shade */
-     , (135,  13, 0.800000011920929) /* ArmorModVsSlash */
-     , (135,  14, 0.800000011920929) /* ArmorModVsPierce */
-     , (135,  15,       1) /* ArmorModVsBludgeon */
-     , (135,  16, 0.200000002980232) /* ArmorModVsCold */
-     , (135,  17, 0.200000002980232) /* ArmorModVsFire */
-     , (135,  18, 0.100000001490116) /* ArmorModVsAcid */
-     , (135,  19, 0.200000002980232) /* ArmorModVsElectric */
-     , (135, 165,       1) /* ArmorModVsNether */;
+VALUES (135,  12, 0.8) /* Shade */
+     , (135,  13, 1.2) /* ArmorModVsSlash */
+     , (135,  14, 0.8) /* ArmorModVsPierce */
+     , (135,  15,   1) /* ArmorModVsBludgeon */
+     , (135,  16, 0.5) /* ArmorModVsCold */
+     , (135,  17, 0.5) /* ArmorModVsFire */
+     , (135,  18, 0.3) /* ArmorModVsAcid */
+     , (135,  19, 0.8) /* ArmorModVsElectric */
+     , (135, 165,   1) /* ArmorModVsNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (135,   1, 'Turban') /* Name */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00044 Buckler.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00044 Buckler.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 44;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (44, 'buckler', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (44,   1,          2) /* ItemType - Armor */
+     , (44,   3,          8) /* PaletteTemplate - Green */
+     , (44,   5,        420) /* EncumbranceVal */
+     , (44,   8,        140) /* Mass */
+     , (44,   9,    2097152) /* ValidLocations - Shield */
+     , (44,  16,          1) /* ItemUseable - No */
+     , (44,  19,       1100) /* Value */
+     , (44,  27,          2) /* ArmorType - Leather */
+     , (44,  28,         10) /* ArmorLevel */
+     , (44,  51,          4) /* CombatUse - Shield */
+     , (44,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (44, 124,          3) /* Version */
+     , (44, 150,        103) /* HookPlacement - Hook */
+     , (44, 151,          2) /* HookType - Wall */
+     , (44, 169,  134284292) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (44,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (44,  13,       1) /* ArmorModVsSlash */
+     , (44,  14,     0.8) /* ArmorModVsPierce */
+     , (44,  15,     1.2) /* ArmorModVsBludgeon */
+     , (44,  16,     0.6) /* ArmorModVsCold */
+     , (44,  17,     0.6) /* ArmorModVsFire */
+     , (44,  18,       1) /* ArmorModVsAcid */
+     , (44,  19,     0.6) /* ArmorModVsElectric */
+     , (44,  39,     0.5) /* DefaultScale */
+     , (44, 110,       1) /* BulkMod */
+     , (44, 111,       2) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (44,   1, 'Buckler') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (44,   1,   33554786) /* Setup */
+     , (44,   3,  536870932) /* SoundTable */
+     , (44,   6,   67111919) /* PaletteBase */
+     , (44,   7,  268435807) /* ClothingBase */
+     , (44,   8,  100668451) /* Icon */
+     , (44,  22,  872415275) /* PhysicsEffectTable */
+     , (44,  36,  234881043) /* MutateFilter */
+     , (44,  46,  939524147) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00091 Kite Shield.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00091 Kite Shield.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 91;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (91, 'shieldkite', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (91,   1,          2) /* ItemType - Armor */
+     , (91,   3,          4) /* PaletteTemplate - Brown */
+     , (91,   5,        690) /* EncumbranceVal */
+     , (91,   8,        230) /* Mass */
+     , (91,   9,    2097152) /* ValidLocations - Shield */
+     , (91,  16,          1) /* ItemUseable - No */
+     , (91,  19,        120) /* Value */
+     , (91,  27,          2) /* ArmorType - Leather */
+     , (91,  28,         20) /* ArmorLevel */
+     , (91,  51,          4) /* CombatUse - Shield */
+     , (91,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (91, 124,          3) /* Version */
+     , (91, 150,        103) /* HookPlacement - Hook */
+     , (91, 151,          2) /* HookType - Wall */
+     , (91, 169,  134284804) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (91,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (91,  13,       1) /* ArmorModVsSlash */
+     , (91,  14,     0.8) /* ArmorModVsPierce */
+     , (91,  15,     1.2) /* ArmorModVsBludgeon */
+     , (91,  16,     0.6) /* ArmorModVsCold */
+     , (91,  17,     0.6) /* ArmorModVsFire */
+     , (91,  18,       1) /* ArmorModVsAcid */
+     , (91,  19,     0.6) /* ArmorModVsElectric */
+     , (91,  39,    0.75) /* DefaultScale */
+     , (91, 110,       1) /* BulkMod */
+     , (91, 111,    1.33) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (91,   1, 'Kite Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (91,   1,   33554788) /* Setup */
+     , (91,   3,  536870932) /* SoundTable */
+     , (91,   6,   67111919) /* PaletteBase */
+     , (91,   7,  268435610) /* ClothingBase */
+     , (91,   8,  100668151) /* Icon */
+     , (91,  22,  872415275) /* PhysicsEffectTable */
+     , (91,  36,  234881043) /* MutateFilter */
+     , (91,  46,  939524147) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00092 Large Kite Shield.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00092 Large Kite Shield.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 92;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (92, 'shieldkitelarge', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (92,   1,          2) /* ItemType - Armor */
+     , (92,   3,          4) /* PaletteTemplate - Brown */
+     , (92,   5,       1380) /* EncumbranceVal */
+     , (92,   8,        460) /* Mass */
+     , (92,   9,    2097152) /* ValidLocations - Shield */
+     , (92,  16,          1) /* ItemUseable - No */
+     , (92,  19,        210) /* Value */
+     , (92,  27,          2) /* ArmorType - Leather */
+     , (92,  28,         40) /* ArmorLevel */
+     , (92,  51,          4) /* CombatUse - Shield */
+     , (92,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (92, 124,          3) /* Version */
+     , (92, 150,        103) /* HookPlacement - Hook */
+     , (92, 151,          2) /* HookType - Wall */
+     , (92, 169,  134285060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (92,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (92,  13,       1) /* ArmorModVsSlash */
+     , (92,  14,     0.8) /* ArmorModVsPierce */
+     , (92,  15,     1.2) /* ArmorModVsBludgeon */
+     , (92,  16,     0.6) /* ArmorModVsCold */
+     , (92,  17,     0.6) /* ArmorModVsFire */
+     , (92,  18,       1) /* ArmorModVsAcid */
+     , (92,  19,     0.6) /* ArmorModVsElectric */
+     , (92,  39,       1) /* DefaultScale */
+     , (92, 110,       1) /* BulkMod */
+     , (92, 111,     1.1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (92,   1, 'Large Kite Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (92,   1,   33554788) /* Setup */
+     , (92,   3,  536870932) /* SoundTable */
+     , (92,   6,   67111919) /* PaletteBase */
+     , (92,   7,  268435609) /* ClothingBase */
+     , (92,   8,  100667360) /* Icon */
+     , (92,  22,  872415275) /* PhysicsEffectTable */
+     , (92,  36,  234881043) /* MutateFilter */
+     , (92,  46,  939524147) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00093 Round Shield.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00093 Round Shield.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 93;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (93, 'shieldround', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (93,   1,          2) /* ItemType - Armor */
+     , (93,   3,          4) /* PaletteTemplate - Brown */
+     , (93,   5,        690) /* EncumbranceVal */
+     , (93,   8,        230) /* Mass */
+     , (93,   9,    2097152) /* ValidLocations - Shield */
+     , (93,  16,          1) /* ItemUseable - No */
+     , (93,  19,       1300) /* Value */
+     , (93,  27,          2) /* ArmorType - Leather */
+     , (93,  28,         20) /* ArmorLevel */
+     , (93,  51,          4) /* CombatUse - Shield */
+     , (93,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (93, 124,          3) /* Version */
+     , (93, 150,        103) /* HookPlacement - Hook */
+     , (93, 151,          2) /* HookType - Wall */
+     , (93, 169,  134284804) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (93,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (93,  13,       1) /* ArmorModVsSlash */
+     , (93,  14,     0.8) /* ArmorModVsPierce */
+     , (93,  15,     1.2) /* ArmorModVsBludgeon */
+     , (93,  16,     0.6) /* ArmorModVsCold */
+     , (93,  17,     0.6) /* ArmorModVsFire */
+     , (93,  18,       1) /* ArmorModVsAcid */
+     , (93,  19,     0.6) /* ArmorModVsElectric */
+     , (93,  39,       1) /* DefaultScale */
+     , (93, 110,       1) /* BulkMod */
+     , (93, 111,    1.33) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (93,   1, 'Round Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (93,   1,   33554786) /* Setup */
+     , (93,   3,  536870932) /* SoundTable */
+     , (93,   6,   67111919) /* PaletteBase */
+     , (93,   7,  268435806) /* ClothingBase */
+     , (93,   8,  100668415) /* Icon */
+     , (93,  22,  872415275) /* PhysicsEffectTable */
+     , (93,  36,  234881043) /* MutateFilter */
+     , (93,  46,  939524147) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00094 Large Round Shield.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00094 Large Round Shield.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 94;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (94, 'shieldroundlarge', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (94,   1,          2) /* ItemType - Armor */
+     , (94,   3,          4) /* PaletteTemplate - Brown */
+     , (94,   5,       1380) /* EncumbranceVal */
+     , (94,   8,        460) /* Mass */
+     , (94,   9,    2097152) /* ValidLocations - Shield */
+     , (94,  16,          1) /* ItemUseable - No */
+     , (94,  19,       1500) /* Value */
+     , (94,  27,          2) /* ArmorType - Leather */
+     , (94,  28,         40) /* ArmorLevel */
+     , (94,  51,          4) /* CombatUse - Shield */
+     , (94,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (94, 124,          3) /* Version */
+     , (94, 150,        103) /* HookPlacement - Hook */
+     , (94, 151,          2) /* HookType - Wall */
+     , (94, 169,  134285060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (94,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (94,  13,       1) /* ArmorModVsSlash */
+     , (94,  14,     0.8) /* ArmorModVsPierce */
+     , (94,  15,     1.2) /* ArmorModVsBludgeon */
+     , (94,  16,     0.6) /* ArmorModVsCold */
+     , (94,  17,     0.6) /* ArmorModVsFire */
+     , (94,  18,       1) /* ArmorModVsAcid */
+     , (94,  19,     0.6) /* ArmorModVsElectric */
+     , (94,  39,    1.25) /* DefaultScale */
+     , (94, 110,       1) /* BulkMod */
+     , (94, 111,     1.1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (94,   1, 'Large Round Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (94,   1,   33554786) /* Setup */
+     , (94,   3,  536870932) /* SoundTable */
+     , (94,   6,   67111919) /* PaletteBase */
+     , (94,   7,  268435602) /* ClothingBase */
+     , (94,   8,  100667361) /* Icon */
+     , (94,  22,  872415275) /* PhysicsEffectTable */
+     , (94,  36,  234881043) /* MutateFilter */
+     , (94,  46,  939524147) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00095 Tower Shield.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/00095 Tower Shield.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 95;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (95, 'shieldtower', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (95,   1,          2) /* ItemType - Armor */
+     , (95,   3,          4) /* PaletteTemplate - Brown */
+     , (95,   5,       2040) /* EncumbranceVal */
+     , (95,   8,        680) /* Mass */
+     , (95,   9,    2097152) /* ValidLocations - Shield */
+     , (95,  16,          1) /* ItemUseable - No */
+     , (95,  19,       1680) /* Value */
+     , (95,  27,          2) /* ArmorType - Leather */
+     , (95,  28,         60) /* ArmorLevel */
+     , (95,  51,          4) /* CombatUse - Shield */
+     , (95,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (95, 124,          3) /* Version */
+     , (95, 150,        103) /* HookPlacement - Hook */
+     , (95, 151,          2) /* HookType - Wall */
+     , (95, 169,  134285060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (95,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (95,  13,       1) /* ArmorModVsSlash */
+     , (95,  14,     0.8) /* ArmorModVsPierce */
+     , (95,  15,     1.2) /* ArmorModVsBludgeon */
+     , (95,  16,     0.6) /* ArmorModVsCold */
+     , (95,  17,     0.6) /* ArmorModVsFire */
+     , (95,  18,       1) /* ArmorModVsAcid */
+     , (95,  19,     0.6) /* ArmorModVsElectric */
+     , (95,  39,       1) /* DefaultScale */
+     , (95, 110,       1) /* BulkMod */
+     , (95, 111,    1.05) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (95,   1, 'Tower Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (95,   1,   33554785) /* Setup */
+     , (95,   3,  536870932) /* SoundTable */
+     , (95,   6,   67111919) /* PaletteBase */
+     , (95,   7,  268435611) /* ClothingBase */
+     , (95,   8,  100667362) /* Icon */
+     , (95,  22,  872415275) /* PhysicsEffectTable */
+     , (95,  36,  234881043) /* MutateFilter */
+     , (95,  46,  939524147) /* TsysMutationFilter */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/21158 Covenant Shield.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Shields/21158 Covenant Shield.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 21158;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (21158, 'shieldcovenant', 1, '2019-11-05 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (21158,   1,          2) /* ItemType - Armor */
+     , (21158,   3,          4) /* PaletteTemplate - Brown */
+     , (21158,   5,       2040) /* EncumbranceVal */
+     , (21158,   8,        680) /* Mass */
+     , (21158,   9,    2097152) /* ValidLocations - Shield */
+     , (21158,  16,          1) /* ItemUseable - No */
+     , (21158,  19,        300) /* Value */
+     , (21158,  27,          2) /* ArmorType - Leather */
+     , (21158,  28,        200) /* ArmorLevel */
+     , (21158,  36,       9999) /* ResistMagic */
+     , (21158,  51,          4) /* CombatUse - Shield */
+     , (21158,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (21158, 124,          3) /* Version */
+     , (21158, 150,        103) /* HookPlacement - Hook */
+     , (21158, 151,          2) /* HookType - Wall */
+     , (21158, 169,  134285060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (21158,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (21158,  13,     1.3) /* ArmorModVsSlash */
+     , (21158,  14,     1.3) /* ArmorModVsPierce */
+     , (21158,  15,     1.3) /* ArmorModVsBludgeon */
+     , (21158,  16,     0.6) /* ArmorModVsCold */
+     , (21158,  17,     0.6) /* ArmorModVsFire */
+     , (21158,  18,     0.6) /* ArmorModVsAcid */
+     , (21158,  19,     0.6) /* ArmorModVsElectric */
+     , (21158,  39,    0.75) /* DefaultScale */
+     , (21158, 110,       1) /* BulkMod */
+     , (21158, 111,    1.05) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (21158,   1, 'Covenant Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (21158,   1,   33557878) /* Setup */
+     , (21158,   3,  536870932) /* SoundTable */
+     , (21158,   6,   67111919) /* PaletteBase */
+     , (21158,   7,  268436441) /* ClothingBase */
+     , (21158,   8,  100667362) /* Icon */
+     , (21158,  22,  872415275) /* PhysicsEffectTable */
+     , (21158,  36,  234881046) /* MutateFilter */
+     , (21158,  46,  939524164) /* TsysMutationFilter */;

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37187 Olthoi Alduressa Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37187 Olthoi Alduressa Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37187;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37187, 'ace37187-olthoialduressagauntlets', 2, '2019-04-24 03:53:25') /* Clothing */;
+VALUES (37187, 'ace37187-olthoialduressagauntlets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37187,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37187,   1,          2) /* ItemType - Armor */
      , (37187,   9,         32) /* ValidLocations - HandWear */
      , (37187,  16,          1) /* ItemUseable - No */
 	 , (37187,  27,          2) /* ArmorType - Leather */
-     , (37187,  28,        225) /* ArmorLevel */
-     , (37187,  53,        101) /* PlacementPosition - Resting */
+     , (37187,  28,        130) /* ArmorLevel */
      , (37187,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37187, 124,          2) /* Version */
+	 , (37187, 124,          3) /* Version */
      , (37187, 151,          2) /* HookType - Wall */
 	 , (37187, 169,  151651588) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37187,  11, True ) /* IgnoreCollisions */
-     , (37187,  13, True ) /* Ethereal */
-     , (37187,  14, True ) /* GravityStatus */
-     , (37187,  19, True ) /* Attackable */
-     , (37187,  22, True ) /* Inscribable */
+VALUES (37187,  22, True ) /* Inscribable */
      , (37187, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37188 Olthoi Amuli Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37188 Olthoi Amuli Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37188;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37188, 'ace37188-olthoiamuligauntlets', 2, '2019-04-22 04:33:31') /* Clothing */;
+VALUES (37188, 'ace37188-olthoiamuligauntlets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37188,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37188,   1,          2) /* ItemType - Armor */
      , (37188,   9,         32) /* ValidLocations - HandWear */
      , (37188,  16,          1) /* ItemUseable - No */
 	 , (37188,  27,          8) /* ArmorType - Scalemail */
-     , (37188,  28,        205) /* ArmorLevel */
-     , (37188,  53,        101) /* PlacementPosition - Resting */
+     , (37188,  28,        140) /* ArmorLevel */
      , (37188,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37188, 124,          2) /* Version */
+	 , (37188, 124,          3) /* Version */
      , (37188, 151,          2) /* HookType - Wall */
 	 , (37188, 169,  151651588) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37188,  11, True ) /* IgnoreCollisions */
-     , (37188,  13, True ) /* Ethereal */
-     , (37188,  14, True ) /* GravityStatus */
-     , (37188,  19, True ) /* Attackable */
-     , (37188,  22, True ) /* Inscribable */
+VALUES (37188,  22, True ) /* Inscribable */
      , (37188, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37189 Olthoi Celdon Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37189 Olthoi Celdon Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37189;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37189, 'ace37189-olthoiceldongauntlets', 2, '2019-05-11 00:00:00') /* Clothing */;
+VALUES (37189, 'ace37189-olthoiceldongauntlets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37189,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37189,   1,          2) /* ItemType - Armor */
      , (37189,   9,         32) /* ValidLocations - HandWear */
      , (37189,  16,          1) /* ItemUseable - No */
 	 , (37189,  27,         32) /* ArmorType - Metal */
-     , (37189,  28,        225) /* ArmorLevel */
-     , (37189,  53,        101) /* PlacementPosition */
+     , (37189,  28,        150) /* ArmorLevel */
      , (37189,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37189, 124,          2) /* Version */
+	 , (37189, 124,          3) /* Version */
      , (37189, 151,          2) /* HookType - Wall */
 	 , (37189, 169,  151651588) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37189,  11, True ) /* IgnoreCollisions */
-     , (37189,  13, True ) /* Ethereal */
-     , (37189,  14, True ) /* GravityStatus */
-     , (37189,  19, True ) /* Attackable */
-     , (37189,  22, True ) /* Inscribable */
+VALUES (37189,  22, True ) /* Inscribable */
      , (37189, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37190 Olthoi Koujia Gauntlets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37190 Olthoi Koujia Gauntlets.sql
@@ -1,28 +1,24 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37190;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37190, 'ace37190-olthoikoujiagauntlets', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (37190, 'ace37190-olthoikoujiagauntlets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37190,   1,          2) /* ItemType - Armor */
+     , (37190,   3,          2) /* PaletteTemplate - Blue */
      , (37190,   4,      32768) /* ClothingPriority - Hands */
      , (37190,   5,        517) /* EncumbranceVal */
      , (37190,   9,         32) /* ValidLocations - HandWear */
      , (37190,  16,          1) /* ItemUseable - No */
 	 , (37190,  27,         32) /* ArmorType - Metal */
-     , (37190,  28,        225) /* ArmorLevel */
-     , (37190,  53,        101) /* PlacementPosition */
+     , (37190,  28,        150) /* ArmorLevel */
      , (37190,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37190, 124,          2) /* Version */
+	 , (37190, 124,          3) /* Version */
      , (37190, 151,          2) /* HookType - Wall */
 	 , (37190, 169,  151651588) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37190,  11, True ) /* IgnoreCollisions */
-     , (37190,  13, True ) /* Ethereal */
-     , (37190,  14, True ) /* GravityStatus */
-     , (37190,  19, True ) /* Attackable */
-     , (37190,  22, True ) /* Inscribable */
+VALUES (37190,  22, True ) /* Inscribable */
      , (37190, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37192 Olthoi Celdon Girth.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37192 Olthoi Celdon Girth.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37192;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37192, 'ace37192-olthoiceldongirth', 2, '2019-05-11 00:00:00') /* Clothing */;
+VALUES (37192, 'ace37192-olthoiceldongirth', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37192,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37192,   1,          2) /* ItemType - Armor */
      , (37192,   9,       1024) /* ValidLocations - AbdomenArmor */
      , (37192,  16,          1) /* ItemUseable - No */
 	 , (37192,  27,         32) /* ArmorType - Metal */
-     , (37192,  28,        225) /* ArmorLevel */
-     , (37192,  53,        101) /* PlacementPosition */
+     , (37192,  28,        110) /* ArmorLevel */
      , (37192,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37192, 124,          2) /* Version */
+	 , (37192, 124,          3) /* Version */
      , (37192, 151,          2) /* HookType - Wall */
      , (37192, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37192,  11, True ) /* IgnoreCollisions */
-     , (37192,  13, True ) /* Ethereal */
-     , (37192,  14, True ) /* GravityStatus */
-     , (37192,  19, True ) /* Attackable */
-     , (37192,  22, True ) /* Inscribable */
+VALUES (37192,  22, True ) /* Inscribable */
      , (37192, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37195 Olthoi Alduressa Helm.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37195 Olthoi Alduressa Helm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37195;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37195, 'ace37195-olthoialduressahelm', 2, '2019-04-23 00:59:22') /* Clothing */;
+VALUES (37195, 'ace37195-olthoialduressahelm', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37195,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37195,   1,          2) /* ItemType - Armor */
      , (37195,   9,          1) /* ValidLocations - HeadWear */
      , (37195,  16,          1) /* ItemUseable - No */
 	 , (37195,  27,         32) /* ArmorType - Metal */
-     , (37195,  28,        225) /* ArmorLevel */
-     , (37195,  53,        101) /* PlacementPosition - Resting */
+     , (37195,  28,        150) /* ArmorLevel */
      , (37195,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37195, 124,          2) /* Version */
+	 , (37195, 124,          3) /* Version */
      , (37195, 151,          2) /* HookType - Wall */
 	 , (37195, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37195,  11, True ) /* IgnoreCollisions */
-     , (37195,  13, True ) /* Ethereal */
-     , (37195,  14, True ) /* GravityStatus */
-     , (37195,  19, True ) /* Attackable */
-     , (37195,  22, True ) /* Inscribable */
+VALUES (37195,  22, True ) /* Inscribable */
      , (37195, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37196 Olthoi Amuli Helm.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37196 Olthoi Amuli Helm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37196;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37196, 'ace37196-olthoiamulihelm', 2, '2019-04-22 04:33:31') /* Clothing */;
+VALUES (37196, 'ace37196-olthoiamulihelm', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37196,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37196,   1,          2) /* ItemType - Armor */
      , (37196,   9,          1) /* ValidLocations - HeadWear */
      , (37196,  16,          1) /* ItemUseable - No */
 	 , (37196,  27,          8) /* ArmorType - Scalemail */
-     , (37196,  28,        205) /* ArmorLevel */
-     , (37196,  53,        101) /* PlacementPosition - Resting */
+     , (37196,  28,        140) /* ArmorLevel */
      , (37196,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37196, 124,          2) /* Version */
+	 , (37196, 124,          3) /* Version */
      , (37196, 151,          2) /* HookType - Wall */
 	 , (37196, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37196,  11, True ) /* IgnoreCollisions */
-     , (37196,  13, True ) /* Ethereal */
-     , (37196,  14, True ) /* GravityStatus */
-     , (37196,  19, True ) /* Attackable */
-     , (37196,  22, True ) /* Inscribable */
+VALUES (37196,  22, True ) /* Inscribable */
      , (37196, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37197 Olthoi Celdon Helm.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37197 Olthoi Celdon Helm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37197;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37197, 'ace37197-olthoiceldonhelm', 2, '2019-05-11 00:00:00') /* Clothing */;
+VALUES (37197, 'ace37197-olthoiceldonhelm', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37197,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37197,   1,          2) /* ItemType - Armor */
      , (37197,   9,          1) /* ValidLocations - HeadWear */
      , (37197,  16,          1) /* ItemUseable - No */
 	 , (37197,  27,         32) /* ArmorType - Metal */
-     , (37197,  28,        225) /* ArmorLevel */
-     , (37197,  53,        101) /* PlacementPosition */
+     , (37197,  28,        140) /* ArmorLevel */
      , (37197,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37197, 124,          2) /* Version */
+	 , (37197, 124,          3) /* Version */
      , (37197, 151,          2) /* HookType - Wall */
 	 , (37197, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37197,  11, True ) /* IgnoreCollisions */
-     , (37197,  13, True ) /* Ethereal */
-     , (37197,  14, True ) /* GravityStatus */
-     , (37197,  19, True ) /* Attackable */
-     , (37197,  22, True ) /* Inscribable */
+VALUES (37197,  22, True ) /* Inscribable */
      , (37197, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37198 Olthoi Koujia Kabuton.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37198 Olthoi Koujia Kabuton.sql
@@ -1,28 +1,24 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37198;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37198, 'ace37198-olthoikoujiakabuton', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (37198, 'ace37198-olthoikoujiakabuton', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37198,   1,          2) /* ItemType - Armor */
+     , (37198,   3,          2) /* PaletteTemplate - Blue */
      , (37198,   4,      16384) /* ClothingPriority - Head */
      , (37198,   5,        426) /* EncumbranceVal */
      , (37198,   9,          1) /* ValidLocations - HeadWear */
      , (37198,  16,          1) /* ItemUseable - No */
 	 , (37198,  27,         32) /* ArmorType - Metal */
-     , (37198,  28,        225) /* ArmorLevel */
-     , (37198,  53,        101) /* PlacementPosition */
+     , (37198,  28,        150) /* ArmorLevel */
      , (37198,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37198, 124,          2) /* Version */
+	 , (37198, 124,          3) /* Version */
      , (37198, 151,          2) /* HookType - Wall */
 	 , (37198, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37198,  11, True ) /* IgnoreCollisions */
-     , (37198,  13, True ) /* Ethereal */
-     , (37198,  14, True ) /* GravityStatus */
-     , (37198,  19, True ) /* Attackable */
-     , (37198,  22, True ) /* Inscribable */
+VALUES (37198,  22, True ) /* Inscribable */
      , (37198, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37200 Olthoi Alduressa Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37200 Olthoi Alduressa Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37200;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37200, 'ace37200-olthoialduressaleggings', 2, '2019-04-23 00:59:22') /* Clothing */;
+VALUES (37200, 'ace37200-olthoialduressaleggings', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37200,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37200,   1,          2) /* ItemType - Armor */
      , (37200,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
      , (37200,  16,          1) /* ItemUseable - No */
 	 , (37200,  27,         32) /* ArmorType - Metal */
-     , (37200,  28,        225) /* ArmorLevel */
-     , (37200,  53,        101) /* PlacementPosition - Resting */
+     , (37200,  28,        110) /* ArmorLevel */
      , (37200,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37200, 124,          2) /* Version */
+	 , (37200, 124,          3) /* Version */
      , (37200, 151,          2) /* HookType - Wall */
 	 , (37200, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37200,  11, True ) /* IgnoreCollisions */
-     , (37200,  13, True ) /* Ethereal */
-     , (37200,  14, True ) /* GravityStatus */
-     , (37200,  19, True ) /* Attackable */
-     , (37200,  22, True ) /* Inscribable */
+VALUES (37200,  22, True ) /* Inscribable */
      , (37200, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37201 Olthoi Amuli Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37201 Olthoi Amuli Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37201;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37201, 'ace37201-olthoiamulileggings', 2, '2019-04-22 04:33:31') /* Clothing */;
+VALUES (37201, 'ace37201-olthoiamulileggings', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37201,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37201,   1,          2) /* ItemType - Armor */
      , (37201,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
      , (37201,  16,          1) /* ItemUseable - No */
 	 , (37201,  27,          8) /* ArmorType - Scalemail */
-     , (37201,  28,        205) /* ArmorLevel */
-     , (37201,  53,        101) /* PlacementPosition - Resting */
+     , (37201,  28,        100) /* ArmorLevel */
      , (37201,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37201, 124,          2) /* Version */
+	 , (37201, 124,          3) /* Version */
      , (37201, 151,          2) /* HookType - Wall */
 	 , (37201, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37201,  11, True ) /* IgnoreCollisions */
-     , (37201,  13, True ) /* Ethereal */
-     , (37201,  14, True ) /* GravityStatus */
-     , (37201,  19, True ) /* Attackable */
-     , (37201,  22, True ) /* Inscribable */
+VALUES (37201,  22, True ) /* Inscribable */
      , (37201, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37202 Olthoi Celdon Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37202 Olthoi Celdon Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37202;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37202, 'ace37202-olthoiceldonleggings', 2, '2019-05-11 00:00:00') /* Clothing */;
+VALUES (37202, 'ace37202-olthoiceldonleggings', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37202,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37202,   1,          2) /* ItemType - Armor */
      , (37202,   9,      24576) /* ValidLocations - UpperLegArmor, LowerLegArmor */
      , (37202,  16,          1) /* ItemUseable - No */
 	 , (37202,  27,         32) /* ArmorType - Metal */
-     , (37202,  28,        225) /* ArmorLevel */
-     , (37202,  53,        101) /* PlacementPosition */
+     , (37202,  28,        110) /* ArmorLevel */
      , (37202,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37202, 124,          2) /* Version */
+	 , (37202, 124,          3) /* Version */
      , (37202, 151,          2) /* HookType - Wall */
 	 , (37202, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37202,  11, True ) /* IgnoreCollisions */
-     , (37202,  13, True ) /* Ethereal */
-     , (37202,  14, True ) /* GravityStatus */
-     , (37202,  19, True ) /* Attackable */
-     , (37202,  22, True ) /* Inscribable */
+VALUES (37202,  22, True ) /* Inscribable */
      , (37202, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37203 Olthoi Koujia Leggings.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37203 Olthoi Koujia Leggings.sql
@@ -1,28 +1,24 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37203;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37203, 'ace37203-olthoikoujialeggings', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (37203, 'ace37203-olthoikoujialeggings', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37203,   1,          2) /* ItemType - Armor */
+     , (37203,   3,          2) /* PaletteTemplate - Blue */
      , (37203,   4,       2816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearAbdomen */
      , (37203,   5,       1251) /* EncumbranceVal */
      , (37203,   9,      25600) /* ValidLocations - AbdomenArmor, UpperLegArmor, LowerLegArmor */
      , (37203,  16,          1) /* ItemUseable - No */
 	 , (37203,  27,         32) /* ArmorType - Metal */
-     , (37203,  28,        225) /* ArmorLevel */
-     , (37203,  53,        101) /* PlacementPosition */
+     , (37203,  28,        110) /* ArmorLevel */
      , (37203,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37203, 124,          2) /* Version */
+	 , (37203, 124,          3) /* Version */
      , (37203, 151,          2) /* HookType - Wall */
 	 , (37203, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37203,  11, True ) /* IgnoreCollisions */
-     , (37203,  13, True ) /* Ethereal */
-     , (37203,  14, True ) /* GravityStatus */
-     , (37203,  19, True ) /* Attackable */
-     , (37203,  22, True ) /* Inscribable */
+VALUES (37203,  22, True ) /* Inscribable */
      , (37203, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37205 Olthoi Celdon Sleeves.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37205 Olthoi Celdon Sleeves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37205;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37205, 'ace37205-olthoiceldonsleeves', 2, '2019-05-11 00:00:00') /* Clothing */;
+VALUES (37205, 'ace37205-olthoiceldonsleeves', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37205,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37205,   1,          2) /* ItemType - Armor */
      , (37205,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
      , (37205,  16,          1) /* ItemUseable - No */
 	 , (37205,  27,         32) /* ArmorType - Metal */
-     , (37205,  28,        225) /* ArmorLevel */
-     , (37205,  53,        101) /* PlacementPosition */
+     , (37205,  28,        110) /* ArmorLevel */
      , (37205,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37205, 124,          2) /* Version */
+	 , (37205, 124,          3) /* Version */
 	 , (37205, 151,          2) /* HookType - Wall */
      , (37205, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37205,  11, True ) /* IgnoreCollisions */
-     , (37205,  13, True ) /* Ethereal */
-     , (37205,  14, True ) /* GravityStatus */
-     , (37205,  19, True ) /* Attackable */
-     , (37205,  22, True ) /* Inscribable */
+VALUES (37205,  22, True ) /* Inscribable */
      , (37205, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37206 Olthoi Koujia Sleeves.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37206 Olthoi Koujia Sleeves.sql
@@ -1,28 +1,24 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37206;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37206, 'ace37206-olthoikoujiasleeves', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (37206, 'ace37206-olthoikoujiasleeves', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37206,   1,          2) /* ItemType - Armor */
+     , (37206,   3,          2) /* PaletteTemplate - Blue */
      , (37206,   4,      12288) /* ClothingPriority - OuterwearUpperArms, OuterwearLowerArms */
      , (37206,   5,        643) /* EncumbranceVal */
      , (37206,   9,       6144) /* ValidLocations - UpperArmArmor, LowerArmArmor */
      , (37206,  16,          1) /* ItemUseable - No */
 	 , (37206,  27,         32) /* ArmorType - Metal */
-     , (37206,  28,        225) /* ArmorLevel */
-     , (37206,  53,        101) /* PlacementPosition */
+     , (37206,  28,        110) /* ArmorLevel */
      , (37206,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37206, 124,          2) /* Version */
+	 , (37206, 124,          3) /* Version */
      , (37206, 151,          2) /* HookType - Wall */
      , (37206, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37206,  11, True ) /* IgnoreCollisions */
-     , (37206,  13, True ) /* Ethereal */
-     , (37206,  14, True ) /* GravityStatus */
-     , (37206,  19, True ) /* Attackable */
-     , (37206,  22, True ) /* Inscribable */
+VALUES (37206,  22, True ) /* Inscribable */
      , (37206, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37207 Olthoi Alduressa Boots.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37207 Olthoi Alduressa Boots.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37207;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37207, 'ace37207-olthoialduressaboots', 2, '2019-05-30 01:39:42') /* Clothing */;
+VALUES (37207, 'ace37207-olthoialduressaboots', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37207,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37207,   1,          2) /* ItemType - Armor */
      , (37207,   9,        256) /* ValidLocations - FootWear */
      , (37207,  16,          1) /* ItemUseable - No */
 	 , (37207,  27,          2) /* ArmorType - Leather */
-     , (37207,  28,        225) /* ArmorLevel */
-     , (37207,  53,        101) /* PlacementPosition - Resting */
+     , (37207,  28,        130) /* ArmorLevel */
      , (37207,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37207, 124,          2) /* Version */
+	 , (37207, 124,          3) /* Version */
      , (37207, 151,          2) /* HookType - Wall */
      , (37207, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37207,  11, True ) /* IgnoreCollisions */
-     , (37207,  13, True ) /* Ethereal */
-     , (37207,  14, True ) /* GravityStatus */
-     , (37207,  19, True ) /* Attackable */
-     , (37207,  22, True ) /* Inscribable */
+VALUES (37207,  22, True ) /* Inscribable */
      , (37207, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37208 Olthoi Amuli Sollerets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37208 Olthoi Amuli Sollerets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37208;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37208, 'ace37208-olthoiamulisollerets', 2, '2019-05-30 01:39:42') /* Clothing */;
+VALUES (37208, 'ace37208-olthoiamulisollerets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37208,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37208,   1,          2) /* ItemType - Armor */
      , (37208,   9,        256) /* ValidLocations - FootWear */
      , (37208,  16,          1) /* ItemUseable - No */
 	 , (37208,  27,          8) /* ArmorType - Scalemail */
-     , (37208,  28,        205) /* ArmorLevel */
-     , (37208,  53,        101) /* PlacementPosition - Resting */
+     , (37208,  28,        140) /* ArmorLevel */
      , (37208,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37208, 124,          2) /* Version */
+	 , (37208, 124,          3) /* Version */
      , (37208, 151,          2) /* HookType - Wall */
      , (37208, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37208,  11, True ) /* IgnoreCollisions */
-     , (37208,  13, True ) /* Ethereal */
-     , (37208,  14, True ) /* GravityStatus */
-     , (37208,  19, True ) /* Attackable */
-     , (37208,  22, True ) /* Inscribable */
+VALUES (37208,  22, True ) /* Inscribable */
      , (37208, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37209 Olthoi Celdon Sollerets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37209 Olthoi Celdon Sollerets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37209;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37209, 'ace37209-olthoiceldonsollerets', 2, '2019-05-30 01:39:42') /* Clothing */;
+VALUES (37209, 'ace37209-olthoiceldonsollerets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37209,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37209,   1,          2) /* ItemType - Armor */
      , (37209,   9,        256) /* ValidLocations - FootWear */
      , (37209,  16,          1) /* ItemUseable - No */
 	 , (37209,  27,         32) /* ArmorType - Metal */
-     , (37209,  28,        225) /* ArmorLevel */
-     , (37209,  53,        101) /* PlacementPosition */
+     , (37209,  28,        150) /* ArmorLevel */
      , (37209,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37209, 124,          2) /* Version */
+	 , (37209, 124,          3) /* Version */
      , (37209, 151,          2) /* HookType - Wall */
      , (37209, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37209,  11, True ) /* IgnoreCollisions */
-     , (37209,  13, True ) /* Ethereal */
-     , (37209,  14, True ) /* GravityStatus */
-     , (37209,  19, True ) /* Attackable */
-     , (37209,  22, True ) /* Inscribable */
+VALUES (37209,  22, True ) /* Inscribable */
      , (37209, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37211 Olthoi Koujia Sollerets.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37211 Olthoi Koujia Sollerets.sql
@@ -1,28 +1,24 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37211;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37211, 'ace37211-olthoikoujiasollerets', 2, '2019-05-30 01:39:42') /* Clothing */;
+VALUES (37211, 'ace37211-olthoikoujiasollerets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37211,   1,          2) /* ItemType - Armor */
+     , (37211,   3,          2) /* PaletteTemplate - Blue */
      , (37211,   4,      65536) /* ClothingPriority - Feet */
      , (37211,   5,        275) /* EncumbranceVal */
      , (37211,   9,        256) /* ValidLocations - FootWear */
      , (37211,  16,          1) /* ItemUseable - No */
 	 , (37211,  27,         32) /* ArmorType - Metal */
-     , (37211,  28,        225) /* ArmorLevel */
-     , (37211,  53,        101) /* PlacementPosition - Resting */
+     , (37211,  28,        150) /* ArmorLevel */
      , (37211,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37211, 124,          2) /* Version */
+	 , (37211, 124,          3) /* Version */
      , (37211, 151,          2) /* HookType - Wall */
      , (37211, 169,  168429060) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37211,  11, True ) /* IgnoreCollisions */
-     , (37211,  13, True ) /* Ethereal */
-     , (37211,  14, True ) /* GravityStatus */
-     , (37211,  19, True ) /* Attackable */
-     , (37211,  22, True ) /* Inscribable */
+VALUES (37211,  22, True ) /* Inscribable */
      , (37211, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37214 Olthoi Celdon Breastplate.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37214 Olthoi Celdon Breastplate.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37214;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37214, 'ace37214-olthoiceldonbreastplate', 2, '2019-05-11 00:00:00') /* Clothing */;
+VALUES (37214, 'ace37214-olthoiceldonbreastplate', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37214,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37214,   1,          2) /* ItemType - Armor */
      , (37214,   9,        512) /* ValidLocations - ChestArmor */
      , (37214,  16,          1) /* ItemUseable - No */
 	 , (37214,  27,         32) /* ArmorType - Metal */
-     , (37214,  28,        225) /* ArmorLevel */
-     , (37214,  53,        101) /* PlacementPosition */
+     , (37214,  28,        110) /* ArmorLevel */
      , (37214,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37214, 124,          2) /* Version */
+	 , (37214, 124,          3) /* Version */
      , (37214, 151,          2) /* HookType - Wall */
      , (37214, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37214,  11, True ) /* IgnoreCollisions */
-     , (37214,  13, True ) /* Ethereal */
-     , (37214,  14, True ) /* GravityStatus */
-     , (37214,  19, True ) /* Attackable */
-     , (37214,  22, True ) /* Inscribable */
+VALUES (37214,  22, True ) /* Inscribable */
      , (37214, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37215 Olthoi Koujia Breastplate.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37215 Olthoi Koujia Breastplate.sql
@@ -1,28 +1,24 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37215;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37215, 'ace37215-olthoikoujiabreastplate', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (37215, 'ace37215-olthoikoujiabreastplate', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37215,   1,          2) /* ItemType - Armor */
+     , (37215,   3,          2) /* PaletteTemplate - Blue */
      , (37215,   4,       1024) /* ClothingPriority - OuterwearChest */
      , (37215,   5,       1063) /* EncumbranceVal */
      , (37215,   9,        512) /* ValidLocations - ChestArmor */
      , (37215,  16,          1) /* ItemUseable - No */
 	 , (37215,  27,         32) /* ArmorType - Metal */
-     , (37215,  28,        225) /* ArmorLevel */
-     , (37215,  53,        101) /* PlacementPosition */
+     , (37215,  28,        110) /* ArmorLevel */
      , (37215,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37215, 124,          2) /* Version */
+	 , (37215, 124,          3) /* Version */
      , (37215, 151,          2) /* HookType - Wall */
      , (37215, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37215,  11, True ) /* IgnoreCollisions */
-     , (37215,  13, True ) /* Ethereal */
-     , (37215,  14, True ) /* GravityStatus */
-     , (37215,  19, True ) /* Attackable */
-     , (37215,  22, True ) /* Inscribable */
+VALUES (37215,  22, True ) /* Inscribable */
      , (37215, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37217 Olthoi Alduressa Coat.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37217 Olthoi Alduressa Coat.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37217;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37217, 'ace37217-olthoialduressacoat', 2, '2019-04-23 00:59:22') /* Clothing */;
+VALUES (37217, 'ace37217-olthoialduressacoat', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37217,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37217,   1,          2) /* ItemType - Armor */
      , (37217,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
      , (37217,  16,          1) /* ItemUseable - No */
 	 , (37217,  27,         32) /* ArmorType - Metal */
-     , (37217,  28,        225) /* ArmorLevel */
-     , (37217,  53,        101) /* PlacementPosition - Resting */
+     , (37217,  28,        110) /* ArmorLevel */
      , (37217,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37217, 124,          2) /* Version */
+	 , (37217, 124,          3) /* Version */
      , (37217, 151,          2) /* HookType - Wall */
      , (37217, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37217,  11, True ) /* IgnoreCollisions */
-     , (37217,  13, True ) /* Ethereal */
-     , (37217,  14, True ) /* GravityStatus */
-     , (37217,  19, True ) /* Attackable */
-     , (37217,  22, True ) /* Inscribable */
+VALUES (37217,  22, True ) /* Inscribable */
      , (37217, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37299 Olthoi Amuli Coat.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Clothing/Armor/37299 Olthoi Amuli Coat.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37299;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37299, 'ace37299-olthoiamulicoat', 2, '2019-04-22 04:33:31') /* Clothing */;
+VALUES (37299, 'ace37299-olthoiamulicoat', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37299,   1,          2) /* ItemType - Armor */
@@ -10,19 +10,14 @@ VALUES (37299,   1,          2) /* ItemType - Armor */
      , (37299,   9,       6656) /* ValidLocations - ChestArmor, UpperArmArmor, LowerArmArmor */
      , (37299,  16,          1) /* ItemUseable - No */
 	 , (37299,  27,          8) /* ArmorType - Scalemail */
-     , (37299,  28,        205) /* ArmorLevel */
-     , (37299,  53,        101) /* PlacementPosition - Resting */
+     , (37299,  28,        100) /* ArmorLevel */
      , (37299,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (37299, 124,          2) /* Version */
+	 , (37299, 124,          3) /* Version */
      , (37299, 151,          2) /* HookType - Wall */
      , (37299, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37299,  11, True ) /* IgnoreCollisions */
-     , (37299,  13, True ) /* Ethereal */
-     , (37299,  14, True ) /* GravityStatus */
-     , (37299,  19, True ) /* Attackable */
-     , (37299,  22, True ) /* Inscribable */
+VALUES (37299,  22, True ) /* Inscribable */
      , (37299, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42749 Haebrean Breastplate.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42749 Haebrean Breastplate.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42749;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42749, 'ace42749-haebreanbreastplate', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42749, 'ace42749-haebreanbreastplate', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42749,   1,          2) /* ItemType - Armor */
@@ -14,6 +14,7 @@ VALUES (42749,   1,          2) /* ItemType - Armor */
      , (42749,  27,         32) /* ArmorType - Metal */
      , (42749,  28,        110) /* ArmorLevel */
      , (42749,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42749, 124,          3) /* Version */
      , (42749, 169,  118097668) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42750 Haebrean Gauntlets.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42750 Haebrean Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42750;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42750, 'ace42750-haebreangauntlets', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42750, 'ace42750-haebreangauntlets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42750,   1,          2) /* ItemType - Armor */
@@ -12,10 +12,11 @@ VALUES (42750,   1,          2) /* ItemType - Armor */
      , (42750,  16,          1) /* ItemUseable - No */
      , (42750,  19,        653) /* Value */
      , (42750,  27,         32) /* ArmorType - Metal */
-     , (42750,  28,        100) /* ArmorLevel */
+     , (42750,  28,        150) /* ArmorLevel */
      , (42750,  44,          3) /* Damage */
      , (42750,  45,          4) /* DamageType - Bludgeon */
      , (42750,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42750, 124,          3) /* Version */
      , (42750, 169,  151651588) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42751 Haebrean Girth.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42751 Haebrean Girth.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42751;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42751, 'ace42751-haebreangirth', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42751, 'ace42751-haebreangirth', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42751,   1,          2) /* ItemType - Armor */
@@ -15,6 +15,7 @@ VALUES (42751,   1,          2) /* ItemType - Armor */
      , (42751,  27,         32) /* ArmorType - Metal */
      , (42751,  28,        110) /* ArmorLevel */
      , (42751,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42751, 124,          3) /* Version */
      , (42751, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42752 Haebrean Greaves.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42752 Haebrean Greaves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42752;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42752, 'ace42752-haebreangreaves', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42752, 'ace42752-haebreangreaves', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42752,   1,          2) /* ItemType - Armor */
@@ -13,8 +13,9 @@ VALUES (42752,   1,          2) /* ItemType - Armor */
      , (42752,  16,          1) /* ItemUseable - No */
      , (42752,  19,        653) /* Value */
      , (42752,  27,         32) /* ArmorType - Metal */
-     , (42752,  28,        100) /* ArmorLevel */
+     , (42752,  28,        110) /* ArmorLevel */
      , (42752,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42752, 124,          3) /* Version */
      , (42752, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42753 Haebrean Helm.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42753 Haebrean Helm.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42753;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42753, 'ace42753-haebreanhelm', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42753, 'ace42753-haebreanhelm', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42753,   1,          2) /* ItemType - Armor */
@@ -16,6 +16,7 @@ VALUES (42753,   1,          2) /* ItemType - Armor */
      , (42753,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (42753, 150,        103) /* HookPlacement - Hook */
      , (42753, 151,          2) /* HookType - Wall */
+	 , (42753, 124,          3) /* Version */
      , (42753, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42754 Haebrean Pauldrons.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42754 Haebrean Pauldrons.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42754;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42754, 'ace42754-haebreanpauldrons', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42754, 'ace42754-haebreanpauldrons', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42754,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (42754,   1,          2) /* ItemType - Armor */
      , (42754,  16,          1) /* ItemUseable - No */
      , (42754,  19,        653) /* Value */
      , (42754,  27,         32) /* ArmorType - Metal */
-     , (42754,  28,        100) /* ArmorLevel */
+     , (42754,  28,        110) /* ArmorLevel */
      , (42754,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42754, 124,          3) /* Version */
      , (42754, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42755 Haebrean Boots.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42755 Haebrean Boots.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42755;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42755, 'ace42755-haebreanboots', 2, '2019-09-13 00:00:00') /* Clothing */;
+VALUES (42755, 'ace42755-haebreanboots', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42755,   1,          2) /* ItemType - Armor */
@@ -12,10 +12,11 @@ VALUES (42755,   1,          2) /* ItemType - Armor */
      , (42755,  16,          1) /* ItemUseable - No */
      , (42755,  19,        654) /* Value */
      , (42755,  27,         32) /* ArmorType - Metal */
-     , (42755,  28,        100) /* ArmorLevel */
+     , (42755,  28,        150) /* ArmorLevel */
      , (42755,  44,          3) /* Damage */
      , (42755,  45,          4) /* DamageType - Bludgeon */
      , (42755,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42755, 124,          3) /* Version */
      , (42755, 169,  118096132) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42756 Haebrean Tassets.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42756 Haebrean Tassets.sql
@@ -1,20 +1,20 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42756;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42756, 'ace42756-haebreantassets', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42756, 'ace42756-haebreantassets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42756,   1,          2) /* ItemType - Armor */
      , (42756,   3,         20) /* PaletteTemplate - Silver */
      , (42756,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
      , (42756,   5,        919) /* EncumbranceVal */
-
      , (42756,   9,       8192) /* ValidLocations - UpperLegArmor */
      , (42756,  16,          1) /* ItemUseable - No */
      , (42756,  19,        653) /* Value */
      , (42756,  27,         32) /* ArmorType - Metal */
-     , (42756,  28,        100) /* ArmorLevel */
+     , (42756,  28,        110) /* ArmorLevel */
      , (42756,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42756, 124,          3) /* Version */
      , (42756, 169,  252313860) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42757 Haebrean Vambraces.sql
+++ b/Database/Patches/2010-05-Celebration/9 WeenieDefaults/Clothing/Armor/42757 Haebrean Vambraces.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42757;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42757, 'ace42757-haebreanvambraces', 2, '2019-09-13 02:11:06') /* Clothing */;
+VALUES (42757, 'ace42757-haebreanvambraces', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42757,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (42757,   1,          2) /* ItemType - Armor */
      , (42757,  16,          1) /* ItemUseable - No */
      , (42757,  19,        653) /* Value */
      , (42757,  27,         32) /* ArmorType - Metal */
-     , (42757,  28,        100) /* ArmorLevel */
+     , (42757,  28,        110) /* ArmorLevel */
      , (42757,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (42757, 124,          3) /* Version */
      , (42757, 169,  118097156) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43048 Knorr Academy Breastplate.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43048 Knorr Academy Breastplate.sql
@@ -1,0 +1,44 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43048;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43048, 'ace43048-knorracademybreastplate', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43048,   1,          2) /* ItemType - Armor */
+     , (43048,   3,         10) /* PaletteTemplate - LightBlue */
+     , (43048,   4,       1024) /* ClothingPriority - OuterwearChest */
+     , (43048,   5,        420) /* EncumbranceVal */
+     , (43048,   9,        512) /* ValidLocations - ChestArmor */
+     , (43048,  16,          1) /* ItemUseable - No */
+     , (43048,  19,       1400) /* Value */
+     , (43048,  27,          2) /* ArmorType - Leather */
+     , (43048,  28,         90) /* ArmorLevel */
+     , (43048,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43048, 124,          3) /* Version */
+     , (43048, 169,  118163214) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43048,  22, True ) /* Inscribable */
+     , (43048, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43048,  12,  0.2679) /* Shade */
+     , (43048,  13,       1) /* ArmorModVsSlash */
+     , (43048,  14,     0.8) /* ArmorModVsPierce */
+     , (43048,  15,       1) /* ArmorModVsBludgeon */
+     , (43048,  16,     0.5) /* ArmorModVsCold */
+     , (43048,  17,     0.5) /* ArmorModVsFire */
+     , (43048,  18,     0.3) /* ArmorModVsAcid */
+     , (43048,  19,     0.6) /* ArmorModVsElectric */
+     , (43048, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43048,   1, 'Knorr Academy Breastplate') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43048,   1,   33554642) /* Setup */
+     , (43048,   3,  536870932) /* SoundTable */
+     , (43048,   6,   67108990) /* PaletteBase */
+     , (43048,   7,  268437426) /* ClothingBase */
+     , (43048,   8,  100691382) /* Icon */
+     , (43048,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43049 Knorr Academy Gauntlets.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43049 Knorr Academy Gauntlets.sql
@@ -1,0 +1,41 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43049;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43049, 'ace43049-knorracademygauntlets', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43049,   1,          2) /* ItemType - Armor */
+     , (43049,   4,      32768) /* ClothingPriority - Hands */
+     , (43049,   5,        205) /* EncumbranceVal */
+     , (43049,   9,         32) /* ValidLocations - HandWear */
+     , (43049,  16,          1) /* ItemUseable - No */
+     , (43049,  19,       1520) /* Value */
+     , (43049,  27,          2) /* ArmorType - Leather */
+     , (43049,  28,        130) /* ArmorLevel */
+     , (43049,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43049, 124,          3) /* Version */
+     , (43049, 169,  151717134) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43049,  22, True ) /* Inscribable */
+     , (43049, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43049,  13,       1) /* ArmorModVsSlash */
+     , (43049,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (43049,  15,       1) /* ArmorModVsBludgeon */
+     , (43049,  16, 0.945883989334106) /* ArmorModVsCold */
+     , (43049,  17,     0.5) /* ArmorModVsFire */
+     , (43049,  18, 0.685886800289154) /* ArmorModVsAcid */
+     , (43049,  19, 0.600000023841858) /* ArmorModVsElectric */
+     , (43049, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43049,   1, 'Knorr Academy Gauntlets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43049,   1,   33554648) /* Setup */
+     , (43049,   3,  536870932) /* SoundTable */
+     , (43049,   6,   67108990) /* PaletteBase */
+     , (43049,   8,  100667319) /* Icon */
+     , (43049,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43050 Knorr Academy Girth.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43050 Knorr Academy Girth.sql
@@ -1,40 +1,40 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43050;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43050, 'ace43050-knorracademygirth', 2, '2019-02-04 06:52:23') /* Clothing */;
+VALUES (43050, 'ace43050-knorracademygirth', 2, '2019-11-11 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43050,   1,          2) /* ItemType - Armor */
+     , (43050,   3,          1) /* PaletteTemplate - AquaBlue */
      , (43050,   4,       2048) /* ClothingPriority - OuterwearAbdomen */
-     , (43050,   5,        210) /* EncumbranceVal */
+     , (43050,   5,        270) /* EncumbranceVal */
+     , (43050,   8,         90) /* Mass */
      , (43050,   9,       1024) /* ValidLocations - AbdomenArmor */
      , (43050,  16,          1) /* ItemUseable - No */
-     , (43050,  19,      13882) /* Value */
-     , (43050,  28,        286) /* ArmorLevel */
-     , (43050,  53,        101) /* PlacementPosition */
-     , (43050,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+     , (43050,  19,       1350) /* Value */
+     , (43050,  27,          2) /* ArmorType - Leather */
+     , (43050,  28,         90) /* ArmorLevel */
+     , (43050,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43050, 124,          3) /* Version */
+     , (43050, 169,  118161678) /* TsysMutationData */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (43050,  11, True ) /* IgnoreCollisions */
-     , (43050,  13, True ) /* Ethereal */
-     , (43050,  14, True ) /* GravityStatus */
-     , (43050,  19, True ) /* Attackable */
-     , (43050,  22, True ) /* Inscribable */
+VALUES (43050,  22, True ) /* Inscribable */
      , (43050, 100, True ) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (43050,  13,       1) /* ArmorModVsSlash */
-     , (43050,  14, 0.800000011920929) /* ArmorModVsPierce */
+VALUES (43050,  12,    0.66) /* Shade */
+     , (43050,  13,       1) /* ArmorModVsSlash */
+     , (43050,  14,     0.8) /* ArmorModVsPierce */
      , (43050,  15,       1) /* ArmorModVsBludgeon */
-     , (43050,  16, 1.2812819480896) /* ArmorModVsCold */
+     , (43050,  16,     1.2) /* ArmorModVsCold */
      , (43050,  17,     0.5) /* ArmorModVsFire */
-     , (43050,  18, 0.300000011920929) /* ArmorModVsAcid */
-     , (43050,  19, 0.600000023841858) /* ArmorModVsElectric */
+     , (43050,  18,     0.3) /* ArmorModVsAcid */
+     , (43050,  19,     0.4) /* ArmorModVsElectric */
      , (43050, 165,       1) /* ArmorModVsNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (43050,   1, 'Knorr Academy Girth') /* Name */
-     , (43050,  16, 'Knorr Academy Girth') /* LongDesc */;
+VALUES (43050,   1, 'Knorr Academy Girth') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (43050,   1,   33554655) /* Setup */

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43051 Knorr Academy Greaves.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43051 Knorr Academy Greaves.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43051;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43051, 'ace43051-knorracademygreaves', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43051,   1,          2) /* ItemType - Armor */
+     , (43051,   3,          8) /* PaletteTemplate - Green */
+     , (43051,   4,        512) /* ClothingPriority - OuterwearLowerLegs */
+     , (43051,   5,        245) /* EncumbranceVal */
+     , (43051,   9,      16384) /* ValidLocations - LowerLegArmor */
+     , (43051,  16,          1) /* ItemUseable - No */
+     , (43051,  19,      18665) /* Value */
+     , (43051,  27,          2) /* ArmorType - Leather */
+     , (43051,  28,         90) /* ArmorLevel */
+     , (43051,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43051, 124,          3) /* Version */
+     , (43051, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43051,  22, True ) /* Inscribable */
+     , (43051, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43051,  12,  0.1071) /* Shade */
+     , (43051,  13,       1) /* ArmorModVsSlash */
+     , (43051,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (43051,  15,       1) /* ArmorModVsBludgeon */
+     , (43051,  16,     0.5) /* ArmorModVsCold */
+     , (43051,  17,     0.5) /* ArmorModVsFire */
+     , (43051,  18, 0.300000011920929) /* ArmorModVsAcid */
+     , (43051,  19, 1.32307624816895) /* ArmorModVsElectric */
+     , (43051,  39, 1.33000004291534) /* DefaultScale */
+     , (43051, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43051,   1, 'Knorr Academy Greaves') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43051,   1,   33554641) /* Setup */
+     , (43051,   3,  536870932) /* SoundTable */
+     , (43051,   6,   67108990) /* PaletteBase */
+     , (43051,   7,  268437429) /* ClothingBase */
+     , (43051,   8,  100691418) /* Icon */
+     , (43051,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43052 Knorr Academy Pauldrons.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43052 Knorr Academy Pauldrons.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43052;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43052, 'ace43052-knorracademypauldrons', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43052,   1,          2) /* ItemType - Armor */
+     , (43052,   3,          5) /* PaletteTemplate - DarkBlue */
+     , (43052,   4,       4096) /* ClothingPriority - OuterwearUpperArms */
+     , (43052,   5,        216) /* EncumbranceVal */
+     , (43052,   9,       2048) /* ValidLocations - UpperArmArmor */
+     , (43052,  16,          1) /* ItemUseable - No */
+     , (43052,  19,      22202) /* Value */
+     , (43052,  27,          2) /* ArmorType - Leather */
+     , (43052,  28,         90) /* ArmorLevel */
+     , (43052,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43052, 124,          3) /* Version */
+     , (43052, 169,  118161678) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43052,  22, True ) /* Inscribable */
+     , (43052, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43052,  12,  0.8036) /* Shade */
+     , (43052,  13,       1) /* ArmorModVsSlash */
+     , (43052,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (43052,  15,       1) /* ArmorModVsBludgeon */
+     , (43052,  16,     0.5) /* ArmorModVsCold */
+     , (43052,  17, 1.22090244293213) /* ArmorModVsFire */
+     , (43052,  18, 0.300000011920929) /* ArmorModVsAcid */
+     , (43052,  19, 0.868743121623993) /* ArmorModVsElectric */
+     , (43052,  39, 1.10000002384186) /* DefaultScale */
+     , (43052, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43052,   1, 'Knorr Academy Pauldrons') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43052,   1,   33554641) /* Setup */
+     , (43052,   3,  536870932) /* SoundTable */
+     , (43052,   6,   67108990) /* PaletteBase */
+     , (43052,   7,  268437431) /* ClothingBase */
+     , (43052,   8,  100691437) /* Icon */
+     , (43052,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43053 Knorr Academy Boots.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43053 Knorr Academy Boots.sql
@@ -1,0 +1,44 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43053;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43053, 'ace43053-knorracademyboots', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43053,   1,          2) /* ItemType - Armor */
+     , (43053,   3,          2) /* PaletteTemplate - Blue */
+     , (43053,   4,      65536) /* ClothingPriority - Feet */
+     , (43053,   5,        296) /* EncumbranceVal */
+     , (43053,   9,        384) /* ValidLocations - LowerLegWear, FootWear */
+     , (43053,  16,          1) /* ItemUseable - No */
+     , (43053,  19,       1320) /* Value */
+     , (43053,  27,          2) /* ArmorType - Leather */
+     , (43053,  28,        130) /* ArmorLevel */
+     , (43053,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43053, 124,          3) /* Version */
+     , (43053, 169,  185271566) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43053,  22, True ) /* Inscribable */
+     , (43053, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43053,  12,       1) /* Shade */
+     , (43053,  13,       1) /* ArmorModVsSlash */
+     , (43053,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (43053,  15,       1) /* ArmorModVsBludgeon */
+     , (43053,  16, 0.938957393169403) /* ArmorModVsCold */
+     , (43053,  17,     0.5) /* ArmorModVsFire */
+     , (43053,  18, 0.660831034183502) /* ArmorModVsAcid */
+     , (43053,  19, 0.600000023841858) /* ArmorModVsElectric */
+     , (43053, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43053,   1, 'Knorr Academy Boots') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43053,   1,   33554654) /* Setup */
+     , (43053,   3,  536870932) /* SoundTable */
+     , (43053,   6,   67108990) /* PaletteBase */
+     , (43053,   7,  268437432) /* ClothingBase */
+     , (43053,   8,  100669194) /* Icon */
+     , (43053,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43054 Knorr Academy Tassets.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43054 Knorr Academy Tassets.sql
@@ -1,0 +1,45 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43054;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43054, 'ace43054-knorracademytassets', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43054,   1,          2) /* ItemType - Armor */
+     , (43054,   3,         12) /* PaletteTemplate - Navy */
+     , (43054,   4,        256) /* ClothingPriority - OuterwearUpperLegs */
+     , (43054,   5,        311) /* EncumbranceVal */
+     , (43054,   9,       8192) /* ValidLocations - UpperLegArmor */
+     , (43054,  16,          1) /* ItemUseable - No */
+     , (43054,  19,       1254) /* Value */
+     , (43054,  27,          2) /* ArmorType - Leather */
+     , (43054,  28,         90) /* ArmorLevel */
+     , (43054,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43054, 124,          3) /* Version */
+     , (43054, 169,  252379406) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43054,  22, True ) /* Inscribable */
+     , (43054, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43054,  12,  0.6607) /* Shade */
+     , (43054,  13,       1) /* ArmorModVsSlash */
+     , (43054,  14, 0.800000011920929) /* ArmorModVsPierce */
+     , (43054,  15,       1) /* ArmorModVsBludgeon */
+     , (43054,  16, 1.18691027164459) /* ArmorModVsCold */
+     , (43054,  17,     0.5) /* ArmorModVsFire */
+     , (43054,  18, 0.300000011920929) /* ArmorModVsAcid */
+     , (43054,  19, 1.27069795131683) /* ArmorModVsElectric */
+     , (43054,  39, 1.33000004291534) /* DefaultScale */
+     , (43054, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43054,   1, 'Knorr Academy Tassets') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43054,   1,   33554656) /* Setup */
+     , (43054,   3,  536870932) /* SoundTable */
+     , (43054,   6,   67108990) /* PaletteBase */
+     , (43054,   7,  268437433) /* ClothingBase */
+     , (43054,   8,  100691426) /* Icon */
+     , (43054,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43055 Knorr Academy Vambraces.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43055 Knorr Academy Vambraces.sql
@@ -1,0 +1,44 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43055;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43055, 'ace43055-knorracademyvambraces', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43055,   1,          2) /* ItemType - Armor */
+     , (43055,   3,         13) /* PaletteTemplate - Purple */
+     , (43055,   4,       8192) /* ClothingPriority - OuterwearLowerArms */
+     , (43055,   5,        151) /* EncumbranceVal */
+     , (43055,   9,       4096) /* ValidLocations - LowerArmArmor */
+     , (43055,  16,          1) /* ItemUseable - No */
+     , (43055,  19,       1323) /* Value */
+     , (43055,  27,          2) /* ArmorType - Leather */
+     , (43055,  28,         90) /* ArmorLevel */
+     , (43055,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43055, 124,          3) /* Version */
+     , (43055, 169,  118162702) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43055,  22, True ) /* Inscribable */
+     , (43055, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43055,  12,  0.8393) /* Shade */
+     , (43055,  13,       1) /* ArmorModVsSlash */
+     , (43055,  14,     0.8) /* ArmorModVsPierce */
+     , (43055,  15,       1) /* ArmorModVsBludgeon */
+     , (43055,  16,     0.5) /* ArmorModVsCold */
+     , (43055,  17,     0.5) /* ArmorModVsFire */
+     , (43055,  18,     0.3) /* ArmorModVsAcid */
+     , (43055,  19,     0.6) /* ArmorModVsElectric */
+     , (43055, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43055,   1, 'Knorr Academy Vambraces') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43055,   1,   33554641) /* Setup */
+     , (43055,   3,  536870932) /* SoundTable */
+     , (43055,   6,   67108990) /* PaletteBase */
+     , (43055,   7,  268437425) /* ClothingBase */
+     , (43055,   8,  100691405) /* Icon */
+     , (43055,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43068 Knorr Academy Helm.sql
+++ b/Database/Patches/2010-07-FillingInTheBlanks/9 WeenieDefaults/Clothing/Armor/43068 Knorr Academy Helm.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43068;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43068, 'ace43068-knorracademyhelm', 2, '2019-11-11 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43068,   1,          2) /* ItemType - Armor */
+     , (43068,   3,         14) /* PaletteTemplate - Red */
+     , (43068,   4,      16384) /* ClothingPriority - Head */
+     , (43068,   5,         88) /* EncumbranceVal */
+     , (43068,   9,          1) /* ValidLocations - HeadWear */
+     , (43068,  16,          1) /* ItemUseable - No */
+     , (43068,  19,       1120) /* Value */
+     , (43068,  27,         32) /* ArmorType - Metal */
+     , (43068,  28,        150) /* ArmorLevel */
+     , (43068,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43068, 124,          3) /* Version */
+     , (43068, 150,        103) /* HookPlacement - Hook */
+     , (43068, 151,          2) /* HookType - Wall */
+     , (43068, 169,  168429060) /* TsysMutationData */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43068,  22, True ) /* Inscribable */
+     , (43068, 100, True ) /* Dyable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43068,  12,  0.4286) /* Shade */
+     , (43068,  13,     1.2) /* ArmorModVsSlash */
+     , (43068,  14,     0.8) /* ArmorModVsPierce */
+     , (43068,  15,       1) /* ArmorModVsBludgeon */
+     , (43068,  16,     0.5) /* ArmorModVsCold */
+     , (43068,  17,  0.9335) /* ArmorModVsFire */
+     , (43068,  18,   0.772) /* ArmorModVsAcid */
+     , (43068,  19,     0.8) /* ArmorModVsElectric */
+     , (43068, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43068,   1, 'Knorr Academy Helm') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43068,   1,   33559082) /* Setup */
+     , (43068,   3,  536870932) /* SoundTable */
+     , (43068,   6,   67108990) /* PaletteBase */
+     , (43068,   7,  268437430) /* ClothingBase */
+     , (43068,   8,  100691377) /* Icon */
+     , (43068,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43828 Sedgemail Leather Vest.sql
+++ b/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43828 Sedgemail Leather Vest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43828;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43828, 'ace43828-sedgemailleathervest', 2, '2019-08-21 00:00:00') /* Clothing */;
+VALUES (43828, 'ace43828-sedgemailleathervest', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43828,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (43828,   1,          2) /* ItemType - Armor */
      , (43828,  16,          1) /* ItemUseable - No */
      , (43828,  19,        265) /* Value */
      , (43828,  27,          4) /* ArmorType - StuddedLeather */
-     , (43828,  28,         30) /* ArmorLevel */
+     , (43828,  28,         90) /* ArmorLevel */
      , (43828,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43828, 124,          3) /* Version */
      , (43828, 150,        103) /* HookPlacement - Hook */
      , (43828, 151,          2) /* HookType - Wall */
      , (43828, 169,  118163214) /* TsysMutationData */;

--- a/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43829 Sedgemail Leather Cowl.sql
+++ b/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43829 Sedgemail Leather Cowl.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43829;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43829, 'ace43829-sedgemailleathercowl', 2, '2019-08-21 00:00:00') /* Clothing */;
+VALUES (43829, 'ace43829-sedgemailleathercowl', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43829,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (43829,   1,          2) /* ItemType - Armor */
      , (43829,  16,          1) /* ItemUseable - No */
      , (43829,  19,        115) /* Value */
      , (43829,  27,          4) /* ArmorType - StuddedLeather */
-     , (43829,  28,         30) /* ArmorLevel */
+     , (43829,  28,        130) /* ArmorLevel */
      , (43829,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43829, 124,          3) /* Version */
      , (43829, 150,        103) /* HookPlacement - Hook */
      , (43829, 151,          2) /* HookType - Wall */
      , (43829, 169,  168493326) /* TsysMutationData */;

--- a/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43830 Sedgemail Leather Gauntlets.sql
+++ b/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43830 Sedgemail Leather Gauntlets.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43830;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43830, 'ace43830-sedgemailleathergauntlets', 2, '2019-08-21 00:00:00') /* Clothing */;
+VALUES (43830, 'ace43830-sedgemailleathergauntlets', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43830,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (43830,   1,          2) /* ItemType - Armor */
      , (43830,  16,          1) /* ItemUseable - No */
      , (43830,  19,        115) /* Value */
      , (43830,  27,          4) /* ArmorType - StuddedLeather */
-     , (43830,  28,         30) /* ArmorLevel */
+     , (43830,  28,        130) /* ArmorLevel */
      , (43830,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43830, 124,          3) /* Version */
      , (43830, 150,        103) /* HookPlacement - Hook */
      , (43830, 151,          2) /* HookType - Wall */
      , (43830, 169,  151717134) /* TsysMutationData */;

--- a/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43831 Sedgemail Leather Pants.sql
+++ b/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43831 Sedgemail Leather Pants.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43831;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43831, 'ace43831-sedgemailleatherpants', 2, '2019-08-21 00:00:00') /* Clothing */;
+VALUES (43831, 'ace43831-sedgemailleatherpants', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43831,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (43831,   1,          2) /* ItemType - Armor */
      , (43831,  16,          1) /* ItemUseable - No */
      , (43831,  19,        215) /* Value */
      , (43831,  27,          4) /* ArmorType - StuddedLeather */
-     , (43831,  28,         30) /* ArmorLevel */
+     , (43831,  28,         90) /* ArmorLevel */
      , (43831,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43831, 124,          3) /* Version */
      , (43831, 150,        103) /* HookPlacement - Hook */
      , (43831, 151,          2) /* HookType - Wall */
      , (43831, 169,  252379406) /* TsysMutationData */;

--- a/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43832 Sedgemail Leather Shoes.sql
+++ b/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43832 Sedgemail Leather Shoes.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43832;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43832, 'ace43832-sedgemailleathershoes', 2, '2019-08-21 00:00:00') /* Clothing */;
+VALUES (43832, 'ace43832-sedgemailleathershoes', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43832,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (43832,   1,          2) /* ItemType - Armor */
      , (43832,  16,          1) /* ItemUseable - No */
      , (43832,  19,        215) /* Value */
      , (43832,  27,          4) /* ArmorType - StuddedLeather */
-     , (43832,  28,         30) /* ArmorLevel */
+     , (43832,  28,        130) /* ArmorLevel */
      , (43832,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43832, 124,          3) /* Version */
      , (43832, 150,        103) /* HookPlacement - Hook */
      , (43832, 151,          2) /* HookType - Wall */
      , (43832, 169,  185271566) /* TsysMutationData */;

--- a/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43833 Sedgemail Leather Sleeves.sql
+++ b/Database/Patches/2011-03-HiddenInShadows/9 WeenieDefaults/Clothing/Armor/43833 Sedgemail Leather Sleeves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 43833;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (43833, 'ace43833-sedgemailleathersleeves', 2, '2019-02-10 00:00:00') /* Clothing */;
+VALUES (43833, 'ace43833-sedgemailleathersleeves', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (43833,   1,          2) /* ItemType - Armor */
@@ -12,8 +12,9 @@ VALUES (43833,   1,          2) /* ItemType - Armor */
      , (43833,  16,          1) /* ItemUseable - No */
      , (43833,  19,        215) /* Value */
      , (43833,  27,          4) /* ArmorType - StuddedLeather */
-     , (43833,  28,         30) /* ArmorLevel */
+     , (43833,  28,         90) /* ArmorLevel */
      , (43833,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (43833, 124,          3) /* Version */
      , (43833, 150,        103) /* HookPlacement - Hook */
      , (43833, 151,          2) /* HookType - Wall */
      , (43833, 169,  118161678) /* TsysMutationData */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44799 Faran Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44799 Faran Over-robe.sql
@@ -14,6 +14,7 @@ VALUES (44799,   1,          2) /* ItemType - Armor */
      , (44799,  27,          2) /* ArmorType - Leather */
      , (44799,  28,         20) /* ArmorLevel */
      , (44799,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (44799, 124,          3) /* Version */
      , (44799, 169,  118161678) /* TsysMutationData */
      , (44799, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44799 Faran Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44799 Faran Over-robe.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44799;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44799, 'ace44799-faranoverrobe', 2, '2019-08-15 00:00:00') /* Clothing */;
+VALUES (44799, 'ace44799-faranoverrobe', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44799,   1,          2) /* ItemType - Armor */
@@ -14,7 +14,7 @@ VALUES (44799,   1,          2) /* ItemType - Armor */
      , (44799,  27,          2) /* ArmorType - Leather */
      , (44799,  28,         20) /* ArmorLevel */
      , (44799,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (44799, 124,          3) /* Version */
+     , (44799, 124,          3) /* Version */
      , (44799, 169,  118161678) /* TsysMutationData */
      , (44799, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44800 Dho Vest and Over-Robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44800 Dho Vest and Over-Robe.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44800;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44800, 'ace44800-dhovestandoverrobe', 2, '2019-08-15 00:00:00') /* Clothing */;
+VALUES (44800, 'ace44800-dhovestandoverrobe', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44800,   1,          2) /* ItemType - Armor */
@@ -14,7 +14,7 @@ VALUES (44800,   1,          2) /* ItemType - Armor */
      , (44800,  27,          2) /* ArmorType - Leather */
      , (44800,  28,         20) /* ArmorLevel */
      , (44800,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (44800, 124,          3) /* Version */
+     , (44800, 124,          3) /* Version */
      , (44800, 169,  118161678) /* TsysMutationData */
      , (44800, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44800 Dho Vest and Over-Robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44800 Dho Vest and Over-Robe.sql
@@ -14,6 +14,7 @@ VALUES (44800,   1,          2) /* ItemType - Armor */
      , (44800,  27,          2) /* ArmorType - Leather */
      , (44800,  28,         20) /* ArmorLevel */
      , (44800,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (44800, 124,          3) /* Version */
      , (44800, 169,  118161678) /* TsysMutationData */
      , (44800, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44801 Suikan Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44801 Suikan Over-robe.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44801;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44801, 'ace44801-suikanoverrobe', 2, '2019-08-15 00:00:00') /* Clothing */;
+VALUES (44801, 'ace44801-suikanoverrobe', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44801,   1,          2) /* ItemType - Armor */
@@ -14,7 +14,7 @@ VALUES (44801,   1,          2) /* ItemType - Armor */
      , (44801,  27,          2) /* ArmorType - Leather */
      , (44801,  28,         20) /* ArmorLevel */
      , (44801,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (44801, 124,          3) /* Version */
+     , (44801, 124,          3) /* Version */
      , (44801, 169,  118161678) /* TsysMutationData */
      , (44801, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44801 Suikan Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44801 Suikan Over-robe.sql
@@ -14,6 +14,7 @@ VALUES (44801,   1,          2) /* ItemType - Armor */
      , (44801,  27,          2) /* ArmorType - Leather */
      , (44801,  28,         20) /* ArmorLevel */
      , (44801,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (44801, 124,          3) /* Version */
      , (44801, 169,  118161678) /* TsysMutationData */
      , (44801, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44802 Vestiri Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44802 Vestiri Over-robe.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44802;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44802, 'ace44802-vestirioverrobe', 2, '2019-08-15 00:00:00') /* Clothing */;
+VALUES (44802, 'ace44802-vestirioverrobe', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44802,   1,          2) /* ItemType - Armor */
@@ -14,7 +14,7 @@ VALUES (44802,   1,          2) /* ItemType - Armor */
      , (44802,  27,          2) /* ArmorType - Leather */
      , (44802,  28,         90) /* ArmorLevel */
      , (44802,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (44802, 124,          3) /* Version */
+     , (44802, 124,          3) /* Version */
      , (44802, 169,  118161678) /* TsysMutationData */
      , (44802, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44802 Vestiri Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44802 Vestiri Over-robe.sql
@@ -12,8 +12,9 @@ VALUES (44802,   1,          2) /* ItemType - Armor */
      , (44802,  16,          1) /* ItemUseable - No */
      , (44802,  19,        150) /* Value */
      , (44802,  27,          2) /* ArmorType - Leather */
-     , (44802,  28,         20) /* ArmorLevel */
+     , (44802,  28,         90) /* ArmorLevel */
      , (44802,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (44802, 124,          3) /* Version */
      , (44802, 169,  118161678) /* TsysMutationData */
      , (44802, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44803 Empyrean Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44803 Empyrean Over-robe.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44803;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44803, 'ace44803-empyreanoverrobe', 2, '2019-08-15 00:00:00') /* Clothing */;
+VALUES (44803, 'ace44803-empyreanoverrobe', 2, '2019-11-05 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44803,   1,          2) /* ItemType - Armor */
@@ -14,7 +14,7 @@ VALUES (44803,   1,          2) /* ItemType - Armor */
      , (44803,  27,          2) /* ArmorType - Leather */
      , (44803,  28,         90) /* ArmorLevel */
      , (44803,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-	 , (44803, 124,          3) /* Version */
+     , (44803, 124,          3) /* Version */
      , (44803, 169,  118161678) /* TsysMutationData */
      , (44803, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44803 Empyrean Over-robe.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Clothing/Armor/44803 Empyrean Over-robe.sql
@@ -12,8 +12,9 @@ VALUES (44803,   1,          2) /* ItemType - Armor */
      , (44803,  16,          1) /* ItemUseable - No */
      , (44803,  19,        150) /* Value */
      , (44803,  27,          2) /* ArmorType - Leather */
-     , (44803,  28,         20) /* ArmorLevel */
+     , (44803,  28,         90) /* ArmorLevel */
      , (44803,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+	 , (44803, 124,          3) /* Version */
      , (44803, 169,  118161678) /* TsysMutationData */
      , (44803, 9013,     81664) /* VisualClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */;
 


### PR DESCRIPTION
- Reconcile armor and clothing weenies from DB with PCAP data, as provided by site http://ac.yotesfan.com/json/validate.php
- Mirror similar changes store bought armor items to other loot armor treasure weenies not available via merchant to allow loot code to generalize ArmorTypes

**Note:** The contents of this PR should not be added to the released database, until after ACE PR #[2391](https://github.com/ACEmulator/ACE/pull/2391) has been merged, or more AL value overruns may result