### PR TITLE
Correct atlatl/quarrel prismatic success_message

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06010 Prismatic Quarrel.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06010 Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6010;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6010, 0, 37 /* Fletching */, 210, 0, 43958 /* Prismatic Quarrel */, 10, 'You make a bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6010, 0, 37 /* Fletching */, 210, 0, 43958 /* Prismatic Quarrel */, 10, 'You make a bundle of prismatic quarrels.', 0, 0, 'You fail to make a bundle of prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6010, 44070 /* Bundle of Prismatic Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2019-02-07 07:16:36');
+VALUES (6010, 44070 /* Bundle of Prismatic Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2020-05-13 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06011 Prismatic Quarrel.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06011 Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6011;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6011, 0, 37 /* Fletching */, 230, 0, 43958 /* Prismatic Quarrel */, 500, 'You make a bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6011, 0, 37 /* Fletching */, 230, 0, 43958 /* Prismatic Quarrel */, 500, 'You make a big bundle of prismatic quarrels.', 0, 0, 'You fail to make a big bundle of prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
 VALUES (6011, 44071 /* Wrapped Bundle of Prismatic Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2019-02-07 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06012 Greater Prismatic Quarrel.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06012 Greater Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6012;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6012, 0, 37 /* Fletching */, 370, 0, 43957, 10, 'You make a bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6012, 0, 37 /* Fletching */, 370, 0, 43957, 10, 'You make a bundle of greater prismatic quarrels.', 0, 0, 'You fail to make a bundle of greater prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6012, 44069,  5339 /* Bundle of Quarrelshafts */, '2019-02-07 07:16:36');
+VALUES (6012, 44069,  5339 /* Bundle of Quarrelshafts */, '2020-05-13 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06013 Greater Prismatic Quarrel.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06013 Greater Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6013;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6013, 0, 37 /* Fletching */, 375, 0, 43957, 500, 'You make a big bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6013, 0, 37 /* Fletching */, 375, 0, 43957, 500, 'You make a big bundle of greater prismatic quarrels.', 0, 0, 'You fail to make a bundle of greater prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6013, 44073,  9378 /* Wrapped Bundle of Quarrelshafts */, '2019-02-07 07:16:36');
+VALUES (6013, 44073,  9378 /* Wrapped Bundle of Quarrelshafts */, '2020-05-13 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06016 Prismatic Atlatl Dart.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06016 Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6016;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6016, 0, 37 /* Fletching */, 210, 0, 43955 /* Prismatic Atlatl Dart */, 10, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6016, 0, 37 /* Fletching */, 210, 0, 43955 /* Prismatic Atlatl Dart */, 10, 'You make a bundle of prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
 VALUES (6016, 44070 /* Bundle of Prismatic Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2019-02-07 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06017 Prismatic Atlatl Dart.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06017 Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6017;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6017, 0, 37 /* Fletching */, 230, 0, 43955 /* Prismatic Atlatl Dart */, 500, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6017, 0, 37 /* Fletching */, 230, 0, 43955 /* Prismatic Atlatl Dart */, 500, 'You make a big bundle of prismatic atlatl darts.', 0, 0, 'You fail to make a big bundle of prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6017, 44071 /* Wrapped Bundle of Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2019-02-07 07:16:36');
+VALUES (6017, 44071 /* Wrapped Bundle of Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2020-05-13 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06018 Greater Prismatic Atlatl Dart.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06018 Greater Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6018;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6018, 0, 37 /* Fletching */, 370, 0, 43954, 10, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6018, 0, 37 /* Fletching */, 370, 0, 43954, 10, 'You make a bundle of greater prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of greater prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6018, 44069, 15296 /* Bundle of Atlatl Dart Shafts */, '2019-02-07 07:16:36');
+VALUES (6018, 44069, 15296 /* Bundle of Atlatl Dart Shafts */, '2020-05-13 07:16:36');

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06019 Greater Prismatic Atlatl Dart.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/06019 Greater Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6019;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6019, 0, 37 /* Fletching */, 375, 0, 43954, 500, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
+VALUES (6019, 0, 37 /* Fletching */, 375, 0, 43954, 500, 'You make a big bundle of greater prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of greater prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2019-02-07 07:16:36');
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6019, 44073, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2019-02-07 07:16:36');
+VALUES (6019, 44073, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2020-05-13 07:16:36');


### PR DESCRIPTION
Standard and greater prismatic atlatl and quarrels success_message for crafting were using "you make a bundle of deadly XYZ".

Corrected