### PR TITLE
Update Gear Knight recall drop point

### DIFF
--- a/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/216F.sql
+++ b/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/216F.sql
@@ -1,0 +1,1 @@
+DELETE FROM `encounter` WHERE `landblock` = 8559;

--- a/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/2170.sql
+++ b/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/2170.sql
@@ -1,0 +1,1 @@
+DELETE FROM `encounter` WHERE `landblock` = 8560;

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05330 Gear Knight Invasion Area Camp Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05330 Gear Knight Invasion Area Camp Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 5330;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (5330, 'Gear Knight Invasion Area Camp Recall', 0x21700103, 156, 12, 177.704987, 0.714421, 0, 0, 0.699716, '2020-03-29 00:00:00');
-/* @teleloc 0x21700103 [156.000000 12.000000 177.704987] 0.714421 0.000000 0.000000 0.699716 */
+VALUES (5330, 'Gear Knight Invasion Area Camp Recall', 0x21700031, 145.131454, 12.087982, 178.005, 0.696707, 0, 0, -0.717356, '2020-03-29 00:00:00');
+/* @teleloc 0x21700031 [145.131454 12.087982 178.004990] 0.696707 0.000000 0.000000 -0.717356 */

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05330 Gear Knight Invasion Area Camp Recall.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05330 Gear Knight Invasion Area Camp Recall.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 5330;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (5330, 'Gear Knight Invasion Area Camp Recall', 560988209, 145.5065, 14.36704, 178.005, 1, 0, 0, 0, '2020-01-11 00:00:00');
-/* @teleloc 0x21700031 [145.5065 14.36704 178.005] 1 0 0 0 */
+VALUES (5330, 'Gear Knight Invasion Area Camp Recall', 0x21700103, 156, 12, 177.704987, 0.714421, 0, 0, 0.699716, '2020-03-29 00:00:00');
+/* @teleloc 0x21700103 [156.000000 12.000000 177.704987] 0.714421 0.000000 0.000000 0.699716 */


### PR DESCRIPTION
- Update Gear Knight Invasion Area Camp Recall to drop players at the tent encampment
- Remove some encounter spawn table entries, so the recall drop is not a hot drop
