### PR TITLE
Geomancers :: add missing data

### DIFF
--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49517 Iaret.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49517 Iaret.sql
@@ -15,8 +15,10 @@ VALUES (49517,   1,         16) /* ItemType - Creature */
      , (49517,  75,          0) /* MerchandiseMinValue */
      , (49517,  76,    1000000) /* MerchandiseMaxValue */
      , (49517,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (49517, 113,          2) /* Gender - Female */
      , (49517, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (49517, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+     , (49517, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (49517, 188,          9) /* HeritageGroup - Empyrean */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49517,   1, True ) /* Stuck */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49517 Iaret.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49517 Iaret.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49517;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49517, 'ace49517-iaret', 12, '2019-04-09 02:25:16') /* Vendor */;
+VALUES (49517, 'ace49517-iaret', 12, '2019-12-23 00:00:00') /* Vendor */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49517,   1,         16) /* ItemType - Creature */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49518 Asenala.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49518 Asenala.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49518;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49518, 'ace49518-asenala', 12, '2019-04-09 02:25:16') /* Vendor */;
+VALUES (49518, 'ace49518-asenala', 12, '2019-12-23 00:00:00') /* Vendor */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49518,   1,         16) /* ItemType - Creature */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49518 Asenala.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49518 Asenala.sql
@@ -15,8 +15,10 @@ VALUES (49518,   1,         16) /* ItemType - Creature */
      , (49518,  75,          0) /* MerchandiseMinValue */
      , (49518,  76,    1000000) /* MerchandiseMaxValue */
      , (49518,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (49518, 113,          2) /* Gender - Female */
      , (49518, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (49518, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+     , (49518, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (49518, 188,          9) /* HeritageGroup - Empyrean */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49518,   1, True ) /* Stuck */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49519 Keminub.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49519 Keminub.sql
@@ -15,8 +15,10 @@ VALUES (49519,   1,         16) /* ItemType - Creature */
      , (49519,  75,          0) /* MerchandiseMinValue */
      , (49519,  76,    1000000) /* MerchandiseMaxValue */
      , (49519,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (49519, 113,          2) /* Gender - Female */
      , (49519, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (49519, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+     , (49519, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (49519, 188,          9) /* HeritageGroup - Empyrean */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49519,   1, True ) /* Stuck */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49519 Keminub.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49519 Keminub.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49519;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49519, 'ace49519-keminub', 12, '2019-04-09 02:25:16') /* Vendor */;
+VALUES (49519, 'ace49519-keminub', 12, '2019-12-23 00:00:00') /* Vendor */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49519,   1,         16) /* ItemType - Creature */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49520 Sacmisi.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49520 Sacmisi.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49520;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49520, 'ace49520-sacmisi', 12, '2019-04-09 02:25:16') /* Vendor */;
+VALUES (49520, 'ace49520-sacmisi', 12, '2019-12-23 00:00:00') /* Vendor */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49520,   1,         16) /* ItemType - Creature */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49520 Sacmisi.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Vendor/49520 Sacmisi.sql
@@ -15,8 +15,10 @@ VALUES (49520,   1,         16) /* ItemType - Creature */
      , (49520,  75,          0) /* MerchandiseMinValue */
      , (49520,  76,    1000000) /* MerchandiseMaxValue */
      , (49520,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (49520, 113,          2) /* Gender - Female */
      , (49520, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (49520, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+     , (49520, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (49520, 188,          9) /* HeritageGroup - Empyrean */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49520,   1, True ) /* Stuck */


### PR DESCRIPTION
- non-critical fix to add missing Gender and HeritageGroup integers to the four Geomancer vendors
