### PR TITLE
Chest changes and remove two encounters

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/05015 Large Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/05015 Large Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 5015;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (5015, 'chestfolthiddagger', 20, '2005-02-09 10:00:00') /* Chest */;
+VALUES (5015, 'chestfolthiddagger', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (5015,   1,        512) /* ItemType - Container */
@@ -45,5 +45,5 @@ VALUES (5015,   1,   33554556) /* Setup */
      , (5015,  22,  872415275) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (5015, 1,  5016, 1200, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dull Dagger (5016) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
-     , (5015, 1, 34346, 1200, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Ancient Shard of Metal (34346) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */;
+VALUES (5015, -1,  5016, 1200, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dull Dagger (5016) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (5015, -1, 34346, 1200, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Ancient Shard of Metal (34346) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/28813 Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/28813 Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28813;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28813, 'chestlorcasammel', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (28813, 'chestlorcasammel', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28813,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (28813,   1,        512) /* ItemType - Container */
      , (28813,  16,         48) /* ItemUseable - ViewedRemote */
      , (28813,  19,        200) /* Value */
      , (28813,  38,        250) /* ResistLockpick */
+     , (28813,  81,          1) /* MaxGeneratedObjects */
      , (28813,  82,          1) /* InitGeneratedObjects */
      , (28813,  83,          2) /* ActivationResponse - Use */
      , (28813,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29059 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29059 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29059;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29059, 'chesthealingorb', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29059, 'chesthealingorb', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29059,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29059,   1,        512) /* ItemType - Container */
      , (29059,  16,         48) /* ItemUseable - ViewedRemote */
      , (29059,  19,        200) /* Value */
      , (29059,  38,        250) /* ResistLockpick */
+     , (29059,  81,          1) /* MaxGeneratedObjects */
      , (29059,  82,          1) /* InitGeneratedObjects */
      , (29059,  83,          2) /* ActivationResponse - Use */
      , (29059,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29060 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29060 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29060;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29060, 'chesthealingtihn', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29060, 'chesthealingtihn', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29060,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29060,   1,        512) /* ItemType - Container */
      , (29060,  16,         48) /* ItemUseable - ViewedRemote */
      , (29060,  19,        200) /* Value */
      , (29060,  38,        250) /* ResistLockpick */
+     , (29060,  81,          1) /* MaxGeneratedObjects */
      , (29060,  82,          1) /* InitGeneratedObjects */
      , (29060,  83,          2) /* ActivationResponse - Use */
      , (29060,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29061 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29061 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29061;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29061, 'chesthealingpedestal', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29061, 'chesthealingpedestal', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29061,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29061,   1,        512) /* ItemType - Container */
      , (29061,  16,         48) /* ItemUseable - ViewedRemote */
      , (29061,  19,        200) /* Value */
      , (29061,  38,        250) /* ResistLockpick */
+     , (29061,  81,          1) /* MaxGeneratedObjects */
      , (29061,  82,          1) /* InitGeneratedObjects */
      , (29061,  83,          2) /* ActivationResponse - Use */
      , (29061,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29062 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29062 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29062;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29062, 'chesthealinglavus', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29062, 'chesthealinglavus', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29062,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29062,   1,        512) /* ItemType - Container */
      , (29062,  16,         48) /* ItemUseable - ViewedRemote */
      , (29062,  19,        200) /* Value */
      , (29062,  38,        250) /* ResistLockpick */
+     , (29062,  81,          1) /* MaxGeneratedObjects */
      , (29062,  82,          1) /* InitGeneratedObjects */
      , (29062,  83,          2) /* ActivationResponse - Use */
      , (29062,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29063 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29063 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29063;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29063, 'chesthealinghook', 20, '2019-07-12 04:44:07') /* Chest */;
+VALUES (29063, 'chesthealinghook', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29063,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29063,   1,        512) /* ItemType - Container */
      , (29063,  16,         48) /* ItemUseable - ViewedRemote */
      , (29063,  19,        200) /* Value */
      , (29063,  38,        250) /* ResistLockpick */
+     , (29063,  81,          1) /* MaxGeneratedObjects */
      , (29063,  81,          1) /* MaxGeneratedObjects */
      , (29063,  82,          1) /* InitGeneratedObjects */
      , (29063,  83,          2) /* ActivationResponse - Use */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29063 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29063 Old Chest.sql
@@ -12,7 +12,6 @@ VALUES (29063,   1,        512) /* ItemType - Container */
      , (29063,  19,        200) /* Value */
      , (29063,  38,        250) /* ResistLockpick */
      , (29063,  81,          1) /* MaxGeneratedObjects */
-     , (29063,  81,          1) /* MaxGeneratedObjects */
      , (29063,  82,          1) /* InitGeneratedObjects */
      , (29063,  83,          2) /* ActivationResponse - Use */
      , (29063,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29077 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29077 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29077;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29077, 'chestthrungussultry1', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29077, 'chestthrungussultry1', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29077,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29077,   1,        512) /* ItemType - Container */
      , (29077,  16,         48) /* ItemUseable - ViewedRemote */
      , (29077,  19,        200) /* Value */
      , (29077,  38,        250) /* ResistLockpick */
+     , (29077,  81,          1) /* MaxGeneratedObjects */
      , (29077,  82,          1) /* InitGeneratedObjects */
      , (29077,  83,          2) /* ActivationResponse - Use */
      , (29077,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29078 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29078 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29078;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29078, 'chestthrungussultry2', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29078, 'chestthrungussultry2', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29078,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29078,   1,        512) /* ItemType - Container */
      , (29078,  16,         48) /* ItemUseable - ViewedRemote */
      , (29078,  19,        200) /* Value */
      , (29078,  38,        250) /* ResistLockpick */
+     , (29078,  81,          1) /* MaxGeneratedObjects */
      , (29078,  82,          1) /* InitGeneratedObjects */
      , (29078,  83,          2) /* ActivationResponse - Use */
      , (29078,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29079 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29079 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29079;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29079, 'chestthrungushumid1', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29079, 'chestthrungushumid1', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29079,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29079,   1,        512) /* ItemType - Container */
      , (29079,  16,         48) /* ItemUseable - ViewedRemote */
      , (29079,  19,        200) /* Value */
      , (29079,  38,        250) /* ResistLockpick */
+     , (29079,  81,          1) /* MaxGeneratedObjects */
      , (29079,  82,          1) /* InitGeneratedObjects */
      , (29079,  83,          2) /* ActivationResponse - Use */
      , (29079,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29080 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29080 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29080;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29080, 'chestthrungushumid2', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29080, 'chestthrungushumid2', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29080,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29080,   1,        512) /* ItemType - Container */
      , (29080,  16,         48) /* ItemUseable - ViewedRemote */
      , (29080,  19,        200) /* Value */
      , (29080,  38,        250) /* ResistLockpick */
+     , (29080,  81,          1) /* MaxGeneratedObjects */
      , (29080,  82,          1) /* InitGeneratedObjects */
      , (29080,  83,          2) /* ActivationResponse - Use */
      , (29080,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29081 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29081 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29081;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29081, 'chestthrungussteaming1', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29081, 'chestthrungussteaming1', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29081,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29081,   1,        512) /* ItemType - Container */
      , (29081,  16,         48) /* ItemUseable - ViewedRemote */
      , (29081,  19,        200) /* Value */
      , (29081,  38,        250) /* ResistLockpick */
+     , (29081,  81,          1) /* MaxGeneratedObjects */
      , (29081,  82,          1) /* InitGeneratedObjects */
      , (29081,  83,          2) /* ActivationResponse - Use */
      , (29081,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29082 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29082 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29082;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29082, 'chestthrungussteaming2', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29082, 'chestthrungussteaming2', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29082,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29082,   1,        512) /* ItemType - Container */
      , (29082,  16,         48) /* ItemUseable - ViewedRemote */
      , (29082,  19,        200) /* Value */
      , (29082,  38,        250) /* ResistLockpick */
+     , (29082,  81,          1) /* MaxGeneratedObjects */
      , (29082,  82,          1) /* InitGeneratedObjects */
      , (29082,  83,          2) /* ActivationResponse - Use */
      , (29082,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29083 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29083 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29083;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29083, 'chestthrungusmoist1', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29083, 'chestthrungusmoist1', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29083,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29083,   1,        512) /* ItemType - Container */
      , (29083,  16,         48) /* ItemUseable - ViewedRemote */
      , (29083,  19,        200) /* Value */
      , (29083,  38,        250) /* ResistLockpick */
+     , (29083,  81,          1) /* MaxGeneratedObjects */
      , (29083,  82,          1) /* InitGeneratedObjects */
      , (29083,  83,          2) /* ActivationResponse - Use */
      , (29083,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29084 Old Chest.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Chest/29084 Old Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 29084;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (29084, 'chestthrungusmoist2', 20, '2019-04-08 04:44:07') /* Chest */;
+VALUES (29084, 'chestthrungusmoist2', 20, '2020-03-30 00:00:00') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (29084,   1,        512) /* ItemType - Container */
@@ -11,6 +11,7 @@ VALUES (29084,   1,        512) /* ItemType - Container */
      , (29084,  16,         48) /* ItemUseable - ViewedRemote */
      , (29084,  19,        200) /* Value */
      , (29084,  38,        250) /* ResistLockpick */
+     , (29084,  81,          1) /* MaxGeneratedObjects */
      , (29084,  82,          1) /* InitGeneratedObjects */
      , (29084,  83,          2) /* ActivationResponse - Use */
      , (29084,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */

--- a/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/216F.sql
+++ b/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/216F.sql
@@ -1,0 +1,1 @@
+DELETE FROM `encounter` WHERE `landblock` = 8559;

--- a/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/2170.sql
+++ b/Database/Patches/2009-10-GearsOfChange/1 RegionDescExtendedData/2170.sql
@@ -1,0 +1,1 @@
+DELETE FROM `encounter` WHERE `landblock` = 8560;


### PR DESCRIPTION
- Fix a number of server log warning messages about chest weenies, either missing MaxGeneratedObjects or loopcount > 1000
- Remove two encounter drops nears the Gear Knight Invasion Area Camp Recall drop point
