### PR TITLE
Update 46422 Mastery Reset Certificate.sql

### DIFF
--- a/Database/Patches/2012-08-TheRisenPrincess/9 WeenieDefaults/Generic/Misc/46422 Mastery Reset Certificate.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/9 WeenieDefaults/Generic/Misc/46422 Mastery Reset Certificate.sql
@@ -11,6 +11,9 @@ VALUES (46422,   1,        128) /* ItemType - Misc */
      , (46422,  33,          1) /* Bonded - Bonded */
      , (46422,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (46422, 114,          1) /* Attuned - Attuned */;
+     
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46422,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46422,  39,    0.37) /* DefaultScale */;


### PR DESCRIPTION
Add IsSellable False

All other items on this vendor have it and the wiki says not sell able. I think the pcap just missed this one for some reason. 

https://asheron.fandom.com/wiki/Mastery_Reset_Certificate