### PR TITLE
Legendary Keys Chests Recipe 

### DIFF
--- a/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/6943 Burning Sands Keyring On.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/6943 Burning Sands Keyring On.sql
@@ -1,0 +1,30 @@
+DELETE FROM `recipe` WHERE `id` = 6943;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (6943, 0, 0, 0, 0, 0, 0, 'You add the key to the keyring.', 0, 0, 'You fail to add the key to the keyring. Impossible!', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+
+INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
+VALUES (6943, 1, 193, 24, 3, 'This keyring is full.') /* NumKeys */
+     , (6943, 1,  92, 0, 1, 'This keyring has been used so many times that it has become very fragile. You cannot force another key onto it without breaking the ring.') /* Structure */;
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (6943, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_int` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 1,  92, -1, 2, 0) /* Structure */
+     , (@parent_id, 1, 193, 1, 2, 0) /* NumKeys */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 6943;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (6943, 48954 /* Burning Sands Keyring */, 48746 /* Aged Legendary Key */, '2019-04-15 18:20:10');
+
+
+
+
+
+
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/8360 Shattered Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/8360 Shattered Legendary Key.sql
@@ -1,0 +1,7 @@
+DELETE FROM `recipe` WHERE `id` = 8360;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (8360, 0, 23 /* Lockpick */, 670, 0, 48746 /* Aged Legendary Key */, 1, 'You carefully reassemble the shattered crystalline key, making it usable.', 0, 0, 'You fail to repair the Shattered Legendary Key', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:43');
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (8360, 9295 /* Intricate Carving Tool */, 48908 /* Shattered Legendary Key */, '2019-02-07 07:16:43');

--- a/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/8365 Burning Sands Golem Heart to Keyring.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/8365 Burning Sands Golem Heart to Keyring.sql
@@ -1,0 +1,13 @@
+DELETE FROM `recipe` WHERE `id` = 8365;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (8365, 0, 23 /* Lockpick */, 400, 0, 48954 /* Burning Sands Keyring */, 1, 'You carve the golem heart into a burning sands keyring.', 0, 0, 'You fail to carve the golem heart. The heart is destroyed.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 8365;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (8365, 9295 /* Intricate Carving Tool */,  48941 /* Burning Sands Golem Heart */, '2005-02-09 10:00:00');
+
+
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/8366 Burning Sands Keyring Off.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/4 CraftTable/8366 Burning Sands Keyring Off.sql
@@ -1,0 +1,24 @@
+DELETE FROM `recipe` WHERE `id` = 8366;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (8366, 0, 0, 0, 0, 48746 /*  Aged Legendary Key */, 1, 'You remove one key from the keyring.', 0, 0, 'You fail to remove a key from the keyring. Impossible!', 0, 0, NULL, 0, 0, NULL, 0, 0, NULL, 0, 0, NULL, 0, '2005-02-09 10:00:00');
+
+INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
+VALUES (8366, 0, 193, 0, 1, 'This keyring is already empty!') /* Target.NumKeys LessThanEqual 0 */;
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (8366, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_int` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0, 193, -1, 2, 0) /* On Player.SuccessTarget Add NumKeys -1 to Target */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 8366;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (8366, 9295 /* Intricate Carving Tool */, 48954 /* Burning Sands Keyring */, '2019-07-19 10:00:00');
+
+
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48741 Legendary Armor Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48741 Legendary Armor Chest.sql
@@ -1,0 +1,54 @@
+
+DELETE FROM `weenie` WHERE `class_Id` = 48741;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48741, 'ace48741-legendaryarmorchest', 20, '2019-12-25 01:07:34') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48741,   1,        512) /* ItemType - Container */
+     , (48741,   5,       9000) /* EncumbranceVal */
+     , (48741,   6,        120) /* ItemsCapacity */
+     , (48741,   7,         10) /* ContainersCapacity */
+     , (48741,   8,       3000) /* Mass */
+     , (48741,  16,         48) /* ItemUseable - ViewedRemote */
+     , (48741,  19,       2500) /* Value */
+     , (48741,  37,        240) /* ResistItemAppraisal */
+     , (48741,  38,       9999) /* ResistLockpick */
+     , (48741,  81,          5) /* MaxGeneratedObjects */
+     , (48741,  82,          5) /* InitGeneratedObjects */
+     , (48741,  83,          2) /* ActivationResponse - Use */
+     , (48741,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (48741,  96,        500) /* EncumbranceCapacity */
+     , (48741, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48741,   1, True ) /* Stuck */
+     , (48741,   2, False) /* Open */
+     , (48741,   3, True ) /* Locked */
+     , (48741,  11, True ) /* IgnoreCollisions */
+     , (48741,  12, True ) /* ReportCollisions */
+     , (48741,  13, False) /* Ethereal */
+     , (48741,  14, True ) /* GravityStatus */
+     , (48741,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48741,  39, 1.10000002384186) /* DefaultScale */
+     , (48741,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48741,   1, 'Legendary Armor Chest') /* Name */
+     , (48741,  12, 'keychestleg') /* LockCode */
+     , (48741,  14, 'Use this item to open it and see its contents.') /* Use */
+     , (48741,  16, 'A chest containing the highest quality armor. ') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48741,   1,   33558324) /* Setup */
+     , (48741,   2,  150995235) /* MotionTable */
+     , (48741,   3,  536870945) /* SoundTable */
+     , (48741,   8,  100674256) /* Icon */
+     , (48741,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (48741, -1, 2002, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 8 from Death Treasure Table id: 2002 (x25 up to max of 25) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48742 Legendary Magic Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48742 Legendary Magic Chest.sql
@@ -1,0 +1,55 @@
+
+DELETE FROM `weenie` WHERE `class_Id` = 48742;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48742, 'ace48742-legendarymagicchest', 20, '2019-12-25 01:07:36') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48742,   1,        512) /* ItemType - Container */
+     , (48742,   5,       9000) /* EncumbranceVal */
+     , (48742,   6,        120) /* ItemsCapacity */
+     , (48742,   7,         10) /* ContainersCapacity */
+     , (48742,   8,       3000) /* Mass */
+     , (48742,  16,         48) /* ItemUseable - ViewedRemote */
+     , (48742,  19,       2500) /* Value */
+     , (48742,  37,        240) /* ResistItemAppraisal */
+     , (48742,  38,       9999) /* ResistLockpick */
+     , (48742,  81,          5) /* MaxGeneratedObjects */
+     , (48742,  82,          5) /* InitGeneratedObjects */
+     , (48742,  83,          2) /* ActivationResponse - Use */
+     , (48742,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (48742,  96,        500) /* EncumbranceCapacity */
+     , (48742, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48742,   1, True ) /* Stuck */
+     , (48742,   2, False) /* Open */
+     , (48742,   3, True ) /* Locked */
+     , (48742,  12, True ) /* ReportCollisions */
+     , (48742,  13, False) /* Ethereal */
+     , (48742,  33, False) /* ResetMessagePending */
+     , (48742,  34, False) /* DefaultOpen */
+     , (48742,  35, True ) /* DefaultLocked */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48742,  11,      30) /* ResetInterval */
+     , (48742,  43,       1) /* GeneratorRadius */
+     , (48742,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48742,   1, 'Legendary Magic Chest') /* Name */
+     , (48742,  12, 'keychestleg') /* LockCode */
+     , (48742,  14, 'Use this item to open it and see its contents.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48742,   1,   33558324) /* Setup */
+     , (48742,   2,  150995235) /* MotionTable */
+     , (48742,   3,  536870945) /* SoundTable */
+     , (48742,   8,  100674256) /* Icon */
+     , (48742,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (48742, -1, 2003, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 8 from Death Treasure Table id: 2003 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;
+
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48743 Legendary Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48743 Legendary Chest.sql
@@ -1,0 +1,54 @@
+
+DELETE FROM `weenie` WHERE `class_Id` = 48743;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48743, 'ace48743-legendarychest', 20, '2019-12-25 01:07:36') /* Chest */;
+	 
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48743,   1,        512) /* ItemType - Container */
+     , (48743,   5,       9000) /* EncumbranceVal */
+     , (48743,   6,        120) /* ItemsCapacity */
+     , (48743,   7,         10) /* ContainersCapacity */
+     , (48743,   8,       3000) /* Mass */
+     , (48743,  16,         48) /* ItemUseable - ViewedRemote */
+     , (48743,  19,       2500) /* Value */
+     , (48743,  37,        240) /* ResistItemAppraisal */
+     , (48743,  38,       9999) /* ResistLockpick */
+     , (48743,  81,          5) /* MaxGeneratedObjects */
+     , (48743,  82,          5) /* InitGeneratedObjects */
+     , (48743,  83,          2) /* ActivationResponse - Use */
+     , (48743,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (48743,  96,        500) /* EncumbranceCapacity */
+     , (48743, 100,          1) /* GeneratorType - Relative */;
+	 
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48743,   1, True ) /* Stuck */
+     , (48743,   2, False) /* Open */
+     , (48743,   3, True ) /* Locked */
+     , (48743,  11, True ) /* IgnoreCollisions */
+     , (48743,  12, True ) /* ReportCollisions */
+     , (48743,  13, False) /* Ethereal */
+     , (48743,  14, True ) /* GravityStatus */
+     , (48743,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48743,  39, 1.10000002384186) /* DefaultScale */
+     , (48743,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48743,   1, 'Legendary Chest') /* Name */
+     , (48743,  12, 'keychestleg') /* LockCode */
+     , (48743,  14, 'Use this item to open it and see its contents.') /* Use */
+     , (48743,  16, 'A chest containing the highest quality mixed gear. ') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48743,   1,   33558324) /* Setup */
+     , (48743,   2,  150995235) /* MotionTable */
+     , (48743,   3,  536870945) /* SoundTable */
+     , (48743,   8,  100674256) /* Icon */
+     , (48743,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (48743, -1, 2001, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 8 from Death Treasure Table id: 2001 (x25 up to max of 25) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48744 Legendary Weapon Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Chest/48744 Legendary Weapon Chest.sql
@@ -1,0 +1,55 @@
+
+DELETE FROM `weenie` WHERE `class_Id` = 48744;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48744, 'ace48744-legendaryweaponchest', 20, '2019-12-25 01:07:36') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48744,   1,        512) /* ItemType - Container */
+     , (48744,   5,       9000) /* EncumbranceVal */
+     , (48744,   6,        120) /* ItemsCapacity */
+     , (48744,   7,         10) /* ContainersCapacity */
+     , (48744,   8,       3000) /* Mass */
+     , (48744,  16,         48) /* ItemUseable - ViewedRemote */
+     , (48744,  19,       2500) /* Value */
+     , (48744,  37,        240) /* ResistItemAppraisal */
+     , (48744,  38,       9999) /* ResistLockpick */
+     , (48744,  81,          5) /* MaxGeneratedObjects */
+     , (48744,  82,          5) /* InitGeneratedObjects */
+     , (48744,  83,          2) /* ActivationResponse - Use */
+     , (48744,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (48744,  96,        500) /* EncumbranceCapacity */
+     , (48744, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48744,   1, True ) /* Stuck */
+     , (48744,   2, False) /* Open */
+     , (48744,   3, True ) /* Locked */
+     , (48744,  11, True ) /* IgnoreCollisions */
+     , (48744,  12, True ) /* ReportCollisions */
+     , (48744,  13, False) /* Ethereal */
+     , (48744,  14, True ) /* GravityStatus */
+     , (48744,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48744,  39, 1.10000002384186) /* DefaultScale */
+     , (48744,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48744,   1, 'Legendary Weapon Chest') /* Name */
+     , (48744,  12, 'keychestleg') /* LockCode */
+     , (48744,  14, 'Use this item to open it and see its contents.') /* Use */
+     , (48744,  16, 'A chest containing the highest quality weapons. ') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48744,   1,   33558324) /* Setup */
+     , (48744,   2,  150995235) /* MotionTable */
+     , (48744,   3,  536870945) /* SoundTable */
+     , (48744,   8,  100674256) /* Icon */
+     , (48744,  22,  872415275) /* PhysicsEffectTable */;
+
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (48744, 1, 2004, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 8 from Death Treasure Table id: 2004 (x25 up to max of 25) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;
+
+

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CraftTool/Misc/48954 Burning Sands Keyring.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/CraftTool/Misc/48954 Burning Sands Keyring.sql
@@ -1,0 +1,55 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48954;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48954, 'ace48954-burningsandskeyring', 44, '2019-11-22 00:00:00') /* CraftTool */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48954,   1,        128) /* ItemType - Misc */     
+     , (48954,   5,         40) /* EncumbranceVal */
+	 , (48954,   8,         40) /* Mass */
+     , (48954,   9,          0) /* ValidLocations - None */
+     , (48954,  11,          1) /* MaxStackSize */
+     , (48954,  12,          1) /* StackSize */
+     , (48954,  13,         40) /* StackUnitEncumbrance */
+	 , (48954,  14,         40) /* StackUnitMass */
+     , (48954,  15,         10) /* StackUnitValue */
+     , (48954,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (48954,  19,         10) /* Value */
+	 , (48954,  33,          0) /* Bonded - Normal */
+     , (48954,  65,        101) /* Placement - Resting */
+     , (48954,  91,         50) /* MaxStructure */
+     , (48954,  92,         50) /* Structure */
+     , (48954,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48954,  94,      16384) /* TargetType - Key */
+	 , (48954, 114,          0) /* Attuned - Normal */
+     , (48954, 150,        103) /* HookPlacement - Hook */
+     , (48954, 151,          2) /* HookType - Wall */
+     , (48954, 193,          0) /* NumKeys */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48954,   1, False) /* Stuck */
+     , (48954,  11, True ) /* IgnoreCollisions */
+     , (48954,  13, True ) /* Ethereal */
+     , (48954,  14, True ) /* GravityStatus */
+     , (48954,  19, True ) /* Attackable */
+     , (48954,  22, True ) /* Inscribable */
+     , (48954,  69, False) /* IsSellable */
+     , (48954,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48954,  39,    0.75) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48954,   1, 'Burning Sands Keyring') /* Name */
+     , (48954,  14, 'Use this ring on a Legendary key to add the key to the ring. Use an intricate carving tool on the keyring to pop a key off again. Adding a key uses up one of the ring''s remaining uses, but removing a key does not.') /* Use */
+     , (48954,  16, 'A crude keyring roughly carved out of a burning sands golem heart. ') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48954,   1,   33554790) /* Setup */
+     , (48954,   3,  536870932) /* SoundTable */
+     , (48954,   8,  100693006) /* Icon */
+     , (48954,  22,  872415275) /* PhysicsEffectTable */;
+	 
+	 
+	 
+	 

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Generic/Misc/48941 Burning Sands Golem Heart.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Generic/Misc/48941 Burning Sands Golem Heart.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48941;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48941, 'ace48941-burningsandsgolemheart', 1, '2005-02-09 10:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48941,   1,        128) /* ItemType - Misc */
+     , (48941,   3,          4) /* PaletteTemplate - Brown */
+     , (48941,   5,        225) /* EncumbranceVal */
+     , (48941,   8,        150) /* Mass */
+     , (48941,   9,          0) /* ValidLocations - None */
+     , (48941,  16,          1) /* ItemUseable - No */
+     , (48941,  19,         50) /* Value */
+     , (48941,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48941,  22, True ) /* Inscribable */
+     , (48941,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48941,  39,     0.4) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48941,   1, 'Burning Sands Golem Heart') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48941,   1,   33554817) /* Setup */
+     , (48941,   3,  536870932) /* SoundTable */
+     , (48941,   6,   67111919) /* PaletteBase */
+     , (48941,   7,  268435832) /* ClothingBase */
+     , (48941,   8,  100693005) /* Icon */
+     , (48941,  22,  872415275) /* PhysicsEffectTable */;
+	 
+	 
+	 
+	 

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48746 Aged Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48746 Aged Legendary Key.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48746;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48746, 'ace48746-agedlegendarykey', 22, '2019-12-25 01:07:33') /* Key */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48746,   1,      16384) /* ItemType - Key */
+     , (48746,   5,         30) /* EncumbranceVal */
+     , (48746,  16,    2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (48746,  18,         64) /* UiEffects - Lightning */
+     , (48746,  19,      10000) /* Value */
+     , (48746,  33,          0) /* Bonded - Normal */
+     , (48746,  53,        101) /* PlacementPosition - Resting */
+     , (48746,  91,          1) /* MaxStructure */
+     , (48746,  92,          1) /* Structure */
+     , (48746,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48746,  94,        640) /* TargetType - LockableMagicTarget */
+     , (48746, 114,          0) /* Attuned - Normal */
+     , (48746, 369,        150) /* UseRequiresLevel */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48746,  11, True ) /* IgnoreCollisions */
+     , (48746,  13, True ) /* Ethereal */
+     , (48746,  14, True ) /* GravityStatus */
+     , (48746,  19, True ) /* Attackable */
+     , (48746,  22, True ) /* Inscribable */
+     , (48746,  69, False) /* IsSellable */
+     , (48746,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48746,   1, 'Aged Legendary Key') /* Name */
+     , (48746,  13, 'keychestleg') /* KeyCode */
+     , (48746,  14, 'Use this key to open a Legendary Armor, Magic, or Weapon Chest.') /* Use */
+     , (48746,  16, 'This key has seen better days.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48746,   1,   33554784) /* Setup */
+     , (48746,   3,  536870932) /* SoundTable */
+     , (48746,   8,  100693001) /* Icon */
+     , (48746,  22,  872415275) /* PhysicsEffectTable */;
+	 
+	 
+	 

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48746 Aged Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48746 Aged Legendary Key.sql
@@ -10,7 +10,6 @@ VALUES (48746,   1,      16384) /* ItemType - Key */
      , (48746,  18,         64) /* UiEffects - Lightning */
      , (48746,  19,      10000) /* Value */
      , (48746,  33,          0) /* Bonded - Normal */
-     , (48746,  53,        101) /* PlacementPosition - Resting */
      , (48746,  91,          1) /* MaxStructure */
      , (48746,  92,          1) /* Structure */
      , (48746,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48747 Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48747 Legendary Key.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48747;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48747, 'ace48747-legendarykey', 22, '2019-02-10 00:00:00') /* Key */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48747,   1,      16384) /* ItemType - Key */
+     , (48747,   5,         30) /* EncumbranceVal */
+     , (48747,  16,    2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (48747,  18,         64) /* UiEffects - Lightning */
+     , (48747,  19,      10000) /* Value */
+     , (48747,  33,          0) /* Bonded - Normal */
+     , (48747,  65,        101) /* Placement - Resting */
+     , (48747,  91,          1) /* MaxStructure */
+     , (48747,  92,          1) /* Structure */
+     , (48747,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48747,  94,        640) /* TargetType - LockableMagicTarget */
+     , (48747, 114,          0) /* Attuned - Normal */
+     , (48747, 267,      86400) /* Lifespan */
+     , (48747, 268,      86400) /* RemainingLifespan */
+     , (48747, 369,        150) /* UseRequiresLevel */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48747,   1, False) /* Stuck */
+     , (48747,  11, True ) /* IgnoreCollisions */
+     , (48747,  13, True ) /* Ethereal */
+     , (48747,  14, True ) /* GravityStatus */
+     , (48747,  19, True ) /* Attackable */
+     , (48747,  22, True ) /* Inscribable */
+     , (48747,  69, False) /* IsSellable */
+     , (48747,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48747,   1, 'Legendary Key') /* Name */
+	 , (48747,  13, 'keychestleg') /* KeyCode */
+     , (48747,  14, 'Use this key to open a Legendary Armor, Magic, or Weapon Chest.') /* Use */
+     , (48747,  16, 'A key only heard about in whispers and myths.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48747,   1,   33554784) /* Setup */
+     , (48747,   3,  536870932) /* SoundTable */
+     , (48747,   8,  100693001) /* Icon */
+     , (48747,  22,  872415275) /* PhysicsEffectTable */;
+	 
+	 
+	 
+	 

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48747 Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48747 Legendary Key.sql
@@ -17,7 +17,6 @@ VALUES (48747,   1,      16384) /* ItemType - Key */
      , (48747,  94,        640) /* TargetType - LockableMagicTarget */
      , (48747, 114,          0) /* Attuned - Normal */
      , (48747, 267,      86400) /* Lifespan */
-     , (48747, 268,      86400) /* RemainingLifespan */
      , (48747, 369,        150) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48748 Legendary Key 2 Use.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48748 Legendary Key 2 Use.sql
@@ -17,7 +17,6 @@ VALUES (48748,   1,      16384) /* ItemType - Key */
      , (48748,  94,        640) /* TargetType - LockableMagicTarget */
      , (48748, 114,          0) /* Attuned - Normal */
      , (48748, 267,      86400) /* Lifespan */
-     , (48748, 268,      86400) /* RemainingLifespan */
      , (48748, 369,        150) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48748 Legendary Key 2 Use.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/48748 Legendary Key 2 Use.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48748;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48748, 'ace48748-legendarykey', 22, '2019-02-10 00:00:00') /* Key */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48748,   1,      16384) /* ItemType - Key */
+     , (48748,   5,         30) /* EncumbranceVal */
+     , (48748,  16,    2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (48748,  18,         64) /* UiEffects - Lightning */
+     , (48748,  19,      10000) /* Value */
+     , (48748,  33,          0) /* Bonded - Normal */
+     , (48748,  65,        101) /* Placement - Resting */
+     , (48748,  91,          2) /* MaxStructure */
+     , (48748,  92,          2) /* Structure */
+     , (48748,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48748,  94,        640) /* TargetType - LockableMagicTarget */
+     , (48748, 114,          0) /* Attuned - Normal */
+     , (48748, 267,      86400) /* Lifespan */
+     , (48748, 268,      86400) /* RemainingLifespan */
+     , (48748, 369,        150) /* UseRequiresLevel */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48748,   1, False) /* Stuck */
+     , (48748,  11, True ) /* IgnoreCollisions */
+     , (48748,  13, True ) /* Ethereal */
+     , (48748,  14, True ) /* GravityStatus */
+     , (48748,  19, True ) /* Attackable */
+     , (48748,  22, True ) /* Inscribable */
+     , (48748,  69, False) /* IsSellable */
+     , (48748,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48748,   1, 'Legendary Key') /* Name */
+	 , (48748,  13, 'keychestleg') /* KeyCode */
+     , (48748,  14, 'Use this key to open a Legendary Armor, Magic, or Weapon Chest.') /* Use */
+     , (48748,  16, 'A key only heard about in whispers and myths.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48748,   1,   33554784) /* Setup */
+     , (48748,   3,  536870932) /* SoundTable */
+     , (48748,   8,  100693001) /* Icon */
+     , (48748,  22,  872415275) /* PhysicsEffectTable */;
+	 
+	 
+	 

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/52010 Legendary Key 5 Use.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/52010 Legendary Key 5 Use.sql
@@ -10,14 +10,12 @@ VALUES (52010,   1,      16384) /* ItemType - Key */
      , (52010,  18,         64) /* UiEffects - Lightning */
      , (52010,  19,      10000) /* Value */
      , (52010,  33,          0) /* Bonded - Normal */
-     , (52010,  53,        101) /* PlacementPosition - Resting */
      , (52010,  91,          5) /* MaxStructure */
      , (52010,  92,          5) /* Structure */
      , (52010,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (52010,  94,        640) /* TargetType - LockableMagicTarget */
      , (52010, 114,          0) /* Attuned - Normal */
      , (52010, 267,      86400) /* Lifespan */
-     , (52010, 268,      83211) /* RemainingLifespan */
      , (52010, 369,        150) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/52010 Legendary Key 5 Use.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Key/52010 Legendary Key 5 Use.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 52010;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (52010, 'ace52010-legendarykey', 22, '2019-11-19 01:45:16') /* Key */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (52010,   1,      16384) /* ItemType - Key */
+     , (52010,   5,         30) /* EncumbranceVal */
+     , (52010,  16,    2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (52010,  18,         64) /* UiEffects - Lightning */
+     , (52010,  19,      10000) /* Value */
+     , (52010,  33,          0) /* Bonded - Normal */
+     , (52010,  53,        101) /* PlacementPosition - Resting */
+     , (52010,  91,          5) /* MaxStructure */
+     , (52010,  92,          5) /* Structure */
+     , (52010,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (52010,  94,        640) /* TargetType - LockableMagicTarget */
+     , (52010, 114,          0) /* Attuned - Normal */
+     , (52010, 267,      86400) /* Lifespan */
+     , (52010, 268,      83211) /* RemainingLifespan */
+     , (52010, 369,        150) /* UseRequiresLevel */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (52010,  11, True ) /* IgnoreCollisions */
+     , (52010,  13, True ) /* Ethereal */
+     , (52010,  14, True ) /* GravityStatus */
+     , (52010,  19, True ) /* Attackable */
+     , (52010,  22, True ) /* Inscribable */
+     , (52010,  69, False) /* IsSellable */
+     , (52010,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (52010,   1, 'Legendary Key') /* Name */
+     , (52010,  13, 'keychestleg') /* KeyCode */
+     , (52010,  14, 'Use this key to open a Legendary Armor, Magic, or Weapon Chest.') /* Use */
+     , (52010,  16, 'A key only heard about in whispers and myths.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (52010,   1,   33554784) /* Setup */
+     , (52010,   3,  536870932) /* SoundTable */
+     , (52010,   8,  100693001) /* Icon */
+     , (52010,  22,  872415275) /* PhysicsEffectTable */;
+	 
+	 
+	 
+	 

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Misc/48908 Shattered Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Misc/48908 Shattered Legendary Key.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48908;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48908, 'ace48908-shatteredlegendarykey', 1, '2005-02-09 10:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48908,   1,        128) /* ItemType - Misc */
+     , (48908,   5,         20) /* EncumbranceVal */
+     , (48908,   8,          5) /* Mass */
+     , (48908,   9,          0) /* ValidLocations - None */
+     , (48908,  11,          1) /* MaxStackSize */
+     , (48908,  12,          1) /* StackSize */
+     , (48908,  13,         25) /* StackUnitEncumbrance */
+     , (48908,  14,          5) /* StackUnitMass */
+     , (48908,  15,         20) /* StackUnitValue */
+     , (48908,  16,          1) /* ItemUseable - SourceContainedTargetContained */
+	 , (48908,  18,         64) /* UiEffects - Lightning */
+     , (48908,  19,          0) /* Value */
+	 , (48908,  53,        101) /* PlacementPosition - Resting */
+	 , (48908,  33,          1) /* Bonded - Bonded */
+     , (48908,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48908,  94,        128) /* TargetType - Misc */
+	 , (48908, 114,          1) /* Attuned - Attuned */
+	 , (48908, 267,      86400) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48908,  11, True ) /* IgnoreCollisions */
+     , (48908,  13, True ) /* Ethereal */
+     , (48908,  14, True ) /* GravityStatus */
+     , (48908,  19, True ) /* Attackable */
+     , (48908,  22, True ) /* Inscribable */
+     , (48908,  69, False) /* IsSellable */
+     , (48908,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48908,  39,     0.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48908,   1, 'Shattered Legendary Key') /* Name */
+     , (48908,  14, 'Use an intricate carving tool to carve this into something useful.') /* Use */
+     , (48908,  16, 'A severely damaged and cracked Legendary Key') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48908,   1,   33554784) /* Setup */
+     , (48908,   3,  536870932) /* SoundTable */
+     , (48908,   8,  100693002) /* Icon */
+     , (48908,  22,  872415275) /* PhysicsEffectTable */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Misc/48908 Shattered Legendary Key.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/Misc/48908 Shattered Legendary Key.sql
@@ -44,4 +44,4 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (48908,   1,   33554784) /* Setup */
      , (48908,   3,  536870932) /* SoundTable */
      , (48908,   8,  100693002) /* Icon */
-     , (48908,  22,  872415275) /* PhysicsEffectTable */
+     , (48908,  22,  872415275) /* PhysicsEffectTable */;


### PR DESCRIPTION
This adds Legendary chests and several keys. Along with shattered, burning sands golem heart, keyring and corresponding recipes.

Additionally establishes the treasure profile with simultaneous LSD submission of this content.

Example:

Mana/Legendary forge Chest 1001/2001

Mana/Legendary armor Chest 1002/2002

Mana/Legendary magic Chest 1003/2003

Mana/Legendary weapon Chest 1004/2004
