### PR TITLE
Update portal gems in base to include SharedCooldown/Duration

### DIFF
--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08551 Kelderam's Path.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08551 Kelderam's Path.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8551;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8551, 'gemportalcoipk', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8551,   1,       2048) /* ItemType - Gem */
+     , (8551,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8551,   5,         10) /* EncumbranceVal */
+     , (8551,   8,         10) /* Mass */
+     , (8551,   9,          0) /* ValidLocations - None */
+     , (8551,  11,          1) /* MaxStackSize */
+     , (8551,  12,          1) /* StackSize */
+     , (8551,  13,         10) /* StackUnitEncumbrance */
+     , (8551,  14,         10) /* StackUnitMass */
+     , (8551,  15,      10000) /* StackUnitValue */
+     , (8551,  16,          8) /* ItemUseable - Contained */
+     , (8551,  18,          1) /* UiEffects - Magical */
+     , (8551,  19,      10000) /* Value */
+     , (8551,  33,          1) /* Bonded - Bonded */
+     , (8551,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8551,  94,         16) /* TargetType - Creature */
+     , (8551, 106,        210) /* ItemSpellcraft */
+     , (8551, 107,         50) /* ItemCurMana */
+     , (8551, 108,         50) /* ItemMaxMana */
+     , (8551, 109,          0) /* ItemDifficulty */
+     , (8551, 110,          0) /* ItemAllegianceRankLimit */
+     , (8551, 114,          1) /* Attuned - Attuned */
+     , (8551, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8551,  15, True ) /* LightsStatus */
+     , (8551,  22, True ) /* Inscribable */
+     , (8551,  23, True ) /* DestroyOnSell */
+     , (8551,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8551, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8551,   1, 'Kelderam''s Path') /* Name */
+     , (8551,  15, 'The violet fires of portalspace flicker within this gem''s facets. The gem works best if used outside in a realatively flat area.') /* ShortDesc */
+     , (8551,  16, 'The violet fires of portalspace flicker within this gem''s facets. They seem to flicker, however, and there are red highlights. The artifact feels as if it has been... tainted somehow. The gem works best if used outside in a realatively flat area.') /* LongDesc */
+     , (8551,  33, 'GemIthaencCatacombs') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8551,   1,   33556769) /* Setup */
+     , (8551,   3,  536870932) /* SoundTable */
+     , (8551,   6,   67111919) /* PaletteBase */
+     , (8551,   7,  268435723) /* ClothingBase */
+     , (8551,   8,  100670993) /* Icon */
+     , (8551,  22,  872415275) /* PhysicsEffectTable */
+     , (8551,  28,       2028) /* Spell - The Path to Kelderam's Ward */
+     , (8551,  31,       8534) /* LinkedPortalOne - Kelderam's Path */
+     , (8551,  36,  234881046) /* MutateFilter */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (8551, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'GemIthaencCatacombs', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'The Gem to Kelderam''s Path is yours! If you use this gem, you should be outside of any building on flat ground and away from any structures.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08782 Sepulcher of the Hopeslayer Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08782 Sepulcher of the Hopeslayer Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8782;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8782, 'gemportalhopeslayer', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8782,   1,       2048) /* ItemType - Gem */
+     , (8782,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8782,   5,         50) /* EncumbranceVal */
+     , (8782,   8,         10) /* Mass */
+     , (8782,   9,          0) /* ValidLocations - None */
+     , (8782,  11,          1) /* MaxStackSize */
+     , (8782,  12,          1) /* StackSize */
+     , (8782,  13,         50) /* StackUnitEncumbrance */
+     , (8782,  14,         10) /* StackUnitMass */
+     , (8782,  15,          0) /* StackUnitValue */
+     , (8782,  16,          8) /* ItemUseable - Contained */
+     , (8782,  18,          1) /* UiEffects - Magical */
+     , (8782,  19,          0) /* Value */
+     , (8782,  33,          1) /* Bonded - Bonded */
+     , (8782,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8782,  94,         16) /* TargetType - Creature */
+     , (8782, 106,        210) /* ItemSpellcraft */
+     , (8782, 107,         50) /* ItemCurMana */
+     , (8782, 108,         50) /* ItemMaxMana */
+     , (8782, 109,          0) /* ItemDifficulty */
+     , (8782, 110,          0) /* ItemAllegianceRankLimit */
+     , (8782, 114,          1) /* Attuned - Attuned */
+     , (8782, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8782,  15, True ) /* LightsStatus */
+     , (8782,  22, True ) /* Inscribable */
+     , (8782,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8782, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8782,   1, 'Sepulcher of the Hopeslayer Portal Gem') /* Name */
+     , (8782,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 80+)') /* Use */
+     , (8782,  16, 'A gem that will create a portal to the Sepulcher of the Hopeslayer.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8782,   1,   33556769) /* Setup */
+     , (8782,   3,  536870932) /* SoundTable */
+     , (8782,   6,   67111919) /* PaletteBase */
+     , (8782,   7,  268435723) /* ClothingBase */
+     , (8782,   8,  100670993) /* Icon */
+     , (8782,  22,  872415275) /* PhysicsEffectTable */
+     , (8782,  28,       2040) /* Spell - The Path to Kelderam's Ward */
+     , (8782,  31,       8839) /* LinkedPortalOne - Sepulcher of the Hopeslayer Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08973 Al-Arqas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08973 Al-Arqas Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8973;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8973, 'gemportalalarqas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8973,   1,       2048) /* ItemType - Gem */
+     , (8973,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8973,   5,         10) /* EncumbranceVal */
+     , (8973,   8,         10) /* Mass */
+     , (8973,   9,          0) /* ValidLocations - None */
+     , (8973,  11,         25) /* MaxStackSize */
+     , (8973,  12,          1) /* StackSize */
+     , (8973,  13,         10) /* StackUnitEncumbrance */
+     , (8973,  14,         10) /* StackUnitMass */
+     , (8973,  15,        500) /* StackUnitValue */
+     , (8973,  16,          8) /* ItemUseable - Contained */
+     , (8973,  18,          1) /* UiEffects - Magical */
+     , (8973,  19,        500) /* Value */
+     , (8973,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8973,  94,         16) /* TargetType - Creature */
+     , (8973, 106,        210) /* ItemSpellcraft */
+     , (8973, 107,         50) /* ItemCurMana */
+     , (8973, 108,         50) /* ItemMaxMana */
+     , (8973, 109,          0) /* ItemDifficulty */
+     , (8973, 110,          0) /* ItemAllegianceRankLimit */
+     , (8973, 150,        103) /* HookPlacement - Hook */
+     , (8973, 151,          2) /* HookType - Wall */
+     , (8973, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8973,  15, True ) /* LightsStatus */
+     , (8973,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8973, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8973,   1, 'Al-Arqas Portal Gem') /* Name */
+     , (8973,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (8973,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8973,   1,   33556769) /* Setup */
+     , (8973,   3,  536870932) /* SoundTable */
+     , (8973,   6,   67111919) /* PaletteBase */
+     , (8973,   7,  268435723) /* ClothingBase */
+     , (8973,   8,  100674862) /* Icon */
+     , (8973,  22,  872415275) /* PhysicsEffectTable */
+     , (8973,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8973,  31,       8986) /* LinkedPortalOne - Al-Arqas Portal */
+     , (8973,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08976 Holtburg Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08976 Holtburg Portal Gem.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8976;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8976, 'gemportalholtburg', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8976,   1,       2048) /* ItemType - Gem */
+     , (8976,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8976,   5,         10) /* EncumbranceVal */
+     , (8976,   8,         10) /* Mass */
+     , (8976,   9,          0) /* ValidLocations - None */
+     , (8976,  11,         25) /* MaxStackSize */
+     , (8976,  12,          1) /* StackSize */
+     , (8976,  13,         10) /* StackUnitEncumbrance */
+     , (8976,  14,         10) /* StackUnitMass */
+     , (8976,  15,        500) /* StackUnitValue */
+     , (8976,  16,          8) /* ItemUseable - Contained */
+     , (8976,  18,          1) /* UiEffects - Magical */
+     , (8976,  19,        500) /* Value */
+     , (8976,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8976,  94,         16) /* TargetType - Creature */
+     , (8976, 106,        210) /* ItemSpellcraft */
+     , (8976, 107,         50) /* ItemCurMana */
+     , (8976, 108,         50) /* ItemMaxMana */
+     , (8976, 150,        103) /* HookPlacement - Hook */
+     , (8976, 151,          2) /* HookType - Wall */
+     , (8976, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8976,  15, True ) /* LightsStatus */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8976, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8976,   1, 'Holtburg Portal Gem') /* Name */
+     , (8976,  16, 'Use this gem to summon a short-lived portal to Holtburg. This gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8976,   1,   33556769) /* Setup */
+     , (8976,   3,  536870932) /* SoundTable */
+     , (8976,   6,   67111919) /* PaletteBase */
+     , (8976,   7,  268435723) /* ClothingBase */
+     , (8976,   8,  100674857) /* Icon */
+     , (8976,  22,  872415275) /* PhysicsEffectTable */
+     , (8976,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8976,  31,       8989) /* LinkedPortalOne - Portal to Holtburg */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08977 Lytelthorpe Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08977 Lytelthorpe Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8977;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8977, 'gemportallytelthorpe', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8977,   1,       2048) /* ItemType - Gem */
+     , (8977,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8977,   5,         10) /* EncumbranceVal */
+     , (8977,   8,         10) /* Mass */
+     , (8977,   9,          0) /* ValidLocations - None */
+     , (8977,  11,         25) /* MaxStackSize */
+     , (8977,  12,          1) /* StackSize */
+     , (8977,  13,         10) /* StackUnitEncumbrance */
+     , (8977,  14,         10) /* StackUnitMass */
+     , (8977,  15,        500) /* StackUnitValue */
+     , (8977,  16,          8) /* ItemUseable - Contained */
+     , (8977,  18,          1) /* UiEffects - Magical */
+     , (8977,  19,        500) /* Value */
+     , (8977,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8977,  94,         16) /* TargetType - Creature */
+     , (8977, 106,        210) /* ItemSpellcraft */
+     , (8977, 107,         50) /* ItemCurMana */
+     , (8977, 108,         50) /* ItemMaxMana */
+     , (8977, 109,          0) /* ItemDifficulty */
+     , (8977, 110,          0) /* ItemAllegianceRankLimit */
+     , (8977, 150,        103) /* HookPlacement - Hook */
+     , (8977, 151,          2) /* HookType - Wall */
+     , (8977, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8977,  15, True ) /* LightsStatus */
+     , (8977,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8977, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8977,   1, 'Lytelthorpe Portal Gem') /* Name */
+     , (8977,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (8977,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8977,   1,   33556769) /* Setup */
+     , (8977,   3,  536870932) /* SoundTable */
+     , (8977,   6,   67111919) /* PaletteBase */
+     , (8977,   7,  268435723) /* ClothingBase */
+     , (8977,   8,  100674859) /* Icon */
+     , (8977,  22,  872415275) /* PhysicsEffectTable */
+     , (8977,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8977,  31,       8998) /* LinkedPortalOne - Lytelthorpe Portal */
+     , (8977,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08978 Nanto Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08978 Nanto Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8978;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8978, 'gemportalnanto', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8978,   1,       2048) /* ItemType - Gem */
+     , (8978,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8978,   5,         10) /* EncumbranceVal */
+     , (8978,   8,         10) /* Mass */
+     , (8978,   9,          0) /* ValidLocations - None */
+     , (8978,  11,         25) /* MaxStackSize */
+     , (8978,  12,          1) /* StackSize */
+     , (8978,  13,         10) /* StackUnitEncumbrance */
+     , (8978,  14,         10) /* StackUnitMass */
+     , (8978,  15,        500) /* StackUnitValue */
+     , (8978,  16,          8) /* ItemUseable - Contained */
+     , (8978,  18,          1) /* UiEffects - Magical */
+     , (8978,  19,        500) /* Value */
+     , (8978,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8978,  94,         16) /* TargetType - Creature */
+     , (8978, 106,        210) /* ItemSpellcraft */
+     , (8978, 107,         50) /* ItemCurMana */
+     , (8978, 108,         50) /* ItemMaxMana */
+     , (8978, 109,          0) /* ItemDifficulty */
+     , (8978, 110,          0) /* ItemAllegianceRankLimit */
+     , (8978, 150,        103) /* HookPlacement - Hook */
+     , (8978, 151,          2) /* HookType - Wall */
+     , (8978, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8978,  15, True ) /* LightsStatus */
+     , (8978,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8978, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8978,   1, 'Nanto Portal Gem') /* Name */
+     , (8978,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (8978,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8978,   1,   33556769) /* Setup */
+     , (8978,   3,  536870932) /* SoundTable */
+     , (8978,   6,   67111919) /* PaletteBase */
+     , (8978,   7,  268435723) /* ClothingBase */
+     , (8978,   8,  100674864) /* Icon */
+     , (8978,  22,  872415275) /* PhysicsEffectTable */
+     , (8978,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8978,  31,       8990) /* LinkedPortalOne - Nanto Portal */
+     , (8978,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08979 Rithwic Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08979 Rithwic Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8979;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8979, 'gemportalrithwic', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8979,   1,       2048) /* ItemType - Gem */
+     , (8979,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8979,   5,         10) /* EncumbranceVal */
+     , (8979,   8,         10) /* Mass */
+     , (8979,   9,          0) /* ValidLocations - None */
+     , (8979,  11,         25) /* MaxStackSize */
+     , (8979,  12,          1) /* StackSize */
+     , (8979,  13,         10) /* StackUnitEncumbrance */
+     , (8979,  14,         10) /* StackUnitMass */
+     , (8979,  15,        500) /* StackUnitValue */
+     , (8979,  16,          8) /* ItemUseable - Contained */
+     , (8979,  18,          1) /* UiEffects - Magical */
+     , (8979,  19,        500) /* Value */
+     , (8979,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8979,  94,         16) /* TargetType - Creature */
+     , (8979, 106,        210) /* ItemSpellcraft */
+     , (8979, 107,         50) /* ItemCurMana */
+     , (8979, 108,         50) /* ItemMaxMana */
+     , (8979, 109,          0) /* ItemDifficulty */
+     , (8979, 110,          0) /* ItemAllegianceRankLimit */
+     , (8979, 150,        103) /* HookPlacement - Hook */
+     , (8979, 151,          2) /* HookType - Wall */
+     , (8979, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8979,  15, True ) /* LightsStatus */
+     , (8979,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8979, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8979,   1, 'Rithwic Portal Gem') /* Name */
+     , (8979,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (8979,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8979,   1,   33556769) /* Setup */
+     , (8979,   3,  536870932) /* SoundTable */
+     , (8979,   6,   67111919) /* PaletteBase */
+     , (8979,   7,  268435723) /* ClothingBase */
+     , (8979,   8,  100674856) /* Icon */
+     , (8979,  22,  872415275) /* PhysicsEffectTable */
+     , (8979,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8979,  31,       8991) /* LinkedPortalOne - Rithwic Portal */
+     , (8979,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08980 Samsur Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08980 Samsur Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8980;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8980, 'gemportalsamsur', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8980,   1,       2048) /* ItemType - Gem */
+     , (8980,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8980,   5,         10) /* EncumbranceVal */
+     , (8980,   8,         10) /* Mass */
+     , (8980,   9,          0) /* ValidLocations - None */
+     , (8980,  11,         25) /* MaxStackSize */
+     , (8980,  12,          1) /* StackSize */
+     , (8980,  13,         10) /* StackUnitEncumbrance */
+     , (8980,  14,         10) /* StackUnitMass */
+     , (8980,  15,        500) /* StackUnitValue */
+     , (8980,  16,          8) /* ItemUseable - Contained */
+     , (8980,  18,          1) /* UiEffects - Magical */
+     , (8980,  19,        500) /* Value */
+     , (8980,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8980,  94,         16) /* TargetType - Creature */
+     , (8980, 106,        210) /* ItemSpellcraft */
+     , (8980, 107,         50) /* ItemCurMana */
+     , (8980, 108,         50) /* ItemMaxMana */
+     , (8980, 109,          0) /* ItemDifficulty */
+     , (8980, 110,          0) /* ItemAllegianceRankLimit */
+     , (8980, 150,        103) /* HookPlacement - Hook */
+     , (8980, 151,          2) /* HookType - Wall */
+     , (8980, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8980,  15, True ) /* LightsStatus */
+     , (8980,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8980, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8980,   1, 'Samsur Portal Gem') /* Name */
+     , (8980,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (8980,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8980,   1,   33556769) /* Setup */
+     , (8980,   3,  536870932) /* SoundTable */
+     , (8980,   6,   67111919) /* PaletteBase */
+     , (8980,   7,  268435723) /* ClothingBase */
+     , (8980,   8,  100674863) /* Icon */
+     , (8980,  22,  872415275) /* PhysicsEffectTable */
+     , (8980,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8980,  31,       8992) /* LinkedPortalOne - Samsur Portal */
+     , (8980,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08981 Shoushi Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08981 Shoushi Portal Gem.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8981;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8981, 'gemportalshoushi', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8981,   1,       2048) /* ItemType - Gem */
+     , (8981,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8981,   5,         10) /* EncumbranceVal */
+     , (8981,   8,         10) /* Mass */
+     , (8981,   9,          0) /* ValidLocations - None */
+     , (8981,  11,         25) /* MaxStackSize */
+     , (8981,  12,          1) /* StackSize */
+     , (8981,  13,         10) /* StackUnitEncumbrance */
+     , (8981,  14,         10) /* StackUnitMass */
+     , (8981,  15,        500) /* StackUnitValue */
+     , (8981,  16,          8) /* ItemUseable - Contained */
+     , (8981,  18,          1) /* UiEffects - Magical */
+     , (8981,  19,        500) /* Value */
+     , (8981,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8981,  94,         16) /* TargetType - Creature */
+     , (8981, 106,        210) /* ItemSpellcraft */
+     , (8981, 107,         50) /* ItemCurMana */
+     , (8981, 108,         50) /* ItemMaxMana */
+     , (8981, 150,        103) /* HookPlacement - Hook */
+     , (8981, 151,          2) /* HookType - Wall */
+     , (8981, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8981,  15, True ) /* LightsStatus */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8981, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8981,   1, 'Shoushi Portal Gem') /* Name */
+     , (8981,  16, 'Use this gem to summon a short-lived portal to Shoushi. This gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8981,   1,   33556769) /* Setup */
+     , (8981,   3,  536870932) /* SoundTable */
+     , (8981,   6,   67111919) /* PaletteBase */
+     , (8981,   7,  268435723) /* ClothingBase */
+     , (8981,   8,  100674858) /* Icon */
+     , (8981,  22,  872415275) /* PhysicsEffectTable */
+     , (8981,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8981,  31,       8993) /* LinkedPortalOne - Portal to Shoushi */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08983 Yanshi Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08983 Yanshi Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8983;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8983, 'gemportalyanshi', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8983,   1,       2048) /* ItemType - Gem */
+     , (8983,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8983,   5,         10) /* EncumbranceVal */
+     , (8983,   8,         10) /* Mass */
+     , (8983,   9,          0) /* ValidLocations - None */
+     , (8983,  11,         25) /* MaxStackSize */
+     , (8983,  12,          1) /* StackSize */
+     , (8983,  13,         10) /* StackUnitEncumbrance */
+     , (8983,  14,         10) /* StackUnitMass */
+     , (8983,  15,        500) /* StackUnitValue */
+     , (8983,  16,          8) /* ItemUseable - Contained */
+     , (8983,  18,          1) /* UiEffects - Magical */
+     , (8983,  19,        500) /* Value */
+     , (8983,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8983,  94,         16) /* TargetType - Creature */
+     , (8983, 106,        210) /* ItemSpellcraft */
+     , (8983, 107,         50) /* ItemCurMana */
+     , (8983, 108,         50) /* ItemMaxMana */
+     , (8983, 109,          0) /* ItemDifficulty */
+     , (8983, 110,          0) /* ItemAllegianceRankLimit */
+     , (8983, 150,        103) /* HookPlacement - Hook */
+     , (8983, 151,          2) /* HookType - Wall */
+     , (8983, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8983,  15, True ) /* LightsStatus */
+     , (8983,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8983, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8983,   1, 'Yanshi Portal Gem') /* Name */
+     , (8983,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (8983,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8983,   1,   33556769) /* Setup */
+     , (8983,   3,  536870932) /* SoundTable */
+     , (8983,   6,   67111919) /* PaletteBase */
+     , (8983,   7,  268435723) /* ClothingBase */
+     , (8983,   8,  100674860) /* Icon */
+     , (8983,  22,  872415275) /* PhysicsEffectTable */
+     , (8983,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8983,  31,       8995) /* LinkedPortalOne - Yanshi Portal */
+     , (8983,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08984 Yaraq Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/08984 Yaraq Portal Gem.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8984;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8984, 'gemportalyaraq', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8984,   1,       2048) /* ItemType - Gem */
+     , (8984,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (8984,   5,         10) /* EncumbranceVal */
+     , (8984,   8,         10) /* Mass */
+     , (8984,   9,          0) /* ValidLocations - None */
+     , (8984,  11,         25) /* MaxStackSize */
+     , (8984,  12,          1) /* StackSize */
+     , (8984,  13,         10) /* StackUnitEncumbrance */
+     , (8984,  14,         10) /* StackUnitMass */
+     , (8984,  15,        500) /* StackUnitValue */
+     , (8984,  16,          8) /* ItemUseable - Contained */
+     , (8984,  18,          1) /* UiEffects - Magical */
+     , (8984,  19,        500) /* Value */
+     , (8984,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (8984,  94,         16) /* TargetType - Creature */
+     , (8984, 106,        210) /* ItemSpellcraft */
+     , (8984, 107,         50) /* ItemCurMana */
+     , (8984, 108,         50) /* ItemMaxMana */
+     , (8984, 150,        103) /* HookPlacement - Hook */
+     , (8984, 151,          2) /* HookType - Wall */
+     , (8984, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8984,  15, True ) /* LightsStatus */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8984, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8984,   1, 'Yaraq Portal Gem') /* Name */
+     , (8984,  16, 'Use this gem to summon a short-lived portal to Yaraq. This gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8984,   1,   33556769) /* Setup */
+     , (8984,   3,  536870932) /* SoundTable */
+     , (8984,   6,   67111919) /* PaletteBase */
+     , (8984,   7,  268435723) /* ClothingBase */
+     , (8984,   8,  100674861) /* Icon */
+     , (8984,  22,  872415275) /* PhysicsEffectTable */
+     , (8984,  28,        157) /* Spell - Summon Primary Portal I */
+     , (8984,  31,       8996) /* LinkedPortalOne - Portal to Yaraq */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/10974 Ahruenga Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/10974 Ahruenga Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 10974;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (10974, 'gemportalahruenga-xp', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (10974,   1,       2048) /* ItemType - Gem */
+     , (10974,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (10974,   5,         10) /* EncumbranceVal */
+     , (10974,   8,         10) /* Mass */
+     , (10974,   9,          0) /* ValidLocations - None */
+     , (10974,  11,         25) /* MaxStackSize */
+     , (10974,  12,          1) /* StackSize */
+     , (10974,  13,         10) /* StackUnitEncumbrance */
+     , (10974,  14,         10) /* StackUnitMass */
+     , (10974,  15,      10000) /* StackUnitValue */
+     , (10974,  16,          8) /* ItemUseable - Contained */
+     , (10974,  18,          1) /* UiEffects - Magical */
+     , (10974,  19,      10000) /* Value */
+     , (10974,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (10974,  94,         16) /* TargetType - Creature */
+     , (10974, 106,        210) /* ItemSpellcraft */
+     , (10974, 107,         50) /* ItemCurMana */
+     , (10974, 108,         50) /* ItemMaxMana */
+     , (10974, 109,          0) /* ItemDifficulty */
+     , (10974, 110,          0) /* ItemAllegianceRankLimit */
+     , (10974, 150,        103) /* HookPlacement - Hook */
+     , (10974, 151,          2) /* HookType - Wall */
+     , (10974, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (10974,  15, True ) /* LightsStatus */
+     , (10974,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (10974, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (10974,   1, 'Ahruenga Portal Gem') /* Name */
+     , (10974,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (10974,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (10974,   1,   33556769) /* Setup */
+     , (10974,   3,  536870932) /* SoundTable */
+     , (10974,   6,   67111919) /* PaletteBase */
+     , (10974,   7,  268435723) /* ClothingBase */
+     , (10974,   8,  100670993) /* Icon */
+     , (10974,  22,  872415275) /* PhysicsEffectTable */
+     , (10974,  28,        157) /* Spell - Summon Primary Portal I */
+     , (10974,  31,      10982) /* LinkedPortalOne - Ahurenga Portal */
+     , (10974,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/10975 Habitat Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/10975 Habitat Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 10975;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (10975, 'gemportalhabitat-xp', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (10975,   1,       2048) /* ItemType - Gem */
+     , (10975,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (10975,   5,         10) /* EncumbranceVal */
+     , (10975,   8,         10) /* Mass */
+     , (10975,   9,          0) /* ValidLocations - None */
+     , (10975,  11,          1) /* MaxStackSize */
+     , (10975,  12,          1) /* StackSize */
+     , (10975,  13,         10) /* StackUnitEncumbrance */
+     , (10975,  14,         10) /* StackUnitMass */
+     , (10975,  15,      20000) /* StackUnitValue */
+     , (10975,  16,          8) /* ItemUseable - Contained */
+     , (10975,  18,          1) /* UiEffects - Magical */
+     , (10975,  19,      20000) /* Value */
+     , (10975,  33,          1) /* Bonded - Bonded */
+     , (10975,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (10975,  94,         16) /* TargetType - Creature */
+     , (10975, 106,        210) /* ItemSpellcraft */
+     , (10975, 107,         50) /* ItemCurMana */
+     , (10975, 108,         50) /* ItemMaxMana */
+     , (10975, 109,          0) /* ItemDifficulty */
+     , (10975, 110,          0) /* ItemAllegianceRankLimit */
+     , (10975, 114,          1) /* Attuned - Attuned */
+     , (10975, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (10975,  15, True ) /* LightsStatus */
+     , (10975,  22, True ) /* Inscribable */
+     , (10975,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (10975, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (10975,   1, 'Habitat Portal Gem') /* Name */
+     , (10975,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 80+)') /* Use */
+     , (10975,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (10975,   1,   33556769) /* Setup */
+     , (10975,   3,  536870932) /* SoundTable */
+     , (10975,   6,   67111919) /* PaletteBase */
+     , (10975,   7,  268435723) /* ClothingBase */
+     , (10975,   8,  100670993) /* Icon */
+     , (10975,  22,  872415275) /* PhysicsEffectTable */
+     , (10975,  28,        157) /* Spell - Summon Primary Portal I */
+     , (10975,  31,      10985) /* LinkedPortalOne - Virindi Habitat Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/14913 Invitation Wedding Hall.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/14913 Invitation Wedding Hall.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 14913;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (14913, 'gemportalwedding1', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (14913,   1,       2048) /* ItemType - Gem */
+     , (14913,   5,          5) /* EncumbranceVal */
+     , (14913,   8,          5) /* Mass */
+     , (14913,   9,          0) /* ValidLocations - None */
+     , (14913,  11,          1) /* MaxStackSize */
+     , (14913,  12,          1) /* StackSize */
+     , (14913,  13,          5) /* StackUnitEncumbrance */
+     , (14913,  14,          5) /* StackUnitMass */
+     , (14913,  15,       1000) /* StackUnitValue */
+     , (14913,  16,          8) /* ItemUseable - Contained */
+     , (14913,  18,          1) /* UiEffects - Magical */
+     , (14913,  19,       1000) /* Value */
+     , (14913,  33,          1) /* Bonded - Bonded */
+     , (14913,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (14913,  94,         16) /* TargetType - Creature */
+     , (14913, 106,        210) /* ItemSpellcraft */
+     , (14913, 107,         70) /* ItemCurMana */
+     , (14913, 108,         70) /* ItemMaxMana */
+     , (14913, 109,         10) /* ItemDifficulty */
+     , (14913, 110,          0) /* ItemAllegianceRankLimit */
+     , (14913, 114,          0) /* Attuned - Normal */
+     , (14913, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (14913,  15, True ) /* LightsStatus */
+     , (14913,  22, True ) /* Inscribable */
+     , (14913,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (14913, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (14913,   1, 'Invitation Wedding Hall') /* Name */
+     , (14913,  14, 'Use this invitation at the time of your friends'' wedding to be transported to their celebration in the Wedding Hall.') /* Use */
+     , (14913,  15, 'A wedding invitation.') /* ShortDesc */
+     , (14913,  16, 'A wedding invitation.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (14913,   1,   33557625) /* Setup */
+     , (14913,   3,  536870932) /* SoundTable */
+     , (14913,   8,  100672736) /* Icon */
+     , (14913,  22,  872415275) /* PhysicsEffectTable */
+     , (14913,  28,        157) /* Spell - Summon Primary Portal I */
+     , (14913,  31,      14924) /* LinkedPortalOne - Wedding Hall Portal */
+     , (14913,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/14914 Invitation Plateau.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/14914 Invitation Plateau.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 14914;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (14914, 'gemportalwedding2', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (14914,   1,       2048) /* ItemType - Gem */
+     , (14914,   5,          5) /* EncumbranceVal */
+     , (14914,   8,          5) /* Mass */
+     , (14914,   9,          0) /* ValidLocations - None */
+     , (14914,  11,          1) /* MaxStackSize */
+     , (14914,  12,          1) /* StackSize */
+     , (14914,  13,          5) /* StackUnitEncumbrance */
+     , (14914,  14,          5) /* StackUnitMass */
+     , (14914,  15,       5000) /* StackUnitValue */
+     , (14914,  16,          8) /* ItemUseable - Contained */
+     , (14914,  18,          1) /* UiEffects - Magical */
+     , (14914,  19,       5000) /* Value */
+     , (14914,  33,          1) /* Bonded - Bonded */
+     , (14914,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (14914,  94,         16) /* TargetType - Creature */
+     , (14914, 106,        210) /* ItemSpellcraft */
+     , (14914, 107,         70) /* ItemCurMana */
+     , (14914, 108,         70) /* ItemMaxMana */
+     , (14914, 109,         10) /* ItemDifficulty */
+     , (14914, 110,          0) /* ItemAllegianceRankLimit */
+     , (14914, 114,          0) /* Attuned - Normal */
+     , (14914, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (14914,  15, True ) /* LightsStatus */
+     , (14914,  22, True ) /* Inscribable */
+     , (14914,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (14914, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (14914,   1, 'Invitation Plateau') /* Name */
+     , (14914,  14, 'Use this invitation at the time of your friends'' wedding to be transported to their celebration overlooking Plateau Village.') /* Use */
+     , (14914,  15, 'A wedding invitation.') /* ShortDesc */
+     , (14914,  16, 'A wedding invitation.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (14914,   1,   33557625) /* Setup */
+     , (14914,   3,  536870932) /* SoundTable */
+     , (14914,   8,  100674868) /* Icon */
+     , (14914,  22,  872415275) /* PhysicsEffectTable */
+     , (14914,  28,        157) /* Spell - Summon Primary Portal I */
+     , (14914,  31,      14925) /* LinkedPortalOne - Plateau Wedding Portal */
+     , (14914,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/14915 Invitation Ithanc Cathedral.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/14915 Invitation Ithanc Cathedral.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 14915;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (14915, 'gemportalwedding3', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (14915,   1,       2048) /* ItemType - Gem */
+     , (14915,   5,          5) /* EncumbranceVal */
+     , (14915,   8,          5) /* Mass */
+     , (14915,   9,          0) /* ValidLocations - None */
+     , (14915,  11,          1) /* MaxStackSize */
+     , (14915,  12,          1) /* StackSize */
+     , (14915,  13,          5) /* StackUnitEncumbrance */
+     , (14915,  14,          5) /* StackUnitMass */
+     , (14915,  15,      25000) /* StackUnitValue */
+     , (14915,  16,          8) /* ItemUseable - Contained */
+     , (14915,  18,          1) /* UiEffects - Magical */
+     , (14915,  19,      25000) /* Value */
+     , (14915,  33,          1) /* Bonded - Bonded */
+     , (14915,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (14915,  94,         16) /* TargetType - Creature */
+     , (14915, 106,        210) /* ItemSpellcraft */
+     , (14915, 107,         70) /* ItemCurMana */
+     , (14915, 108,         70) /* ItemMaxMana */
+     , (14915, 109,         10) /* ItemDifficulty */
+     , (14915, 110,          0) /* ItemAllegianceRankLimit */
+     , (14915, 114,          0) /* Attuned - Normal */
+     , (14915, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (14915,  15, True ) /* LightsStatus */
+     , (14915,  22, True ) /* Inscribable */
+     , (14915,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (14915, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (14915,   1, 'Invitation Ithanc Cathedral') /* Name */
+     , (14915,  14, 'Use this invitation at the time of your friends'' wedding to be transported to their celebration overlooking the waterfalls at the Ithanc Cathedral.') /* Use */
+     , (14915,  15, 'A wedding invitation.') /* ShortDesc */
+     , (14915,  16, 'A wedding invitation.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (14915,   1,   33557625) /* Setup */
+     , (14915,   3,  536870932) /* SoundTable */
+     , (14915,   8,  100674867) /* Icon */
+     , (14915,  22,  872415275) /* PhysicsEffectTable */
+     , (14915,  28,        157) /* Spell - Summon Primary Portal I */
+     , (14915,  31,      14926) /* LinkedPortalOne - Cathedral Wedding Portal */
+     , (14915,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26059 Adams' Beach Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26059 Adams' Beach Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26059;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26059, 'gemportaladamsbeach', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26059,   1,       2048) /* ItemType - Gem */
+     , (26059,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26059,   5,         10) /* EncumbranceVal */
+     , (26059,   8,         10) /* Mass */
+     , (26059,   9,          0) /* ValidLocations - None */
+     , (26059,  11,         20) /* MaxStackSize */
+     , (26059,  12,          1) /* StackSize */
+     , (26059,  13,         10) /* StackUnitEncumbrance */
+     , (26059,  14,         10) /* StackUnitMass */
+     , (26059,  15,        500) /* StackUnitValue */
+     , (26059,  16,          8) /* ItemUseable - Contained */
+     , (26059,  18,          1) /* UiEffects - Magical */
+     , (26059,  19,        500) /* Value */
+     , (26059,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26059,  94,         16) /* TargetType - Creature */
+     , (26059, 106,        210) /* ItemSpellcraft */
+     , (26059, 107,         50) /* ItemCurMana */
+     , (26059, 108,         50) /* ItemMaxMana */
+     , (26059, 109,          0) /* ItemDifficulty */
+     , (26059, 110,          0) /* ItemAllegianceRankLimit */
+     , (26059, 150,        103) /* HookPlacement - Hook */
+     , (26059, 151,          2) /* HookType - Wall */
+     , (26059, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26059,  15, True ) /* LightsStatus */
+     , (26059,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26059, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26059,   1, 'Adams'' Beach Portal Gem') /* Name */
+     , (26059,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26059,   1,   33556769) /* Setup */
+     , (26059,   3,  536870932) /* SoundTable */
+     , (26059,   6,   67111919) /* PaletteBase */
+     , (26059,   7,  268435723) /* ClothingBase */
+     , (26059,   8,  100675760) /* Icon */
+     , (26059,  22,  872415275) /* PhysicsEffectTable */
+     , (26059,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26059,  31,      12466) /* LinkedPortalOne - Adams' Beach Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26060 Adept's Domain Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26060 Adept's Domain Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26060;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26060, 'gemportaladeptsdomain', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26060,   1,       2048) /* ItemType - Gem */
+     , (26060,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26060,   5,         10) /* EncumbranceVal */
+     , (26060,   8,         10) /* Mass */
+     , (26060,   9,          0) /* ValidLocations - None */
+     , (26060,  11,         20) /* MaxStackSize */
+     , (26060,  12,          1) /* StackSize */
+     , (26060,  13,         10) /* StackUnitEncumbrance */
+     , (26060,  14,         10) /* StackUnitMass */
+     , (26060,  15,        500) /* StackUnitValue */
+     , (26060,  16,          8) /* ItemUseable - Contained */
+     , (26060,  18,          1) /* UiEffects - Magical */
+     , (26060,  19,        500) /* Value */
+     , (26060,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26060,  94,         16) /* TargetType - Creature */
+     , (26060, 106,        210) /* ItemSpellcraft */
+     , (26060, 107,         50) /* ItemCurMana */
+     , (26060, 108,         50) /* ItemMaxMana */
+     , (26060, 109,          0) /* ItemDifficulty */
+     , (26060, 110,          0) /* ItemAllegianceRankLimit */
+     , (26060, 150,        103) /* HookPlacement - Hook */
+     , (26060, 151,          2) /* HookType - Wall */
+     , (26060, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26060,  15, True ) /* LightsStatus */
+     , (26060,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26060, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26060,   1, 'Adept''s Domain Portal Gem') /* Name */
+     , (26060,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26060,   1,   33556769) /* Setup */
+     , (26060,   3,  536870932) /* SoundTable */
+     , (26060,   6,   67111919) /* PaletteBase */
+     , (26060,   7,  268435723) /* ClothingBase */
+     , (26060,   8,  100675760) /* Icon */
+     , (26060,  22,  872415275) /* PhysicsEffectTable */
+     , (26060,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26060,  31,      15662) /* LinkedPortalOne - Adept's Domain Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26061 Adventurer's Haven Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26061 Adventurer's Haven Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26061;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26061, 'gemportaladventurershavencottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26061,   1,       2048) /* ItemType - Gem */
+     , (26061,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26061,   5,         10) /* EncumbranceVal */
+     , (26061,   8,         10) /* Mass */
+     , (26061,   9,          0) /* ValidLocations - None */
+     , (26061,  11,         20) /* MaxStackSize */
+     , (26061,  12,          1) /* StackSize */
+     , (26061,  13,         10) /* StackUnitEncumbrance */
+     , (26061,  14,         10) /* StackUnitMass */
+     , (26061,  15,        500) /* StackUnitValue */
+     , (26061,  16,          8) /* ItemUseable - Contained */
+     , (26061,  18,          1) /* UiEffects - Magical */
+     , (26061,  19,        500) /* Value */
+     , (26061,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26061,  94,         16) /* TargetType - Creature */
+     , (26061, 106,        210) /* ItemSpellcraft */
+     , (26061, 107,         50) /* ItemCurMana */
+     , (26061, 108,         50) /* ItemMaxMana */
+     , (26061, 109,          0) /* ItemDifficulty */
+     , (26061, 110,          0) /* ItemAllegianceRankLimit */
+     , (26061, 150,        103) /* HookPlacement - Hook */
+     , (26061, 151,          2) /* HookType - Wall */
+     , (26061, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26061,  15, True ) /* LightsStatus */
+     , (26061,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26061, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26061,   1, 'Adventurer''s Haven Cottages Portal Gem') /* Name */
+     , (26061,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26061,   1,   33556769) /* Setup */
+     , (26061,   3,  536870932) /* SoundTable */
+     , (26061,   6,   67111919) /* PaletteBase */
+     , (26061,   7,  268435723) /* ClothingBase */
+     , (26061,   8,  100675760) /* Icon */
+     , (26061,  22,  872415275) /* PhysicsEffectTable */
+     , (26061,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26061,  31,      12467) /* LinkedPortalOne - Adventurer's Haven Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26062 Ahr-Zona Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26062 Ahr-Zona Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26062;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26062, 'gemportalahrzona', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26062,   1,       2048) /* ItemType - Gem */
+     , (26062,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26062,   5,         10) /* EncumbranceVal */
+     , (26062,   8,         10) /* Mass */
+     , (26062,   9,          0) /* ValidLocations - None */
+     , (26062,  11,         20) /* MaxStackSize */
+     , (26062,  12,          1) /* StackSize */
+     , (26062,  13,         10) /* StackUnitEncumbrance */
+     , (26062,  14,         10) /* StackUnitMass */
+     , (26062,  15,        500) /* StackUnitValue */
+     , (26062,  16,          8) /* ItemUseable - Contained */
+     , (26062,  18,          1) /* UiEffects - Magical */
+     , (26062,  19,        500) /* Value */
+     , (26062,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26062,  94,         16) /* TargetType - Creature */
+     , (26062, 106,        210) /* ItemSpellcraft */
+     , (26062, 107,         50) /* ItemCurMana */
+     , (26062, 108,         50) /* ItemMaxMana */
+     , (26062, 109,          0) /* ItemDifficulty */
+     , (26062, 110,          0) /* ItemAllegianceRankLimit */
+     , (26062, 150,        103) /* HookPlacement - Hook */
+     , (26062, 151,          2) /* HookType - Wall */
+     , (26062, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26062,  15, True ) /* LightsStatus */
+     , (26062,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26062, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26062,   1, 'Ahr-Zona Portal Gem') /* Name */
+     , (26062,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26062,   1,   33556769) /* Setup */
+     , (26062,   3,  536870932) /* SoundTable */
+     , (26062,   6,   67111919) /* PaletteBase */
+     , (26062,   7,  268435723) /* ClothingBase */
+     , (26062,   8,  100675760) /* Icon */
+     , (26062,  22,  872415275) /* PhysicsEffectTable */
+     , (26062,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26062,  31,      15138) /* LinkedPortalOne - Ahr-Zona Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26063 Aimaru Plains Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26063 Aimaru Plains Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26063;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26063, 'gemportalaimaruplainscottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26063,   1,       2048) /* ItemType - Gem */
+     , (26063,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26063,   5,         10) /* EncumbranceVal */
+     , (26063,   8,         10) /* Mass */
+     , (26063,   9,          0) /* ValidLocations - None */
+     , (26063,  11,         20) /* MaxStackSize */
+     , (26063,  12,          1) /* StackSize */
+     , (26063,  13,         10) /* StackUnitEncumbrance */
+     , (26063,  14,         10) /* StackUnitMass */
+     , (26063,  15,        500) /* StackUnitValue */
+     , (26063,  16,          8) /* ItemUseable - Contained */
+     , (26063,  18,          1) /* UiEffects - Magical */
+     , (26063,  19,        500) /* Value */
+     , (26063,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26063,  94,         16) /* TargetType - Creature */
+     , (26063, 106,        210) /* ItemSpellcraft */
+     , (26063, 107,         50) /* ItemCurMana */
+     , (26063, 108,         50) /* ItemMaxMana */
+     , (26063, 109,          0) /* ItemDifficulty */
+     , (26063, 110,          0) /* ItemAllegianceRankLimit */
+     , (26063, 150,        103) /* HookPlacement - Hook */
+     , (26063, 151,          2) /* HookType - Wall */
+     , (26063, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26063,  15, True ) /* LightsStatus */
+     , (26063,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26063, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26063,   1, 'Aimaru Plains Cottages Portal Gem') /* Name */
+     , (26063,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26063,   1,   33556769) /* Setup */
+     , (26063,   3,  536870932) /* SoundTable */
+     , (26063,   6,   67111919) /* PaletteBase */
+     , (26063,   7,  268435723) /* ClothingBase */
+     , (26063,   8,  100675760) /* Icon */
+     , (26063,  22,  872415275) /* PhysicsEffectTable */
+     , (26063,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26063,  31,      12468) /* LinkedPortalOne - Aimaru Plains Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26064 Al-Arqis Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26064 Al-Arqis Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26064;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26064, 'gemportalalarqascottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26064,   1,       2048) /* ItemType - Gem */
+     , (26064,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26064,   5,         10) /* EncumbranceVal */
+     , (26064,   8,         10) /* Mass */
+     , (26064,   9,          0) /* ValidLocations - None */
+     , (26064,  11,         20) /* MaxStackSize */
+     , (26064,  12,          1) /* StackSize */
+     , (26064,  13,         10) /* StackUnitEncumbrance */
+     , (26064,  14,         10) /* StackUnitMass */
+     , (26064,  15,        500) /* StackUnitValue */
+     , (26064,  16,          8) /* ItemUseable - Contained */
+     , (26064,  18,          1) /* UiEffects - Magical */
+     , (26064,  19,        500) /* Value */
+     , (26064,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26064,  94,         16) /* TargetType - Creature */
+     , (26064, 106,        210) /* ItemSpellcraft */
+     , (26064, 107,         50) /* ItemCurMana */
+     , (26064, 108,         50) /* ItemMaxMana */
+     , (26064, 109,          0) /* ItemDifficulty */
+     , (26064, 110,          0) /* ItemAllegianceRankLimit */
+     , (26064, 150,        103) /* HookPlacement - Hook */
+     , (26064, 151,          2) /* HookType - Wall */
+     , (26064, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26064,  15, True ) /* LightsStatus */
+     , (26064,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26064, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26064,   1, 'Al-Arqis Cottages Portal Gem') /* Name */
+     , (26064,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26064,   1,   33556769) /* Setup */
+     , (26064,   3,  536870932) /* SoundTable */
+     , (26064,   6,   67111919) /* PaletteBase */
+     , (26064,   7,  268435723) /* ClothingBase */
+     , (26064,   8,  100675760) /* Icon */
+     , (26064,  22,  872415275) /* PhysicsEffectTable */
+     , (26064,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26064,  31,      14610) /* LinkedPortalOne - Al-Arqis Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26065 Alfreth Ridge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26065 Alfreth Ridge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26065;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26065, 'gemportalalfrethridgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26065,   1,       2048) /* ItemType - Gem */
+     , (26065,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26065,   5,         10) /* EncumbranceVal */
+     , (26065,   8,         10) /* Mass */
+     , (26065,   9,          0) /* ValidLocations - None */
+     , (26065,  11,         20) /* MaxStackSize */
+     , (26065,  12,          1) /* StackSize */
+     , (26065,  13,         10) /* StackUnitEncumbrance */
+     , (26065,  14,         10) /* StackUnitMass */
+     , (26065,  15,        500) /* StackUnitValue */
+     , (26065,  16,          8) /* ItemUseable - Contained */
+     , (26065,  18,          1) /* UiEffects - Magical */
+     , (26065,  19,        500) /* Value */
+     , (26065,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26065,  94,         16) /* TargetType - Creature */
+     , (26065, 106,        210) /* ItemSpellcraft */
+     , (26065, 107,         50) /* ItemCurMana */
+     , (26065, 108,         50) /* ItemMaxMana */
+     , (26065, 109,          0) /* ItemDifficulty */
+     , (26065, 110,          0) /* ItemAllegianceRankLimit */
+     , (26065, 150,        103) /* HookPlacement - Hook */
+     , (26065, 151,          2) /* HookType - Wall */
+     , (26065, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26065,  15, True ) /* LightsStatus */
+     , (26065,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26065, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26065,   1, 'Alfreth Ridge Cottages Portal Gem') /* Name */
+     , (26065,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26065,   1,   33556769) /* Setup */
+     , (26065,   3,  536870932) /* SoundTable */
+     , (26065,   6,   67111919) /* PaletteBase */
+     , (26065,   7,  268435723) /* ClothingBase */
+     , (26065,   8,  100675760) /* Icon */
+     , (26065,  22,  872415275) /* PhysicsEffectTable */
+     , (26065,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26065,  31,      14251) /* LinkedPortalOne - Alfreth Ridge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26066 Al-Hatar Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26066 Al-Hatar Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26066;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26066, 'gemportalalhatarsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26066,   1,       2048) /* ItemType - Gem */
+     , (26066,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26066,   5,         10) /* EncumbranceVal */
+     , (26066,   8,         10) /* Mass */
+     , (26066,   9,          0) /* ValidLocations - None */
+     , (26066,  11,         20) /* MaxStackSize */
+     , (26066,  12,          1) /* StackSize */
+     , (26066,  13,         10) /* StackUnitEncumbrance */
+     , (26066,  14,         10) /* StackUnitMass */
+     , (26066,  15,        500) /* StackUnitValue */
+     , (26066,  16,          8) /* ItemUseable - Contained */
+     , (26066,  18,          1) /* UiEffects - Magical */
+     , (26066,  19,        500) /* Value */
+     , (26066,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26066,  94,         16) /* TargetType - Creature */
+     , (26066, 106,        210) /* ItemSpellcraft */
+     , (26066, 107,         50) /* ItemCurMana */
+     , (26066, 108,         50) /* ItemMaxMana */
+     , (26066, 109,          0) /* ItemDifficulty */
+     , (26066, 110,          0) /* ItemAllegianceRankLimit */
+     , (26066, 150,        103) /* HookPlacement - Hook */
+     , (26066, 151,          2) /* HookType - Wall */
+     , (26066, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26066,  15, True ) /* LightsStatus */
+     , (26066,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26066, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26066,   1, 'Al-Hatar Settlement Portal Gem') /* Name */
+     , (26066,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26066,   1,   33556769) /* Setup */
+     , (26066,   3,  536870932) /* SoundTable */
+     , (26066,   6,   67111919) /* PaletteBase */
+     , (26066,   7,  268435723) /* ClothingBase */
+     , (26066,   8,  100675760) /* Icon */
+     , (26066,  22,  872415275) /* PhysicsEffectTable */
+     , (26066,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26066,  31,      12469) /* LinkedPortalOne - Al-Hatar Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26067 Al-Kasan Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26067 Al-Kasan Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26067;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26067, 'gemportalalkasansettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26067,   1,       2048) /* ItemType - Gem */
+     , (26067,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26067,   5,         10) /* EncumbranceVal */
+     , (26067,   8,         10) /* Mass */
+     , (26067,   9,          0) /* ValidLocations - None */
+     , (26067,  11,         20) /* MaxStackSize */
+     , (26067,  12,          1) /* StackSize */
+     , (26067,  13,         10) /* StackUnitEncumbrance */
+     , (26067,  14,         10) /* StackUnitMass */
+     , (26067,  15,        500) /* StackUnitValue */
+     , (26067,  16,          8) /* ItemUseable - Contained */
+     , (26067,  18,          1) /* UiEffects - Magical */
+     , (26067,  19,        500) /* Value */
+     , (26067,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26067,  94,         16) /* TargetType - Creature */
+     , (26067, 106,        210) /* ItemSpellcraft */
+     , (26067, 107,         50) /* ItemCurMana */
+     , (26067, 108,         50) /* ItemMaxMana */
+     , (26067, 109,          0) /* ItemDifficulty */
+     , (26067, 110,          0) /* ItemAllegianceRankLimit */
+     , (26067, 150,        103) /* HookPlacement - Hook */
+     , (26067, 151,          2) /* HookType - Wall */
+     , (26067, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26067,  15, True ) /* LightsStatus */
+     , (26067,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26067, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26067,   1, 'Al-Kasan Settlement Portal Gem') /* Name */
+     , (26067,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26067,   1,   33556769) /* Setup */
+     , (26067,   3,  536870932) /* SoundTable */
+     , (26067,   6,   67111919) /* PaletteBase */
+     , (26067,   7,  268435723) /* ClothingBase */
+     , (26067,   8,  100675760) /* Icon */
+     , (26067,  22,  872415275) /* PhysicsEffectTable */
+     , (26067,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26067,  31,      12470) /* LinkedPortalOne - Al-Kasan Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26068 Al-Mar Oasis Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26068 Al-Mar Oasis Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26068;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26068, 'gemportalalmaroasis', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26068,   1,       2048) /* ItemType - Gem */
+     , (26068,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26068,   5,         10) /* EncumbranceVal */
+     , (26068,   8,         10) /* Mass */
+     , (26068,   9,          0) /* ValidLocations - None */
+     , (26068,  11,         20) /* MaxStackSize */
+     , (26068,  12,          1) /* StackSize */
+     , (26068,  13,         10) /* StackUnitEncumbrance */
+     , (26068,  14,         10) /* StackUnitMass */
+     , (26068,  15,        500) /* StackUnitValue */
+     , (26068,  16,          8) /* ItemUseable - Contained */
+     , (26068,  18,          1) /* UiEffects - Magical */
+     , (26068,  19,        500) /* Value */
+     , (26068,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26068,  94,         16) /* TargetType - Creature */
+     , (26068, 106,        210) /* ItemSpellcraft */
+     , (26068, 107,         50) /* ItemCurMana */
+     , (26068, 108,         50) /* ItemMaxMana */
+     , (26068, 109,          0) /* ItemDifficulty */
+     , (26068, 110,          0) /* ItemAllegianceRankLimit */
+     , (26068, 150,        103) /* HookPlacement - Hook */
+     , (26068, 151,          2) /* HookType - Wall */
+     , (26068, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26068,  15, True ) /* LightsStatus */
+     , (26068,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26068, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26068,   1, 'Al-Mar Oasis Portal Gem') /* Name */
+     , (26068,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26068,   1,   33556769) /* Setup */
+     , (26068,   3,  536870932) /* SoundTable */
+     , (26068,   6,   67111919) /* PaletteBase */
+     , (26068,   7,  268435723) /* ClothingBase */
+     , (26068,   8,  100675760) /* Icon */
+     , (26068,  22,  872415275) /* PhysicsEffectTable */
+     , (26068,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26068,  31,      15139) /* LinkedPortalOne - Al-Mar Oasis Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26069 Al-Nosaj Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26069 Al-Nosaj Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26069;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26069, 'gemportalalnosaj', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26069,   1,       2048) /* ItemType - Gem */
+     , (26069,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26069,   5,         10) /* EncumbranceVal */
+     , (26069,   8,         10) /* Mass */
+     , (26069,   9,          0) /* ValidLocations - None */
+     , (26069,  11,         20) /* MaxStackSize */
+     , (26069,  12,          1) /* StackSize */
+     , (26069,  13,         10) /* StackUnitEncumbrance */
+     , (26069,  14,         10) /* StackUnitMass */
+     , (26069,  15,        500) /* StackUnitValue */
+     , (26069,  16,          8) /* ItemUseable - Contained */
+     , (26069,  18,          1) /* UiEffects - Magical */
+     , (26069,  19,        500) /* Value */
+     , (26069,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26069,  94,         16) /* TargetType - Creature */
+     , (26069, 106,        210) /* ItemSpellcraft */
+     , (26069, 107,         50) /* ItemCurMana */
+     , (26069, 108,         50) /* ItemMaxMana */
+     , (26069, 109,          0) /* ItemDifficulty */
+     , (26069, 110,          0) /* ItemAllegianceRankLimit */
+     , (26069, 150,        103) /* HookPlacement - Hook */
+     , (26069, 151,          2) /* HookType - Wall */
+     , (26069, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26069,  15, True ) /* LightsStatus */
+     , (26069,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26069, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26069,   1, 'Al-Nosaj Portal Gem') /* Name */
+     , (26069,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26069,   1,   33556769) /* Setup */
+     , (26069,   3,  536870932) /* SoundTable */
+     , (26069,   6,   67111919) /* PaletteBase */
+     , (26069,   7,  268435723) /* ClothingBase */
+     , (26069,   8,  100675760) /* Icon */
+     , (26069,  22,  872415275) /* PhysicsEffectTable */
+     , (26069,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26069,  31,      14611) /* LinkedPortalOne - Al-Nosaj Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26070 Aloria Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26070 Aloria Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26070;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26070, 'gemportalaloria', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26070,   1,       2048) /* ItemType - Gem */
+     , (26070,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26070,   5,         10) /* EncumbranceVal */
+     , (26070,   8,         10) /* Mass */
+     , (26070,   9,          0) /* ValidLocations - None */
+     , (26070,  11,         20) /* MaxStackSize */
+     , (26070,  12,          1) /* StackSize */
+     , (26070,  13,         10) /* StackUnitEncumbrance */
+     , (26070,  14,         10) /* StackUnitMass */
+     , (26070,  15,        500) /* StackUnitValue */
+     , (26070,  16,          8) /* ItemUseable - Contained */
+     , (26070,  18,          1) /* UiEffects - Magical */
+     , (26070,  19,        500) /* Value */
+     , (26070,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26070,  94,         16) /* TargetType - Creature */
+     , (26070, 106,        210) /* ItemSpellcraft */
+     , (26070, 107,         50) /* ItemCurMana */
+     , (26070, 108,         50) /* ItemMaxMana */
+     , (26070, 109,          0) /* ItemDifficulty */
+     , (26070, 110,          0) /* ItemAllegianceRankLimit */
+     , (26070, 150,        103) /* HookPlacement - Hook */
+     , (26070, 151,          2) /* HookType - Wall */
+     , (26070, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26070,  15, True ) /* LightsStatus */
+     , (26070,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26070, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26070,   1, 'Aloria Portal Gem') /* Name */
+     , (26070,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26070,   1,   33556769) /* Setup */
+     , (26070,   3,  536870932) /* SoundTable */
+     , (26070,   6,   67111919) /* PaletteBase */
+     , (26070,   7,  268435723) /* ClothingBase */
+     , (26070,   8,  100675760) /* Icon */
+     , (26070,  22,  872415275) /* PhysicsEffectTable */
+     , (26070,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26070,  31,      15140) /* LinkedPortalOne - Aloria Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26071 Alvador Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26071 Alvador Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26071;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26071, 'gemportalalvador', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26071,   1,       2048) /* ItemType - Gem */
+     , (26071,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26071,   5,         10) /* EncumbranceVal */
+     , (26071,   8,         10) /* Mass */
+     , (26071,   9,          0) /* ValidLocations - None */
+     , (26071,  11,         20) /* MaxStackSize */
+     , (26071,  12,          1) /* StackSize */
+     , (26071,  13,         10) /* StackUnitEncumbrance */
+     , (26071,  14,         10) /* StackUnitMass */
+     , (26071,  15,        500) /* StackUnitValue */
+     , (26071,  16,          8) /* ItemUseable - Contained */
+     , (26071,  18,          1) /* UiEffects - Magical */
+     , (26071,  19,        500) /* Value */
+     , (26071,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26071,  94,         16) /* TargetType - Creature */
+     , (26071, 106,        210) /* ItemSpellcraft */
+     , (26071, 107,         50) /* ItemCurMana */
+     , (26071, 108,         50) /* ItemMaxMana */
+     , (26071, 109,          0) /* ItemDifficulty */
+     , (26071, 110,          0) /* ItemAllegianceRankLimit */
+     , (26071, 150,        103) /* HookPlacement - Hook */
+     , (26071, 151,          2) /* HookType - Wall */
+     , (26071, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26071,  15, True ) /* LightsStatus */
+     , (26071,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26071, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26071,   1, 'Alvador Portal Gem') /* Name */
+     , (26071,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26071,   1,   33556769) /* Setup */
+     , (26071,   3,  536870932) /* SoundTable */
+     , (26071,   6,   67111919) /* PaletteBase */
+     , (26071,   7,  268435723) /* ClothingBase */
+     , (26071,   8,  100675760) /* Icon */
+     , (26071,  22,  872415275) /* PhysicsEffectTable */
+     , (26071,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26071,  31,      14252) /* LinkedPortalOne - Alvador Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26072 Amarand Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26072 Amarand Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26072;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26072, 'gemportalamarandvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26072,   1,       2048) /* ItemType - Gem */
+     , (26072,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26072,   5,         10) /* EncumbranceVal */
+     , (26072,   8,         10) /* Mass */
+     , (26072,   9,          0) /* ValidLocations - None */
+     , (26072,  11,         20) /* MaxStackSize */
+     , (26072,  12,          1) /* StackSize */
+     , (26072,  13,         10) /* StackUnitEncumbrance */
+     , (26072,  14,         10) /* StackUnitMass */
+     , (26072,  15,        500) /* StackUnitValue */
+     , (26072,  16,          8) /* ItemUseable - Contained */
+     , (26072,  18,          1) /* UiEffects - Magical */
+     , (26072,  19,        500) /* Value */
+     , (26072,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26072,  94,         16) /* TargetType - Creature */
+     , (26072, 106,        210) /* ItemSpellcraft */
+     , (26072, 107,         50) /* ItemCurMana */
+     , (26072, 108,         50) /* ItemMaxMana */
+     , (26072, 109,          0) /* ItemDifficulty */
+     , (26072, 110,          0) /* ItemAllegianceRankLimit */
+     , (26072, 150,        103) /* HookPlacement - Hook */
+     , (26072, 151,          2) /* HookType - Wall */
+     , (26072, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26072,  15, True ) /* LightsStatus */
+     , (26072,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26072, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26072,   1, 'Amarand Villas Portal Gem') /* Name */
+     , (26072,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26072,   1,   33556769) /* Setup */
+     , (26072,   3,  536870932) /* SoundTable */
+     , (26072,   6,   67111919) /* PaletteBase */
+     , (26072,   7,  268435723) /* ClothingBase */
+     , (26072,   8,  100675760) /* Icon */
+     , (26072,  22,  872415275) /* PhysicsEffectTable */
+     , (26072,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26072,  31,      19138) /* LinkedPortalOne - Amarand Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26073 Anadil Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26073 Anadil Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26073;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26073, 'gemportalanadil', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26073,   1,       2048) /* ItemType - Gem */
+     , (26073,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26073,   5,         10) /* EncumbranceVal */
+     , (26073,   8,         10) /* Mass */
+     , (26073,   9,          0) /* ValidLocations - None */
+     , (26073,  11,         20) /* MaxStackSize */
+     , (26073,  12,          1) /* StackSize */
+     , (26073,  13,         10) /* StackUnitEncumbrance */
+     , (26073,  14,         10) /* StackUnitMass */
+     , (26073,  15,        500) /* StackUnitValue */
+     , (26073,  16,          8) /* ItemUseable - Contained */
+     , (26073,  18,          1) /* UiEffects - Magical */
+     , (26073,  19,        500) /* Value */
+     , (26073,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26073,  94,         16) /* TargetType - Creature */
+     , (26073, 106,        210) /* ItemSpellcraft */
+     , (26073, 107,         50) /* ItemCurMana */
+     , (26073, 108,         50) /* ItemMaxMana */
+     , (26073, 109,          0) /* ItemDifficulty */
+     , (26073, 110,          0) /* ItemAllegianceRankLimit */
+     , (26073, 150,        103) /* HookPlacement - Hook */
+     , (26073, 151,          2) /* HookType - Wall */
+     , (26073, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26073,  15, True ) /* LightsStatus */
+     , (26073,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26073, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26073,   1, 'Anadil Portal Gem') /* Name */
+     , (26073,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26073,   1,   33556769) /* Setup */
+     , (26073,   3,  536870932) /* SoundTable */
+     , (26073,   6,   67111919) /* PaletteBase */
+     , (26073,   7,  268435723) /* ClothingBase */
+     , (26073,   8,  100675760) /* Icon */
+     , (26073,  22,  872415275) /* PhysicsEffectTable */
+     , (26073,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26073,  31,      15141) /* LinkedPortalOne - Anadil Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26074 Aqalah Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26074 Aqalah Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26074;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26074, 'gemportalaqalah', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26074,   1,       2048) /* ItemType - Gem */
+     , (26074,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26074,   5,         10) /* EncumbranceVal */
+     , (26074,   8,         10) /* Mass */
+     , (26074,   9,          0) /* ValidLocations - None */
+     , (26074,  11,         20) /* MaxStackSize */
+     , (26074,  12,          1) /* StackSize */
+     , (26074,  13,         10) /* StackUnitEncumbrance */
+     , (26074,  14,         10) /* StackUnitMass */
+     , (26074,  15,        500) /* StackUnitValue */
+     , (26074,  16,          8) /* ItemUseable - Contained */
+     , (26074,  18,          1) /* UiEffects - Magical */
+     , (26074,  19,        500) /* Value */
+     , (26074,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26074,  94,         16) /* TargetType - Creature */
+     , (26074, 106,        210) /* ItemSpellcraft */
+     , (26074, 107,         50) /* ItemCurMana */
+     , (26074, 108,         50) /* ItemMaxMana */
+     , (26074, 109,          0) /* ItemDifficulty */
+     , (26074, 110,          0) /* ItemAllegianceRankLimit */
+     , (26074, 150,        103) /* HookPlacement - Hook */
+     , (26074, 151,          2) /* HookType - Wall */
+     , (26074, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26074,  15, True ) /* LightsStatus */
+     , (26074,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26074, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26074,   1, 'Aqalah Portal Gem') /* Name */
+     , (26074,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26074,   1,   33556769) /* Setup */
+     , (26074,   3,  536870932) /* SoundTable */
+     , (26074,   6,   67111919) /* PaletteBase */
+     , (26074,   7,  268435723) /* ClothingBase */
+     , (26074,   8,  100675760) /* Icon */
+     , (26074,  22,  872415275) /* PhysicsEffectTable */
+     , (26074,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26074,  31,      12471) /* LinkedPortalOne - Aqalah Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26075 Ardent Realm Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26075 Ardent Realm Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26075;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26075, 'gemportalardentrealm', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26075,   1,       2048) /* ItemType - Gem */
+     , (26075,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26075,   5,         10) /* EncumbranceVal */
+     , (26075,   8,         10) /* Mass */
+     , (26075,   9,          0) /* ValidLocations - None */
+     , (26075,  11,         20) /* MaxStackSize */
+     , (26075,  12,          1) /* StackSize */
+     , (26075,  13,         10) /* StackUnitEncumbrance */
+     , (26075,  14,         10) /* StackUnitMass */
+     , (26075,  15,        500) /* StackUnitValue */
+     , (26075,  16,          8) /* ItemUseable - Contained */
+     , (26075,  18,          1) /* UiEffects - Magical */
+     , (26075,  19,        500) /* Value */
+     , (26075,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26075,  94,         16) /* TargetType - Creature */
+     , (26075, 106,        210) /* ItemSpellcraft */
+     , (26075, 107,         50) /* ItemCurMana */
+     , (26075, 108,         50) /* ItemMaxMana */
+     , (26075, 109,          0) /* ItemDifficulty */
+     , (26075, 110,          0) /* ItemAllegianceRankLimit */
+     , (26075, 150,        103) /* HookPlacement - Hook */
+     , (26075, 151,          2) /* HookType - Wall */
+     , (26075, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26075,  15, True ) /* LightsStatus */
+     , (26075,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26075, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26075,   1, 'Ardent Realm Portal Gem') /* Name */
+     , (26075,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26075,   1,   33556769) /* Setup */
+     , (26075,   3,  536870932) /* SoundTable */
+     , (26075,   6,   67111919) /* PaletteBase */
+     , (26075,   7,  268435723) /* ClothingBase */
+     , (26075,   8,  100675760) /* Icon */
+     , (26075,  22,  872415275) /* PhysicsEffectTable */
+     , (26075,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26075,  31,      15663) /* LinkedPortalOne - Ardent Realm Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26076 Ariake Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26076 Ariake Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26076;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26076, 'gemportalariake', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26076,   1,       2048) /* ItemType - Gem */
+     , (26076,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26076,   5,         10) /* EncumbranceVal */
+     , (26076,   8,         10) /* Mass */
+     , (26076,   9,          0) /* ValidLocations - None */
+     , (26076,  11,         20) /* MaxStackSize */
+     , (26076,  12,          1) /* StackSize */
+     , (26076,  13,         10) /* StackUnitEncumbrance */
+     , (26076,  14,         10) /* StackUnitMass */
+     , (26076,  15,        500) /* StackUnitValue */
+     , (26076,  16,          8) /* ItemUseable - Contained */
+     , (26076,  18,          1) /* UiEffects - Magical */
+     , (26076,  19,        500) /* Value */
+     , (26076,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26076,  94,         16) /* TargetType - Creature */
+     , (26076, 106,        210) /* ItemSpellcraft */
+     , (26076, 107,         50) /* ItemCurMana */
+     , (26076, 108,         50) /* ItemMaxMana */
+     , (26076, 109,          0) /* ItemDifficulty */
+     , (26076, 110,          0) /* ItemAllegianceRankLimit */
+     , (26076, 150,        103) /* HookPlacement - Hook */
+     , (26076, 151,          2) /* HookType - Wall */
+     , (26076, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26076,  15, True ) /* LightsStatus */
+     , (26076,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26076, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26076,   1, 'Ariake Portal Gem') /* Name */
+     , (26076,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26076,   1,   33556769) /* Setup */
+     , (26076,   3,  536870932) /* SoundTable */
+     , (26076,   6,   67111919) /* PaletteBase */
+     , (26076,   7,  268435723) /* ClothingBase */
+     , (26076,   8,  100675760) /* Icon */
+     , (26076,  22,  872415275) /* PhysicsEffectTable */
+     , (26076,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26076,  31,      12472) /* LinkedPortalOne - Ariake Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26077 Arida Butte Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26077 Arida Butte Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26077;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26077, 'gemportalaridabutte', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26077,   1,       2048) /* ItemType - Gem */
+     , (26077,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26077,   5,         10) /* EncumbranceVal */
+     , (26077,   8,         10) /* Mass */
+     , (26077,   9,          0) /* ValidLocations - None */
+     , (26077,  11,         20) /* MaxStackSize */
+     , (26077,  12,          1) /* StackSize */
+     , (26077,  13,         10) /* StackUnitEncumbrance */
+     , (26077,  14,         10) /* StackUnitMass */
+     , (26077,  15,        500) /* StackUnitValue */
+     , (26077,  16,          8) /* ItemUseable - Contained */
+     , (26077,  18,          1) /* UiEffects - Magical */
+     , (26077,  19,        500) /* Value */
+     , (26077,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26077,  94,         16) /* TargetType - Creature */
+     , (26077, 106,        210) /* ItemSpellcraft */
+     , (26077, 107,         50) /* ItemCurMana */
+     , (26077, 108,         50) /* ItemMaxMana */
+     , (26077, 109,          0) /* ItemDifficulty */
+     , (26077, 110,          0) /* ItemAllegianceRankLimit */
+     , (26077, 150,        103) /* HookPlacement - Hook */
+     , (26077, 151,          2) /* HookType - Wall */
+     , (26077, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26077,  15, True ) /* LightsStatus */
+     , (26077,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26077, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26077,   1, 'Arida Butte Portal Gem') /* Name */
+     , (26077,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26077,   1,   33556769) /* Setup */
+     , (26077,   3,  536870932) /* SoundTable */
+     , (26077,   6,   67111919) /* PaletteBase */
+     , (26077,   7,  268435723) /* ClothingBase */
+     , (26077,   8,  100675760) /* Icon */
+     , (26077,  22,  872415275) /* PhysicsEffectTable */
+     , (26077,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26077,  31,      12473) /* LinkedPortalOne - Arida Butte Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26078 Arqasanti Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26078 Arqasanti Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26078;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26078, 'gemportalarqasanti', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26078,   1,       2048) /* ItemType - Gem */
+     , (26078,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26078,   5,         10) /* EncumbranceVal */
+     , (26078,   8,         10) /* Mass */
+     , (26078,   9,          0) /* ValidLocations - None */
+     , (26078,  11,         20) /* MaxStackSize */
+     , (26078,  12,          1) /* StackSize */
+     , (26078,  13,         10) /* StackUnitEncumbrance */
+     , (26078,  14,         10) /* StackUnitMass */
+     , (26078,  15,        500) /* StackUnitValue */
+     , (26078,  16,          8) /* ItemUseable - Contained */
+     , (26078,  18,          1) /* UiEffects - Magical */
+     , (26078,  19,        500) /* Value */
+     , (26078,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26078,  94,         16) /* TargetType - Creature */
+     , (26078, 106,        210) /* ItemSpellcraft */
+     , (26078, 107,         50) /* ItemCurMana */
+     , (26078, 108,         50) /* ItemMaxMana */
+     , (26078, 109,          0) /* ItemDifficulty */
+     , (26078, 110,          0) /* ItemAllegianceRankLimit */
+     , (26078, 150,        103) /* HookPlacement - Hook */
+     , (26078, 151,          2) /* HookType - Wall */
+     , (26078, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26078,  15, True ) /* LightsStatus */
+     , (26078,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26078, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26078,   1, 'Arqasanti Portal Gem') /* Name */
+     , (26078,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26078,   1,   33556769) /* Setup */
+     , (26078,   3,  536870932) /* SoundTable */
+     , (26078,   6,   67111919) /* PaletteBase */
+     , (26078,   7,  268435723) /* ClothingBase */
+     , (26078,   8,  100675760) /* Icon */
+     , (26078,  22,  872415275) /* PhysicsEffectTable */
+     , (26078,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26078,  31,      12474) /* LinkedPortalOne - Arqasanti Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26079 Arrak Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26079 Arrak Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26079;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26079, 'gemportalarrak', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26079,   1,       2048) /* ItemType - Gem */
+     , (26079,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26079,   5,         10) /* EncumbranceVal */
+     , (26079,   8,         10) /* Mass */
+     , (26079,   9,          0) /* ValidLocations - None */
+     , (26079,  11,         20) /* MaxStackSize */
+     , (26079,  12,          1) /* StackSize */
+     , (26079,  13,         10) /* StackUnitEncumbrance */
+     , (26079,  14,         10) /* StackUnitMass */
+     , (26079,  15,        500) /* StackUnitValue */
+     , (26079,  16,          8) /* ItemUseable - Contained */
+     , (26079,  18,          1) /* UiEffects - Magical */
+     , (26079,  19,        500) /* Value */
+     , (26079,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26079,  94,         16) /* TargetType - Creature */
+     , (26079, 106,        210) /* ItemSpellcraft */
+     , (26079, 107,         50) /* ItemCurMana */
+     , (26079, 108,         50) /* ItemMaxMana */
+     , (26079, 109,          0) /* ItemDifficulty */
+     , (26079, 110,          0) /* ItemAllegianceRankLimit */
+     , (26079, 150,        103) /* HookPlacement - Hook */
+     , (26079, 151,          2) /* HookType - Wall */
+     , (26079, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26079,  15, True ) /* LightsStatus */
+     , (26079,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26079, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26079,   1, 'Arrak Portal Gem') /* Name */
+     , (26079,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26079,   1,   33556769) /* Setup */
+     , (26079,   3,  536870932) /* SoundTable */
+     , (26079,   6,   67111919) /* PaletteBase */
+     , (26079,   7,  268435723) /* ClothingBase */
+     , (26079,   8,  100675760) /* Icon */
+     , (26079,  22,  872415275) /* PhysicsEffectTable */
+     , (26079,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26079,  31,      14253) /* LinkedPortalOne - Arrak Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26080 Arrowdale Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26080 Arrowdale Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26080;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26080, 'gemportalarrowdalecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26080,   1,       2048) /* ItemType - Gem */
+     , (26080,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26080,   5,         10) /* EncumbranceVal */
+     , (26080,   8,         10) /* Mass */
+     , (26080,   9,          0) /* ValidLocations - None */
+     , (26080,  11,         20) /* MaxStackSize */
+     , (26080,  12,          1) /* StackSize */
+     , (26080,  13,         10) /* StackUnitEncumbrance */
+     , (26080,  14,         10) /* StackUnitMass */
+     , (26080,  15,        500) /* StackUnitValue */
+     , (26080,  16,          8) /* ItemUseable - Contained */
+     , (26080,  18,          1) /* UiEffects - Magical */
+     , (26080,  19,        500) /* Value */
+     , (26080,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26080,  94,         16) /* TargetType - Creature */
+     , (26080, 106,        210) /* ItemSpellcraft */
+     , (26080, 107,         50) /* ItemCurMana */
+     , (26080, 108,         50) /* ItemMaxMana */
+     , (26080, 109,          0) /* ItemDifficulty */
+     , (26080, 110,          0) /* ItemAllegianceRankLimit */
+     , (26080, 150,        103) /* HookPlacement - Hook */
+     , (26080, 151,          2) /* HookType - Wall */
+     , (26080, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26080,  15, True ) /* LightsStatus */
+     , (26080,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26080, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26080,   1, 'Arrowdale Cottages Portal Gem') /* Name */
+     , (26080,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26080,   1,   33556769) /* Setup */
+     , (26080,   3,  536870932) /* SoundTable */
+     , (26080,   6,   67111919) /* PaletteBase */
+     , (26080,   7,  268435723) /* ClothingBase */
+     , (26080,   8,  100675760) /* Icon */
+     , (26080,  22,  872415275) /* PhysicsEffectTable */
+     , (26080,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26080,  31,      15664) /* LinkedPortalOne - Arrowdale Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26081 Artifice Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26081 Artifice Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26081;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26081, 'gemportalartificecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26081,   1,       2048) /* ItemType - Gem */
+     , (26081,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26081,   5,         10) /* EncumbranceVal */
+     , (26081,   8,         10) /* Mass */
+     , (26081,   9,          0) /* ValidLocations - None */
+     , (26081,  11,         20) /* MaxStackSize */
+     , (26081,  12,          1) /* StackSize */
+     , (26081,  13,         10) /* StackUnitEncumbrance */
+     , (26081,  14,         10) /* StackUnitMass */
+     , (26081,  15,        500) /* StackUnitValue */
+     , (26081,  16,          8) /* ItemUseable - Contained */
+     , (26081,  18,          1) /* UiEffects - Magical */
+     , (26081,  19,        500) /* Value */
+     , (26081,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26081,  94,         16) /* TargetType - Creature */
+     , (26081, 106,        210) /* ItemSpellcraft */
+     , (26081, 107,         50) /* ItemCurMana */
+     , (26081, 108,         50) /* ItemMaxMana */
+     , (26081, 109,          0) /* ItemDifficulty */
+     , (26081, 110,          0) /* ItemAllegianceRankLimit */
+     , (26081, 150,        103) /* HookPlacement - Hook */
+     , (26081, 151,          2) /* HookType - Wall */
+     , (26081, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26081,  15, True ) /* LightsStatus */
+     , (26081,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26081, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26081,   1, 'Artifice Cottages Portal Gem') /* Name */
+     , (26081,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26081,   1,   33556769) /* Setup */
+     , (26081,   3,  536870932) /* SoundTable */
+     , (26081,   6,   67111919) /* PaletteBase */
+     , (26081,   7,  268435723) /* ClothingBase */
+     , (26081,   8,  100675760) /* Icon */
+     , (26081,  22,  872415275) /* PhysicsEffectTable */
+     , (26081,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26081,  31,      15665) /* LinkedPortalOne - Artifice Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26082 Asandra Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26082 Asandra Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26082;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26082, 'gemportalasandracottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26082,   1,       2048) /* ItemType - Gem */
+     , (26082,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26082,   5,         10) /* EncumbranceVal */
+     , (26082,   8,         10) /* Mass */
+     , (26082,   9,          0) /* ValidLocations - None */
+     , (26082,  11,         20) /* MaxStackSize */
+     , (26082,  12,          1) /* StackSize */
+     , (26082,  13,         10) /* StackUnitEncumbrance */
+     , (26082,  14,         10) /* StackUnitMass */
+     , (26082,  15,        500) /* StackUnitValue */
+     , (26082,  16,          8) /* ItemUseable - Contained */
+     , (26082,  18,          1) /* UiEffects - Magical */
+     , (26082,  19,        500) /* Value */
+     , (26082,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26082,  94,         16) /* TargetType - Creature */
+     , (26082, 106,        210) /* ItemSpellcraft */
+     , (26082, 107,         50) /* ItemCurMana */
+     , (26082, 108,         50) /* ItemMaxMana */
+     , (26082, 109,          0) /* ItemDifficulty */
+     , (26082, 110,          0) /* ItemAllegianceRankLimit */
+     , (26082, 150,        103) /* HookPlacement - Hook */
+     , (26082, 151,          2) /* HookType - Wall */
+     , (26082, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26082,  15, True ) /* LightsStatus */
+     , (26082,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26082, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26082,   1, 'Asandra Cottages Portal Gem') /* Name */
+     , (26082,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26082,   1,   33556769) /* Setup */
+     , (26082,   3,  536870932) /* SoundTable */
+     , (26082,   6,   67111919) /* PaletteBase */
+     , (26082,   7,  268435723) /* ClothingBase */
+     , (26082,   8,  100675760) /* Icon */
+     , (26082,  22,  872415275) /* PhysicsEffectTable */
+     , (26082,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26082,  31,      15142) /* LinkedPortalOne - Asandra Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26083 Asbel Domain Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26083 Asbel Domain Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26083;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26083, 'gemportalasbeldomain', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26083,   1,       2048) /* ItemType - Gem */
+     , (26083,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26083,   5,         10) /* EncumbranceVal */
+     , (26083,   8,         10) /* Mass */
+     , (26083,   9,          0) /* ValidLocations - None */
+     , (26083,  11,         20) /* MaxStackSize */
+     , (26083,  12,          1) /* StackSize */
+     , (26083,  13,         10) /* StackUnitEncumbrance */
+     , (26083,  14,         10) /* StackUnitMass */
+     , (26083,  15,        500) /* StackUnitValue */
+     , (26083,  16,          8) /* ItemUseable - Contained */
+     , (26083,  18,          1) /* UiEffects - Magical */
+     , (26083,  19,        500) /* Value */
+     , (26083,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26083,  94,         16) /* TargetType - Creature */
+     , (26083, 106,        210) /* ItemSpellcraft */
+     , (26083, 107,         50) /* ItemCurMana */
+     , (26083, 108,         50) /* ItemMaxMana */
+     , (26083, 109,          0) /* ItemDifficulty */
+     , (26083, 110,          0) /* ItemAllegianceRankLimit */
+     , (26083, 150,        103) /* HookPlacement - Hook */
+     , (26083, 151,          2) /* HookType - Wall */
+     , (26083, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26083,  15, True ) /* LightsStatus */
+     , (26083,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26083, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26083,   1, 'Asbel Domain Portal Gem') /* Name */
+     , (26083,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26083,   1,   33556769) /* Setup */
+     , (26083,   3,  536870932) /* SoundTable */
+     , (26083,   6,   67111919) /* PaletteBase */
+     , (26083,   7,  268435723) /* ClothingBase */
+     , (26083,   8,  100675760) /* Icon */
+     , (26083,  22,  872415275) /* PhysicsEffectTable */
+     , (26083,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26083,  31,      15143) /* LinkedPortalOne - Asbel Domain Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26084 Auralla Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26084 Auralla Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26084;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26084, 'gemportalaurallasettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26084,   1,       2048) /* ItemType - Gem */
+     , (26084,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26084,   5,         10) /* EncumbranceVal */
+     , (26084,   8,         10) /* Mass */
+     , (26084,   9,          0) /* ValidLocations - None */
+     , (26084,  11,         20) /* MaxStackSize */
+     , (26084,  12,          1) /* StackSize */
+     , (26084,  13,         10) /* StackUnitEncumbrance */
+     , (26084,  14,         10) /* StackUnitMass */
+     , (26084,  15,        500) /* StackUnitValue */
+     , (26084,  16,          8) /* ItemUseable - Contained */
+     , (26084,  18,          1) /* UiEffects - Magical */
+     , (26084,  19,        500) /* Value */
+     , (26084,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26084,  94,         16) /* TargetType - Creature */
+     , (26084, 106,        210) /* ItemSpellcraft */
+     , (26084, 107,         50) /* ItemCurMana */
+     , (26084, 108,         50) /* ItemMaxMana */
+     , (26084, 109,          0) /* ItemDifficulty */
+     , (26084, 110,          0) /* ItemAllegianceRankLimit */
+     , (26084, 150,        103) /* HookPlacement - Hook */
+     , (26084, 151,          2) /* HookType - Wall */
+     , (26084, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26084,  15, True ) /* LightsStatus */
+     , (26084,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26084, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26084,   1, 'Auralla Settlement Portal Gem') /* Name */
+     , (26084,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26084,   1,   33556769) /* Setup */
+     , (26084,   3,  536870932) /* SoundTable */
+     , (26084,   6,   67111919) /* PaletteBase */
+     , (26084,   7,  268435723) /* ClothingBase */
+     , (26084,   8,  100675760) /* Icon */
+     , (26084,  22,  872415275) /* PhysicsEffectTable */
+     , (26084,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26084,  31,      14254) /* LinkedPortalOne - Auralla Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26085 Auroch Pasture Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26085 Auroch Pasture Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26085;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26085, 'gemportalaurochpastureestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26085,   1,       2048) /* ItemType - Gem */
+     , (26085,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26085,   5,         10) /* EncumbranceVal */
+     , (26085,   8,         10) /* Mass */
+     , (26085,   9,          0) /* ValidLocations - None */
+     , (26085,  11,         20) /* MaxStackSize */
+     , (26085,  12,          1) /* StackSize */
+     , (26085,  13,         10) /* StackUnitEncumbrance */
+     , (26085,  14,         10) /* StackUnitMass */
+     , (26085,  15,        500) /* StackUnitValue */
+     , (26085,  16,          8) /* ItemUseable - Contained */
+     , (26085,  18,          1) /* UiEffects - Magical */
+     , (26085,  19,        500) /* Value */
+     , (26085,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26085,  94,         16) /* TargetType - Creature */
+     , (26085, 106,        210) /* ItemSpellcraft */
+     , (26085, 107,         50) /* ItemCurMana */
+     , (26085, 108,         50) /* ItemMaxMana */
+     , (26085, 109,          0) /* ItemDifficulty */
+     , (26085, 110,          0) /* ItemAllegianceRankLimit */
+     , (26085, 150,        103) /* HookPlacement - Hook */
+     , (26085, 151,          2) /* HookType - Wall */
+     , (26085, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26085,  15, True ) /* LightsStatus */
+     , (26085,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26085, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26085,   1, 'Auroch Pasture Estates Portal Gem') /* Name */
+     , (26085,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26085,   1,   33556769) /* Setup */
+     , (26085,   3,  536870932) /* SoundTable */
+     , (26085,   6,   67111919) /* PaletteBase */
+     , (26085,   7,  268435723) /* ClothingBase */
+     , (26085,   8,  100675760) /* Icon */
+     , (26085,  22,  872415275) /* PhysicsEffectTable */
+     , (26085,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26085,  31,      13131) /* LinkedPortalOne - Auroch Pasture Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26086 Avatania Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26086 Avatania Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26086;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26086, 'gemportalavataniacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26086,   1,       2048) /* ItemType - Gem */
+     , (26086,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26086,   5,         10) /* EncumbranceVal */
+     , (26086,   8,         10) /* Mass */
+     , (26086,   9,          0) /* ValidLocations - None */
+     , (26086,  11,         20) /* MaxStackSize */
+     , (26086,  12,          1) /* StackSize */
+     , (26086,  13,         10) /* StackUnitEncumbrance */
+     , (26086,  14,         10) /* StackUnitMass */
+     , (26086,  15,        500) /* StackUnitValue */
+     , (26086,  16,          8) /* ItemUseable - Contained */
+     , (26086,  18,          1) /* UiEffects - Magical */
+     , (26086,  19,        500) /* Value */
+     , (26086,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26086,  94,         16) /* TargetType - Creature */
+     , (26086, 106,        210) /* ItemSpellcraft */
+     , (26086, 107,         50) /* ItemCurMana */
+     , (26086, 108,         50) /* ItemMaxMana */
+     , (26086, 109,          0) /* ItemDifficulty */
+     , (26086, 110,          0) /* ItemAllegianceRankLimit */
+     , (26086, 150,        103) /* HookPlacement - Hook */
+     , (26086, 151,          2) /* HookType - Wall */
+     , (26086, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26086,  15, True ) /* LightsStatus */
+     , (26086,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26086, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26086,   1, 'Avatania Cottages Portal Gem') /* Name */
+     , (26086,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26086,   1,   33556769) /* Setup */
+     , (26086,   3,  536870932) /* SoundTable */
+     , (26086,   6,   67111919) /* PaletteBase */
+     , (26086,   7,  268435723) /* ClothingBase */
+     , (26086,   8,  100675760) /* Icon */
+     , (26086,  22,  872415275) /* PhysicsEffectTable */
+     , (26086,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26086,  31,      15144) /* LinkedPortalOne - Avatania Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26087 Axefall Glen Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26087 Axefall Glen Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26087;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26087, 'gemportalaxefallglen', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26087,   1,       2048) /* ItemType - Gem */
+     , (26087,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26087,   5,         10) /* EncumbranceVal */
+     , (26087,   8,         10) /* Mass */
+     , (26087,   9,          0) /* ValidLocations - None */
+     , (26087,  11,         20) /* MaxStackSize */
+     , (26087,  12,          1) /* StackSize */
+     , (26087,  13,         10) /* StackUnitEncumbrance */
+     , (26087,  14,         10) /* StackUnitMass */
+     , (26087,  15,        500) /* StackUnitValue */
+     , (26087,  16,          8) /* ItemUseable - Contained */
+     , (26087,  18,          1) /* UiEffects - Magical */
+     , (26087,  19,        500) /* Value */
+     , (26087,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26087,  94,         16) /* TargetType - Creature */
+     , (26087, 106,        210) /* ItemSpellcraft */
+     , (26087, 107,         50) /* ItemCurMana */
+     , (26087, 108,         50) /* ItemMaxMana */
+     , (26087, 109,          0) /* ItemDifficulty */
+     , (26087, 110,          0) /* ItemAllegianceRankLimit */
+     , (26087, 150,        103) /* HookPlacement - Hook */
+     , (26087, 151,          2) /* HookType - Wall */
+     , (26087, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26087,  15, True ) /* LightsStatus */
+     , (26087,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26087, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26087,   1, 'Axefall Glen Portal Gem') /* Name */
+     , (26087,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26087,   1,   33556769) /* Setup */
+     , (26087,   3,  536870932) /* SoundTable */
+     , (26087,   6,   67111919) /* PaletteBase */
+     , (26087,   7,  268435723) /* ClothingBase */
+     , (26087,   8,  100675760) /* Icon */
+     , (26087,  22,  872415275) /* PhysicsEffectTable */
+     , (26087,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26087,  31,      15666) /* LinkedPortalOne - Axefall Glen Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26088 Ayn Tayan Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26088 Ayn Tayan Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26088;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26088, 'gemportalayntayan', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26088,   1,       2048) /* ItemType - Gem */
+     , (26088,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26088,   5,         10) /* EncumbranceVal */
+     , (26088,   8,         10) /* Mass */
+     , (26088,   9,          0) /* ValidLocations - None */
+     , (26088,  11,         20) /* MaxStackSize */
+     , (26088,  12,          1) /* StackSize */
+     , (26088,  13,         10) /* StackUnitEncumbrance */
+     , (26088,  14,         10) /* StackUnitMass */
+     , (26088,  15,        500) /* StackUnitValue */
+     , (26088,  16,          8) /* ItemUseable - Contained */
+     , (26088,  18,          1) /* UiEffects - Magical */
+     , (26088,  19,        500) /* Value */
+     , (26088,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26088,  94,         16) /* TargetType - Creature */
+     , (26088, 106,        210) /* ItemSpellcraft */
+     , (26088, 107,         50) /* ItemCurMana */
+     , (26088, 108,         50) /* ItemMaxMana */
+     , (26088, 109,          0) /* ItemDifficulty */
+     , (26088, 110,          0) /* ItemAllegianceRankLimit */
+     , (26088, 150,        103) /* HookPlacement - Hook */
+     , (26088, 151,          2) /* HookType - Wall */
+     , (26088, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26088,  15, True ) /* LightsStatus */
+     , (26088,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26088, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26088,   1, 'Ayn Tayan Portal Gem') /* Name */
+     , (26088,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26088,   1,   33556769) /* Setup */
+     , (26088,   3,  536870932) /* SoundTable */
+     , (26088,   6,   67111919) /* PaletteBase */
+     , (26088,   7,  268435723) /* ClothingBase */
+     , (26088,   8,  100675760) /* Icon */
+     , (26088,  22,  872415275) /* PhysicsEffectTable */
+     , (26088,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26088,  31,      12475) /* LinkedPortalOne - Ayn Tayan Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26089 Azaroth Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26089 Azaroth Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26089;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26089, 'gemportalazarothcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26089,   1,       2048) /* ItemType - Gem */
+     , (26089,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26089,   5,         10) /* EncumbranceVal */
+     , (26089,   8,         10) /* Mass */
+     , (26089,   9,          0) /* ValidLocations - None */
+     , (26089,  11,         20) /* MaxStackSize */
+     , (26089,  12,          1) /* StackSize */
+     , (26089,  13,         10) /* StackUnitEncumbrance */
+     , (26089,  14,         10) /* StackUnitMass */
+     , (26089,  15,        500) /* StackUnitValue */
+     , (26089,  16,          8) /* ItemUseable - Contained */
+     , (26089,  18,          1) /* UiEffects - Magical */
+     , (26089,  19,        500) /* Value */
+     , (26089,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26089,  94,         16) /* TargetType - Creature */
+     , (26089, 106,        210) /* ItemSpellcraft */
+     , (26089, 107,         50) /* ItemCurMana */
+     , (26089, 108,         50) /* ItemMaxMana */
+     , (26089, 109,          0) /* ItemDifficulty */
+     , (26089, 110,          0) /* ItemAllegianceRankLimit */
+     , (26089, 150,        103) /* HookPlacement - Hook */
+     , (26089, 151,          2) /* HookType - Wall */
+     , (26089, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26089,  15, True ) /* LightsStatus */
+     , (26089,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26089, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26089,   1, 'Azaroth Cottages Portal Gem') /* Name */
+     , (26089,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26089,   1,   33556769) /* Setup */
+     , (26089,   3,  536870932) /* SoundTable */
+     , (26089,   6,   67111919) /* PaletteBase */
+     , (26089,   7,  268435723) /* ClothingBase */
+     , (26089,   8,  100675760) /* Icon */
+     , (26089,  22,  872415275) /* PhysicsEffectTable */
+     , (26089,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26089,  31,      15145) /* LinkedPortalOne - Azaroth Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26090 Bandit Road Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26090 Bandit Road Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26090;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26090, 'gemportalbanditroadvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26090,   1,       2048) /* ItemType - Gem */
+     , (26090,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26090,   5,         10) /* EncumbranceVal */
+     , (26090,   8,         10) /* Mass */
+     , (26090,   9,          0) /* ValidLocations - None */
+     , (26090,  11,         20) /* MaxStackSize */
+     , (26090,  12,          1) /* StackSize */
+     , (26090,  13,         10) /* StackUnitEncumbrance */
+     , (26090,  14,         10) /* StackUnitMass */
+     , (26090,  15,        500) /* StackUnitValue */
+     , (26090,  16,          8) /* ItemUseable - Contained */
+     , (26090,  18,          1) /* UiEffects - Magical */
+     , (26090,  19,        500) /* Value */
+     , (26090,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26090,  94,         16) /* TargetType - Creature */
+     , (26090, 106,        210) /* ItemSpellcraft */
+     , (26090, 107,         50) /* ItemCurMana */
+     , (26090, 108,         50) /* ItemMaxMana */
+     , (26090, 109,          0) /* ItemDifficulty */
+     , (26090, 110,          0) /* ItemAllegianceRankLimit */
+     , (26090, 150,        103) /* HookPlacement - Hook */
+     , (26090, 151,          2) /* HookType - Wall */
+     , (26090, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26090,  15, True ) /* LightsStatus */
+     , (26090,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26090, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26090,   1, 'Bandit Road Villas Portal Gem') /* Name */
+     , (26090,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26090,   1,   33556769) /* Setup */
+     , (26090,   3,  536870932) /* SoundTable */
+     , (26090,   6,   67111919) /* PaletteBase */
+     , (26090,   7,  268435723) /* ClothingBase */
+     , (26090,   8,  100675760) /* Icon */
+     , (26090,  22,  872415275) /* PhysicsEffectTable */
+     , (26090,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26090,  31,      13091) /* LinkedPortalOne - Bandit Road Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26091 Baron's Domain Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26091 Baron's Domain Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26091;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26091, 'gemportalbaronsdomain', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26091,   1,       2048) /* ItemType - Gem */
+     , (26091,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26091,   5,         10) /* EncumbranceVal */
+     , (26091,   8,         10) /* Mass */
+     , (26091,   9,          0) /* ValidLocations - None */
+     , (26091,  11,         20) /* MaxStackSize */
+     , (26091,  12,          1) /* StackSize */
+     , (26091,  13,         10) /* StackUnitEncumbrance */
+     , (26091,  14,         10) /* StackUnitMass */
+     , (26091,  15,        500) /* StackUnitValue */
+     , (26091,  16,          8) /* ItemUseable - Contained */
+     , (26091,  18,          1) /* UiEffects - Magical */
+     , (26091,  19,        500) /* Value */
+     , (26091,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26091,  94,         16) /* TargetType - Creature */
+     , (26091, 106,        210) /* ItemSpellcraft */
+     , (26091, 107,         50) /* ItemCurMana */
+     , (26091, 108,         50) /* ItemMaxMana */
+     , (26091, 109,          0) /* ItemDifficulty */
+     , (26091, 110,          0) /* ItemAllegianceRankLimit */
+     , (26091, 150,        103) /* HookPlacement - Hook */
+     , (26091, 151,          2) /* HookType - Wall */
+     , (26091, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26091,  15, True ) /* LightsStatus */
+     , (26091,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26091, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26091,   1, 'Baron''s Domain Portal Gem') /* Name */
+     , (26091,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26091,   1,   33556769) /* Setup */
+     , (26091,   3,  536870932) /* SoundTable */
+     , (26091,   6,   67111919) /* PaletteBase */
+     , (26091,   7,  268435723) /* ClothingBase */
+     , (26091,   8,  100675760) /* Icon */
+     , (26091,  22,  872415275) /* PhysicsEffectTable */
+     , (26091,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26091,  31,      15667) /* LinkedPortalOne - Baron's Domain Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26092 Bay of Sands Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26092 Bay of Sands Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26092;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26092, 'gemportalbayofsands', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26092,   1,       2048) /* ItemType - Gem */
+     , (26092,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26092,   5,         10) /* EncumbranceVal */
+     , (26092,   8,         10) /* Mass */
+     , (26092,   9,          0) /* ValidLocations - None */
+     , (26092,  11,         20) /* MaxStackSize */
+     , (26092,  12,          1) /* StackSize */
+     , (26092,  13,         10) /* StackUnitEncumbrance */
+     , (26092,  14,         10) /* StackUnitMass */
+     , (26092,  15,        500) /* StackUnitValue */
+     , (26092,  16,          8) /* ItemUseable - Contained */
+     , (26092,  18,          1) /* UiEffects - Magical */
+     , (26092,  19,        500) /* Value */
+     , (26092,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26092,  94,         16) /* TargetType - Creature */
+     , (26092, 106,        210) /* ItemSpellcraft */
+     , (26092, 107,         50) /* ItemCurMana */
+     , (26092, 108,         50) /* ItemMaxMana */
+     , (26092, 109,          0) /* ItemDifficulty */
+     , (26092, 110,          0) /* ItemAllegianceRankLimit */
+     , (26092, 150,        103) /* HookPlacement - Hook */
+     , (26092, 151,          2) /* HookType - Wall */
+     , (26092, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26092,  15, True ) /* LightsStatus */
+     , (26092,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26092, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26092,   1, 'Bay of Sands Portal Gem') /* Name */
+     , (26092,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26092,   1,   33556769) /* Setup */
+     , (26092,   3,  536870932) /* SoundTable */
+     , (26092,   6,   67111919) /* PaletteBase */
+     , (26092,   7,  268435723) /* ClothingBase */
+     , (26092,   8,  100675760) /* Icon */
+     , (26092,  22,  872415275) /* PhysicsEffectTable */
+     , (26092,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26092,  31,      12476) /* LinkedPortalOne - Bay of Sands Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26093 Beach Pass Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26093 Beach Pass Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26093;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26093, 'gemportalbeachpassvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26093,   1,       2048) /* ItemType - Gem */
+     , (26093,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26093,   5,         10) /* EncumbranceVal */
+     , (26093,   8,         10) /* Mass */
+     , (26093,   9,          0) /* ValidLocations - None */
+     , (26093,  11,         20) /* MaxStackSize */
+     , (26093,  12,          1) /* StackSize */
+     , (26093,  13,         10) /* StackUnitEncumbrance */
+     , (26093,  14,         10) /* StackUnitMass */
+     , (26093,  15,        500) /* StackUnitValue */
+     , (26093,  16,          8) /* ItemUseable - Contained */
+     , (26093,  18,          1) /* UiEffects - Magical */
+     , (26093,  19,        500) /* Value */
+     , (26093,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26093,  94,         16) /* TargetType - Creature */
+     , (26093, 106,        210) /* ItemSpellcraft */
+     , (26093, 107,         50) /* ItemCurMana */
+     , (26093, 108,         50) /* ItemMaxMana */
+     , (26093, 109,          0) /* ItemDifficulty */
+     , (26093, 110,          0) /* ItemAllegianceRankLimit */
+     , (26093, 150,        103) /* HookPlacement - Hook */
+     , (26093, 151,          2) /* HookType - Wall */
+     , (26093, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26093,  15, True ) /* LightsStatus */
+     , (26093,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26093, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26093,   1, 'Beach Pass Villas Portal Gem') /* Name */
+     , (26093,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26093,   1,   33556769) /* Setup */
+     , (26093,   3,  536870932) /* SoundTable */
+     , (26093,   6,   67111919) /* PaletteBase */
+     , (26093,   7,  268435723) /* ClothingBase */
+     , (26093,   8,  100675760) /* Icon */
+     , (26093,  22,  872415275) /* PhysicsEffectTable */
+     , (26093,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26093,  31,      13092) /* LinkedPortalOne - Beach Pass Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26094 Bellig Mesa Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26094 Bellig Mesa Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26094;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26094, 'gemportalbelligmesacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26094,   1,       2048) /* ItemType - Gem */
+     , (26094,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26094,   5,         10) /* EncumbranceVal */
+     , (26094,   8,         10) /* Mass */
+     , (26094,   9,          0) /* ValidLocations - None */
+     , (26094,  11,         20) /* MaxStackSize */
+     , (26094,  12,          1) /* StackSize */
+     , (26094,  13,         10) /* StackUnitEncumbrance */
+     , (26094,  14,         10) /* StackUnitMass */
+     , (26094,  15,        500) /* StackUnitValue */
+     , (26094,  16,          8) /* ItemUseable - Contained */
+     , (26094,  18,          1) /* UiEffects - Magical */
+     , (26094,  19,        500) /* Value */
+     , (26094,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26094,  94,         16) /* TargetType - Creature */
+     , (26094, 106,        210) /* ItemSpellcraft */
+     , (26094, 107,         50) /* ItemCurMana */
+     , (26094, 108,         50) /* ItemMaxMana */
+     , (26094, 109,          0) /* ItemDifficulty */
+     , (26094, 110,          0) /* ItemAllegianceRankLimit */
+     , (26094, 150,        103) /* HookPlacement - Hook */
+     , (26094, 151,          2) /* HookType - Wall */
+     , (26094, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26094,  15, True ) /* LightsStatus */
+     , (26094,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26094, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26094,   1, 'Bellig Mesa Cottages Portal Gem') /* Name */
+     , (26094,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26094,   1,   33556769) /* Setup */
+     , (26094,   3,  536870932) /* SoundTable */
+     , (26094,   6,   67111919) /* PaletteBase */
+     , (26094,   7,  268435723) /* ClothingBase */
+     , (26094,   8,  100675760) /* Icon */
+     , (26094,  22,  872415275) /* PhysicsEffectTable */
+     , (26094,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26094,  31,      14612) /* LinkedPortalOne - Bellig Mesa Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26095 Bhah Dhah Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26095 Bhah Dhah Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26095;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26095, 'gemportalbhahdhahvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26095,   1,       2048) /* ItemType - Gem */
+     , (26095,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26095,   5,         10) /* EncumbranceVal */
+     , (26095,   8,         10) /* Mass */
+     , (26095,   9,          0) /* ValidLocations - None */
+     , (26095,  11,         20) /* MaxStackSize */
+     , (26095,  12,          1) /* StackSize */
+     , (26095,  13,         10) /* StackUnitEncumbrance */
+     , (26095,  14,         10) /* StackUnitMass */
+     , (26095,  15,        500) /* StackUnitValue */
+     , (26095,  16,          8) /* ItemUseable - Contained */
+     , (26095,  18,          1) /* UiEffects - Magical */
+     , (26095,  19,        500) /* Value */
+     , (26095,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26095,  94,         16) /* TargetType - Creature */
+     , (26095, 106,        210) /* ItemSpellcraft */
+     , (26095, 107,         50) /* ItemCurMana */
+     , (26095, 108,         50) /* ItemMaxMana */
+     , (26095, 109,          0) /* ItemDifficulty */
+     , (26095, 110,          0) /* ItemAllegianceRankLimit */
+     , (26095, 150,        103) /* HookPlacement - Hook */
+     , (26095, 151,          2) /* HookType - Wall */
+     , (26095, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26095,  15, True ) /* LightsStatus */
+     , (26095,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26095, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26095,   1, 'Bhah Dhah Villas Portal Gem') /* Name */
+     , (26095,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26095,   1,   33556769) /* Setup */
+     , (26095,   3,  536870932) /* SoundTable */
+     , (26095,   6,   67111919) /* PaletteBase */
+     , (26095,   7,  268435723) /* ClothingBase */
+     , (26095,   8,  100675760) /* Icon */
+     , (26095,  22,  872415275) /* PhysicsEffectTable */
+     , (26095,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26095,  31,      13093) /* LinkedPortalOne - Bhah Dhah Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26096 Blackmire Edge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26096 Blackmire Edge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26096;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26096, 'gemportalblackmireedgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26096,   1,       2048) /* ItemType - Gem */
+     , (26096,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26096,   5,         10) /* EncumbranceVal */
+     , (26096,   8,         10) /* Mass */
+     , (26096,   9,          0) /* ValidLocations - None */
+     , (26096,  11,         20) /* MaxStackSize */
+     , (26096,  12,          1) /* StackSize */
+     , (26096,  13,         10) /* StackUnitEncumbrance */
+     , (26096,  14,         10) /* StackUnitMass */
+     , (26096,  15,        500) /* StackUnitValue */
+     , (26096,  16,          8) /* ItemUseable - Contained */
+     , (26096,  18,          1) /* UiEffects - Magical */
+     , (26096,  19,        500) /* Value */
+     , (26096,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26096,  94,         16) /* TargetType - Creature */
+     , (26096, 106,        210) /* ItemSpellcraft */
+     , (26096, 107,         50) /* ItemCurMana */
+     , (26096, 108,         50) /* ItemMaxMana */
+     , (26096, 109,          0) /* ItemDifficulty */
+     , (26096, 110,          0) /* ItemAllegianceRankLimit */
+     , (26096, 150,        103) /* HookPlacement - Hook */
+     , (26096, 151,          2) /* HookType - Wall */
+     , (26096, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26096,  15, True ) /* LightsStatus */
+     , (26096,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26096, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26096,   1, 'Blackmire Edge Cottages Portal Gem') /* Name */
+     , (26096,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26096,   1,   33556769) /* Setup */
+     , (26096,   3,  536870932) /* SoundTable */
+     , (26096,   6,   67111919) /* PaletteBase */
+     , (26096,   7,  268435723) /* ClothingBase */
+     , (26096,   8,  100675760) /* Icon */
+     , (26096,  22,  872415275) /* PhysicsEffectTable */
+     , (26096,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26096,  31,      12477) /* LinkedPortalOne - Blackmire Edge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26097 Blazing Wand Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26097 Blazing Wand Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26097;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26097, 'gemportalblazingwandvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26097,   1,       2048) /* ItemType - Gem */
+     , (26097,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26097,   5,         10) /* EncumbranceVal */
+     , (26097,   8,         10) /* Mass */
+     , (26097,   9,          0) /* ValidLocations - None */
+     , (26097,  11,         20) /* MaxStackSize */
+     , (26097,  12,          1) /* StackSize */
+     , (26097,  13,         10) /* StackUnitEncumbrance */
+     , (26097,  14,         10) /* StackUnitMass */
+     , (26097,  15,        500) /* StackUnitValue */
+     , (26097,  16,          8) /* ItemUseable - Contained */
+     , (26097,  18,          1) /* UiEffects - Magical */
+     , (26097,  19,        500) /* Value */
+     , (26097,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26097,  94,         16) /* TargetType - Creature */
+     , (26097, 106,        210) /* ItemSpellcraft */
+     , (26097, 107,         50) /* ItemCurMana */
+     , (26097, 108,         50) /* ItemMaxMana */
+     , (26097, 109,          0) /* ItemDifficulty */
+     , (26097, 110,          0) /* ItemAllegianceRankLimit */
+     , (26097, 150,        103) /* HookPlacement - Hook */
+     , (26097, 151,          2) /* HookType - Wall */
+     , (26097, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26097,  15, True ) /* LightsStatus */
+     , (26097,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26097, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26097,   1, 'Blazing Wand Villas Portal Gem') /* Name */
+     , (26097,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26097,   1,   33556769) /* Setup */
+     , (26097,   3,  536870932) /* SoundTable */
+     , (26097,   6,   67111919) /* PaletteBase */
+     , (26097,   7,  268435723) /* ClothingBase */
+     , (26097,   8,  100675760) /* Icon */
+     , (26097,  22,  872415275) /* PhysicsEffectTable */
+     , (26097,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26097,  31,      15668) /* LinkedPortalOne - Blazing Wand Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26098 Bleached Skull Wastes Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26098 Bleached Skull Wastes Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26098;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26098, 'gemportalbleachedskullwastessettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26098,   1,       2048) /* ItemType - Gem */
+     , (26098,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26098,   5,         10) /* EncumbranceVal */
+     , (26098,   8,         10) /* Mass */
+     , (26098,   9,          0) /* ValidLocations - None */
+     , (26098,  11,         20) /* MaxStackSize */
+     , (26098,  12,          1) /* StackSize */
+     , (26098,  13,         10) /* StackUnitEncumbrance */
+     , (26098,  14,         10) /* StackUnitMass */
+     , (26098,  15,        500) /* StackUnitValue */
+     , (26098,  16,          8) /* ItemUseable - Contained */
+     , (26098,  18,          1) /* UiEffects - Magical */
+     , (26098,  19,        500) /* Value */
+     , (26098,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26098,  94,         16) /* TargetType - Creature */
+     , (26098, 106,        210) /* ItemSpellcraft */
+     , (26098, 107,         50) /* ItemCurMana */
+     , (26098, 108,         50) /* ItemMaxMana */
+     , (26098, 109,          0) /* ItemDifficulty */
+     , (26098, 110,          0) /* ItemAllegianceRankLimit */
+     , (26098, 150,        103) /* HookPlacement - Hook */
+     , (26098, 151,          2) /* HookType - Wall */
+     , (26098, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26098,  15, True ) /* LightsStatus */
+     , (26098,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26098, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26098,   1, 'Bleached Skull Wastes Settlement Portal Gem') /* Name */
+     , (26098,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26098,   1,   33556769) /* Setup */
+     , (26098,   3,  536870932) /* SoundTable */
+     , (26098,   6,   67111919) /* PaletteBase */
+     , (26098,   7,  268435723) /* ClothingBase */
+     , (26098,   8,  100675760) /* Icon */
+     , (26098,  22,  872415275) /* PhysicsEffectTable */
+     , (26098,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26098,  31,      14613) /* LinkedPortalOne - Bleached Skull Wastes Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26099 Bleak Valley Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26099 Bleak Valley Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26099;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26099, 'gemportalbleakvalley', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26099,   1,       2048) /* ItemType - Gem */
+     , (26099,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26099,   5,         10) /* EncumbranceVal */
+     , (26099,   8,         10) /* Mass */
+     , (26099,   9,          0) /* ValidLocations - None */
+     , (26099,  11,         20) /* MaxStackSize */
+     , (26099,  12,          1) /* StackSize */
+     , (26099,  13,         10) /* StackUnitEncumbrance */
+     , (26099,  14,         10) /* StackUnitMass */
+     , (26099,  15,        500) /* StackUnitValue */
+     , (26099,  16,          8) /* ItemUseable - Contained */
+     , (26099,  18,          1) /* UiEffects - Magical */
+     , (26099,  19,        500) /* Value */
+     , (26099,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26099,  94,         16) /* TargetType - Creature */
+     , (26099, 106,        210) /* ItemSpellcraft */
+     , (26099, 107,         50) /* ItemCurMana */
+     , (26099, 108,         50) /* ItemMaxMana */
+     , (26099, 109,          0) /* ItemDifficulty */
+     , (26099, 110,          0) /* ItemAllegianceRankLimit */
+     , (26099, 150,        103) /* HookPlacement - Hook */
+     , (26099, 151,          2) /* HookType - Wall */
+     , (26099, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26099,  15, True ) /* LightsStatus */
+     , (26099,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26099, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26099,   1, 'Bleak Valley Portal Gem') /* Name */
+     , (26099,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26099,   1,   33556769) /* Setup */
+     , (26099,   3,  536870932) /* SoundTable */
+     , (26099,   6,   67111919) /* PaletteBase */
+     , (26099,   7,  268435723) /* ClothingBase */
+     , (26099,   8,  100675760) /* Icon */
+     , (26099,  22,  872415275) /* PhysicsEffectTable */
+     , (26099,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26099,  31,      14614) /* LinkedPortalOne - Bleak Valley Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26100 Bluewater Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26100 Bluewater Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26100;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26100, 'gemportalbluewatercottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26100,   1,       2048) /* ItemType - Gem */
+     , (26100,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26100,   5,         10) /* EncumbranceVal */
+     , (26100,   8,         10) /* Mass */
+     , (26100,   9,          0) /* ValidLocations - None */
+     , (26100,  11,         20) /* MaxStackSize */
+     , (26100,  12,          1) /* StackSize */
+     , (26100,  13,         10) /* StackUnitEncumbrance */
+     , (26100,  14,         10) /* StackUnitMass */
+     , (26100,  15,        500) /* StackUnitValue */
+     , (26100,  16,          8) /* ItemUseable - Contained */
+     , (26100,  18,          1) /* UiEffects - Magical */
+     , (26100,  19,        500) /* Value */
+     , (26100,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26100,  94,         16) /* TargetType - Creature */
+     , (26100, 106,        210) /* ItemSpellcraft */
+     , (26100, 107,         50) /* ItemCurMana */
+     , (26100, 108,         50) /* ItemMaxMana */
+     , (26100, 109,          0) /* ItemDifficulty */
+     , (26100, 110,          0) /* ItemAllegianceRankLimit */
+     , (26100, 150,        103) /* HookPlacement - Hook */
+     , (26100, 151,          2) /* HookType - Wall */
+     , (26100, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26100,  15, True ) /* LightsStatus */
+     , (26100,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26100, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26100,   1, 'Bluewater Cottages Portal Gem') /* Name */
+     , (26100,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26100,   1,   33556769) /* Setup */
+     , (26100,   3,  536870932) /* SoundTable */
+     , (26100,   6,   67111919) /* PaletteBase */
+     , (26100,   7,  268435723) /* ClothingBase */
+     , (26100,   8,  100675760) /* Icon */
+     , (26100,  22,  872415275) /* PhysicsEffectTable */
+     , (26100,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26100,  31,      12478) /* LinkedPortalOne - Bluewater Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26101 Brazenn Domain Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26101 Brazenn Domain Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26101;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26101, 'gemportalbrazenndomain', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26101,   1,       2048) /* ItemType - Gem */
+     , (26101,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26101,   5,         10) /* EncumbranceVal */
+     , (26101,   8,         10) /* Mass */
+     , (26101,   9,          0) /* ValidLocations - None */
+     , (26101,  11,         20) /* MaxStackSize */
+     , (26101,  12,          1) /* StackSize */
+     , (26101,  13,         10) /* StackUnitEncumbrance */
+     , (26101,  14,         10) /* StackUnitMass */
+     , (26101,  15,        500) /* StackUnitValue */
+     , (26101,  16,          8) /* ItemUseable - Contained */
+     , (26101,  18,          1) /* UiEffects - Magical */
+     , (26101,  19,        500) /* Value */
+     , (26101,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26101,  94,         16) /* TargetType - Creature */
+     , (26101, 106,        210) /* ItemSpellcraft */
+     , (26101, 107,         50) /* ItemCurMana */
+     , (26101, 108,         50) /* ItemMaxMana */
+     , (26101, 109,          0) /* ItemDifficulty */
+     , (26101, 110,          0) /* ItemAllegianceRankLimit */
+     , (26101, 150,        103) /* HookPlacement - Hook */
+     , (26101, 151,          2) /* HookType - Wall */
+     , (26101, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26101,  15, True ) /* LightsStatus */
+     , (26101,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26101, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26101,   1, 'Brazenn Domain Portal Gem') /* Name */
+     , (26101,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26101,   1,   33556769) /* Setup */
+     , (26101,   3,  536870932) /* SoundTable */
+     , (26101,   6,   67111919) /* PaletteBase */
+     , (26101,   7,  268435723) /* ClothingBase */
+     , (26101,   8,  100675760) /* Icon */
+     , (26101,  22,  872415275) /* PhysicsEffectTable */
+     , (26101,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26101,  31,      15146) /* LinkedPortalOne - Brazenn Domain Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26102 Bretslef Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26102 Bretslef Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26102;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26102, 'gemportalbretslefcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26102,   1,       2048) /* ItemType - Gem */
+     , (26102,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26102,   5,         10) /* EncumbranceVal */
+     , (26102,   8,         10) /* Mass */
+     , (26102,   9,          0) /* ValidLocations - None */
+     , (26102,  11,         20) /* MaxStackSize */
+     , (26102,  12,          1) /* StackSize */
+     , (26102,  13,         10) /* StackUnitEncumbrance */
+     , (26102,  14,         10) /* StackUnitMass */
+     , (26102,  15,        500) /* StackUnitValue */
+     , (26102,  16,          8) /* ItemUseable - Contained */
+     , (26102,  18,          1) /* UiEffects - Magical */
+     , (26102,  19,        500) /* Value */
+     , (26102,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26102,  94,         16) /* TargetType - Creature */
+     , (26102, 106,        210) /* ItemSpellcraft */
+     , (26102, 107,         50) /* ItemCurMana */
+     , (26102, 108,         50) /* ItemMaxMana */
+     , (26102, 109,          0) /* ItemDifficulty */
+     , (26102, 110,          0) /* ItemAllegianceRankLimit */
+     , (26102, 150,        103) /* HookPlacement - Hook */
+     , (26102, 151,          2) /* HookType - Wall */
+     , (26102, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26102,  15, True ) /* LightsStatus */
+     , (26102,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26102, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26102,   1, 'Bretslef Cottages Portal Gem') /* Name */
+     , (26102,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26102,   1,   33556769) /* Setup */
+     , (26102,   3,  536870932) /* SoundTable */
+     , (26102,   6,   67111919) /* PaletteBase */
+     , (26102,   7,  268435723) /* ClothingBase */
+     , (26102,   8,  100675760) /* Icon */
+     , (26102,  22,  872415275) /* PhysicsEffectTable */
+     , (26102,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26102,  31,      14615) /* LinkedPortalOne - Bretslef Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26103 Brigand Sands Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26103 Brigand Sands Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26103;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26103, 'gemportalbrigandsandscottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26103,   1,       2048) /* ItemType - Gem */
+     , (26103,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26103,   5,         10) /* EncumbranceVal */
+     , (26103,   8,         10) /* Mass */
+     , (26103,   9,          0) /* ValidLocations - None */
+     , (26103,  11,         20) /* MaxStackSize */
+     , (26103,  12,          1) /* StackSize */
+     , (26103,  13,         10) /* StackUnitEncumbrance */
+     , (26103,  14,         10) /* StackUnitMass */
+     , (26103,  15,        500) /* StackUnitValue */
+     , (26103,  16,          8) /* ItemUseable - Contained */
+     , (26103,  18,          1) /* UiEffects - Magical */
+     , (26103,  19,        500) /* Value */
+     , (26103,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26103,  94,         16) /* TargetType - Creature */
+     , (26103, 106,        210) /* ItemSpellcraft */
+     , (26103, 107,         50) /* ItemCurMana */
+     , (26103, 108,         50) /* ItemMaxMana */
+     , (26103, 109,          0) /* ItemDifficulty */
+     , (26103, 110,          0) /* ItemAllegianceRankLimit */
+     , (26103, 150,        103) /* HookPlacement - Hook */
+     , (26103, 151,          2) /* HookType - Wall */
+     , (26103, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26103,  15, True ) /* LightsStatus */
+     , (26103,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26103, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26103,   1, 'Brigand Sands Cottages Portal Gem') /* Name */
+     , (26103,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26103,   1,   33556769) /* Setup */
+     , (26103,   3,  536870932) /* SoundTable */
+     , (26103,   6,   67111919) /* PaletteBase */
+     , (26103,   7,  268435723) /* ClothingBase */
+     , (26103,   8,  100675760) /* Icon */
+     , (26103,  22,  872415275) /* PhysicsEffectTable */
+     , (26103,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26103,  31,      13094) /* LinkedPortalOne - Brigand Sands Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26104 Brigands Bay Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26104 Brigands Bay Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26104;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26104, 'gemportalbrigandsbaysettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26104,   1,       2048) /* ItemType - Gem */
+     , (26104,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26104,   5,         10) /* EncumbranceVal */
+     , (26104,   8,         10) /* Mass */
+     , (26104,   9,          0) /* ValidLocations - None */
+     , (26104,  11,         20) /* MaxStackSize */
+     , (26104,  12,          1) /* StackSize */
+     , (26104,  13,         10) /* StackUnitEncumbrance */
+     , (26104,  14,         10) /* StackUnitMass */
+     , (26104,  15,        500) /* StackUnitValue */
+     , (26104,  16,          8) /* ItemUseable - Contained */
+     , (26104,  18,          1) /* UiEffects - Magical */
+     , (26104,  19,        500) /* Value */
+     , (26104,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26104,  94,         16) /* TargetType - Creature */
+     , (26104, 106,        210) /* ItemSpellcraft */
+     , (26104, 107,         50) /* ItemCurMana */
+     , (26104, 108,         50) /* ItemMaxMana */
+     , (26104, 109,          0) /* ItemDifficulty */
+     , (26104, 110,          0) /* ItemAllegianceRankLimit */
+     , (26104, 150,        103) /* HookPlacement - Hook */
+     , (26104, 151,          2) /* HookType - Wall */
+     , (26104, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26104,  15, True ) /* LightsStatus */
+     , (26104,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26104, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26104,   1, 'Brigands Bay Settlement Portal Gem') /* Name */
+     , (26104,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26104,   1,   33556769) /* Setup */
+     , (26104,   3,  536870932) /* SoundTable */
+     , (26104,   6,   67111919) /* PaletteBase */
+     , (26104,   7,  268435723) /* ClothingBase */
+     , (26104,   8,  100675760) /* Icon */
+     , (26104,  22,  872415275) /* PhysicsEffectTable */
+     , (26104,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26104,  31,      12479) /* LinkedPortalOne - Brigands Bay Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26105 Bright Blade Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26105 Bright Blade Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26105;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26105, 'gemportalbrightbladecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26105,   1,       2048) /* ItemType - Gem */
+     , (26105,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26105,   5,         10) /* EncumbranceVal */
+     , (26105,   8,         10) /* Mass */
+     , (26105,   9,          0) /* ValidLocations - None */
+     , (26105,  11,         20) /* MaxStackSize */
+     , (26105,  12,          1) /* StackSize */
+     , (26105,  13,         10) /* StackUnitEncumbrance */
+     , (26105,  14,         10) /* StackUnitMass */
+     , (26105,  15,        500) /* StackUnitValue */
+     , (26105,  16,          8) /* ItemUseable - Contained */
+     , (26105,  18,          1) /* UiEffects - Magical */
+     , (26105,  19,        500) /* Value */
+     , (26105,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26105,  94,         16) /* TargetType - Creature */
+     , (26105, 106,        210) /* ItemSpellcraft */
+     , (26105, 107,         50) /* ItemCurMana */
+     , (26105, 108,         50) /* ItemMaxMana */
+     , (26105, 109,          0) /* ItemDifficulty */
+     , (26105, 110,          0) /* ItemAllegianceRankLimit */
+     , (26105, 150,        103) /* HookPlacement - Hook */
+     , (26105, 151,          2) /* HookType - Wall */
+     , (26105, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26105,  15, True ) /* LightsStatus */
+     , (26105,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26105, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26105,   1, 'Bright Blade Cottages Portal Gem') /* Name */
+     , (26105,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26105,   1,   33556769) /* Setup */
+     , (26105,   3,  536870932) /* SoundTable */
+     , (26105,   6,   67111919) /* PaletteBase */
+     , (26105,   7,  268435723) /* ClothingBase */
+     , (26105,   8,  100675760) /* Icon */
+     , (26105,  22,  872415275) /* PhysicsEffectTable */
+     , (26105,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26105,  31,      15147) /* LinkedPortalOne - Bright Blade Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26106 Broadacre Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26106 Broadacre Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26106;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26106, 'gemportalbroadacrecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26106,   1,       2048) /* ItemType - Gem */
+     , (26106,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26106,   5,         10) /* EncumbranceVal */
+     , (26106,   8,         10) /* Mass */
+     , (26106,   9,          0) /* ValidLocations - None */
+     , (26106,  11,         20) /* MaxStackSize */
+     , (26106,  12,          1) /* StackSize */
+     , (26106,  13,         10) /* StackUnitEncumbrance */
+     , (26106,  14,         10) /* StackUnitMass */
+     , (26106,  15,        500) /* StackUnitValue */
+     , (26106,  16,          8) /* ItemUseable - Contained */
+     , (26106,  18,          1) /* UiEffects - Magical */
+     , (26106,  19,        500) /* Value */
+     , (26106,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26106,  94,         16) /* TargetType - Creature */
+     , (26106, 106,        210) /* ItemSpellcraft */
+     , (26106, 107,         50) /* ItemCurMana */
+     , (26106, 108,         50) /* ItemMaxMana */
+     , (26106, 109,          0) /* ItemDifficulty */
+     , (26106, 110,          0) /* ItemAllegianceRankLimit */
+     , (26106, 150,        103) /* HookPlacement - Hook */
+     , (26106, 151,          2) /* HookType - Wall */
+     , (26106, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26106,  15, True ) /* LightsStatus */
+     , (26106,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26106, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26106,   1, 'Broadacre Cottages Portal Gem') /* Name */
+     , (26106,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26106,   1,   33556769) /* Setup */
+     , (26106,   3,  536870932) /* SoundTable */
+     , (26106,   6,   67111919) /* PaletteBase */
+     , (26106,   7,  268435723) /* ClothingBase */
+     , (26106,   8,  100675760) /* Icon */
+     , (26106,  22,  872415275) /* PhysicsEffectTable */
+     , (26106,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26106,  31,      12480) /* LinkedPortalOne - Broadacre Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26107 Broken Haft Vale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26107 Broken Haft Vale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26107;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26107, 'gemportalbrokenhaftvale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26107,   1,       2048) /* ItemType - Gem */
+     , (26107,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26107,   5,         10) /* EncumbranceVal */
+     , (26107,   8,         10) /* Mass */
+     , (26107,   9,          0) /* ValidLocations - None */
+     , (26107,  11,         20) /* MaxStackSize */
+     , (26107,  12,          1) /* StackSize */
+     , (26107,  13,         10) /* StackUnitEncumbrance */
+     , (26107,  14,         10) /* StackUnitMass */
+     , (26107,  15,        500) /* StackUnitValue */
+     , (26107,  16,          8) /* ItemUseable - Contained */
+     , (26107,  18,          1) /* UiEffects - Magical */
+     , (26107,  19,        500) /* Value */
+     , (26107,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26107,  94,         16) /* TargetType - Creature */
+     , (26107, 106,        210) /* ItemSpellcraft */
+     , (26107, 107,         50) /* ItemCurMana */
+     , (26107, 108,         50) /* ItemMaxMana */
+     , (26107, 109,          0) /* ItemDifficulty */
+     , (26107, 110,          0) /* ItemAllegianceRankLimit */
+     , (26107, 150,        103) /* HookPlacement - Hook */
+     , (26107, 151,          2) /* HookType - Wall */
+     , (26107, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26107,  15, True ) /* LightsStatus */
+     , (26107,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26107, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26107,   1, 'Broken Haft Vale Portal Gem') /* Name */
+     , (26107,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26107,   1,   33556769) /* Setup */
+     , (26107,   3,  536870932) /* SoundTable */
+     , (26107,   6,   67111919) /* PaletteBase */
+     , (26107,   7,  268435723) /* ClothingBase */
+     , (26107,   8,  100675760) /* Icon */
+     , (26107,  22,  872415275) /* PhysicsEffectTable */
+     , (26107,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26107,  31,      15669) /* LinkedPortalOne - Broken Haft Vale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26108 Broken Sword Bethel Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26108 Broken Sword Bethel Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26108;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26108, 'gemportalbrokenswordbethelsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26108,   1,       2048) /* ItemType - Gem */
+     , (26108,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26108,   5,         10) /* EncumbranceVal */
+     , (26108,   8,         10) /* Mass */
+     , (26108,   9,          0) /* ValidLocations - None */
+     , (26108,  11,         20) /* MaxStackSize */
+     , (26108,  12,          1) /* StackSize */
+     , (26108,  13,         10) /* StackUnitEncumbrance */
+     , (26108,  14,         10) /* StackUnitMass */
+     , (26108,  15,        500) /* StackUnitValue */
+     , (26108,  16,          8) /* ItemUseable - Contained */
+     , (26108,  18,          1) /* UiEffects - Magical */
+     , (26108,  19,        500) /* Value */
+     , (26108,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26108,  94,         16) /* TargetType - Creature */
+     , (26108, 106,        210) /* ItemSpellcraft */
+     , (26108, 107,         50) /* ItemCurMana */
+     , (26108, 108,         50) /* ItemMaxMana */
+     , (26108, 109,          0) /* ItemDifficulty */
+     , (26108, 110,          0) /* ItemAllegianceRankLimit */
+     , (26108, 150,        103) /* HookPlacement - Hook */
+     , (26108, 151,          2) /* HookType - Wall */
+     , (26108, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26108,  15, True ) /* LightsStatus */
+     , (26108,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26108, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26108,   1, 'Broken Sword Bethel Settlement Portal Gem') /* Name */
+     , (26108,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26108,   1,   33556769) /* Setup */
+     , (26108,   3,  536870932) /* SoundTable */
+     , (26108,   6,   67111919) /* PaletteBase */
+     , (26108,   7,  268435723) /* ClothingBase */
+     , (26108,   8,  100675760) /* Icon */
+     , (26108,  22,  872415275) /* PhysicsEffectTable */
+     , (26108,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26108,  31,      12481) /* LinkedPortalOne - Broken Sword Bethel Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26109 Bucolic Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26109 Bucolic Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26109;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26109, 'gemportalbucolicvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26109,   1,       2048) /* ItemType - Gem */
+     , (26109,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26109,   5,         10) /* EncumbranceVal */
+     , (26109,   8,         10) /* Mass */
+     , (26109,   9,          0) /* ValidLocations - None */
+     , (26109,  11,         20) /* MaxStackSize */
+     , (26109,  12,          1) /* StackSize */
+     , (26109,  13,         10) /* StackUnitEncumbrance */
+     , (26109,  14,         10) /* StackUnitMass */
+     , (26109,  15,        500) /* StackUnitValue */
+     , (26109,  16,          8) /* ItemUseable - Contained */
+     , (26109,  18,          1) /* UiEffects - Magical */
+     , (26109,  19,        500) /* Value */
+     , (26109,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26109,  94,         16) /* TargetType - Creature */
+     , (26109, 106,        210) /* ItemSpellcraft */
+     , (26109, 107,         50) /* ItemCurMana */
+     , (26109, 108,         50) /* ItemMaxMana */
+     , (26109, 109,          0) /* ItemDifficulty */
+     , (26109, 110,          0) /* ItemAllegianceRankLimit */
+     , (26109, 150,        103) /* HookPlacement - Hook */
+     , (26109, 151,          2) /* HookType - Wall */
+     , (26109, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26109,  15, True ) /* LightsStatus */
+     , (26109,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26109, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26109,   1, 'Bucolic Villas Portal Gem') /* Name */
+     , (26109,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26109,   1,   33556769) /* Setup */
+     , (26109,   3,  536870932) /* SoundTable */
+     , (26109,   6,   67111919) /* PaletteBase */
+     , (26109,   7,  268435723) /* ClothingBase */
+     , (26109,   8,  100675760) /* Icon */
+     , (26109,  22,  872415275) /* PhysicsEffectTable */
+     , (26109,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26109,  31,      13095) /* LinkedPortalOne - Bucolic Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26110 Cactus Acres Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26110 Cactus Acres Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26110;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26110, 'gemportalcactusacres', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26110,   1,       2048) /* ItemType - Gem */
+     , (26110,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26110,   5,         10) /* EncumbranceVal */
+     , (26110,   8,         10) /* Mass */
+     , (26110,   9,          0) /* ValidLocations - None */
+     , (26110,  11,         20) /* MaxStackSize */
+     , (26110,  12,          1) /* StackSize */
+     , (26110,  13,         10) /* StackUnitEncumbrance */
+     , (26110,  14,         10) /* StackUnitMass */
+     , (26110,  15,        500) /* StackUnitValue */
+     , (26110,  16,          8) /* ItemUseable - Contained */
+     , (26110,  18,          1) /* UiEffects - Magical */
+     , (26110,  19,        500) /* Value */
+     , (26110,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26110,  94,         16) /* TargetType - Creature */
+     , (26110, 106,        210) /* ItemSpellcraft */
+     , (26110, 107,         50) /* ItemCurMana */
+     , (26110, 108,         50) /* ItemMaxMana */
+     , (26110, 109,          0) /* ItemDifficulty */
+     , (26110, 110,          0) /* ItemAllegianceRankLimit */
+     , (26110, 150,        103) /* HookPlacement - Hook */
+     , (26110, 151,          2) /* HookType - Wall */
+     , (26110, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26110,  15, True ) /* LightsStatus */
+     , (26110,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26110, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26110,   1, 'Cactus Acres Portal Gem') /* Name */
+     , (26110,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26110,   1,   33556769) /* Setup */
+     , (26110,   3,  536870932) /* SoundTable */
+     , (26110,   6,   67111919) /* PaletteBase */
+     , (26110,   7,  268435723) /* ClothingBase */
+     , (26110,   8,  100675760) /* Icon */
+     , (26110,  22,  872415275) /* PhysicsEffectTable */
+     , (26110,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26110,  31,      14255) /* LinkedPortalOne - Cactus Acres Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26111 Caerlin Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26111 Caerlin Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26111;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26111, 'gemportalcaerlincottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26111,   1,       2048) /* ItemType - Gem */
+     , (26111,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26111,   5,         10) /* EncumbranceVal */
+     , (26111,   8,         10) /* Mass */
+     , (26111,   9,          0) /* ValidLocations - None */
+     , (26111,  11,         20) /* MaxStackSize */
+     , (26111,  12,          1) /* StackSize */
+     , (26111,  13,         10) /* StackUnitEncumbrance */
+     , (26111,  14,         10) /* StackUnitMass */
+     , (26111,  15,        500) /* StackUnitValue */
+     , (26111,  16,          8) /* ItemUseable - Contained */
+     , (26111,  18,          1) /* UiEffects - Magical */
+     , (26111,  19,        500) /* Value */
+     , (26111,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26111,  94,         16) /* TargetType - Creature */
+     , (26111, 106,        210) /* ItemSpellcraft */
+     , (26111, 107,         50) /* ItemCurMana */
+     , (26111, 108,         50) /* ItemMaxMana */
+     , (26111, 109,          0) /* ItemDifficulty */
+     , (26111, 110,          0) /* ItemAllegianceRankLimit */
+     , (26111, 150,        103) /* HookPlacement - Hook */
+     , (26111, 151,          2) /* HookType - Wall */
+     , (26111, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26111,  15, True ) /* LightsStatus */
+     , (26111,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26111, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26111,   1, 'Caerlin Cottages Portal Gem') /* Name */
+     , (26111,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26111,   1,   33556769) /* Setup */
+     , (26111,   3,  536870932) /* SoundTable */
+     , (26111,   6,   67111919) /* PaletteBase */
+     , (26111,   7,  268435723) /* ClothingBase */
+     , (26111,   8,  100675760) /* Icon */
+     , (26111,  22,  872415275) /* PhysicsEffectTable */
+     , (26111,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26111,  31,      15148) /* LinkedPortalOne - Caerlin Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26112 Cape Feirgard Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26112 Cape Feirgard Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26112;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26112, 'gemportalcapefeirgardcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26112,   1,       2048) /* ItemType - Gem */
+     , (26112,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26112,   5,         10) /* EncumbranceVal */
+     , (26112,   8,         10) /* Mass */
+     , (26112,   9,          0) /* ValidLocations - None */
+     , (26112,  11,         20) /* MaxStackSize */
+     , (26112,  12,          1) /* StackSize */
+     , (26112,  13,         10) /* StackUnitEncumbrance */
+     , (26112,  14,         10) /* StackUnitMass */
+     , (26112,  15,        500) /* StackUnitValue */
+     , (26112,  16,          8) /* ItemUseable - Contained */
+     , (26112,  18,          1) /* UiEffects - Magical */
+     , (26112,  19,        500) /* Value */
+     , (26112,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26112,  94,         16) /* TargetType - Creature */
+     , (26112, 106,        210) /* ItemSpellcraft */
+     , (26112, 107,         50) /* ItemCurMana */
+     , (26112, 108,         50) /* ItemMaxMana */
+     , (26112, 109,          0) /* ItemDifficulty */
+     , (26112, 110,          0) /* ItemAllegianceRankLimit */
+     , (26112, 150,        103) /* HookPlacement - Hook */
+     , (26112, 151,          2) /* HookType - Wall */
+     , (26112, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26112,  15, True ) /* LightsStatus */
+     , (26112,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26112, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26112,   1, 'Cape Feirgard Cottages Portal Gem') /* Name */
+     , (26112,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26112,   1,   33556769) /* Setup */
+     , (26112,   3,  536870932) /* SoundTable */
+     , (26112,   6,   67111919) /* PaletteBase */
+     , (26112,   7,  268435723) /* ClothingBase */
+     , (26112,   8,  100675760) /* Icon */
+     , (26112,  22,  872415275) /* PhysicsEffectTable */
+     , (26112,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26112,  31,      12482) /* LinkedPortalOne - Cape Feirgard Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26113 Celcynd Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26113 Celcynd Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26113;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26113, 'gemportalcelcyndcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26113,   1,       2048) /* ItemType - Gem */
+     , (26113,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26113,   5,         10) /* EncumbranceVal */
+     , (26113,   8,         10) /* Mass */
+     , (26113,   9,          0) /* ValidLocations - None */
+     , (26113,  11,         20) /* MaxStackSize */
+     , (26113,  12,          1) /* StackSize */
+     , (26113,  13,         10) /* StackUnitEncumbrance */
+     , (26113,  14,         10) /* StackUnitMass */
+     , (26113,  15,        500) /* StackUnitValue */
+     , (26113,  16,          8) /* ItemUseable - Contained */
+     , (26113,  18,          1) /* UiEffects - Magical */
+     , (26113,  19,        500) /* Value */
+     , (26113,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26113,  94,         16) /* TargetType - Creature */
+     , (26113, 106,        210) /* ItemSpellcraft */
+     , (26113, 107,         50) /* ItemCurMana */
+     , (26113, 108,         50) /* ItemMaxMana */
+     , (26113, 109,          0) /* ItemDifficulty */
+     , (26113, 110,          0) /* ItemAllegianceRankLimit */
+     , (26113, 150,        103) /* HookPlacement - Hook */
+     , (26113, 151,          2) /* HookType - Wall */
+     , (26113, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26113,  15, True ) /* LightsStatus */
+     , (26113,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26113, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26113,   1, 'Celcynd Cottages Portal Gem') /* Name */
+     , (26113,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26113,   1,   33556769) /* Setup */
+     , (26113,   3,  536870932) /* SoundTable */
+     , (26113,   6,   67111919) /* PaletteBase */
+     , (26113,   7,  268435723) /* ClothingBase */
+     , (26113,   8,  100675760) /* Icon */
+     , (26113,  22,  872415275) /* PhysicsEffectTable */
+     , (26113,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26113,  31,      14616) /* LinkedPortalOne - Celcynd Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26114 Celdiseth's Beach Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26114 Celdiseth's Beach Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26114;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26114, 'gemportalceldisethsbeachsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26114,   1,       2048) /* ItemType - Gem */
+     , (26114,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26114,   5,         10) /* EncumbranceVal */
+     , (26114,   8,         10) /* Mass */
+     , (26114,   9,          0) /* ValidLocations - None */
+     , (26114,  11,         20) /* MaxStackSize */
+     , (26114,  12,          1) /* StackSize */
+     , (26114,  13,         10) /* StackUnitEncumbrance */
+     , (26114,  14,         10) /* StackUnitMass */
+     , (26114,  15,        500) /* StackUnitValue */
+     , (26114,  16,          8) /* ItemUseable - Contained */
+     , (26114,  18,          1) /* UiEffects - Magical */
+     , (26114,  19,        500) /* Value */
+     , (26114,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26114,  94,         16) /* TargetType - Creature */
+     , (26114, 106,        210) /* ItemSpellcraft */
+     , (26114, 107,         50) /* ItemCurMana */
+     , (26114, 108,         50) /* ItemMaxMana */
+     , (26114, 109,          0) /* ItemDifficulty */
+     , (26114, 110,          0) /* ItemAllegianceRankLimit */
+     , (26114, 150,        103) /* HookPlacement - Hook */
+     , (26114, 151,          2) /* HookType - Wall */
+     , (26114, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26114,  15, True ) /* LightsStatus */
+     , (26114,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26114, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26114,   1, 'Celdiseth''s Beach Settlement Portal Gem') /* Name */
+     , (26114,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26114,   1,   33556769) /* Setup */
+     , (26114,   3,  536870932) /* SoundTable */
+     , (26114,   6,   67111919) /* PaletteBase */
+     , (26114,   7,  268435723) /* ClothingBase */
+     , (26114,   8,  100675760) /* Icon */
+     , (26114,  22,  872415275) /* PhysicsEffectTable */
+     , (26114,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26114,  31,      12483) /* LinkedPortalOne - Celdiseth's Beach Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26115 Charbone Ridge Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26115 Charbone Ridge Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26115;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26115, 'gemportalcharboneridge', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26115,   1,       2048) /* ItemType - Gem */
+     , (26115,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26115,   5,         10) /* EncumbranceVal */
+     , (26115,   8,         10) /* Mass */
+     , (26115,   9,          0) /* ValidLocations - None */
+     , (26115,  11,         20) /* MaxStackSize */
+     , (26115,  12,          1) /* StackSize */
+     , (26115,  13,         10) /* StackUnitEncumbrance */
+     , (26115,  14,         10) /* StackUnitMass */
+     , (26115,  15,        500) /* StackUnitValue */
+     , (26115,  16,          8) /* ItemUseable - Contained */
+     , (26115,  18,          1) /* UiEffects - Magical */
+     , (26115,  19,        500) /* Value */
+     , (26115,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26115,  94,         16) /* TargetType - Creature */
+     , (26115, 106,        210) /* ItemSpellcraft */
+     , (26115, 107,         50) /* ItemCurMana */
+     , (26115, 108,         50) /* ItemMaxMana */
+     , (26115, 109,          0) /* ItemDifficulty */
+     , (26115, 110,          0) /* ItemAllegianceRankLimit */
+     , (26115, 150,        103) /* HookPlacement - Hook */
+     , (26115, 151,          2) /* HookType - Wall */
+     , (26115, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26115,  15, True ) /* LightsStatus */
+     , (26115,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26115, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26115,   1, 'Charbone Ridge Portal Gem') /* Name */
+     , (26115,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26115,   1,   33556769) /* Setup */
+     , (26115,   3,  536870932) /* SoundTable */
+     , (26115,   6,   67111919) /* PaletteBase */
+     , (26115,   7,  268435723) /* ClothingBase */
+     , (26115,   8,  100675760) /* Icon */
+     , (26115,  22,  872415275) /* PhysicsEffectTable */
+     , (26115,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26115,  31,      13096) /* LinkedPortalOne - Charbone Ridge Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26116 Charnhold Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26116 Charnhold Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26116;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26116, 'gemportalcharnhold', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26116,   1,       2048) /* ItemType - Gem */
+     , (26116,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26116,   5,         10) /* EncumbranceVal */
+     , (26116,   8,         10) /* Mass */
+     , (26116,   9,          0) /* ValidLocations - None */
+     , (26116,  11,         20) /* MaxStackSize */
+     , (26116,  12,          1) /* StackSize */
+     , (26116,  13,         10) /* StackUnitEncumbrance */
+     , (26116,  14,         10) /* StackUnitMass */
+     , (26116,  15,        500) /* StackUnitValue */
+     , (26116,  16,          8) /* ItemUseable - Contained */
+     , (26116,  18,          1) /* UiEffects - Magical */
+     , (26116,  19,        500) /* Value */
+     , (26116,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26116,  94,         16) /* TargetType - Creature */
+     , (26116, 106,        210) /* ItemSpellcraft */
+     , (26116, 107,         50) /* ItemCurMana */
+     , (26116, 108,         50) /* ItemMaxMana */
+     , (26116, 109,          0) /* ItemDifficulty */
+     , (26116, 110,          0) /* ItemAllegianceRankLimit */
+     , (26116, 150,        103) /* HookPlacement - Hook */
+     , (26116, 151,          2) /* HookType - Wall */
+     , (26116, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26116,  15, True ) /* LightsStatus */
+     , (26116,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26116, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26116,   1, 'Charnhold Portal Gem') /* Name */
+     , (26116,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26116,   1,   33556769) /* Setup */
+     , (26116,   3,  536870932) /* SoundTable */
+     , (26116,   6,   67111919) /* PaletteBase */
+     , (26116,   7,  268435723) /* ClothingBase */
+     , (26116,   8,  100675760) /* Icon */
+     , (26116,  22,  872415275) /* PhysicsEffectTable */
+     , (26116,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26116,  31,      19139) /* LinkedPortalOne - Charnhold Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26117 Chi Zou Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26117 Chi Zou Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26117;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26117, 'gemportalchizoucottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26117,   1,       2048) /* ItemType - Gem */
+     , (26117,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26117,   5,         10) /* EncumbranceVal */
+     , (26117,   8,         10) /* Mass */
+     , (26117,   9,          0) /* ValidLocations - None */
+     , (26117,  11,         20) /* MaxStackSize */
+     , (26117,  12,          1) /* StackSize */
+     , (26117,  13,         10) /* StackUnitEncumbrance */
+     , (26117,  14,         10) /* StackUnitMass */
+     , (26117,  15,        500) /* StackUnitValue */
+     , (26117,  16,          8) /* ItemUseable - Contained */
+     , (26117,  18,          1) /* UiEffects - Magical */
+     , (26117,  19,        500) /* Value */
+     , (26117,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26117,  94,         16) /* TargetType - Creature */
+     , (26117, 106,        210) /* ItemSpellcraft */
+     , (26117, 107,         50) /* ItemCurMana */
+     , (26117, 108,         50) /* ItemMaxMana */
+     , (26117, 109,          0) /* ItemDifficulty */
+     , (26117, 110,          0) /* ItemAllegianceRankLimit */
+     , (26117, 150,        103) /* HookPlacement - Hook */
+     , (26117, 151,          2) /* HookType - Wall */
+     , (26117, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26117,  15, True ) /* LightsStatus */
+     , (26117,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26117, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26117,   1, 'Chi Zou Cottages Portal Gem') /* Name */
+     , (26117,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26117,   1,   33556769) /* Setup */
+     , (26117,   3,  536870932) /* SoundTable */
+     , (26117,   6,   67111919) /* PaletteBase */
+     , (26117,   7,  268435723) /* ClothingBase */
+     , (26117,   8,  100675760) /* Icon */
+     , (26117,  22,  872415275) /* PhysicsEffectTable */
+     , (26117,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26117,  31,      12484) /* LinkedPortalOne - Chi Zou Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26118 Cliffside Overlook Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26118 Cliffside Overlook Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26118;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26118, 'gemportalcliffsideoverlook', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26118,   1,       2048) /* ItemType - Gem */
+     , (26118,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26118,   5,         10) /* EncumbranceVal */
+     , (26118,   8,         10) /* Mass */
+     , (26118,   9,          0) /* ValidLocations - None */
+     , (26118,  11,         20) /* MaxStackSize */
+     , (26118,  12,          1) /* StackSize */
+     , (26118,  13,         10) /* StackUnitEncumbrance */
+     , (26118,  14,         10) /* StackUnitMass */
+     , (26118,  15,        500) /* StackUnitValue */
+     , (26118,  16,          8) /* ItemUseable - Contained */
+     , (26118,  18,          1) /* UiEffects - Magical */
+     , (26118,  19,        500) /* Value */
+     , (26118,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26118,  94,         16) /* TargetType - Creature */
+     , (26118, 106,        210) /* ItemSpellcraft */
+     , (26118, 107,         50) /* ItemCurMana */
+     , (26118, 108,         50) /* ItemMaxMana */
+     , (26118, 109,          0) /* ItemDifficulty */
+     , (26118, 110,          0) /* ItemAllegianceRankLimit */
+     , (26118, 150,        103) /* HookPlacement - Hook */
+     , (26118, 151,          2) /* HookType - Wall */
+     , (26118, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26118,  15, True ) /* LightsStatus */
+     , (26118,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26118, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26118,   1, 'Cliffside Overlook Portal Gem') /* Name */
+     , (26118,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26118,   1,   33556769) /* Setup */
+     , (26118,   3,  536870932) /* SoundTable */
+     , (26118,   6,   67111919) /* PaletteBase */
+     , (26118,   7,  268435723) /* ClothingBase */
+     , (26118,   8,  100675760) /* Icon */
+     , (26118,  22,  872415275) /* PhysicsEffectTable */
+     , (26118,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26118,  31,      14256) /* LinkedPortalOne - Cliffside Overlook Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26119 Colier View Hill Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26119 Colier View Hill Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26119;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26119, 'gemportalcolierviewhill', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26119,   1,       2048) /* ItemType - Gem */
+     , (26119,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26119,   5,         10) /* EncumbranceVal */
+     , (26119,   8,         10) /* Mass */
+     , (26119,   9,          0) /* ValidLocations - None */
+     , (26119,  11,         20) /* MaxStackSize */
+     , (26119,  12,          1) /* StackSize */
+     , (26119,  13,         10) /* StackUnitEncumbrance */
+     , (26119,  14,         10) /* StackUnitMass */
+     , (26119,  15,        500) /* StackUnitValue */
+     , (26119,  16,          8) /* ItemUseable - Contained */
+     , (26119,  18,          1) /* UiEffects - Magical */
+     , (26119,  19,        500) /* Value */
+     , (26119,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26119,  94,         16) /* TargetType - Creature */
+     , (26119, 106,        210) /* ItemSpellcraft */
+     , (26119, 107,         50) /* ItemCurMana */
+     , (26119, 108,         50) /* ItemMaxMana */
+     , (26119, 109,          0) /* ItemDifficulty */
+     , (26119, 110,          0) /* ItemAllegianceRankLimit */
+     , (26119, 150,        103) /* HookPlacement - Hook */
+     , (26119, 151,          2) /* HookType - Wall */
+     , (26119, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26119,  15, True ) /* LightsStatus */
+     , (26119,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26119, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26119,   1, 'Colier View Hill Portal Gem') /* Name */
+     , (26119,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26119,   1,   33556769) /* Setup */
+     , (26119,   3,  536870932) /* SoundTable */
+     , (26119,   6,   67111919) /* PaletteBase */
+     , (26119,   7,  268435723) /* ClothingBase */
+     , (26119,   8,  100675760) /* Icon */
+     , (26119,  22,  872415275) /* PhysicsEffectTable */
+     , (26119,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26119,  31,      15670) /* LinkedPortalOne - Colier View Hill Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26120 Cragstone Farms Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26120 Cragstone Farms Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26120;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26120, 'gemportalcragstonefarms', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26120,   1,       2048) /* ItemType - Gem */
+     , (26120,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26120,   5,         10) /* EncumbranceVal */
+     , (26120,   8,         10) /* Mass */
+     , (26120,   9,          0) /* ValidLocations - None */
+     , (26120,  11,         20) /* MaxStackSize */
+     , (26120,  12,          1) /* StackSize */
+     , (26120,  13,         10) /* StackUnitEncumbrance */
+     , (26120,  14,         10) /* StackUnitMass */
+     , (26120,  15,        500) /* StackUnitValue */
+     , (26120,  16,          8) /* ItemUseable - Contained */
+     , (26120,  18,          1) /* UiEffects - Magical */
+     , (26120,  19,        500) /* Value */
+     , (26120,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26120,  94,         16) /* TargetType - Creature */
+     , (26120, 106,        210) /* ItemSpellcraft */
+     , (26120, 107,         50) /* ItemCurMana */
+     , (26120, 108,         50) /* ItemMaxMana */
+     , (26120, 109,          0) /* ItemDifficulty */
+     , (26120, 110,          0) /* ItemAllegianceRankLimit */
+     , (26120, 150,        103) /* HookPlacement - Hook */
+     , (26120, 151,          2) /* HookType - Wall */
+     , (26120, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26120,  15, True ) /* LightsStatus */
+     , (26120,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26120, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26120,   1, 'Cragstone Farms Portal Gem') /* Name */
+     , (26120,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26120,   1,   33556769) /* Setup */
+     , (26120,   3,  536870932) /* SoundTable */
+     , (26120,   6,   67111919) /* PaletteBase */
+     , (26120,   7,  268435723) /* ClothingBase */
+     , (26120,   8,  100675760) /* Icon */
+     , (26120,  22,  872415275) /* PhysicsEffectTable */
+     , (26120,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26120,  31,      12485) /* LinkedPortalOne - Cragstone Farms Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26121 Crescent Lane Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26121 Crescent Lane Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26121;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26121, 'gemportalcrescentlanecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26121,   1,       2048) /* ItemType - Gem */
+     , (26121,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26121,   5,         10) /* EncumbranceVal */
+     , (26121,   8,         10) /* Mass */
+     , (26121,   9,          0) /* ValidLocations - None */
+     , (26121,  11,         20) /* MaxStackSize */
+     , (26121,  12,          1) /* StackSize */
+     , (26121,  13,         10) /* StackUnitEncumbrance */
+     , (26121,  14,         10) /* StackUnitMass */
+     , (26121,  15,        500) /* StackUnitValue */
+     , (26121,  16,          8) /* ItemUseable - Contained */
+     , (26121,  18,          1) /* UiEffects - Magical */
+     , (26121,  19,        500) /* Value */
+     , (26121,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26121,  94,         16) /* TargetType - Creature */
+     , (26121, 106,        210) /* ItemSpellcraft */
+     , (26121, 107,         50) /* ItemCurMana */
+     , (26121, 108,         50) /* ItemMaxMana */
+     , (26121, 109,          0) /* ItemDifficulty */
+     , (26121, 110,          0) /* ItemAllegianceRankLimit */
+     , (26121, 150,        103) /* HookPlacement - Hook */
+     , (26121, 151,          2) /* HookType - Wall */
+     , (26121, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26121,  15, True ) /* LightsStatus */
+     , (26121,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26121, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26121,   1, 'Crescent Lane Cottages Portal Gem') /* Name */
+     , (26121,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26121,   1,   33556769) /* Setup */
+     , (26121,   3,  536870932) /* SoundTable */
+     , (26121,   6,   67111919) /* PaletteBase */
+     , (26121,   7,  268435723) /* ClothingBase */
+     , (26121,   8,  100675760) /* Icon */
+     , (26121,  22,  872415275) /* PhysicsEffectTable */
+     , (26121,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26121,  31,      14257) /* LinkedPortalOne - Crescent Lane Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26122 Crescent Ridge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26122 Crescent Ridge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26122;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26122, 'gemportalcrescentridgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26122,   1,       2048) /* ItemType - Gem */
+     , (26122,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26122,   5,         10) /* EncumbranceVal */
+     , (26122,   8,         10) /* Mass */
+     , (26122,   9,          0) /* ValidLocations - None */
+     , (26122,  11,         20) /* MaxStackSize */
+     , (26122,  12,          1) /* StackSize */
+     , (26122,  13,         10) /* StackUnitEncumbrance */
+     , (26122,  14,         10) /* StackUnitMass */
+     , (26122,  15,        500) /* StackUnitValue */
+     , (26122,  16,          8) /* ItemUseable - Contained */
+     , (26122,  18,          1) /* UiEffects - Magical */
+     , (26122,  19,        500) /* Value */
+     , (26122,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26122,  94,         16) /* TargetType - Creature */
+     , (26122, 106,        210) /* ItemSpellcraft */
+     , (26122, 107,         50) /* ItemCurMana */
+     , (26122, 108,         50) /* ItemMaxMana */
+     , (26122, 109,          0) /* ItemDifficulty */
+     , (26122, 110,          0) /* ItemAllegianceRankLimit */
+     , (26122, 150,        103) /* HookPlacement - Hook */
+     , (26122, 151,          2) /* HookType - Wall */
+     , (26122, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26122,  15, True ) /* LightsStatus */
+     , (26122,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26122, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26122,   1, 'Crescent Ridge Cottages Portal Gem') /* Name */
+     , (26122,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26122,   1,   33556769) /* Setup */
+     , (26122,   3,  536870932) /* SoundTable */
+     , (26122,   6,   67111919) /* PaletteBase */
+     , (26122,   7,  268435723) /* ClothingBase */
+     , (26122,   8,  100675760) /* Icon */
+     , (26122,  22,  872415275) /* PhysicsEffectTable */
+     , (26122,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26122,  31,      14258) /* LinkedPortalOne - Crescent Ridge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26123 Dagger Vale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26123 Dagger Vale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26123;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26123, 'gemportaldaggervale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26123,   1,       2048) /* ItemType - Gem */
+     , (26123,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26123,   5,         10) /* EncumbranceVal */
+     , (26123,   8,         10) /* Mass */
+     , (26123,   9,          0) /* ValidLocations - None */
+     , (26123,  11,         20) /* MaxStackSize */
+     , (26123,  12,          1) /* StackSize */
+     , (26123,  13,         10) /* StackUnitEncumbrance */
+     , (26123,  14,         10) /* StackUnitMass */
+     , (26123,  15,        500) /* StackUnitValue */
+     , (26123,  16,          8) /* ItemUseable - Contained */
+     , (26123,  18,          1) /* UiEffects - Magical */
+     , (26123,  19,        500) /* Value */
+     , (26123,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26123,  94,         16) /* TargetType - Creature */
+     , (26123, 106,        210) /* ItemSpellcraft */
+     , (26123, 107,         50) /* ItemCurMana */
+     , (26123, 108,         50) /* ItemMaxMana */
+     , (26123, 109,          0) /* ItemDifficulty */
+     , (26123, 110,          0) /* ItemAllegianceRankLimit */
+     , (26123, 150,        103) /* HookPlacement - Hook */
+     , (26123, 151,          2) /* HookType - Wall */
+     , (26123, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26123,  15, True ) /* LightsStatus */
+     , (26123,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26123, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26123,   1, 'Dagger Vale Portal Gem') /* Name */
+     , (26123,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26123,   1,   33556769) /* Setup */
+     , (26123,   3,  536870932) /* SoundTable */
+     , (26123,   6,   67111919) /* PaletteBase */
+     , (26123,   7,  268435723) /* ClothingBase */
+     , (26123,   8,  100675760) /* Icon */
+     , (26123,  22,  872415275) /* PhysicsEffectTable */
+     , (26123,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26123,  31,      15149) /* LinkedPortalOne - Dagger Vale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26124 Dame Tolani Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26124 Dame Tolani Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26124;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26124, 'gemportaldametolanivillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26124,   1,       2048) /* ItemType - Gem */
+     , (26124,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26124,   5,         10) /* EncumbranceVal */
+     , (26124,   8,         10) /* Mass */
+     , (26124,   9,          0) /* ValidLocations - None */
+     , (26124,  11,         20) /* MaxStackSize */
+     , (26124,  12,          1) /* StackSize */
+     , (26124,  13,         10) /* StackUnitEncumbrance */
+     , (26124,  14,         10) /* StackUnitMass */
+     , (26124,  15,        500) /* StackUnitValue */
+     , (26124,  16,          8) /* ItemUseable - Contained */
+     , (26124,  18,          1) /* UiEffects - Magical */
+     , (26124,  19,        500) /* Value */
+     , (26124,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26124,  94,         16) /* TargetType - Creature */
+     , (26124, 106,        210) /* ItemSpellcraft */
+     , (26124, 107,         50) /* ItemCurMana */
+     , (26124, 108,         50) /* ItemMaxMana */
+     , (26124, 109,          0) /* ItemDifficulty */
+     , (26124, 110,          0) /* ItemAllegianceRankLimit */
+     , (26124, 150,        103) /* HookPlacement - Hook */
+     , (26124, 151,          2) /* HookType - Wall */
+     , (26124, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26124,  15, True ) /* LightsStatus */
+     , (26124,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26124, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26124,   1, 'Dame Tolani Villas Portal Gem') /* Name */
+     , (26124,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26124,   1,   33556769) /* Setup */
+     , (26124,   3,  536870932) /* SoundTable */
+     , (26124,   6,   67111919) /* PaletteBase */
+     , (26124,   7,  268435723) /* ClothingBase */
+     , (26124,   8,  100675760) /* Icon */
+     , (26124,  22,  872415275) /* PhysicsEffectTable */
+     , (26124,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26124,  31,      19140) /* LinkedPortalOne - Dame Tolani Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26125 Darasa Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26125 Darasa Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26125;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26125, 'gemportaldarasavillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26125,   1,       2048) /* ItemType - Gem */
+     , (26125,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26125,   5,         10) /* EncumbranceVal */
+     , (26125,   8,         10) /* Mass */
+     , (26125,   9,          0) /* ValidLocations - None */
+     , (26125,  11,         20) /* MaxStackSize */
+     , (26125,  12,          1) /* StackSize */
+     , (26125,  13,         10) /* StackUnitEncumbrance */
+     , (26125,  14,         10) /* StackUnitMass */
+     , (26125,  15,        500) /* StackUnitValue */
+     , (26125,  16,          8) /* ItemUseable - Contained */
+     , (26125,  18,          1) /* UiEffects - Magical */
+     , (26125,  19,        500) /* Value */
+     , (26125,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26125,  94,         16) /* TargetType - Creature */
+     , (26125, 106,        210) /* ItemSpellcraft */
+     , (26125, 107,         50) /* ItemCurMana */
+     , (26125, 108,         50) /* ItemMaxMana */
+     , (26125, 109,          0) /* ItemDifficulty */
+     , (26125, 110,          0) /* ItemAllegianceRankLimit */
+     , (26125, 150,        103) /* HookPlacement - Hook */
+     , (26125, 151,          2) /* HookType - Wall */
+     , (26125, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26125,  15, True ) /* LightsStatus */
+     , (26125,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26125, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26125,   1, 'Darasa Villas Portal Gem') /* Name */
+     , (26125,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26125,   1,   33556769) /* Setup */
+     , (26125,   3,  536870932) /* SoundTable */
+     , (26125,   6,   67111919) /* PaletteBase */
+     , (26125,   7,  268435723) /* ClothingBase */
+     , (26125,   8,  100675760) /* Icon */
+     , (26125,  22,  872415275) /* PhysicsEffectTable */
+     , (26125,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26125,  31,      19141) /* LinkedPortalOne - Darasa Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26126 Darawyll Village Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26126 Darawyll Village Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26126;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26126, 'gemportaldarawyllvillage', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26126,   1,       2048) /* ItemType - Gem */
+     , (26126,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26126,   5,         10) /* EncumbranceVal */
+     , (26126,   8,         10) /* Mass */
+     , (26126,   9,          0) /* ValidLocations - None */
+     , (26126,  11,         20) /* MaxStackSize */
+     , (26126,  12,          1) /* StackSize */
+     , (26126,  13,         10) /* StackUnitEncumbrance */
+     , (26126,  14,         10) /* StackUnitMass */
+     , (26126,  15,        500) /* StackUnitValue */
+     , (26126,  16,          8) /* ItemUseable - Contained */
+     , (26126,  18,          1) /* UiEffects - Magical */
+     , (26126,  19,        500) /* Value */
+     , (26126,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26126,  94,         16) /* TargetType - Creature */
+     , (26126, 106,        210) /* ItemSpellcraft */
+     , (26126, 107,         50) /* ItemCurMana */
+     , (26126, 108,         50) /* ItemMaxMana */
+     , (26126, 109,          0) /* ItemDifficulty */
+     , (26126, 110,          0) /* ItemAllegianceRankLimit */
+     , (26126, 150,        103) /* HookPlacement - Hook */
+     , (26126, 151,          2) /* HookType - Wall */
+     , (26126, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26126,  15, True ) /* LightsStatus */
+     , (26126,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26126, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26126,   1, 'Darawyll Village Portal Gem') /* Name */
+     , (26126,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26126,   1,   33556769) /* Setup */
+     , (26126,   3,  536870932) /* SoundTable */
+     , (26126,   6,   67111919) /* PaletteBase */
+     , (26126,   7,  268435723) /* ClothingBase */
+     , (26126,   8,  100675760) /* Icon */
+     , (26126,  22,  872415275) /* PhysicsEffectTable */
+     , (26126,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26126,  31,      15150) /* LinkedPortalOne - Darawyll Village Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26127 Deepvale Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26127 Deepvale Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26127;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26127, 'gemportaldeepvalecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26127,   1,       2048) /* ItemType - Gem */
+     , (26127,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26127,   5,         10) /* EncumbranceVal */
+     , (26127,   8,         10) /* Mass */
+     , (26127,   9,          0) /* ValidLocations - None */
+     , (26127,  11,         20) /* MaxStackSize */
+     , (26127,  12,          1) /* StackSize */
+     , (26127,  13,         10) /* StackUnitEncumbrance */
+     , (26127,  14,         10) /* StackUnitMass */
+     , (26127,  15,        500) /* StackUnitValue */
+     , (26127,  16,          8) /* ItemUseable - Contained */
+     , (26127,  18,          1) /* UiEffects - Magical */
+     , (26127,  19,        500) /* Value */
+     , (26127,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26127,  94,         16) /* TargetType - Creature */
+     , (26127, 106,        210) /* ItemSpellcraft */
+     , (26127, 107,         50) /* ItemCurMana */
+     , (26127, 108,         50) /* ItemMaxMana */
+     , (26127, 109,          0) /* ItemDifficulty */
+     , (26127, 110,          0) /* ItemAllegianceRankLimit */
+     , (26127, 150,        103) /* HookPlacement - Hook */
+     , (26127, 151,          2) /* HookType - Wall */
+     , (26127, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26127,  15, True ) /* LightsStatus */
+     , (26127,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26127, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26127,   1, 'Deepvale Cottages Portal Gem') /* Name */
+     , (26127,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26127,   1,   33556769) /* Setup */
+     , (26127,   3,  536870932) /* SoundTable */
+     , (26127,   6,   67111919) /* PaletteBase */
+     , (26127,   7,  268435723) /* ClothingBase */
+     , (26127,   8,  100675760) /* Icon */
+     , (26127,  22,  872415275) /* PhysicsEffectTable */
+     , (26127,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26127,  31,      15671) /* LinkedPortalOne - Deepvale Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26128 Defiant Prey Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26128 Defiant Prey Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26128;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26128, 'gemportaldefiantpreycottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26128,   1,       2048) /* ItemType - Gem */
+     , (26128,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26128,   5,         10) /* EncumbranceVal */
+     , (26128,   8,         10) /* Mass */
+     , (26128,   9,          0) /* ValidLocations - None */
+     , (26128,  11,         20) /* MaxStackSize */
+     , (26128,  12,          1) /* StackSize */
+     , (26128,  13,         10) /* StackUnitEncumbrance */
+     , (26128,  14,         10) /* StackUnitMass */
+     , (26128,  15,        500) /* StackUnitValue */
+     , (26128,  16,          8) /* ItemUseable - Contained */
+     , (26128,  18,          1) /* UiEffects - Magical */
+     , (26128,  19,        500) /* Value */
+     , (26128,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26128,  94,         16) /* TargetType - Creature */
+     , (26128, 106,        210) /* ItemSpellcraft */
+     , (26128, 107,         50) /* ItemCurMana */
+     , (26128, 108,         50) /* ItemMaxMana */
+     , (26128, 109,          0) /* ItemDifficulty */
+     , (26128, 110,          0) /* ItemAllegianceRankLimit */
+     , (26128, 150,        103) /* HookPlacement - Hook */
+     , (26128, 151,          2) /* HookType - Wall */
+     , (26128, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26128,  15, True ) /* LightsStatus */
+     , (26128,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26128, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26128,   1, 'Defiant Prey Cottages Portal Gem') /* Name */
+     , (26128,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26128,   1,   33556769) /* Setup */
+     , (26128,   3,  536870932) /* SoundTable */
+     , (26128,   6,   67111919) /* PaletteBase */
+     , (26128,   7,  268435723) /* ClothingBase */
+     , (26128,   8,  100675760) /* Icon */
+     , (26128,  22,  872415275) /* PhysicsEffectTable */
+     , (26128,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26128,  31,      19142) /* LinkedPortalOne - Defiant Prey Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26129 Demonsbane Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26129 Demonsbane Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26129;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26129, 'gemportaldemonsbanecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26129,   1,       2048) /* ItemType - Gem */
+     , (26129,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26129,   5,         10) /* EncumbranceVal */
+     , (26129,   8,         10) /* Mass */
+     , (26129,   9,          0) /* ValidLocations - None */
+     , (26129,  11,         20) /* MaxStackSize */
+     , (26129,  12,          1) /* StackSize */
+     , (26129,  13,         10) /* StackUnitEncumbrance */
+     , (26129,  14,         10) /* StackUnitMass */
+     , (26129,  15,        500) /* StackUnitValue */
+     , (26129,  16,          8) /* ItemUseable - Contained */
+     , (26129,  18,          1) /* UiEffects - Magical */
+     , (26129,  19,        500) /* Value */
+     , (26129,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26129,  94,         16) /* TargetType - Creature */
+     , (26129, 106,        210) /* ItemSpellcraft */
+     , (26129, 107,         50) /* ItemCurMana */
+     , (26129, 108,         50) /* ItemMaxMana */
+     , (26129, 109,          0) /* ItemDifficulty */
+     , (26129, 110,          0) /* ItemAllegianceRankLimit */
+     , (26129, 150,        103) /* HookPlacement - Hook */
+     , (26129, 151,          2) /* HookType - Wall */
+     , (26129, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26129,  15, True ) /* LightsStatus */
+     , (26129,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26129, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26129,   1, 'Demonsbane Cottages Portal Gem') /* Name */
+     , (26129,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26129,   1,   33556769) /* Setup */
+     , (26129,   3,  536870932) /* SoundTable */
+     , (26129,   6,   67111919) /* PaletteBase */
+     , (26129,   7,  268435723) /* ClothingBase */
+     , (26129,   8,  100675760) /* Icon */
+     , (26129,  22,  872415275) /* PhysicsEffectTable */
+     , (26129,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26129,  31,      15672) /* LinkedPortalOne - Demonsbane Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26130 Desert Boundary Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26130 Desert Boundary Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26130;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26130, 'gemportaldesertboundarycottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26130,   1,       2048) /* ItemType - Gem */
+     , (26130,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26130,   5,         10) /* EncumbranceVal */
+     , (26130,   8,         10) /* Mass */
+     , (26130,   9,          0) /* ValidLocations - None */
+     , (26130,  11,         20) /* MaxStackSize */
+     , (26130,  12,          1) /* StackSize */
+     , (26130,  13,         10) /* StackUnitEncumbrance */
+     , (26130,  14,         10) /* StackUnitMass */
+     , (26130,  15,        500) /* StackUnitValue */
+     , (26130,  16,          8) /* ItemUseable - Contained */
+     , (26130,  18,          1) /* UiEffects - Magical */
+     , (26130,  19,        500) /* Value */
+     , (26130,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26130,  94,         16) /* TargetType - Creature */
+     , (26130, 106,        210) /* ItemSpellcraft */
+     , (26130, 107,         50) /* ItemCurMana */
+     , (26130, 108,         50) /* ItemMaxMana */
+     , (26130, 109,          0) /* ItemDifficulty */
+     , (26130, 110,          0) /* ItemAllegianceRankLimit */
+     , (26130, 150,        103) /* HookPlacement - Hook */
+     , (26130, 151,          2) /* HookType - Wall */
+     , (26130, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26130,  15, True ) /* LightsStatus */
+     , (26130,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26130, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26130,   1, 'Desert Boundary Cottages Portal Gem') /* Name */
+     , (26130,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26130,   1,   33556769) /* Setup */
+     , (26130,   3,  536870932) /* SoundTable */
+     , (26130,   6,   67111919) /* PaletteBase */
+     , (26130,   7,  268435723) /* ClothingBase */
+     , (26130,   8,  100675760) /* Icon */
+     , (26130,  22,  872415275) /* PhysicsEffectTable */
+     , (26130,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26130,  31,      14617) /* LinkedPortalOne - Desert Boundary Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26131 Desert Mirage Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26131 Desert Mirage Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26131;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26131, 'gemportaldesertmiragecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26131,   1,       2048) /* ItemType - Gem */
+     , (26131,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26131,   5,         10) /* EncumbranceVal */
+     , (26131,   8,         10) /* Mass */
+     , (26131,   9,          0) /* ValidLocations - None */
+     , (26131,  11,         20) /* MaxStackSize */
+     , (26131,  12,          1) /* StackSize */
+     , (26131,  13,         10) /* StackUnitEncumbrance */
+     , (26131,  14,         10) /* StackUnitMass */
+     , (26131,  15,        500) /* StackUnitValue */
+     , (26131,  16,          8) /* ItemUseable - Contained */
+     , (26131,  18,          1) /* UiEffects - Magical */
+     , (26131,  19,        500) /* Value */
+     , (26131,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26131,  94,         16) /* TargetType - Creature */
+     , (26131, 106,        210) /* ItemSpellcraft */
+     , (26131, 107,         50) /* ItemCurMana */
+     , (26131, 108,         50) /* ItemMaxMana */
+     , (26131, 109,          0) /* ItemDifficulty */
+     , (26131, 110,          0) /* ItemAllegianceRankLimit */
+     , (26131, 150,        103) /* HookPlacement - Hook */
+     , (26131, 151,          2) /* HookType - Wall */
+     , (26131, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26131,  15, True ) /* LightsStatus */
+     , (26131,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26131, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26131,   1, 'Desert Mirage Cottages Portal Gem') /* Name */
+     , (26131,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26131,   1,   33556769) /* Setup */
+     , (26131,   3,  536870932) /* SoundTable */
+     , (26131,   6,   67111919) /* PaletteBase */
+     , (26131,   7,  268435723) /* ClothingBase */
+     , (26131,   8,  100675760) /* Icon */
+     , (26131,  22,  872415275) /* PhysicsEffectTable */
+     , (26131,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26131,  31,      14618) /* LinkedPortalOne - Desert Mirage Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26132 Desert Vanguard Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26132 Desert Vanguard Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26132;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26132, 'gemportaldesertvanguardcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26132,   1,       2048) /* ItemType - Gem */
+     , (26132,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26132,   5,         10) /* EncumbranceVal */
+     , (26132,   8,         10) /* Mass */
+     , (26132,   9,          0) /* ValidLocations - None */
+     , (26132,  11,         20) /* MaxStackSize */
+     , (26132,  12,          1) /* StackSize */
+     , (26132,  13,         10) /* StackUnitEncumbrance */
+     , (26132,  14,         10) /* StackUnitMass */
+     , (26132,  15,        500) /* StackUnitValue */
+     , (26132,  16,          8) /* ItemUseable - Contained */
+     , (26132,  18,          1) /* UiEffects - Magical */
+     , (26132,  19,        500) /* Value */
+     , (26132,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26132,  94,         16) /* TargetType - Creature */
+     , (26132, 106,        210) /* ItemSpellcraft */
+     , (26132, 107,         50) /* ItemCurMana */
+     , (26132, 108,         50) /* ItemMaxMana */
+     , (26132, 109,          0) /* ItemDifficulty */
+     , (26132, 110,          0) /* ItemAllegianceRankLimit */
+     , (26132, 150,        103) /* HookPlacement - Hook */
+     , (26132, 151,          2) /* HookType - Wall */
+     , (26132, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26132,  15, True ) /* LightsStatus */
+     , (26132,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26132, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26132,   1, 'Desert Vanguard Cottages Portal Gem') /* Name */
+     , (26132,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26132,   1,   33556769) /* Setup */
+     , (26132,   3,  536870932) /* SoundTable */
+     , (26132,   6,   67111919) /* PaletteBase */
+     , (26132,   7,  268435723) /* ClothingBase */
+     , (26132,   8,  100675760) /* Icon */
+     , (26132,  22,  872415275) /* PhysicsEffectTable */
+     , (26132,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26132,  31,      14619) /* LinkedPortalOne - Desert Vanguard Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26133 Desolation Beach  Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26133 Desolation Beach  Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26133;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26133, 'gemportaldesolationbeach', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26133,   1,       2048) /* ItemType - Gem */
+     , (26133,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26133,   5,         10) /* EncumbranceVal */
+     , (26133,   8,         10) /* Mass */
+     , (26133,   9,          0) /* ValidLocations - None */
+     , (26133,  11,         20) /* MaxStackSize */
+     , (26133,  12,          1) /* StackSize */
+     , (26133,  13,         10) /* StackUnitEncumbrance */
+     , (26133,  14,         10) /* StackUnitMass */
+     , (26133,  15,        500) /* StackUnitValue */
+     , (26133,  16,          8) /* ItemUseable - Contained */
+     , (26133,  18,          1) /* UiEffects - Magical */
+     , (26133,  19,        500) /* Value */
+     , (26133,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26133,  94,         16) /* TargetType - Creature */
+     , (26133, 106,        210) /* ItemSpellcraft */
+     , (26133, 107,         50) /* ItemCurMana */
+     , (26133, 108,         50) /* ItemMaxMana */
+     , (26133, 109,          0) /* ItemDifficulty */
+     , (26133, 110,          0) /* ItemAllegianceRankLimit */
+     , (26133, 150,        103) /* HookPlacement - Hook */
+     , (26133, 151,          2) /* HookType - Wall */
+     , (26133, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26133,  15, True ) /* LightsStatus */
+     , (26133,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26133, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26133,   1, 'Desolation Beach  Portal Gem') /* Name */
+     , (26133,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26133,   1,   33556769) /* Setup */
+     , (26133,   3,  536870932) /* SoundTable */
+     , (26133,   6,   67111919) /* PaletteBase */
+     , (26133,   7,  268435723) /* ClothingBase */
+     , (26133,   8,  100675760) /* Icon */
+     , (26133,  22,  872415275) /* PhysicsEffectTable */
+     , (26133,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26133,  31,      12486) /* LinkedPortalOne - Desolation Beach  Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26134 Devana Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26134 Devana Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26134;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26134, 'gemportaldevana', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26134,   1,       2048) /* ItemType - Gem */
+     , (26134,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26134,   5,         10) /* EncumbranceVal */
+     , (26134,   8,         10) /* Mass */
+     , (26134,   9,          0) /* ValidLocations - None */
+     , (26134,  11,         20) /* MaxStackSize */
+     , (26134,  12,          1) /* StackSize */
+     , (26134,  13,         10) /* StackUnitEncumbrance */
+     , (26134,  14,         10) /* StackUnitMass */
+     , (26134,  15,        500) /* StackUnitValue */
+     , (26134,  16,          8) /* ItemUseable - Contained */
+     , (26134,  18,          1) /* UiEffects - Magical */
+     , (26134,  19,        500) /* Value */
+     , (26134,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26134,  94,         16) /* TargetType - Creature */
+     , (26134, 106,        210) /* ItemSpellcraft */
+     , (26134, 107,         50) /* ItemCurMana */
+     , (26134, 108,         50) /* ItemMaxMana */
+     , (26134, 109,          0) /* ItemDifficulty */
+     , (26134, 110,          0) /* ItemAllegianceRankLimit */
+     , (26134, 150,        103) /* HookPlacement - Hook */
+     , (26134, 151,          2) /* HookType - Wall */
+     , (26134, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26134,  15, True ) /* LightsStatus */
+     , (26134,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26134, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26134,   1, 'Devana Portal Gem') /* Name */
+     , (26134,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26134,   1,   33556769) /* Setup */
+     , (26134,   3,  536870932) /* SoundTable */
+     , (26134,   6,   67111919) /* PaletteBase */
+     , (26134,   7,  268435723) /* ClothingBase */
+     , (26134,   8,  100675760) /* Icon */
+     , (26134,  22,  872415275) /* PhysicsEffectTable */
+     , (26134,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26134,  31,      15151) /* LinkedPortalOne - Devana Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26135 Dillo Butte Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26135 Dillo Butte Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26135;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26135, 'gemportaldillobuttesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26135,   1,       2048) /* ItemType - Gem */
+     , (26135,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26135,   5,         10) /* EncumbranceVal */
+     , (26135,   8,         10) /* Mass */
+     , (26135,   9,          0) /* ValidLocations - None */
+     , (26135,  11,         20) /* MaxStackSize */
+     , (26135,  12,          1) /* StackSize */
+     , (26135,  13,         10) /* StackUnitEncumbrance */
+     , (26135,  14,         10) /* StackUnitMass */
+     , (26135,  15,        500) /* StackUnitValue */
+     , (26135,  16,          8) /* ItemUseable - Contained */
+     , (26135,  18,          1) /* UiEffects - Magical */
+     , (26135,  19,        500) /* Value */
+     , (26135,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26135,  94,         16) /* TargetType - Creature */
+     , (26135, 106,        210) /* ItemSpellcraft */
+     , (26135, 107,         50) /* ItemCurMana */
+     , (26135, 108,         50) /* ItemMaxMana */
+     , (26135, 109,          0) /* ItemDifficulty */
+     , (26135, 110,          0) /* ItemAllegianceRankLimit */
+     , (26135, 150,        103) /* HookPlacement - Hook */
+     , (26135, 151,          2) /* HookType - Wall */
+     , (26135, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26135,  15, True ) /* LightsStatus */
+     , (26135,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26135, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26135,   1, 'Dillo Butte Settlement Portal Gem') /* Name */
+     , (26135,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26135,   1,   33556769) /* Setup */
+     , (26135,   3,  536870932) /* SoundTable */
+     , (26135,   6,   67111919) /* PaletteBase */
+     , (26135,   7,  268435723) /* ClothingBase */
+     , (26135,   8,  100675760) /* Icon */
+     , (26135,  22,  872415275) /* PhysicsEffectTable */
+     , (26135,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26135,  31,      14259) /* LinkedPortalOne - Dillo Butte Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26136 Dires' Door Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26136 Dires' Door Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26136;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26136, 'gemportaldiresdoorestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26136,   1,       2048) /* ItemType - Gem */
+     , (26136,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26136,   5,         10) /* EncumbranceVal */
+     , (26136,   8,         10) /* Mass */
+     , (26136,   9,          0) /* ValidLocations - None */
+     , (26136,  11,         20) /* MaxStackSize */
+     , (26136,  12,          1) /* StackSize */
+     , (26136,  13,         10) /* StackUnitEncumbrance */
+     , (26136,  14,         10) /* StackUnitMass */
+     , (26136,  15,        500) /* StackUnitValue */
+     , (26136,  16,          8) /* ItemUseable - Contained */
+     , (26136,  18,          1) /* UiEffects - Magical */
+     , (26136,  19,        500) /* Value */
+     , (26136,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26136,  94,         16) /* TargetType - Creature */
+     , (26136, 106,        210) /* ItemSpellcraft */
+     , (26136, 107,         50) /* ItemCurMana */
+     , (26136, 108,         50) /* ItemMaxMana */
+     , (26136, 109,          0) /* ItemDifficulty */
+     , (26136, 110,          0) /* ItemAllegianceRankLimit */
+     , (26136, 150,        103) /* HookPlacement - Hook */
+     , (26136, 151,          2) /* HookType - Wall */
+     , (26136, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26136,  15, True ) /* LightsStatus */
+     , (26136,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26136, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26136,   1, 'Dires'' Door Estates Portal Gem') /* Name */
+     , (26136,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26136,   1,   33556769) /* Setup */
+     , (26136,   3,  536870932) /* SoundTable */
+     , (26136,   6,   67111919) /* PaletteBase */
+     , (26136,   7,  268435723) /* ClothingBase */
+     , (26136,   8,  100675760) /* Icon */
+     , (26136,  22,  872415275) /* PhysicsEffectTable */
+     , (26136,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26136,  31,      13097) /* LinkedPortalOne - Dires' Door Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26137 Dire's Edge Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26137 Dire's Edge Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26137;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26137, 'gemportaldiresedge', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26137,   1,       2048) /* ItemType - Gem */
+     , (26137,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26137,   5,         10) /* EncumbranceVal */
+     , (26137,   8,         10) /* Mass */
+     , (26137,   9,          0) /* ValidLocations - None */
+     , (26137,  11,         20) /* MaxStackSize */
+     , (26137,  12,          1) /* StackSize */
+     , (26137,  13,         10) /* StackUnitEncumbrance */
+     , (26137,  14,         10) /* StackUnitMass */
+     , (26137,  15,        500) /* StackUnitValue */
+     , (26137,  16,          8) /* ItemUseable - Contained */
+     , (26137,  18,          1) /* UiEffects - Magical */
+     , (26137,  19,        500) /* Value */
+     , (26137,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26137,  94,         16) /* TargetType - Creature */
+     , (26137, 106,        210) /* ItemSpellcraft */
+     , (26137, 107,         50) /* ItemCurMana */
+     , (26137, 108,         50) /* ItemMaxMana */
+     , (26137, 109,          0) /* ItemDifficulty */
+     , (26137, 110,          0) /* ItemAllegianceRankLimit */
+     , (26137, 150,        103) /* HookPlacement - Hook */
+     , (26137, 151,          2) /* HookType - Wall */
+     , (26137, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26137,  15, True ) /* LightsStatus */
+     , (26137,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26137, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26137,   1, 'Dire''s Edge Portal Gem') /* Name */
+     , (26137,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26137,   1,   33556769) /* Setup */
+     , (26137,   3,  536870932) /* SoundTable */
+     , (26137,   6,   67111919) /* PaletteBase */
+     , (26137,   7,  268435723) /* ClothingBase */
+     , (26137,   8,  100675760) /* Icon */
+     , (26137,  22,  872415275) /* PhysicsEffectTable */
+     , (26137,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26137,  31,      13098) /* LinkedPortalOne - Dire's Edge Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26138 Direvale Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26138 Direvale Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26138;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26138, 'gemportaldirevalevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26138,   1,       2048) /* ItemType - Gem */
+     , (26138,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26138,   5,         10) /* EncumbranceVal */
+     , (26138,   8,         10) /* Mass */
+     , (26138,   9,          0) /* ValidLocations - None */
+     , (26138,  11,         20) /* MaxStackSize */
+     , (26138,  12,          1) /* StackSize */
+     , (26138,  13,         10) /* StackUnitEncumbrance */
+     , (26138,  14,         10) /* StackUnitMass */
+     , (26138,  15,        500) /* StackUnitValue */
+     , (26138,  16,          8) /* ItemUseable - Contained */
+     , (26138,  18,          1) /* UiEffects - Magical */
+     , (26138,  19,        500) /* Value */
+     , (26138,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26138,  94,         16) /* TargetType - Creature */
+     , (26138, 106,        210) /* ItemSpellcraft */
+     , (26138, 107,         50) /* ItemCurMana */
+     , (26138, 108,         50) /* ItemMaxMana */
+     , (26138, 109,          0) /* ItemDifficulty */
+     , (26138, 110,          0) /* ItemAllegianceRankLimit */
+     , (26138, 150,        103) /* HookPlacement - Hook */
+     , (26138, 151,          2) /* HookType - Wall */
+     , (26138, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26138,  15, True ) /* LightsStatus */
+     , (26138,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26138, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26138,   1, 'Direvale Villas Portal Gem') /* Name */
+     , (26138,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26138,   1,   33556769) /* Setup */
+     , (26138,   3,  536870932) /* SoundTable */
+     , (26138,   6,   67111919) /* PaletteBase */
+     , (26138,   7,  268435723) /* ClothingBase */
+     , (26138,   8,  100675760) /* Icon */
+     , (26138,  22,  872415275) /* PhysicsEffectTable */
+     , (26138,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26138,  31,      15152) /* LinkedPortalOne - Direvale Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26139 Djebel al-Nar Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26139 Djebel al-Nar Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26139;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26139, 'gemportaldjebelalnarcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26139,   1,       2048) /* ItemType - Gem */
+     , (26139,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26139,   5,         10) /* EncumbranceVal */
+     , (26139,   8,         10) /* Mass */
+     , (26139,   9,          0) /* ValidLocations - None */
+     , (26139,  11,         20) /* MaxStackSize */
+     , (26139,  12,          1) /* StackSize */
+     , (26139,  13,         10) /* StackUnitEncumbrance */
+     , (26139,  14,         10) /* StackUnitMass */
+     , (26139,  15,        500) /* StackUnitValue */
+     , (26139,  16,          8) /* ItemUseable - Contained */
+     , (26139,  18,          1) /* UiEffects - Magical */
+     , (26139,  19,        500) /* Value */
+     , (26139,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26139,  94,         16) /* TargetType - Creature */
+     , (26139, 106,        210) /* ItemSpellcraft */
+     , (26139, 107,         50) /* ItemCurMana */
+     , (26139, 108,         50) /* ItemMaxMana */
+     , (26139, 109,          0) /* ItemDifficulty */
+     , (26139, 110,          0) /* ItemAllegianceRankLimit */
+     , (26139, 150,        103) /* HookPlacement - Hook */
+     , (26139, 151,          2) /* HookType - Wall */
+     , (26139, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26139,  15, True ) /* LightsStatus */
+     , (26139,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26139, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26139,   1, 'Djebel al-Nar Cottages Portal Gem') /* Name */
+     , (26139,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26139,   1,   33556769) /* Setup */
+     , (26139,   3,  536870932) /* SoundTable */
+     , (26139,   6,   67111919) /* PaletteBase */
+     , (26139,   7,  268435723) /* ClothingBase */
+     , (26139,   8,  100675760) /* Icon */
+     , (26139,  22,  872415275) /* PhysicsEffectTable */
+     , (26139,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26139,  31,      14620) /* LinkedPortalOne - Djebel al-Nar Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26140 Djinaya Wind Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26140 Djinaya Wind Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26140;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26140, 'gemportaldjinayawindcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26140,   1,       2048) /* ItemType - Gem */
+     , (26140,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26140,   5,         10) /* EncumbranceVal */
+     , (26140,   8,         10) /* Mass */
+     , (26140,   9,          0) /* ValidLocations - None */
+     , (26140,  11,         20) /* MaxStackSize */
+     , (26140,  12,          1) /* StackSize */
+     , (26140,  13,         10) /* StackUnitEncumbrance */
+     , (26140,  14,         10) /* StackUnitMass */
+     , (26140,  15,        500) /* StackUnitValue */
+     , (26140,  16,          8) /* ItemUseable - Contained */
+     , (26140,  18,          1) /* UiEffects - Magical */
+     , (26140,  19,        500) /* Value */
+     , (26140,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26140,  94,         16) /* TargetType - Creature */
+     , (26140, 106,        210) /* ItemSpellcraft */
+     , (26140, 107,         50) /* ItemCurMana */
+     , (26140, 108,         50) /* ItemMaxMana */
+     , (26140, 109,          0) /* ItemDifficulty */
+     , (26140, 110,          0) /* ItemAllegianceRankLimit */
+     , (26140, 150,        103) /* HookPlacement - Hook */
+     , (26140, 151,          2) /* HookType - Wall */
+     , (26140, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26140,  15, True ) /* LightsStatus */
+     , (26140,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26140, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26140,   1, 'Djinaya Wind Cottages Portal Gem') /* Name */
+     , (26140,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26140,   1,   33556769) /* Setup */
+     , (26140,   3,  536870932) /* SoundTable */
+     , (26140,   6,   67111919) /* PaletteBase */
+     , (26140,   7,  268435723) /* ClothingBase */
+     , (26140,   8,  100675760) /* Icon */
+     , (26140,  22,  872415275) /* PhysicsEffectTable */
+     , (26140,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26140,  31,      14621) /* LinkedPortalOne - Djinaya Wind Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26141 Dovetail Valley Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26141 Dovetail Valley Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26141;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26141, 'gemportaldovetailvalleyvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26141,   1,       2048) /* ItemType - Gem */
+     , (26141,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26141,   5,         10) /* EncumbranceVal */
+     , (26141,   8,         10) /* Mass */
+     , (26141,   9,          0) /* ValidLocations - None */
+     , (26141,  11,         20) /* MaxStackSize */
+     , (26141,  12,          1) /* StackSize */
+     , (26141,  13,         10) /* StackUnitEncumbrance */
+     , (26141,  14,         10) /* StackUnitMass */
+     , (26141,  15,        500) /* StackUnitValue */
+     , (26141,  16,          8) /* ItemUseable - Contained */
+     , (26141,  18,          1) /* UiEffects - Magical */
+     , (26141,  19,        500) /* Value */
+     , (26141,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26141,  94,         16) /* TargetType - Creature */
+     , (26141, 106,        210) /* ItemSpellcraft */
+     , (26141, 107,         50) /* ItemCurMana */
+     , (26141, 108,         50) /* ItemMaxMana */
+     , (26141, 109,          0) /* ItemDifficulty */
+     , (26141, 110,          0) /* ItemAllegianceRankLimit */
+     , (26141, 150,        103) /* HookPlacement - Hook */
+     , (26141, 151,          2) /* HookType - Wall */
+     , (26141, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26141,  15, True ) /* LightsStatus */
+     , (26141,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26141, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26141,   1, 'Dovetail Valley Villas Portal Gem') /* Name */
+     , (26141,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26141,   1,   33556769) /* Setup */
+     , (26141,   3,  536870932) /* SoundTable */
+     , (26141,   6,   67111919) /* PaletteBase */
+     , (26141,   7,  268435723) /* ClothingBase */
+     , (26141,   8,  100675760) /* Icon */
+     , (26141,  22,  872415275) /* PhysicsEffectTable */
+     , (26141,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26141,  31,      15153) /* LinkedPortalOne - Dovetail Valley Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26142 Driftwood Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26142 Driftwood Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26142;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26142, 'gemportaldriftwoodcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26142,   1,       2048) /* ItemType - Gem */
+     , (26142,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26142,   5,         10) /* EncumbranceVal */
+     , (26142,   8,         10) /* Mass */
+     , (26142,   9,          0) /* ValidLocations - None */
+     , (26142,  11,         20) /* MaxStackSize */
+     , (26142,  12,          1) /* StackSize */
+     , (26142,  13,         10) /* StackUnitEncumbrance */
+     , (26142,  14,         10) /* StackUnitMass */
+     , (26142,  15,        500) /* StackUnitValue */
+     , (26142,  16,          8) /* ItemUseable - Contained */
+     , (26142,  18,          1) /* UiEffects - Magical */
+     , (26142,  19,        500) /* Value */
+     , (26142,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26142,  94,         16) /* TargetType - Creature */
+     , (26142, 106,        210) /* ItemSpellcraft */
+     , (26142, 107,         50) /* ItemCurMana */
+     , (26142, 108,         50) /* ItemMaxMana */
+     , (26142, 109,          0) /* ItemDifficulty */
+     , (26142, 110,          0) /* ItemAllegianceRankLimit */
+     , (26142, 150,        103) /* HookPlacement - Hook */
+     , (26142, 151,          2) /* HookType - Wall */
+     , (26142, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26142,  15, True ) /* LightsStatus */
+     , (26142,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26142, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26142,   1, 'Driftwood Cottages Portal Gem') /* Name */
+     , (26142,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26142,   1,   33556769) /* Setup */
+     , (26142,   3,  536870932) /* SoundTable */
+     , (26142,   6,   67111919) /* PaletteBase */
+     , (26142,   7,  268435723) /* ClothingBase */
+     , (26142,   8,  100675760) /* Icon */
+     , (26142,  22,  872415275) /* PhysicsEffectTable */
+     , (26142,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26142,  31,      14260) /* LinkedPortalOne - Driftwood Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26143 Dry Bone Manors Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26143 Dry Bone Manors Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26143;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26143, 'gemportaldrybonemanors', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26143,   1,       2048) /* ItemType - Gem */
+     , (26143,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26143,   5,         10) /* EncumbranceVal */
+     , (26143,   8,         10) /* Mass */
+     , (26143,   9,          0) /* ValidLocations - None */
+     , (26143,  11,         20) /* MaxStackSize */
+     , (26143,  12,          1) /* StackSize */
+     , (26143,  13,         10) /* StackUnitEncumbrance */
+     , (26143,  14,         10) /* StackUnitMass */
+     , (26143,  15,        500) /* StackUnitValue */
+     , (26143,  16,          8) /* ItemUseable - Contained */
+     , (26143,  18,          1) /* UiEffects - Magical */
+     , (26143,  19,        500) /* Value */
+     , (26143,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26143,  94,         16) /* TargetType - Creature */
+     , (26143, 106,        210) /* ItemSpellcraft */
+     , (26143, 107,         50) /* ItemCurMana */
+     , (26143, 108,         50) /* ItemMaxMana */
+     , (26143, 109,          0) /* ItemDifficulty */
+     , (26143, 110,          0) /* ItemAllegianceRankLimit */
+     , (26143, 150,        103) /* HookPlacement - Hook */
+     , (26143, 151,          2) /* HookType - Wall */
+     , (26143, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26143,  15, True ) /* LightsStatus */
+     , (26143,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26143, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26143,   1, 'Dry Bone Manors Portal Gem') /* Name */
+     , (26143,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26143,   1,   33556769) /* Setup */
+     , (26143,   3,  536870932) /* SoundTable */
+     , (26143,   6,   67111919) /* PaletteBase */
+     , (26143,   7,  268435723) /* ClothingBase */
+     , (26143,   8,  100675760) /* Icon */
+     , (26143,  22,  872415275) /* PhysicsEffectTable */
+     , (26143,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26143,  31,      13099) /* LinkedPortalOne - Dry Bone Manors Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26144 Dryreach Beach Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26144 Dryreach Beach Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26144;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26144, 'gemportaldryreachbeachcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26144,   1,       2048) /* ItemType - Gem */
+     , (26144,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26144,   5,         10) /* EncumbranceVal */
+     , (26144,   8,         10) /* Mass */
+     , (26144,   9,          0) /* ValidLocations - None */
+     , (26144,  11,         20) /* MaxStackSize */
+     , (26144,  12,          1) /* StackSize */
+     , (26144,  13,         10) /* StackUnitEncumbrance */
+     , (26144,  14,         10) /* StackUnitMass */
+     , (26144,  15,        500) /* StackUnitValue */
+     , (26144,  16,          8) /* ItemUseable - Contained */
+     , (26144,  18,          1) /* UiEffects - Magical */
+     , (26144,  19,        500) /* Value */
+     , (26144,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26144,  94,         16) /* TargetType - Creature */
+     , (26144, 106,        210) /* ItemSpellcraft */
+     , (26144, 107,         50) /* ItemCurMana */
+     , (26144, 108,         50) /* ItemMaxMana */
+     , (26144, 109,          0) /* ItemDifficulty */
+     , (26144, 110,          0) /* ItemAllegianceRankLimit */
+     , (26144, 150,        103) /* HookPlacement - Hook */
+     , (26144, 151,          2) /* HookType - Wall */
+     , (26144, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26144,  15, True ) /* LightsStatus */
+     , (26144,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26144, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26144,   1, 'Dryreach Beach Cottages Portal Gem') /* Name */
+     , (26144,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26144,   1,   33556769) /* Setup */
+     , (26144,   3,  536870932) /* SoundTable */
+     , (26144,   6,   67111919) /* PaletteBase */
+     , (26144,   7,  268435723) /* ClothingBase */
+     , (26144,   8,  100675760) /* Icon */
+     , (26144,  22,  872415275) /* PhysicsEffectTable */
+     , (26144,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26144,  31,      12487) /* LinkedPortalOne - Dryreach Beach Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26145 Dryreach Beach Manors Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26145 Dryreach Beach Manors Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26145;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26145, 'gemportaldryreachbeachmanors', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26145,   1,       2048) /* ItemType - Gem */
+     , (26145,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26145,   5,         10) /* EncumbranceVal */
+     , (26145,   8,         10) /* Mass */
+     , (26145,   9,          0) /* ValidLocations - None */
+     , (26145,  11,         20) /* MaxStackSize */
+     , (26145,  12,          1) /* StackSize */
+     , (26145,  13,         10) /* StackUnitEncumbrance */
+     , (26145,  14,         10) /* StackUnitMass */
+     , (26145,  15,        500) /* StackUnitValue */
+     , (26145,  16,          8) /* ItemUseable - Contained */
+     , (26145,  18,          1) /* UiEffects - Magical */
+     , (26145,  19,        500) /* Value */
+     , (26145,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26145,  94,         16) /* TargetType - Creature */
+     , (26145, 106,        210) /* ItemSpellcraft */
+     , (26145, 107,         50) /* ItemCurMana */
+     , (26145, 108,         50) /* ItemMaxMana */
+     , (26145, 109,          0) /* ItemDifficulty */
+     , (26145, 110,          0) /* ItemAllegianceRankLimit */
+     , (26145, 150,        103) /* HookPlacement - Hook */
+     , (26145, 151,          2) /* HookType - Wall */
+     , (26145, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26145,  15, True ) /* LightsStatus */
+     , (26145,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26145, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26145,   1, 'Dryreach Beach Manors Portal Gem') /* Name */
+     , (26145,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26145,   1,   33556769) /* Setup */
+     , (26145,   3,  536870932) /* SoundTable */
+     , (26145,   6,   67111919) /* PaletteBase */
+     , (26145,   7,  268435723) /* ClothingBase */
+     , (26145,   8,  100675760) /* Icon */
+     , (26145,  22,  872415275) /* PhysicsEffectTable */
+     , (26145,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26145,  31,      13100) /* LinkedPortalOne - Dryreach Beach Manors Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26146 Drytree Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26146 Drytree Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26146;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26146, 'gemportaldrytreesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26146,   1,       2048) /* ItemType - Gem */
+     , (26146,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26146,   5,         10) /* EncumbranceVal */
+     , (26146,   8,         10) /* Mass */
+     , (26146,   9,          0) /* ValidLocations - None */
+     , (26146,  11,         20) /* MaxStackSize */
+     , (26146,  12,          1) /* StackSize */
+     , (26146,  13,         10) /* StackUnitEncumbrance */
+     , (26146,  14,         10) /* StackUnitMass */
+     , (26146,  15,        500) /* StackUnitValue */
+     , (26146,  16,          8) /* ItemUseable - Contained */
+     , (26146,  18,          1) /* UiEffects - Magical */
+     , (26146,  19,        500) /* Value */
+     , (26146,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26146,  94,         16) /* TargetType - Creature */
+     , (26146, 106,        210) /* ItemSpellcraft */
+     , (26146, 107,         50) /* ItemCurMana */
+     , (26146, 108,         50) /* ItemMaxMana */
+     , (26146, 109,          0) /* ItemDifficulty */
+     , (26146, 110,          0) /* ItemAllegianceRankLimit */
+     , (26146, 150,        103) /* HookPlacement - Hook */
+     , (26146, 151,          2) /* HookType - Wall */
+     , (26146, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26146,  15, True ) /* LightsStatus */
+     , (26146,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26146, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26146,   1, 'Drytree Settlement Portal Gem') /* Name */
+     , (26146,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26146,   1,   33556769) /* Setup */
+     , (26146,   3,  536870932) /* SoundTable */
+     , (26146,   6,   67111919) /* PaletteBase */
+     , (26146,   7,  268435723) /* ClothingBase */
+     , (26146,   8,  100675760) /* Icon */
+     , (26146,  22,  872415275) /* PhysicsEffectTable */
+     , (26146,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26146,  31,      15154) /* LinkedPortalOne - Drytree Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26147 Dunes End Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26147 Dunes End Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26147;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26147, 'gemportaldunesendcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26147,   1,       2048) /* ItemType - Gem */
+     , (26147,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26147,   5,         10) /* EncumbranceVal */
+     , (26147,   8,         10) /* Mass */
+     , (26147,   9,          0) /* ValidLocations - None */
+     , (26147,  11,         20) /* MaxStackSize */
+     , (26147,  12,          1) /* StackSize */
+     , (26147,  13,         10) /* StackUnitEncumbrance */
+     , (26147,  14,         10) /* StackUnitMass */
+     , (26147,  15,        500) /* StackUnitValue */
+     , (26147,  16,          8) /* ItemUseable - Contained */
+     , (26147,  18,          1) /* UiEffects - Magical */
+     , (26147,  19,        500) /* Value */
+     , (26147,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26147,  94,         16) /* TargetType - Creature */
+     , (26147, 106,        210) /* ItemSpellcraft */
+     , (26147, 107,         50) /* ItemCurMana */
+     , (26147, 108,         50) /* ItemMaxMana */
+     , (26147, 109,          0) /* ItemDifficulty */
+     , (26147, 110,          0) /* ItemAllegianceRankLimit */
+     , (26147, 150,        103) /* HookPlacement - Hook */
+     , (26147, 151,          2) /* HookType - Wall */
+     , (26147, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26147,  15, True ) /* LightsStatus */
+     , (26147,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26147, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26147,   1, 'Dunes End Cottages Portal Gem') /* Name */
+     , (26147,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26147,   1,   33556769) /* Setup */
+     , (26147,   3,  536870932) /* SoundTable */
+     , (26147,   6,   67111919) /* PaletteBase */
+     , (26147,   7,  268435723) /* ClothingBase */
+     , (26147,   8,  100675760) /* Icon */
+     , (26147,  22,  872415275) /* PhysicsEffectTable */
+     , (26147,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26147,  31,      12488) /* LinkedPortalOne - Dunes End Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26148 Durglen Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26148 Durglen Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26148;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26148, 'gemportaldurglen', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26148,   1,       2048) /* ItemType - Gem */
+     , (26148,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26148,   5,         10) /* EncumbranceVal */
+     , (26148,   8,         10) /* Mass */
+     , (26148,   9,          0) /* ValidLocations - None */
+     , (26148,  11,         20) /* MaxStackSize */
+     , (26148,  12,          1) /* StackSize */
+     , (26148,  13,         10) /* StackUnitEncumbrance */
+     , (26148,  14,         10) /* StackUnitMass */
+     , (26148,  15,        500) /* StackUnitValue */
+     , (26148,  16,          8) /* ItemUseable - Contained */
+     , (26148,  18,          1) /* UiEffects - Magical */
+     , (26148,  19,        500) /* Value */
+     , (26148,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26148,  94,         16) /* TargetType - Creature */
+     , (26148, 106,        210) /* ItemSpellcraft */
+     , (26148, 107,         50) /* ItemCurMana */
+     , (26148, 108,         50) /* ItemMaxMana */
+     , (26148, 109,          0) /* ItemDifficulty */
+     , (26148, 110,          0) /* ItemAllegianceRankLimit */
+     , (26148, 150,        103) /* HookPlacement - Hook */
+     , (26148, 151,          2) /* HookType - Wall */
+     , (26148, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26148,  15, True ) /* LightsStatus */
+     , (26148,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26148, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26148,   1, 'Durglen Portal Gem') /* Name */
+     , (26148,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26148,   1,   33556769) /* Setup */
+     , (26148,   3,  536870932) /* SoundTable */
+     , (26148,   6,   67111919) /* PaletteBase */
+     , (26148,   7,  268435723) /* ClothingBase */
+     , (26148,   8,  100675760) /* Icon */
+     , (26148,  22,  872415275) /* PhysicsEffectTable */
+     , (26148,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26148,  31,      15155) /* LinkedPortalOne - Durglen Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26149 East Al-Jalima Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26149 East Al-Jalima Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26149;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26149, 'gemportaleastaljalimavillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26149,   1,       2048) /* ItemType - Gem */
+     , (26149,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26149,   5,         10) /* EncumbranceVal */
+     , (26149,   8,         10) /* Mass */
+     , (26149,   9,          0) /* ValidLocations - None */
+     , (26149,  11,         20) /* MaxStackSize */
+     , (26149,  12,          1) /* StackSize */
+     , (26149,  13,         10) /* StackUnitEncumbrance */
+     , (26149,  14,         10) /* StackUnitMass */
+     , (26149,  15,        500) /* StackUnitValue */
+     , (26149,  16,          8) /* ItemUseable - Contained */
+     , (26149,  18,          1) /* UiEffects - Magical */
+     , (26149,  19,        500) /* Value */
+     , (26149,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26149,  94,         16) /* TargetType - Creature */
+     , (26149, 106,        210) /* ItemSpellcraft */
+     , (26149, 107,         50) /* ItemCurMana */
+     , (26149, 108,         50) /* ItemMaxMana */
+     , (26149, 109,          0) /* ItemDifficulty */
+     , (26149, 110,          0) /* ItemAllegianceRankLimit */
+     , (26149, 150,        103) /* HookPlacement - Hook */
+     , (26149, 151,          2) /* HookType - Wall */
+     , (26149, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26149,  15, True ) /* LightsStatus */
+     , (26149,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26149, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26149,   1, 'East Al-Jalima Villas Portal Gem') /* Name */
+     , (26149,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26149,   1,   33556769) /* Setup */
+     , (26149,   3,  536870932) /* SoundTable */
+     , (26149,   6,   67111919) /* PaletteBase */
+     , (26149,   7,  268435723) /* ClothingBase */
+     , (26149,   8,  100675760) /* Icon */
+     , (26149,  22,  872415275) /* PhysicsEffectTable */
+     , (26149,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26149,  31,      15156) /* LinkedPortalOne - East Al-Jalima Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26150 East Arwic Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26150 East Arwic Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26150;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26150, 'gemportaleastarwiccottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26150,   1,       2048) /* ItemType - Gem */
+     , (26150,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26150,   5,         10) /* EncumbranceVal */
+     , (26150,   8,         10) /* Mass */
+     , (26150,   9,          0) /* ValidLocations - None */
+     , (26150,  11,         20) /* MaxStackSize */
+     , (26150,  12,          1) /* StackSize */
+     , (26150,  13,         10) /* StackUnitEncumbrance */
+     , (26150,  14,         10) /* StackUnitMass */
+     , (26150,  15,        500) /* StackUnitValue */
+     , (26150,  16,          8) /* ItemUseable - Contained */
+     , (26150,  18,          1) /* UiEffects - Magical */
+     , (26150,  19,        500) /* Value */
+     , (26150,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26150,  94,         16) /* TargetType - Creature */
+     , (26150, 106,        210) /* ItemSpellcraft */
+     , (26150, 107,         50) /* ItemCurMana */
+     , (26150, 108,         50) /* ItemMaxMana */
+     , (26150, 109,          0) /* ItemDifficulty */
+     , (26150, 110,          0) /* ItemAllegianceRankLimit */
+     , (26150, 150,        103) /* HookPlacement - Hook */
+     , (26150, 151,          2) /* HookType - Wall */
+     , (26150, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26150,  15, True ) /* LightsStatus */
+     , (26150,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26150, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26150,   1, 'East Arwic Cottages Portal Gem') /* Name */
+     , (26150,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26150,   1,   33556769) /* Setup */
+     , (26150,   3,  536870932) /* SoundTable */
+     , (26150,   6,   67111919) /* PaletteBase */
+     , (26150,   7,  268435723) /* ClothingBase */
+     , (26150,   8,  100675760) /* Icon */
+     , (26150,  22,  872415275) /* PhysicsEffectTable */
+     , (26150,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26150,  31,      14622) /* LinkedPortalOne - East Arwic Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26151 West Baishi Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26151 West Baishi Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26151;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26151, 'gemportaleastbaishisettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26151,   1,       2048) /* ItemType - Gem */
+     , (26151,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26151,   5,         10) /* EncumbranceVal */
+     , (26151,   8,         10) /* Mass */
+     , (26151,   9,          0) /* ValidLocations - None */
+     , (26151,  11,         20) /* MaxStackSize */
+     , (26151,  12,          1) /* StackSize */
+     , (26151,  13,         10) /* StackUnitEncumbrance */
+     , (26151,  14,         10) /* StackUnitMass */
+     , (26151,  15,        500) /* StackUnitValue */
+     , (26151,  16,          8) /* ItemUseable - Contained */
+     , (26151,  18,          1) /* UiEffects - Magical */
+     , (26151,  19,        500) /* Value */
+     , (26151,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26151,  94,         16) /* TargetType - Creature */
+     , (26151, 106,        210) /* ItemSpellcraft */
+     , (26151, 107,         50) /* ItemCurMana */
+     , (26151, 108,         50) /* ItemMaxMana */
+     , (26151, 109,          0) /* ItemDifficulty */
+     , (26151, 110,          0) /* ItemAllegianceRankLimit */
+     , (26151, 150,        103) /* HookPlacement - Hook */
+     , (26151, 151,          2) /* HookType - Wall */
+     , (26151, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26151,  15, True ) /* LightsStatus */
+     , (26151,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26151, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26151,   1, 'West Baishi Settlement Portal Gem') /* Name */
+     , (26151,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26151,   1,   33556769) /* Setup */
+     , (26151,   3,  536870932) /* SoundTable */
+     , (26151,   6,   67111919) /* PaletteBase */
+     , (26151,   7,  268435723) /* ClothingBase */
+     , (26151,   8,  100675760) /* Icon */
+     , (26151,  22,  872415275) /* PhysicsEffectTable */
+     , (26151,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26151,  31,      14261) /* LinkedPortalOne - West Baishi Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26152 East Danby Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26152 East Danby Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26152;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26152, 'gemportaleastdanby', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26152,   1,       2048) /* ItemType - Gem */
+     , (26152,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26152,   5,         10) /* EncumbranceVal */
+     , (26152,   8,         10) /* Mass */
+     , (26152,   9,          0) /* ValidLocations - None */
+     , (26152,  11,         20) /* MaxStackSize */
+     , (26152,  12,          1) /* StackSize */
+     , (26152,  13,         10) /* StackUnitEncumbrance */
+     , (26152,  14,         10) /* StackUnitMass */
+     , (26152,  15,        500) /* StackUnitValue */
+     , (26152,  16,          8) /* ItemUseable - Contained */
+     , (26152,  18,          1) /* UiEffects - Magical */
+     , (26152,  19,        500) /* Value */
+     , (26152,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26152,  94,         16) /* TargetType - Creature */
+     , (26152, 106,        210) /* ItemSpellcraft */
+     , (26152, 107,         50) /* ItemCurMana */
+     , (26152, 108,         50) /* ItemMaxMana */
+     , (26152, 109,          0) /* ItemDifficulty */
+     , (26152, 110,          0) /* ItemAllegianceRankLimit */
+     , (26152, 150,        103) /* HookPlacement - Hook */
+     , (26152, 151,          2) /* HookType - Wall */
+     , (26152, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26152,  15, True ) /* LightsStatus */
+     , (26152,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26152, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26152,   1, 'East Danby Portal Gem') /* Name */
+     , (26152,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26152,   1,   33556769) /* Setup */
+     , (26152,   3,  536870932) /* SoundTable */
+     , (26152,   6,   67111919) /* PaletteBase */
+     , (26152,   7,  268435723) /* ClothingBase */
+     , (26152,   8,  100675760) /* Icon */
+     , (26152,  22,  872415275) /* PhysicsEffectTable */
+     , (26152,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26152,  31,      13101) /* LinkedPortalOne - East Danby Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26153 East Esper Valley  Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26153 East Esper Valley  Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26153;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26153, 'gemportaleastespervalley', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26153,   1,       2048) /* ItemType - Gem */
+     , (26153,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26153,   5,         10) /* EncumbranceVal */
+     , (26153,   8,         10) /* Mass */
+     , (26153,   9,          0) /* ValidLocations - None */
+     , (26153,  11,         20) /* MaxStackSize */
+     , (26153,  12,          1) /* StackSize */
+     , (26153,  13,         10) /* StackUnitEncumbrance */
+     , (26153,  14,         10) /* StackUnitMass */
+     , (26153,  15,        500) /* StackUnitValue */
+     , (26153,  16,          8) /* ItemUseable - Contained */
+     , (26153,  18,          1) /* UiEffects - Magical */
+     , (26153,  19,        500) /* Value */
+     , (26153,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26153,  94,         16) /* TargetType - Creature */
+     , (26153, 106,        210) /* ItemSpellcraft */
+     , (26153, 107,         50) /* ItemCurMana */
+     , (26153, 108,         50) /* ItemMaxMana */
+     , (26153, 109,          0) /* ItemDifficulty */
+     , (26153, 110,          0) /* ItemAllegianceRankLimit */
+     , (26153, 150,        103) /* HookPlacement - Hook */
+     , (26153, 151,          2) /* HookType - Wall */
+     , (26153, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26153,  15, True ) /* LightsStatus */
+     , (26153,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26153, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26153,   1, 'East Esper Valley  Portal Gem') /* Name */
+     , (26153,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26153,   1,   33556769) /* Setup */
+     , (26153,   3,  536870932) /* SoundTable */
+     , (26153,   6,   67111919) /* PaletteBase */
+     , (26153,   7,  268435723) /* ClothingBase */
+     , (26153,   8,  100675760) /* Icon */
+     , (26153,  22,  872415275) /* PhysicsEffectTable */
+     , (26153,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26153,  31,      12489) /* LinkedPortalOne - East Esper Valley  Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26154 East Lytelthorpe Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26154 East Lytelthorpe Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26154;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26154, 'gemportaleastlytelthorpesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26154,   1,       2048) /* ItemType - Gem */
+     , (26154,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26154,   5,         10) /* EncumbranceVal */
+     , (26154,   8,         10) /* Mass */
+     , (26154,   9,          0) /* ValidLocations - None */
+     , (26154,  11,         20) /* MaxStackSize */
+     , (26154,  12,          1) /* StackSize */
+     , (26154,  13,         10) /* StackUnitEncumbrance */
+     , (26154,  14,         10) /* StackUnitMass */
+     , (26154,  15,        500) /* StackUnitValue */
+     , (26154,  16,          8) /* ItemUseable - Contained */
+     , (26154,  18,          1) /* UiEffects - Magical */
+     , (26154,  19,        500) /* Value */
+     , (26154,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26154,  94,         16) /* TargetType - Creature */
+     , (26154, 106,        210) /* ItemSpellcraft */
+     , (26154, 107,         50) /* ItemCurMana */
+     , (26154, 108,         50) /* ItemMaxMana */
+     , (26154, 109,          0) /* ItemDifficulty */
+     , (26154, 110,          0) /* ItemAllegianceRankLimit */
+     , (26154, 150,        103) /* HookPlacement - Hook */
+     , (26154, 151,          2) /* HookType - Wall */
+     , (26154, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26154,  15, True ) /* LightsStatus */
+     , (26154,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26154, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26154,   1, 'East Lytelthorpe Settlement Portal Gem') /* Name */
+     , (26154,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26154,   1,   33556769) /* Setup */
+     , (26154,   3,  536870932) /* SoundTable */
+     , (26154,   6,   67111919) /* PaletteBase */
+     , (26154,   7,  268435723) /* ClothingBase */
+     , (26154,   8,  100675760) /* Icon */
+     , (26154,  22,  872415275) /* PhysicsEffectTable */
+     , (26154,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26154,  31,      12490) /* LinkedPortalOne - East Lytelthorpe Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26155 East Morntide Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26155 East Morntide Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26155;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26155, 'gemportaleastmorntidesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26155,   1,       2048) /* ItemType - Gem */
+     , (26155,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26155,   5,         10) /* EncumbranceVal */
+     , (26155,   8,         10) /* Mass */
+     , (26155,   9,          0) /* ValidLocations - None */
+     , (26155,  11,         20) /* MaxStackSize */
+     , (26155,  12,          1) /* StackSize */
+     , (26155,  13,         10) /* StackUnitEncumbrance */
+     , (26155,  14,         10) /* StackUnitMass */
+     , (26155,  15,        500) /* StackUnitValue */
+     , (26155,  16,          8) /* ItemUseable - Contained */
+     , (26155,  18,          1) /* UiEffects - Magical */
+     , (26155,  19,        500) /* Value */
+     , (26155,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26155,  94,         16) /* TargetType - Creature */
+     , (26155, 106,        210) /* ItemSpellcraft */
+     , (26155, 107,         50) /* ItemCurMana */
+     , (26155, 108,         50) /* ItemMaxMana */
+     , (26155, 109,          0) /* ItemDifficulty */
+     , (26155, 110,          0) /* ItemAllegianceRankLimit */
+     , (26155, 150,        103) /* HookPlacement - Hook */
+     , (26155, 151,          2) /* HookType - Wall */
+     , (26155, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26155,  15, True ) /* LightsStatus */
+     , (26155,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26155, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26155,   1, 'East Morntide Settlement Portal Gem') /* Name */
+     , (26155,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26155,   1,   33556769) /* Setup */
+     , (26155,   3,  536870932) /* SoundTable */
+     , (26155,   6,   67111919) /* PaletteBase */
+     , (26155,   7,  268435723) /* ClothingBase */
+     , (26155,   8,  100675760) /* Icon */
+     , (26155,  22,  872415275) /* PhysicsEffectTable */
+     , (26155,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26155,  31,      15157) /* LinkedPortalOne - East Morntide Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26156 East Morntide Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26156 East Morntide Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26156;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26156, 'gemportaleastmorntidevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26156,   1,       2048) /* ItemType - Gem */
+     , (26156,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26156,   5,         10) /* EncumbranceVal */
+     , (26156,   8,         10) /* Mass */
+     , (26156,   9,          0) /* ValidLocations - None */
+     , (26156,  11,         20) /* MaxStackSize */
+     , (26156,  12,          1) /* StackSize */
+     , (26156,  13,         10) /* StackUnitEncumbrance */
+     , (26156,  14,         10) /* StackUnitMass */
+     , (26156,  15,        500) /* StackUnitValue */
+     , (26156,  16,          8) /* ItemUseable - Contained */
+     , (26156,  18,          1) /* UiEffects - Magical */
+     , (26156,  19,        500) /* Value */
+     , (26156,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26156,  94,         16) /* TargetType - Creature */
+     , (26156, 106,        210) /* ItemSpellcraft */
+     , (26156, 107,         50) /* ItemCurMana */
+     , (26156, 108,         50) /* ItemMaxMana */
+     , (26156, 109,          0) /* ItemDifficulty */
+     , (26156, 110,          0) /* ItemAllegianceRankLimit */
+     , (26156, 150,        103) /* HookPlacement - Hook */
+     , (26156, 151,          2) /* HookType - Wall */
+     , (26156, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26156,  15, True ) /* LightsStatus */
+     , (26156,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26156, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26156,   1, 'East Morntide Villas Portal Gem') /* Name */
+     , (26156,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26156,   1,   33556769) /* Setup */
+     , (26156,   3,  536870932) /* SoundTable */
+     , (26156,   6,   67111919) /* PaletteBase */
+     , (26156,   7,  268435723) /* ClothingBase */
+     , (26156,   8,  100675760) /* Icon */
+     , (26156,  22,  872415275) /* PhysicsEffectTable */
+     , (26156,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26156,  31,      14623) /* LinkedPortalOne - East Morntide Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26157 East Plateau Villa Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26157 East Plateau Villa Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26157;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26157, 'gemportaleastplateauvilla', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26157,   1,       2048) /* ItemType - Gem */
+     , (26157,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26157,   5,         10) /* EncumbranceVal */
+     , (26157,   8,         10) /* Mass */
+     , (26157,   9,          0) /* ValidLocations - None */
+     , (26157,  11,         20) /* MaxStackSize */
+     , (26157,  12,          1) /* StackSize */
+     , (26157,  13,         10) /* StackUnitEncumbrance */
+     , (26157,  14,         10) /* StackUnitMass */
+     , (26157,  15,        500) /* StackUnitValue */
+     , (26157,  16,          8) /* ItemUseable - Contained */
+     , (26157,  18,          1) /* UiEffects - Magical */
+     , (26157,  19,        500) /* Value */
+     , (26157,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26157,  94,         16) /* TargetType - Creature */
+     , (26157, 106,        210) /* ItemSpellcraft */
+     , (26157, 107,         50) /* ItemCurMana */
+     , (26157, 108,         50) /* ItemMaxMana */
+     , (26157, 109,          0) /* ItemDifficulty */
+     , (26157, 110,          0) /* ItemAllegianceRankLimit */
+     , (26157, 150,        103) /* HookPlacement - Hook */
+     , (26157, 151,          2) /* HookType - Wall */
+     , (26157, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26157,  15, True ) /* LightsStatus */
+     , (26157,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26157, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26157,   1, 'East Plateau Villa Portal Gem') /* Name */
+     , (26157,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26157,   1,   33556769) /* Setup */
+     , (26157,   3,  536870932) /* SoundTable */
+     , (26157,   6,   67111919) /* PaletteBase */
+     , (26157,   7,  268435723) /* ClothingBase */
+     , (26157,   8,  100675760) /* Icon */
+     , (26157,  22,  872415275) /* PhysicsEffectTable */
+     , (26157,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26157,  31,      14624) /* LinkedPortalOne - East Plateau Villa Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26158 East Rithwic Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26158 East Rithwic Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26158;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26158, 'gemportaleastrithwicestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26158,   1,       2048) /* ItemType - Gem */
+     , (26158,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26158,   5,         10) /* EncumbranceVal */
+     , (26158,   8,         10) /* Mass */
+     , (26158,   9,          0) /* ValidLocations - None */
+     , (26158,  11,         20) /* MaxStackSize */
+     , (26158,  12,          1) /* StackSize */
+     , (26158,  13,         10) /* StackUnitEncumbrance */
+     , (26158,  14,         10) /* StackUnitMass */
+     , (26158,  15,        500) /* StackUnitValue */
+     , (26158,  16,          8) /* ItemUseable - Contained */
+     , (26158,  18,          1) /* UiEffects - Magical */
+     , (26158,  19,        500) /* Value */
+     , (26158,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26158,  94,         16) /* TargetType - Creature */
+     , (26158, 106,        210) /* ItemSpellcraft */
+     , (26158, 107,         50) /* ItemCurMana */
+     , (26158, 108,         50) /* ItemMaxMana */
+     , (26158, 109,          0) /* ItemDifficulty */
+     , (26158, 110,          0) /* ItemAllegianceRankLimit */
+     , (26158, 150,        103) /* HookPlacement - Hook */
+     , (26158, 151,          2) /* HookType - Wall */
+     , (26158, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26158,  15, True ) /* LightsStatus */
+     , (26158,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26158, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26158,   1, 'East Rithwic Estates Portal Gem') /* Name */
+     , (26158,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26158,   1,   33556769) /* Setup */
+     , (26158,   3,  536870932) /* SoundTable */
+     , (26158,   6,   67111919) /* PaletteBase */
+     , (26158,   7,  268435723) /* ClothingBase */
+     , (26158,   8,  100675760) /* Icon */
+     , (26158,  22,  872415275) /* PhysicsEffectTable */
+     , (26158,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26158,  31,      13102) /* LinkedPortalOne - East Rithwic Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26159 East Sawato Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26159 East Sawato Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26159;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26159, 'gemportaleastsawatocottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26159,   1,       2048) /* ItemType - Gem */
+     , (26159,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26159,   5,         10) /* EncumbranceVal */
+     , (26159,   8,         10) /* Mass */
+     , (26159,   9,          0) /* ValidLocations - None */
+     , (26159,  11,         20) /* MaxStackSize */
+     , (26159,  12,          1) /* StackSize */
+     , (26159,  13,         10) /* StackUnitEncumbrance */
+     , (26159,  14,         10) /* StackUnitMass */
+     , (26159,  15,        500) /* StackUnitValue */
+     , (26159,  16,          8) /* ItemUseable - Contained */
+     , (26159,  18,          1) /* UiEffects - Magical */
+     , (26159,  19,        500) /* Value */
+     , (26159,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26159,  94,         16) /* TargetType - Creature */
+     , (26159, 106,        210) /* ItemSpellcraft */
+     , (26159, 107,         50) /* ItemCurMana */
+     , (26159, 108,         50) /* ItemMaxMana */
+     , (26159, 109,          0) /* ItemDifficulty */
+     , (26159, 110,          0) /* ItemAllegianceRankLimit */
+     , (26159, 150,        103) /* HookPlacement - Hook */
+     , (26159, 151,          2) /* HookType - Wall */
+     , (26159, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26159,  15, True ) /* LightsStatus */
+     , (26159,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26159, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26159,   1, 'East Sawato Cottages Portal Gem') /* Name */
+     , (26159,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26159,   1,   33556769) /* Setup */
+     , (26159,   3,  536870932) /* SoundTable */
+     , (26159,   6,   67111919) /* PaletteBase */
+     , (26159,   7,  268435723) /* ClothingBase */
+     , (26159,   8,  100675760) /* Icon */
+     , (26159,  22,  872415275) /* PhysicsEffectTable */
+     , (26159,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26159,  31,      12491) /* LinkedPortalOne - West Sawato Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26160 East Sawato Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26160 East Sawato Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26160;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26160, 'gemportaleastsawatosettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26160,   1,       2048) /* ItemType - Gem */
+     , (26160,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26160,   5,         10) /* EncumbranceVal */
+     , (26160,   8,         10) /* Mass */
+     , (26160,   9,          0) /* ValidLocations - None */
+     , (26160,  11,         20) /* MaxStackSize */
+     , (26160,  12,          1) /* StackSize */
+     , (26160,  13,         10) /* StackUnitEncumbrance */
+     , (26160,  14,         10) /* StackUnitMass */
+     , (26160,  15,        500) /* StackUnitValue */
+     , (26160,  16,          8) /* ItemUseable - Contained */
+     , (26160,  18,          1) /* UiEffects - Magical */
+     , (26160,  19,        500) /* Value */
+     , (26160,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26160,  94,         16) /* TargetType - Creature */
+     , (26160, 106,        210) /* ItemSpellcraft */
+     , (26160, 107,         50) /* ItemCurMana */
+     , (26160, 108,         50) /* ItemMaxMana */
+     , (26160, 109,          0) /* ItemDifficulty */
+     , (26160, 110,          0) /* ItemAllegianceRankLimit */
+     , (26160, 150,        103) /* HookPlacement - Hook */
+     , (26160, 151,          2) /* HookType - Wall */
+     , (26160, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26160,  15, True ) /* LightsStatus */
+     , (26160,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26160, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26160,   1, 'East Sawato Settlement Portal Gem') /* Name */
+     , (26160,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26160,   1,   33556769) /* Setup */
+     , (26160,   3,  536870932) /* SoundTable */
+     , (26160,   6,   67111919) /* PaletteBase */
+     , (26160,   7,  268435723) /* ClothingBase */
+     , (26160,   8,  100675760) /* Icon */
+     , (26160,  22,  872415275) /* PhysicsEffectTable */
+     , (26160,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26160,  31,      12492) /* LinkedPortalOne - East Sawato Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26161 East Span Way Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26161 East Span Way Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26161;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26161, 'gemportaleastspanwaysettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26161,   1,       2048) /* ItemType - Gem */
+     , (26161,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26161,   5,         10) /* EncumbranceVal */
+     , (26161,   8,         10) /* Mass */
+     , (26161,   9,          0) /* ValidLocations - None */
+     , (26161,  11,         20) /* MaxStackSize */
+     , (26161,  12,          1) /* StackSize */
+     , (26161,  13,         10) /* StackUnitEncumbrance */
+     , (26161,  14,         10) /* StackUnitMass */
+     , (26161,  15,        500) /* StackUnitValue */
+     , (26161,  16,          8) /* ItemUseable - Contained */
+     , (26161,  18,          1) /* UiEffects - Magical */
+     , (26161,  19,        500) /* Value */
+     , (26161,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26161,  94,         16) /* TargetType - Creature */
+     , (26161, 106,        210) /* ItemSpellcraft */
+     , (26161, 107,         50) /* ItemCurMana */
+     , (26161, 108,         50) /* ItemMaxMana */
+     , (26161, 109,          0) /* ItemDifficulty */
+     , (26161, 110,          0) /* ItemAllegianceRankLimit */
+     , (26161, 150,        103) /* HookPlacement - Hook */
+     , (26161, 151,          2) /* HookType - Wall */
+     , (26161, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26161,  15, True ) /* LightsStatus */
+     , (26161,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26161, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26161,   1, 'East Span Way Settlement Portal Gem') /* Name */
+     , (26161,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26161,   1,   33556769) /* Setup */
+     , (26161,   3,  536870932) /* SoundTable */
+     , (26161,   6,   67111919) /* PaletteBase */
+     , (26161,   7,  268435723) /* ClothingBase */
+     , (26161,   8,  100675760) /* Icon */
+     , (26161,  22,  872415275) /* PhysicsEffectTable */
+     , (26161,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26161,  31,      12493) /* LinkedPortalOne - East Span Way Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26162 Eaves of Tiofor Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26162 Eaves of Tiofor Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26162;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26162, 'gemportaleavesoftioforsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26162,   1,       2048) /* ItemType - Gem */
+     , (26162,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26162,   5,         10) /* EncumbranceVal */
+     , (26162,   8,         10) /* Mass */
+     , (26162,   9,          0) /* ValidLocations - None */
+     , (26162,  11,         20) /* MaxStackSize */
+     , (26162,  12,          1) /* StackSize */
+     , (26162,  13,         10) /* StackUnitEncumbrance */
+     , (26162,  14,         10) /* StackUnitMass */
+     , (26162,  15,        500) /* StackUnitValue */
+     , (26162,  16,          8) /* ItemUseable - Contained */
+     , (26162,  18,          1) /* UiEffects - Magical */
+     , (26162,  19,        500) /* Value */
+     , (26162,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26162,  94,         16) /* TargetType - Creature */
+     , (26162, 106,        210) /* ItemSpellcraft */
+     , (26162, 107,         50) /* ItemCurMana */
+     , (26162, 108,         50) /* ItemMaxMana */
+     , (26162, 109,          0) /* ItemDifficulty */
+     , (26162, 110,          0) /* ItemAllegianceRankLimit */
+     , (26162, 150,        103) /* HookPlacement - Hook */
+     , (26162, 151,          2) /* HookType - Wall */
+     , (26162, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26162,  15, True ) /* LightsStatus */
+     , (26162,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26162, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26162,   1, 'Eaves of Tiofor Settlement Portal Gem') /* Name */
+     , (26162,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26162,   1,   33556769) /* Setup */
+     , (26162,   3,  536870932) /* SoundTable */
+     , (26162,   6,   67111919) /* PaletteBase */
+     , (26162,   7,  268435723) /* ClothingBase */
+     , (26162,   8,  100675760) /* Icon */
+     , (26162,  22,  872415275) /* PhysicsEffectTable */
+     , (26162,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26162,  31,      12494) /* LinkedPortalOne - Eaves of Tiofor Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26163 Ebbing Tide Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26163 Ebbing Tide Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26163;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26163, 'gemportalebbingtidevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26163,   1,       2048) /* ItemType - Gem */
+     , (26163,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26163,   5,         10) /* EncumbranceVal */
+     , (26163,   8,         10) /* Mass */
+     , (26163,   9,          0) /* ValidLocations - None */
+     , (26163,  11,         20) /* MaxStackSize */
+     , (26163,  12,          1) /* StackSize */
+     , (26163,  13,         10) /* StackUnitEncumbrance */
+     , (26163,  14,         10) /* StackUnitMass */
+     , (26163,  15,        500) /* StackUnitValue */
+     , (26163,  16,          8) /* ItemUseable - Contained */
+     , (26163,  18,          1) /* UiEffects - Magical */
+     , (26163,  19,        500) /* Value */
+     , (26163,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26163,  94,         16) /* TargetType - Creature */
+     , (26163, 106,        210) /* ItemSpellcraft */
+     , (26163, 107,         50) /* ItemCurMana */
+     , (26163, 108,         50) /* ItemMaxMana */
+     , (26163, 109,          0) /* ItemDifficulty */
+     , (26163, 110,          0) /* ItemAllegianceRankLimit */
+     , (26163, 150,        103) /* HookPlacement - Hook */
+     , (26163, 151,          2) /* HookType - Wall */
+     , (26163, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26163,  15, True ) /* LightsStatus */
+     , (26163,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26163, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26163,   1, 'Ebbing Tide Villas Portal Gem') /* Name */
+     , (26163,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26163,   1,   33556769) /* Setup */
+     , (26163,   3,  536870932) /* SoundTable */
+     , (26163,   6,   67111919) /* PaletteBase */
+     , (26163,   7,  268435723) /* ClothingBase */
+     , (26163,   8,  100675760) /* Icon */
+     , (26163,  22,  872415275) /* PhysicsEffectTable */
+     , (26163,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26163,  31,      19143) /* LinkedPortalOne - Ebbing Tide Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26164 Embara Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26164 Embara Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26164;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26164, 'gemportalembara', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26164,   1,       2048) /* ItemType - Gem */
+     , (26164,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26164,   5,         10) /* EncumbranceVal */
+     , (26164,   8,         10) /* Mass */
+     , (26164,   9,          0) /* ValidLocations - None */
+     , (26164,  11,         20) /* MaxStackSize */
+     , (26164,  12,          1) /* StackSize */
+     , (26164,  13,         10) /* StackUnitEncumbrance */
+     , (26164,  14,         10) /* StackUnitMass */
+     , (26164,  15,        500) /* StackUnitValue */
+     , (26164,  16,          8) /* ItemUseable - Contained */
+     , (26164,  18,          1) /* UiEffects - Magical */
+     , (26164,  19,        500) /* Value */
+     , (26164,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26164,  94,         16) /* TargetType - Creature */
+     , (26164, 106,        210) /* ItemSpellcraft */
+     , (26164, 107,         50) /* ItemCurMana */
+     , (26164, 108,         50) /* ItemMaxMana */
+     , (26164, 109,          0) /* ItemDifficulty */
+     , (26164, 110,          0) /* ItemAllegianceRankLimit */
+     , (26164, 150,        103) /* HookPlacement - Hook */
+     , (26164, 151,          2) /* HookType - Wall */
+     , (26164, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26164,  15, True ) /* LightsStatus */
+     , (26164,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26164, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26164,   1, 'Embara Portal Gem') /* Name */
+     , (26164,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26164,   1,   33556769) /* Setup */
+     , (26164,   3,  536870932) /* SoundTable */
+     , (26164,   6,   67111919) /* PaletteBase */
+     , (26164,   7,  268435723) /* ClothingBase */
+     , (26164,   8,  100675760) /* Icon */
+     , (26164,  22,  872415275) /* PhysicsEffectTable */
+     , (26164,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26164,  31,      14625) /* LinkedPortalOne - Embara Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26165 Empyrean Fields Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26165 Empyrean Fields Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26165;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26165, 'gemportalempyreanfieldscottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26165,   1,       2048) /* ItemType - Gem */
+     , (26165,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26165,   5,         10) /* EncumbranceVal */
+     , (26165,   8,         10) /* Mass */
+     , (26165,   9,          0) /* ValidLocations - None */
+     , (26165,  11,         20) /* MaxStackSize */
+     , (26165,  12,          1) /* StackSize */
+     , (26165,  13,         10) /* StackUnitEncumbrance */
+     , (26165,  14,         10) /* StackUnitMass */
+     , (26165,  15,        500) /* StackUnitValue */
+     , (26165,  16,          8) /* ItemUseable - Contained */
+     , (26165,  18,          1) /* UiEffects - Magical */
+     , (26165,  19,        500) /* Value */
+     , (26165,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26165,  94,         16) /* TargetType - Creature */
+     , (26165, 106,        210) /* ItemSpellcraft */
+     , (26165, 107,         50) /* ItemCurMana */
+     , (26165, 108,         50) /* ItemMaxMana */
+     , (26165, 109,          0) /* ItemDifficulty */
+     , (26165, 110,          0) /* ItemAllegianceRankLimit */
+     , (26165, 150,        103) /* HookPlacement - Hook */
+     , (26165, 151,          2) /* HookType - Wall */
+     , (26165, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26165,  15, True ) /* LightsStatus */
+     , (26165,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26165, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26165,   1, 'Empyrean Fields Cottages Portal Gem') /* Name */
+     , (26165,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26165,   1,   33556769) /* Setup */
+     , (26165,   3,  536870932) /* SoundTable */
+     , (26165,   6,   67111919) /* PaletteBase */
+     , (26165,   7,  268435723) /* ClothingBase */
+     , (26165,   8,  100675760) /* Icon */
+     , (26165,  22,  872415275) /* PhysicsEffectTable */
+     , (26165,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26165,  31,      14626) /* LinkedPortalOne - Empyrean Fields Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26166 Empyrean Shore Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26166 Empyrean Shore Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26166;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26166, 'gemportalempyreanshorevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26166,   1,       2048) /* ItemType - Gem */
+     , (26166,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26166,   5,         10) /* EncumbranceVal */
+     , (26166,   8,         10) /* Mass */
+     , (26166,   9,          0) /* ValidLocations - None */
+     , (26166,  11,         20) /* MaxStackSize */
+     , (26166,  12,          1) /* StackSize */
+     , (26166,  13,         10) /* StackUnitEncumbrance */
+     , (26166,  14,         10) /* StackUnitMass */
+     , (26166,  15,        500) /* StackUnitValue */
+     , (26166,  16,          8) /* ItemUseable - Contained */
+     , (26166,  18,          1) /* UiEffects - Magical */
+     , (26166,  19,        500) /* Value */
+     , (26166,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26166,  94,         16) /* TargetType - Creature */
+     , (26166, 106,        210) /* ItemSpellcraft */
+     , (26166, 107,         50) /* ItemCurMana */
+     , (26166, 108,         50) /* ItemMaxMana */
+     , (26166, 109,          0) /* ItemDifficulty */
+     , (26166, 110,          0) /* ItemAllegianceRankLimit */
+     , (26166, 150,        103) /* HookPlacement - Hook */
+     , (26166, 151,          2) /* HookType - Wall */
+     , (26166, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26166,  15, True ) /* LightsStatus */
+     , (26166,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26166, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26166,   1, 'Empyrean Shore Villas Portal Gem') /* Name */
+     , (26166,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26166,   1,   33556769) /* Setup */
+     , (26166,   3,  536870932) /* SoundTable */
+     , (26166,   6,   67111919) /* PaletteBase */
+     , (26166,   7,  268435723) /* ClothingBase */
+     , (26166,   8,  100675760) /* Icon */
+     , (26166,  22,  872415275) /* PhysicsEffectTable */
+     , (26166,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26166,  31,      14627) /* LinkedPortalOne - Empyrean Shore Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26167 Enchanter's Meadow Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26167 Enchanter's Meadow Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26167;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26167, 'gemportalenchantersmeadow', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26167,   1,       2048) /* ItemType - Gem */
+     , (26167,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26167,   5,         10) /* EncumbranceVal */
+     , (26167,   8,         10) /* Mass */
+     , (26167,   9,          0) /* ValidLocations - None */
+     , (26167,  11,         20) /* MaxStackSize */
+     , (26167,  12,          1) /* StackSize */
+     , (26167,  13,         10) /* StackUnitEncumbrance */
+     , (26167,  14,         10) /* StackUnitMass */
+     , (26167,  15,        500) /* StackUnitValue */
+     , (26167,  16,          8) /* ItemUseable - Contained */
+     , (26167,  18,          1) /* UiEffects - Magical */
+     , (26167,  19,        500) /* Value */
+     , (26167,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26167,  94,         16) /* TargetType - Creature */
+     , (26167, 106,        210) /* ItemSpellcraft */
+     , (26167, 107,         50) /* ItemCurMana */
+     , (26167, 108,         50) /* ItemMaxMana */
+     , (26167, 109,          0) /* ItemDifficulty */
+     , (26167, 110,          0) /* ItemAllegianceRankLimit */
+     , (26167, 150,        103) /* HookPlacement - Hook */
+     , (26167, 151,          2) /* HookType - Wall */
+     , (26167, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26167,  15, True ) /* LightsStatus */
+     , (26167,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26167, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26167,   1, 'Enchanter''s Meadow Portal Gem') /* Name */
+     , (26167,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26167,   1,   33556769) /* Setup */
+     , (26167,   3,  536870932) /* SoundTable */
+     , (26167,   6,   67111919) /* PaletteBase */
+     , (26167,   7,  268435723) /* ClothingBase */
+     , (26167,   8,  100675760) /* Icon */
+     , (26167,  22,  872415275) /* PhysicsEffectTable */
+     , (26167,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26167,  31,      13103) /* LinkedPortalOne - Enchanter's Meadow Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26168 Eotensfang Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26168 Eotensfang Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26168;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26168, 'gemportaleotensfangcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26168,   1,       2048) /* ItemType - Gem */
+     , (26168,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26168,   5,         10) /* EncumbranceVal */
+     , (26168,   8,         10) /* Mass */
+     , (26168,   9,          0) /* ValidLocations - None */
+     , (26168,  11,         20) /* MaxStackSize */
+     , (26168,  12,          1) /* StackSize */
+     , (26168,  13,         10) /* StackUnitEncumbrance */
+     , (26168,  14,         10) /* StackUnitMass */
+     , (26168,  15,        500) /* StackUnitValue */
+     , (26168,  16,          8) /* ItemUseable - Contained */
+     , (26168,  18,          1) /* UiEffects - Magical */
+     , (26168,  19,        500) /* Value */
+     , (26168,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26168,  94,         16) /* TargetType - Creature */
+     , (26168, 106,        210) /* ItemSpellcraft */
+     , (26168, 107,         50) /* ItemCurMana */
+     , (26168, 108,         50) /* ItemMaxMana */
+     , (26168, 109,          0) /* ItemDifficulty */
+     , (26168, 110,          0) /* ItemAllegianceRankLimit */
+     , (26168, 150,        103) /* HookPlacement - Hook */
+     , (26168, 151,          2) /* HookType - Wall */
+     , (26168, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26168,  15, True ) /* LightsStatus */
+     , (26168,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26168, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26168,   1, 'Eotensfang Cottages Portal Gem') /* Name */
+     , (26168,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26168,   1,   33556769) /* Setup */
+     , (26168,   3,  536870932) /* SoundTable */
+     , (26168,   6,   67111919) /* PaletteBase */
+     , (26168,   7,  268435723) /* ClothingBase */
+     , (26168,   8,  100675760) /* Icon */
+     , (26168,  22,  872415275) /* PhysicsEffectTable */
+     , (26168,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26168,  31,      14628) /* LinkedPortalOne - Eotensfang Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26169 Erevana Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26169 Erevana Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26169;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26169, 'gemportalerevanavillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26169,   1,       2048) /* ItemType - Gem */
+     , (26169,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26169,   5,         10) /* EncumbranceVal */
+     , (26169,   8,         10) /* Mass */
+     , (26169,   9,          0) /* ValidLocations - None */
+     , (26169,  11,         20) /* MaxStackSize */
+     , (26169,  12,          1) /* StackSize */
+     , (26169,  13,         10) /* StackUnitEncumbrance */
+     , (26169,  14,         10) /* StackUnitMass */
+     , (26169,  15,        500) /* StackUnitValue */
+     , (26169,  16,          8) /* ItemUseable - Contained */
+     , (26169,  18,          1) /* UiEffects - Magical */
+     , (26169,  19,        500) /* Value */
+     , (26169,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26169,  94,         16) /* TargetType - Creature */
+     , (26169, 106,        210) /* ItemSpellcraft */
+     , (26169, 107,         50) /* ItemCurMana */
+     , (26169, 108,         50) /* ItemMaxMana */
+     , (26169, 109,          0) /* ItemDifficulty */
+     , (26169, 110,          0) /* ItemAllegianceRankLimit */
+     , (26169, 150,        103) /* HookPlacement - Hook */
+     , (26169, 151,          2) /* HookType - Wall */
+     , (26169, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26169,  15, True ) /* LightsStatus */
+     , (26169,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26169, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26169,   1, 'Erevana Villas Portal Gem') /* Name */
+     , (26169,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26169,   1,   33556769) /* Setup */
+     , (26169,   3,  536870932) /* SoundTable */
+     , (26169,   6,   67111919) /* PaletteBase */
+     , (26169,   7,  268435723) /* ClothingBase */
+     , (26169,   8,  100675760) /* Icon */
+     , (26169,  22,  872415275) /* PhysicsEffectTable */
+     , (26169,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26169,  31,      14629) /* LinkedPortalOne - Erevana Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26170 Evensong Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26170 Evensong Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26170;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26170, 'gemportalevensongsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26170,   1,       2048) /* ItemType - Gem */
+     , (26170,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26170,   5,         10) /* EncumbranceVal */
+     , (26170,   8,         10) /* Mass */
+     , (26170,   9,          0) /* ValidLocations - None */
+     , (26170,  11,         20) /* MaxStackSize */
+     , (26170,  12,          1) /* StackSize */
+     , (26170,  13,         10) /* StackUnitEncumbrance */
+     , (26170,  14,         10) /* StackUnitMass */
+     , (26170,  15,        500) /* StackUnitValue */
+     , (26170,  16,          8) /* ItemUseable - Contained */
+     , (26170,  18,          1) /* UiEffects - Magical */
+     , (26170,  19,        500) /* Value */
+     , (26170,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26170,  94,         16) /* TargetType - Creature */
+     , (26170, 106,        210) /* ItemSpellcraft */
+     , (26170, 107,         50) /* ItemCurMana */
+     , (26170, 108,         50) /* ItemMaxMana */
+     , (26170, 109,          0) /* ItemDifficulty */
+     , (26170, 110,          0) /* ItemAllegianceRankLimit */
+     , (26170, 150,        103) /* HookPlacement - Hook */
+     , (26170, 151,          2) /* HookType - Wall */
+     , (26170, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26170,  15, True ) /* LightsStatus */
+     , (26170,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26170, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26170,   1, 'Evensong Settlement Portal Gem') /* Name */
+     , (26170,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26170,   1,   33556769) /* Setup */
+     , (26170,   3,  536870932) /* SoundTable */
+     , (26170,   6,   67111919) /* PaletteBase */
+     , (26170,   7,  268435723) /* ClothingBase */
+     , (26170,   8,  100675760) /* Icon */
+     , (26170,  22,  872415275) /* PhysicsEffectTable */
+     , (26170,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26170,  31,      12495) /* LinkedPortalOne - Evensong Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26171 Explorer's Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26171 Explorer's Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26171;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26171, 'gemportalexplorersvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26171,   1,       2048) /* ItemType - Gem */
+     , (26171,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26171,   5,         10) /* EncumbranceVal */
+     , (26171,   8,         10) /* Mass */
+     , (26171,   9,          0) /* ValidLocations - None */
+     , (26171,  11,         20) /* MaxStackSize */
+     , (26171,  12,          1) /* StackSize */
+     , (26171,  13,         10) /* StackUnitEncumbrance */
+     , (26171,  14,         10) /* StackUnitMass */
+     , (26171,  15,        500) /* StackUnitValue */
+     , (26171,  16,          8) /* ItemUseable - Contained */
+     , (26171,  18,          1) /* UiEffects - Magical */
+     , (26171,  19,        500) /* Value */
+     , (26171,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26171,  94,         16) /* TargetType - Creature */
+     , (26171, 106,        210) /* ItemSpellcraft */
+     , (26171, 107,         50) /* ItemCurMana */
+     , (26171, 108,         50) /* ItemMaxMana */
+     , (26171, 109,          0) /* ItemDifficulty */
+     , (26171, 110,          0) /* ItemAllegianceRankLimit */
+     , (26171, 150,        103) /* HookPlacement - Hook */
+     , (26171, 151,          2) /* HookType - Wall */
+     , (26171, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26171,  15, True ) /* LightsStatus */
+     , (26171,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26171, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26171,   1, 'Explorer''s Villas Portal Gem') /* Name */
+     , (26171,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26171,   1,   33556769) /* Setup */
+     , (26171,   3,  536870932) /* SoundTable */
+     , (26171,   6,   67111919) /* PaletteBase */
+     , (26171,   7,  268435723) /* ClothingBase */
+     , (26171,   8,  100675760) /* Icon */
+     , (26171,  22,  872415275) /* PhysicsEffectTable */
+     , (26171,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26171,  31,      19144) /* LinkedPortalOne - Explorer's Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26172 Fadsahil Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26172 Fadsahil Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26172;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26172, 'gemportalfadsahilsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26172,   1,       2048) /* ItemType - Gem */
+     , (26172,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26172,   5,         10) /* EncumbranceVal */
+     , (26172,   8,         10) /* Mass */
+     , (26172,   9,          0) /* ValidLocations - None */
+     , (26172,  11,         20) /* MaxStackSize */
+     , (26172,  12,          1) /* StackSize */
+     , (26172,  13,         10) /* StackUnitEncumbrance */
+     , (26172,  14,         10) /* StackUnitMass */
+     , (26172,  15,        500) /* StackUnitValue */
+     , (26172,  16,          8) /* ItemUseable - Contained */
+     , (26172,  18,          1) /* UiEffects - Magical */
+     , (26172,  19,        500) /* Value */
+     , (26172,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26172,  94,         16) /* TargetType - Creature */
+     , (26172, 106,        210) /* ItemSpellcraft */
+     , (26172, 107,         50) /* ItemCurMana */
+     , (26172, 108,         50) /* ItemMaxMana */
+     , (26172, 109,          0) /* ItemDifficulty */
+     , (26172, 110,          0) /* ItemAllegianceRankLimit */
+     , (26172, 150,        103) /* HookPlacement - Hook */
+     , (26172, 151,          2) /* HookType - Wall */
+     , (26172, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26172,  15, True ) /* LightsStatus */
+     , (26172,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26172, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26172,   1, 'Fadsahil Settlement Portal Gem') /* Name */
+     , (26172,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26172,   1,   33556769) /* Setup */
+     , (26172,   3,  536870932) /* SoundTable */
+     , (26172,   6,   67111919) /* PaletteBase */
+     , (26172,   7,  268435723) /* ClothingBase */
+     , (26172,   8,  100675760) /* Icon */
+     , (26172,  22,  872415275) /* PhysicsEffectTable */
+     , (26172,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26172,  31,      14630) /* LinkedPortalOne - Fadsahil Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26173 Faranar Foothills Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26173 Faranar Foothills Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26173;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26173, 'gemportalfaranarfoothills', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26173,   1,       2048) /* ItemType - Gem */
+     , (26173,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26173,   5,         10) /* EncumbranceVal */
+     , (26173,   8,         10) /* Mass */
+     , (26173,   9,          0) /* ValidLocations - None */
+     , (26173,  11,         20) /* MaxStackSize */
+     , (26173,  12,          1) /* StackSize */
+     , (26173,  13,         10) /* StackUnitEncumbrance */
+     , (26173,  14,         10) /* StackUnitMass */
+     , (26173,  15,        500) /* StackUnitValue */
+     , (26173,  16,          8) /* ItemUseable - Contained */
+     , (26173,  18,          1) /* UiEffects - Magical */
+     , (26173,  19,        500) /* Value */
+     , (26173,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26173,  94,         16) /* TargetType - Creature */
+     , (26173, 106,        210) /* ItemSpellcraft */
+     , (26173, 107,         50) /* ItemCurMana */
+     , (26173, 108,         50) /* ItemMaxMana */
+     , (26173, 109,          0) /* ItemDifficulty */
+     , (26173, 110,          0) /* ItemAllegianceRankLimit */
+     , (26173, 150,        103) /* HookPlacement - Hook */
+     , (26173, 151,          2) /* HookType - Wall */
+     , (26173, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26173,  15, True ) /* LightsStatus */
+     , (26173,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26173, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26173,   1, 'Faranar Foothills Portal Gem') /* Name */
+     , (26173,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26173,   1,   33556769) /* Setup */
+     , (26173,   3,  536870932) /* SoundTable */
+     , (26173,   6,   67111919) /* PaletteBase */
+     , (26173,   7,  268435723) /* ClothingBase */
+     , (26173,   8,  100675760) /* Icon */
+     , (26173,  22,  872415275) /* PhysicsEffectTable */
+     , (26173,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26173,  31,      12496) /* LinkedPortalOne - Faranar Foothills Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26174 Far Claw Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26174 Far Claw Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26174;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26174, 'gemportalfarclawvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26174,   1,       2048) /* ItemType - Gem */
+     , (26174,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26174,   5,         10) /* EncumbranceVal */
+     , (26174,   8,         10) /* Mass */
+     , (26174,   9,          0) /* ValidLocations - None */
+     , (26174,  11,         20) /* MaxStackSize */
+     , (26174,  12,          1) /* StackSize */
+     , (26174,  13,         10) /* StackUnitEncumbrance */
+     , (26174,  14,         10) /* StackUnitMass */
+     , (26174,  15,        500) /* StackUnitValue */
+     , (26174,  16,          8) /* ItemUseable - Contained */
+     , (26174,  18,          1) /* UiEffects - Magical */
+     , (26174,  19,        500) /* Value */
+     , (26174,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26174,  94,         16) /* TargetType - Creature */
+     , (26174, 106,        210) /* ItemSpellcraft */
+     , (26174, 107,         50) /* ItemCurMana */
+     , (26174, 108,         50) /* ItemMaxMana */
+     , (26174, 109,          0) /* ItemDifficulty */
+     , (26174, 110,          0) /* ItemAllegianceRankLimit */
+     , (26174, 150,        103) /* HookPlacement - Hook */
+     , (26174, 151,          2) /* HookType - Wall */
+     , (26174, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26174,  15, True ) /* LightsStatus */
+     , (26174,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26174, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26174,   1, 'Far Claw Villas Portal Gem') /* Name */
+     , (26174,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26174,   1,   33556769) /* Setup */
+     , (26174,   3,  536870932) /* SoundTable */
+     , (26174,   6,   67111919) /* PaletteBase */
+     , (26174,   7,  268435723) /* ClothingBase */
+     , (26174,   8,  100675760) /* Icon */
+     , (26174,  22,  872415275) /* PhysicsEffectTable */
+     , (26174,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26174,  31,      13104) /* LinkedPortalOne - Far Claw Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26175 Far Horizon Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26175 Far Horizon Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26175;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26175, 'gemportalfarhorizoncottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26175,   1,       2048) /* ItemType - Gem */
+     , (26175,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26175,   5,         10) /* EncumbranceVal */
+     , (26175,   8,         10) /* Mass */
+     , (26175,   9,          0) /* ValidLocations - None */
+     , (26175,  11,         20) /* MaxStackSize */
+     , (26175,  12,          1) /* StackSize */
+     , (26175,  13,         10) /* StackUnitEncumbrance */
+     , (26175,  14,         10) /* StackUnitMass */
+     , (26175,  15,        500) /* StackUnitValue */
+     , (26175,  16,          8) /* ItemUseable - Contained */
+     , (26175,  18,          1) /* UiEffects - Magical */
+     , (26175,  19,        500) /* Value */
+     , (26175,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26175,  94,         16) /* TargetType - Creature */
+     , (26175, 106,        210) /* ItemSpellcraft */
+     , (26175, 107,         50) /* ItemCurMana */
+     , (26175, 108,         50) /* ItemMaxMana */
+     , (26175, 109,          0) /* ItemDifficulty */
+     , (26175, 110,          0) /* ItemAllegianceRankLimit */
+     , (26175, 150,        103) /* HookPlacement - Hook */
+     , (26175, 151,          2) /* HookType - Wall */
+     , (26175, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26175,  15, True ) /* LightsStatus */
+     , (26175,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26175, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26175,   1, 'Far Horizon Cottages Portal Gem') /* Name */
+     , (26175,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26175,   1,   33556769) /* Setup */
+     , (26175,   3,  536870932) /* SoundTable */
+     , (26175,   6,   67111919) /* PaletteBase */
+     , (26175,   7,  268435723) /* ClothingBase */
+     , (26175,   8,  100675760) /* Icon */
+     , (26175,  22,  872415275) /* PhysicsEffectTable */
+     , (26175,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26175,  31,      15673) /* LinkedPortalOne - Far Horizon Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26176 Fearnot Valley Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26176 Fearnot Valley Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26176;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26176, 'gemportalfearnotvalleycottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26176,   1,       2048) /* ItemType - Gem */
+     , (26176,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26176,   5,         10) /* EncumbranceVal */
+     , (26176,   8,         10) /* Mass */
+     , (26176,   9,          0) /* ValidLocations - None */
+     , (26176,  11,         20) /* MaxStackSize */
+     , (26176,  12,          1) /* StackSize */
+     , (26176,  13,         10) /* StackUnitEncumbrance */
+     , (26176,  14,         10) /* StackUnitMass */
+     , (26176,  15,        500) /* StackUnitValue */
+     , (26176,  16,          8) /* ItemUseable - Contained */
+     , (26176,  18,          1) /* UiEffects - Magical */
+     , (26176,  19,        500) /* Value */
+     , (26176,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26176,  94,         16) /* TargetType - Creature */
+     , (26176, 106,        210) /* ItemSpellcraft */
+     , (26176, 107,         50) /* ItemCurMana */
+     , (26176, 108,         50) /* ItemMaxMana */
+     , (26176, 109,          0) /* ItemDifficulty */
+     , (26176, 110,          0) /* ItemAllegianceRankLimit */
+     , (26176, 150,        103) /* HookPlacement - Hook */
+     , (26176, 151,          2) /* HookType - Wall */
+     , (26176, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26176,  15, True ) /* LightsStatus */
+     , (26176,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26176, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26176,   1, 'Fearnot Valley Cottages Portal Gem') /* Name */
+     , (26176,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26176,   1,   33556769) /* Setup */
+     , (26176,   3,  536870932) /* SoundTable */
+     , (26176,   6,   67111919) /* PaletteBase */
+     , (26176,   7,  268435723) /* ClothingBase */
+     , (26176,   8,  100675760) /* Icon */
+     , (26176,  22,  872415275) /* PhysicsEffectTable */
+     , (26176,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26176,  31,      14631) /* LinkedPortalOne - Fearnot Valley Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26177 Filos' Font Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26177 Filos' Font Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26177;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26177, 'gemportalfilosfontcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26177,   1,       2048) /* ItemType - Gem */
+     , (26177,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26177,   5,         10) /* EncumbranceVal */
+     , (26177,   8,         10) /* Mass */
+     , (26177,   9,          0) /* ValidLocations - None */
+     , (26177,  11,         20) /* MaxStackSize */
+     , (26177,  12,          1) /* StackSize */
+     , (26177,  13,         10) /* StackUnitEncumbrance */
+     , (26177,  14,         10) /* StackUnitMass */
+     , (26177,  15,        500) /* StackUnitValue */
+     , (26177,  16,          8) /* ItemUseable - Contained */
+     , (26177,  18,          1) /* UiEffects - Magical */
+     , (26177,  19,        500) /* Value */
+     , (26177,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26177,  94,         16) /* TargetType - Creature */
+     , (26177, 106,        210) /* ItemSpellcraft */
+     , (26177, 107,         50) /* ItemCurMana */
+     , (26177, 108,         50) /* ItemMaxMana */
+     , (26177, 109,          0) /* ItemDifficulty */
+     , (26177, 110,          0) /* ItemAllegianceRankLimit */
+     , (26177, 150,        103) /* HookPlacement - Hook */
+     , (26177, 151,          2) /* HookType - Wall */
+     , (26177, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26177,  15, True ) /* LightsStatus */
+     , (26177,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26177, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26177,   1, 'Filos'' Font Cottages Portal Gem') /* Name */
+     , (26177,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26177,   1,   33556769) /* Setup */
+     , (26177,   3,  536870932) /* SoundTable */
+     , (26177,   6,   67111919) /* PaletteBase */
+     , (26177,   7,  268435723) /* ClothingBase */
+     , (26177,   8,  100675760) /* Icon */
+     , (26177,  22,  872415275) /* PhysicsEffectTable */
+     , (26177,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26177,  31,      12497) /* LinkedPortalOne - Filos' Font Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26178 Firedew Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26178 Firedew Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26178;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26178, 'gemportalfiredew', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26178,   1,       2048) /* ItemType - Gem */
+     , (26178,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26178,   5,         10) /* EncumbranceVal */
+     , (26178,   8,         10) /* Mass */
+     , (26178,   9,          0) /* ValidLocations - None */
+     , (26178,  11,         20) /* MaxStackSize */
+     , (26178,  12,          1) /* StackSize */
+     , (26178,  13,         10) /* StackUnitEncumbrance */
+     , (26178,  14,         10) /* StackUnitMass */
+     , (26178,  15,        500) /* StackUnitValue */
+     , (26178,  16,          8) /* ItemUseable - Contained */
+     , (26178,  18,          1) /* UiEffects - Magical */
+     , (26178,  19,        500) /* Value */
+     , (26178,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26178,  94,         16) /* TargetType - Creature */
+     , (26178, 106,        210) /* ItemSpellcraft */
+     , (26178, 107,         50) /* ItemCurMana */
+     , (26178, 108,         50) /* ItemMaxMana */
+     , (26178, 109,          0) /* ItemDifficulty */
+     , (26178, 110,          0) /* ItemAllegianceRankLimit */
+     , (26178, 150,        103) /* HookPlacement - Hook */
+     , (26178, 151,          2) /* HookType - Wall */
+     , (26178, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26178,  15, True ) /* LightsStatus */
+     , (26178,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26178, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26178,   1, 'Firedew Portal Gem') /* Name */
+     , (26178,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26178,   1,   33556769) /* Setup */
+     , (26178,   3,  536870932) /* SoundTable */
+     , (26178,   6,   67111919) /* PaletteBase */
+     , (26178,   7,  268435723) /* ClothingBase */
+     , (26178,   8,  100675760) /* Icon */
+     , (26178,  22,  872415275) /* PhysicsEffectTable */
+     , (26178,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26178,  31,      14632) /* LinkedPortalOne - Firedew Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26179 Firesong Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26179 Firesong Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26179;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26179, 'gemportalfiresongcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26179,   1,       2048) /* ItemType - Gem */
+     , (26179,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26179,   5,         10) /* EncumbranceVal */
+     , (26179,   8,         10) /* Mass */
+     , (26179,   9,          0) /* ValidLocations - None */
+     , (26179,  11,         20) /* MaxStackSize */
+     , (26179,  12,          1) /* StackSize */
+     , (26179,  13,         10) /* StackUnitEncumbrance */
+     , (26179,  14,         10) /* StackUnitMass */
+     , (26179,  15,        500) /* StackUnitValue */
+     , (26179,  16,          8) /* ItemUseable - Contained */
+     , (26179,  18,          1) /* UiEffects - Magical */
+     , (26179,  19,        500) /* Value */
+     , (26179,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26179,  94,         16) /* TargetType - Creature */
+     , (26179, 106,        210) /* ItemSpellcraft */
+     , (26179, 107,         50) /* ItemCurMana */
+     , (26179, 108,         50) /* ItemMaxMana */
+     , (26179, 109,          0) /* ItemDifficulty */
+     , (26179, 110,          0) /* ItemAllegianceRankLimit */
+     , (26179, 150,        103) /* HookPlacement - Hook */
+     , (26179, 151,          2) /* HookType - Wall */
+     , (26179, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26179,  15, True ) /* LightsStatus */
+     , (26179,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26179, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26179,   1, 'Firesong Cottages Portal Gem') /* Name */
+     , (26179,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26179,   1,   33556769) /* Setup */
+     , (26179,   3,  536870932) /* SoundTable */
+     , (26179,   6,   67111919) /* PaletteBase */
+     , (26179,   7,  268435723) /* ClothingBase */
+     , (26179,   8,  100675760) /* Icon */
+     , (26179,  22,  872415275) /* PhysicsEffectTable */
+     , (26179,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26179,  31,      19145) /* LinkedPortalOne - Firesong Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26180 Font Alpa Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26180 Font Alpa Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26180;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26180, 'gemportalfontalpa', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26180,   1,       2048) /* ItemType - Gem */
+     , (26180,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26180,   5,         10) /* EncumbranceVal */
+     , (26180,   8,         10) /* Mass */
+     , (26180,   9,          0) /* ValidLocations - None */
+     , (26180,  11,         20) /* MaxStackSize */
+     , (26180,  12,          1) /* StackSize */
+     , (26180,  13,         10) /* StackUnitEncumbrance */
+     , (26180,  14,         10) /* StackUnitMass */
+     , (26180,  15,        500) /* StackUnitValue */
+     , (26180,  16,          8) /* ItemUseable - Contained */
+     , (26180,  18,          1) /* UiEffects - Magical */
+     , (26180,  19,        500) /* Value */
+     , (26180,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26180,  94,         16) /* TargetType - Creature */
+     , (26180, 106,        210) /* ItemSpellcraft */
+     , (26180, 107,         50) /* ItemCurMana */
+     , (26180, 108,         50) /* ItemMaxMana */
+     , (26180, 109,          0) /* ItemDifficulty */
+     , (26180, 110,          0) /* ItemAllegianceRankLimit */
+     , (26180, 150,        103) /* HookPlacement - Hook */
+     , (26180, 151,          2) /* HookType - Wall */
+     , (26180, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26180,  15, True ) /* LightsStatus */
+     , (26180,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26180, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26180,   1, 'Font Alpa Portal Gem') /* Name */
+     , (26180,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26180,   1,   33556769) /* Setup */
+     , (26180,   3,  536870932) /* SoundTable */
+     , (26180,   6,   67111919) /* PaletteBase */
+     , (26180,   7,  268435723) /* ClothingBase */
+     , (26180,   8,  100675760) /* Icon */
+     , (26180,  22,  872415275) /* PhysicsEffectTable */
+     , (26180,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26180,  31,      13105) /* LinkedPortalOne - Font Alpa Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26181 Forgotten Hills Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26181 Forgotten Hills Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26181;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26181, 'gemportalforgottenhills', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26181,   1,       2048) /* ItemType - Gem */
+     , (26181,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26181,   5,         10) /* EncumbranceVal */
+     , (26181,   8,         10) /* Mass */
+     , (26181,   9,          0) /* ValidLocations - None */
+     , (26181,  11,         20) /* MaxStackSize */
+     , (26181,  12,          1) /* StackSize */
+     , (26181,  13,         10) /* StackUnitEncumbrance */
+     , (26181,  14,         10) /* StackUnitMass */
+     , (26181,  15,        500) /* StackUnitValue */
+     , (26181,  16,          8) /* ItemUseable - Contained */
+     , (26181,  18,          1) /* UiEffects - Magical */
+     , (26181,  19,        500) /* Value */
+     , (26181,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26181,  94,         16) /* TargetType - Creature */
+     , (26181, 106,        210) /* ItemSpellcraft */
+     , (26181, 107,         50) /* ItemCurMana */
+     , (26181, 108,         50) /* ItemMaxMana */
+     , (26181, 109,          0) /* ItemDifficulty */
+     , (26181, 110,          0) /* ItemAllegianceRankLimit */
+     , (26181, 150,        103) /* HookPlacement - Hook */
+     , (26181, 151,          2) /* HookType - Wall */
+     , (26181, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26181,  15, True ) /* LightsStatus */
+     , (26181,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26181, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26181,   1, 'Forgotten Hills Portal Gem') /* Name */
+     , (26181,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26181,   1,   33556769) /* Setup */
+     , (26181,   3,  536870932) /* SoundTable */
+     , (26181,   6,   67111919) /* PaletteBase */
+     , (26181,   7,  268435723) /* ClothingBase */
+     , (26181,   8,  100675760) /* Icon */
+     , (26181,  22,  872415275) /* PhysicsEffectTable */
+     , (26181,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26181,  31,      12498) /* LinkedPortalOne - Forgotten Hills Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26182 Four Towers Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26182 Four Towers Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26182;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26182, 'gemportalfourtowerssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26182,   1,       2048) /* ItemType - Gem */
+     , (26182,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26182,   5,         10) /* EncumbranceVal */
+     , (26182,   8,         10) /* Mass */
+     , (26182,   9,          0) /* ValidLocations - None */
+     , (26182,  11,         20) /* MaxStackSize */
+     , (26182,  12,          1) /* StackSize */
+     , (26182,  13,         10) /* StackUnitEncumbrance */
+     , (26182,  14,         10) /* StackUnitMass */
+     , (26182,  15,        500) /* StackUnitValue */
+     , (26182,  16,          8) /* ItemUseable - Contained */
+     , (26182,  18,          1) /* UiEffects - Magical */
+     , (26182,  19,        500) /* Value */
+     , (26182,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26182,  94,         16) /* TargetType - Creature */
+     , (26182, 106,        210) /* ItemSpellcraft */
+     , (26182, 107,         50) /* ItemCurMana */
+     , (26182, 108,         50) /* ItemMaxMana */
+     , (26182, 109,          0) /* ItemDifficulty */
+     , (26182, 110,          0) /* ItemAllegianceRankLimit */
+     , (26182, 150,        103) /* HookPlacement - Hook */
+     , (26182, 151,          2) /* HookType - Wall */
+     , (26182, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26182,  15, True ) /* LightsStatus */
+     , (26182,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26182, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26182,   1, 'Four Towers Settlement Portal Gem') /* Name */
+     , (26182,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26182,   1,   33556769) /* Setup */
+     , (26182,   3,  536870932) /* SoundTable */
+     , (26182,   6,   67111919) /* PaletteBase */
+     , (26182,   7,  268435723) /* ClothingBase */
+     , (26182,   8,  100675760) /* Icon */
+     , (26182,  22,  872415275) /* PhysicsEffectTable */
+     , (26182,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26182,  31,      12499) /* LinkedPortalOne - Four Towers Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26183 Frosty Dale Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26183 Frosty Dale Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26183;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26183, 'gemportalfrostydalecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26183,   1,       2048) /* ItemType - Gem */
+     , (26183,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26183,   5,         10) /* EncumbranceVal */
+     , (26183,   8,         10) /* Mass */
+     , (26183,   9,          0) /* ValidLocations - None */
+     , (26183,  11,         20) /* MaxStackSize */
+     , (26183,  12,          1) /* StackSize */
+     , (26183,  13,         10) /* StackUnitEncumbrance */
+     , (26183,  14,         10) /* StackUnitMass */
+     , (26183,  15,        500) /* StackUnitValue */
+     , (26183,  16,          8) /* ItemUseable - Contained */
+     , (26183,  18,          1) /* UiEffects - Magical */
+     , (26183,  19,        500) /* Value */
+     , (26183,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26183,  94,         16) /* TargetType - Creature */
+     , (26183, 106,        210) /* ItemSpellcraft */
+     , (26183, 107,         50) /* ItemCurMana */
+     , (26183, 108,         50) /* ItemMaxMana */
+     , (26183, 109,          0) /* ItemDifficulty */
+     , (26183, 110,          0) /* ItemAllegianceRankLimit */
+     , (26183, 150,        103) /* HookPlacement - Hook */
+     , (26183, 151,          2) /* HookType - Wall */
+     , (26183, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26183,  15, True ) /* LightsStatus */
+     , (26183,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26183, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26183,   1, 'Frosty Dale Cottages Portal Gem') /* Name */
+     , (26183,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26183,   1,   33556769) /* Setup */
+     , (26183,   3,  536870932) /* SoundTable */
+     , (26183,   6,   67111919) /* PaletteBase */
+     , (26183,   7,  268435723) /* ClothingBase */
+     , (26183,   8,  100675760) /* Icon */
+     , (26183,  22,  872415275) /* PhysicsEffectTable */
+     , (26183,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26183,  31,      13106) /* LinkedPortalOne - Frosty Dale Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26184 Gaerwel Edge Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26184 Gaerwel Edge Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26184;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26184, 'gemportalgaerweledgesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26184,   1,       2048) /* ItemType - Gem */
+     , (26184,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26184,   5,         10) /* EncumbranceVal */
+     , (26184,   8,         10) /* Mass */
+     , (26184,   9,          0) /* ValidLocations - None */
+     , (26184,  11,         20) /* MaxStackSize */
+     , (26184,  12,          1) /* StackSize */
+     , (26184,  13,         10) /* StackUnitEncumbrance */
+     , (26184,  14,         10) /* StackUnitMass */
+     , (26184,  15,        500) /* StackUnitValue */
+     , (26184,  16,          8) /* ItemUseable - Contained */
+     , (26184,  18,          1) /* UiEffects - Magical */
+     , (26184,  19,        500) /* Value */
+     , (26184,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26184,  94,         16) /* TargetType - Creature */
+     , (26184, 106,        210) /* ItemSpellcraft */
+     , (26184, 107,         50) /* ItemCurMana */
+     , (26184, 108,         50) /* ItemMaxMana */
+     , (26184, 109,          0) /* ItemDifficulty */
+     , (26184, 110,          0) /* ItemAllegianceRankLimit */
+     , (26184, 150,        103) /* HookPlacement - Hook */
+     , (26184, 151,          2) /* HookType - Wall */
+     , (26184, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26184,  15, True ) /* LightsStatus */
+     , (26184,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26184, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26184,   1, 'Gaerwel Edge Settlement Portal Gem') /* Name */
+     , (26184,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26184,   1,   33556769) /* Setup */
+     , (26184,   3,  536870932) /* SoundTable */
+     , (26184,   6,   67111919) /* PaletteBase */
+     , (26184,   7,  268435723) /* ClothingBase */
+     , (26184,   8,  100675760) /* Icon */
+     , (26184,  22,  872415275) /* PhysicsEffectTable */
+     , (26184,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26184,  31,      12500) /* LinkedPortalOne - Gaerwel Edge Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26185 Genem Causland Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26185 Genem Causland Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26185;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26185, 'gemportalgenemcausland', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26185,   1,       2048) /* ItemType - Gem */
+     , (26185,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26185,   5,         10) /* EncumbranceVal */
+     , (26185,   8,         10) /* Mass */
+     , (26185,   9,          0) /* ValidLocations - None */
+     , (26185,  11,         20) /* MaxStackSize */
+     , (26185,  12,          1) /* StackSize */
+     , (26185,  13,         10) /* StackUnitEncumbrance */
+     , (26185,  14,         10) /* StackUnitMass */
+     , (26185,  15,        500) /* StackUnitValue */
+     , (26185,  16,          8) /* ItemUseable - Contained */
+     , (26185,  18,          1) /* UiEffects - Magical */
+     , (26185,  19,        500) /* Value */
+     , (26185,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26185,  94,         16) /* TargetType - Creature */
+     , (26185, 106,        210) /* ItemSpellcraft */
+     , (26185, 107,         50) /* ItemCurMana */
+     , (26185, 108,         50) /* ItemMaxMana */
+     , (26185, 109,          0) /* ItemDifficulty */
+     , (26185, 110,          0) /* ItemAllegianceRankLimit */
+     , (26185, 150,        103) /* HookPlacement - Hook */
+     , (26185, 151,          2) /* HookType - Wall */
+     , (26185, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26185,  15, True ) /* LightsStatus */
+     , (26185,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26185, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26185,   1, 'Genem Causland Portal Gem') /* Name */
+     , (26185,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26185,   1,   33556769) /* Setup */
+     , (26185,   3,  536870932) /* SoundTable */
+     , (26185,   6,   67111919) /* PaletteBase */
+     , (26185,   7,  268435723) /* ClothingBase */
+     , (26185,   8,  100675760) /* Icon */
+     , (26185,  22,  872415275) /* PhysicsEffectTable */
+     , (26185,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26185,  31,      15158) /* LinkedPortalOne - Genem Causland Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26186 Gharu'n Victory Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26186 Gharu'n Victory Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26186;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26186, 'gemportalgharunvictoryvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26186,   1,       2048) /* ItemType - Gem */
+     , (26186,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26186,   5,         10) /* EncumbranceVal */
+     , (26186,   8,         10) /* Mass */
+     , (26186,   9,          0) /* ValidLocations - None */
+     , (26186,  11,         20) /* MaxStackSize */
+     , (26186,  12,          1) /* StackSize */
+     , (26186,  13,         10) /* StackUnitEncumbrance */
+     , (26186,  14,         10) /* StackUnitMass */
+     , (26186,  15,        500) /* StackUnitValue */
+     , (26186,  16,          8) /* ItemUseable - Contained */
+     , (26186,  18,          1) /* UiEffects - Magical */
+     , (26186,  19,        500) /* Value */
+     , (26186,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26186,  94,         16) /* TargetType - Creature */
+     , (26186, 106,        210) /* ItemSpellcraft */
+     , (26186, 107,         50) /* ItemCurMana */
+     , (26186, 108,         50) /* ItemMaxMana */
+     , (26186, 109,          0) /* ItemDifficulty */
+     , (26186, 110,          0) /* ItemAllegianceRankLimit */
+     , (26186, 150,        103) /* HookPlacement - Hook */
+     , (26186, 151,          2) /* HookType - Wall */
+     , (26186, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26186,  15, True ) /* LightsStatus */
+     , (26186,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26186, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26186,   1, 'Gharu''n Victory Villas Portal Gem') /* Name */
+     , (26186,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26186,   1,   33556769) /* Setup */
+     , (26186,   3,  536870932) /* SoundTable */
+     , (26186,   6,   67111919) /* PaletteBase */
+     , (26186,   7,  268435723) /* ClothingBase */
+     , (26186,   8,  100675760) /* Icon */
+     , (26186,  22,  872415275) /* PhysicsEffectTable */
+     , (26186,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26186,  31,      15674) /* LinkedPortalOne - Gharu'n Victory Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26187 Glenden Hills East Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26187 Glenden Hills East Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26187;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26187, 'gemportalglendenhillseastsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26187,   1,       2048) /* ItemType - Gem */
+     , (26187,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26187,   5,         10) /* EncumbranceVal */
+     , (26187,   8,         10) /* Mass */
+     , (26187,   9,          0) /* ValidLocations - None */
+     , (26187,  11,         20) /* MaxStackSize */
+     , (26187,  12,          1) /* StackSize */
+     , (26187,  13,         10) /* StackUnitEncumbrance */
+     , (26187,  14,         10) /* StackUnitMass */
+     , (26187,  15,        500) /* StackUnitValue */
+     , (26187,  16,          8) /* ItemUseable - Contained */
+     , (26187,  18,          1) /* UiEffects - Magical */
+     , (26187,  19,        500) /* Value */
+     , (26187,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26187,  94,         16) /* TargetType - Creature */
+     , (26187, 106,        210) /* ItemSpellcraft */
+     , (26187, 107,         50) /* ItemCurMana */
+     , (26187, 108,         50) /* ItemMaxMana */
+     , (26187, 109,          0) /* ItemDifficulty */
+     , (26187, 110,          0) /* ItemAllegianceRankLimit */
+     , (26187, 150,        103) /* HookPlacement - Hook */
+     , (26187, 151,          2) /* HookType - Wall */
+     , (26187, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26187,  15, True ) /* LightsStatus */
+     , (26187,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26187, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26187,   1, 'Glenden Hills East Settlement Portal Gem') /* Name */
+     , (26187,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26187,   1,   33556769) /* Setup */
+     , (26187,   3,  536870932) /* SoundTable */
+     , (26187,   6,   67111919) /* PaletteBase */
+     , (26187,   7,  268435723) /* ClothingBase */
+     , (26187,   8,  100675760) /* Icon */
+     , (26187,  22,  872415275) /* PhysicsEffectTable */
+     , (26187,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26187,  31,      12501) /* LinkedPortalOne - Glenden Hills East Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26188 Glenden Hills North Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26188 Glenden Hills North Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26188;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26188, 'gemportalglendenhillsnorthsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26188,   1,       2048) /* ItemType - Gem */
+     , (26188,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26188,   5,         10) /* EncumbranceVal */
+     , (26188,   8,         10) /* Mass */
+     , (26188,   9,          0) /* ValidLocations - None */
+     , (26188,  11,         20) /* MaxStackSize */
+     , (26188,  12,          1) /* StackSize */
+     , (26188,  13,         10) /* StackUnitEncumbrance */
+     , (26188,  14,         10) /* StackUnitMass */
+     , (26188,  15,        500) /* StackUnitValue */
+     , (26188,  16,          8) /* ItemUseable - Contained */
+     , (26188,  18,          1) /* UiEffects - Magical */
+     , (26188,  19,        500) /* Value */
+     , (26188,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26188,  94,         16) /* TargetType - Creature */
+     , (26188, 106,        210) /* ItemSpellcraft */
+     , (26188, 107,         50) /* ItemCurMana */
+     , (26188, 108,         50) /* ItemMaxMana */
+     , (26188, 109,          0) /* ItemDifficulty */
+     , (26188, 110,          0) /* ItemAllegianceRankLimit */
+     , (26188, 150,        103) /* HookPlacement - Hook */
+     , (26188, 151,          2) /* HookType - Wall */
+     , (26188, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26188,  15, True ) /* LightsStatus */
+     , (26188,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26188, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26188,   1, 'Glenden Hills North Settlement Portal Gem') /* Name */
+     , (26188,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26188,   1,   33556769) /* Setup */
+     , (26188,   3,  536870932) /* SoundTable */
+     , (26188,   6,   67111919) /* PaletteBase */
+     , (26188,   7,  268435723) /* ClothingBase */
+     , (26188,   8,  100675760) /* Icon */
+     , (26188,  22,  872415275) /* PhysicsEffectTable */
+     , (26188,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26188,  31,      12502) /* LinkedPortalOne - Glenden Hills North Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26189 Glystaene Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26189 Glystaene Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26189;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26189, 'gemportalglystaenecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26189,   1,       2048) /* ItemType - Gem */
+     , (26189,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26189,   5,         10) /* EncumbranceVal */
+     , (26189,   8,         10) /* Mass */
+     , (26189,   9,          0) /* ValidLocations - None */
+     , (26189,  11,         20) /* MaxStackSize */
+     , (26189,  12,          1) /* StackSize */
+     , (26189,  13,         10) /* StackUnitEncumbrance */
+     , (26189,  14,         10) /* StackUnitMass */
+     , (26189,  15,        500) /* StackUnitValue */
+     , (26189,  16,          8) /* ItemUseable - Contained */
+     , (26189,  18,          1) /* UiEffects - Magical */
+     , (26189,  19,        500) /* Value */
+     , (26189,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26189,  94,         16) /* TargetType - Creature */
+     , (26189, 106,        210) /* ItemSpellcraft */
+     , (26189, 107,         50) /* ItemCurMana */
+     , (26189, 108,         50) /* ItemMaxMana */
+     , (26189, 109,          0) /* ItemDifficulty */
+     , (26189, 110,          0) /* ItemAllegianceRankLimit */
+     , (26189, 150,        103) /* HookPlacement - Hook */
+     , (26189, 151,          2) /* HookType - Wall */
+     , (26189, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26189,  15, True ) /* LightsStatus */
+     , (26189,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26189, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26189,   1, 'Glystaene Cottages Portal Gem') /* Name */
+     , (26189,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26189,   1,   33556769) /* Setup */
+     , (26189,   3,  536870932) /* SoundTable */
+     , (26189,   6,   67111919) /* PaletteBase */
+     , (26189,   7,  268435723) /* ClothingBase */
+     , (26189,   8,  100675760) /* Icon */
+     , (26189,  22,  872415275) /* PhysicsEffectTable */
+     , (26189,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26189,  31,      15159) /* LinkedPortalOne - Glystaene Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26190 Gredaline Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26190 Gredaline Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26190;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26190, 'gemportalgredalinevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26190,   1,       2048) /* ItemType - Gem */
+     , (26190,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26190,   5,         10) /* EncumbranceVal */
+     , (26190,   8,         10) /* Mass */
+     , (26190,   9,          0) /* ValidLocations - None */
+     , (26190,  11,         20) /* MaxStackSize */
+     , (26190,  12,          1) /* StackSize */
+     , (26190,  13,         10) /* StackUnitEncumbrance */
+     , (26190,  14,         10) /* StackUnitMass */
+     , (26190,  15,        500) /* StackUnitValue */
+     , (26190,  16,          8) /* ItemUseable - Contained */
+     , (26190,  18,          1) /* UiEffects - Magical */
+     , (26190,  19,        500) /* Value */
+     , (26190,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26190,  94,         16) /* TargetType - Creature */
+     , (26190, 106,        210) /* ItemSpellcraft */
+     , (26190, 107,         50) /* ItemCurMana */
+     , (26190, 108,         50) /* ItemMaxMana */
+     , (26190, 109,          0) /* ItemDifficulty */
+     , (26190, 110,          0) /* ItemAllegianceRankLimit */
+     , (26190, 150,        103) /* HookPlacement - Hook */
+     , (26190, 151,          2) /* HookType - Wall */
+     , (26190, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26190,  15, True ) /* LightsStatus */
+     , (26190,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26190, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26190,   1, 'Gredaline Villas Portal Gem') /* Name */
+     , (26190,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26190,   1,   33556769) /* Setup */
+     , (26190,   3,  536870932) /* SoundTable */
+     , (26190,   6,   67111919) /* PaletteBase */
+     , (26190,   7,  268435723) /* ClothingBase */
+     , (26190,   8,  100675760) /* Icon */
+     , (26190,  22,  872415275) /* PhysicsEffectTable */
+     , (26190,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26190,  31,      19146) /* LinkedPortalOne - Gredaline Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26191 Greenswath Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26191 Greenswath Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26191;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26191, 'gemportalgreenswath', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26191,   1,       2048) /* ItemType - Gem */
+     , (26191,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26191,   5,         10) /* EncumbranceVal */
+     , (26191,   8,         10) /* Mass */
+     , (26191,   9,          0) /* ValidLocations - None */
+     , (26191,  11,         20) /* MaxStackSize */
+     , (26191,  12,          1) /* StackSize */
+     , (26191,  13,         10) /* StackUnitEncumbrance */
+     , (26191,  14,         10) /* StackUnitMass */
+     , (26191,  15,        500) /* StackUnitValue */
+     , (26191,  16,          8) /* ItemUseable - Contained */
+     , (26191,  18,          1) /* UiEffects - Magical */
+     , (26191,  19,        500) /* Value */
+     , (26191,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26191,  94,         16) /* TargetType - Creature */
+     , (26191, 106,        210) /* ItemSpellcraft */
+     , (26191, 107,         50) /* ItemCurMana */
+     , (26191, 108,         50) /* ItemMaxMana */
+     , (26191, 109,          0) /* ItemDifficulty */
+     , (26191, 110,          0) /* ItemAllegianceRankLimit */
+     , (26191, 150,        103) /* HookPlacement - Hook */
+     , (26191, 151,          2) /* HookType - Wall */
+     , (26191, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26191,  15, True ) /* LightsStatus */
+     , (26191,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26191, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26191,   1, 'Greenswath Portal Gem') /* Name */
+     , (26191,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26191,   1,   33556769) /* Setup */
+     , (26191,   3,  536870932) /* SoundTable */
+     , (26191,   6,   67111919) /* PaletteBase */
+     , (26191,   7,  268435723) /* ClothingBase */
+     , (26191,   8,  100675760) /* Icon */
+     , (26191,  22,  872415275) /* PhysicsEffectTable */
+     , (26191,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26191,  31,      14262) /* LinkedPortalOne - Greenswath Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26192 Greenvale Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26192 Greenvale Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26192;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26192, 'gemportalgreenvalesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26192,   1,       2048) /* ItemType - Gem */
+     , (26192,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26192,   5,         10) /* EncumbranceVal */
+     , (26192,   8,         10) /* Mass */
+     , (26192,   9,          0) /* ValidLocations - None */
+     , (26192,  11,         20) /* MaxStackSize */
+     , (26192,  12,          1) /* StackSize */
+     , (26192,  13,         10) /* StackUnitEncumbrance */
+     , (26192,  14,         10) /* StackUnitMass */
+     , (26192,  15,        500) /* StackUnitValue */
+     , (26192,  16,          8) /* ItemUseable - Contained */
+     , (26192,  18,          1) /* UiEffects - Magical */
+     , (26192,  19,        500) /* Value */
+     , (26192,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26192,  94,         16) /* TargetType - Creature */
+     , (26192, 106,        210) /* ItemSpellcraft */
+     , (26192, 107,         50) /* ItemCurMana */
+     , (26192, 108,         50) /* ItemMaxMana */
+     , (26192, 109,          0) /* ItemDifficulty */
+     , (26192, 110,          0) /* ItemAllegianceRankLimit */
+     , (26192, 150,        103) /* HookPlacement - Hook */
+     , (26192, 151,          2) /* HookType - Wall */
+     , (26192, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26192,  15, True ) /* LightsStatus */
+     , (26192,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26192, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26192,   1, 'Greenvale Settlement Portal Gem') /* Name */
+     , (26192,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26192,   1,   33556769) /* Setup */
+     , (26192,   3,  536870932) /* SoundTable */
+     , (26192,   6,   67111919) /* PaletteBase */
+     , (26192,   7,  268435723) /* ClothingBase */
+     , (26192,   8,  100675760) /* Icon */
+     , (26192,  22,  872415275) /* PhysicsEffectTable */
+     , (26192,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26192,  31,      13107) /* LinkedPortalOne - Greenvale Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26193 Haliana Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26193 Haliana Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26193;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26193, 'gemportalhaliana', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26193,   1,       2048) /* ItemType - Gem */
+     , (26193,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26193,   5,         10) /* EncumbranceVal */
+     , (26193,   8,         10) /* Mass */
+     , (26193,   9,          0) /* ValidLocations - None */
+     , (26193,  11,         20) /* MaxStackSize */
+     , (26193,  12,          1) /* StackSize */
+     , (26193,  13,         10) /* StackUnitEncumbrance */
+     , (26193,  14,         10) /* StackUnitMass */
+     , (26193,  15,        500) /* StackUnitValue */
+     , (26193,  16,          8) /* ItemUseable - Contained */
+     , (26193,  18,          1) /* UiEffects - Magical */
+     , (26193,  19,        500) /* Value */
+     , (26193,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26193,  94,         16) /* TargetType - Creature */
+     , (26193, 106,        210) /* ItemSpellcraft */
+     , (26193, 107,         50) /* ItemCurMana */
+     , (26193, 108,         50) /* ItemMaxMana */
+     , (26193, 109,          0) /* ItemDifficulty */
+     , (26193, 110,          0) /* ItemAllegianceRankLimit */
+     , (26193, 150,        103) /* HookPlacement - Hook */
+     , (26193, 151,          2) /* HookType - Wall */
+     , (26193, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26193,  15, True ) /* LightsStatus */
+     , (26193,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26193, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26193,   1, 'Haliana Portal Gem') /* Name */
+     , (26193,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26193,   1,   33556769) /* Setup */
+     , (26193,   3,  536870932) /* SoundTable */
+     , (26193,   6,   67111919) /* PaletteBase */
+     , (26193,   7,  268435723) /* ClothingBase */
+     , (26193,   8,  100675760) /* Icon */
+     , (26193,  22,  872415275) /* PhysicsEffectTable */
+     , (26193,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26193,  31,      14263) /* LinkedPortalOne - Haliana Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26194 Hamud Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26194 Hamud Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26194;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26194, 'gemportalhamudcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26194,   1,       2048) /* ItemType - Gem */
+     , (26194,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26194,   5,         10) /* EncumbranceVal */
+     , (26194,   8,         10) /* Mass */
+     , (26194,   9,          0) /* ValidLocations - None */
+     , (26194,  11,         20) /* MaxStackSize */
+     , (26194,  12,          1) /* StackSize */
+     , (26194,  13,         10) /* StackUnitEncumbrance */
+     , (26194,  14,         10) /* StackUnitMass */
+     , (26194,  15,        500) /* StackUnitValue */
+     , (26194,  16,          8) /* ItemUseable - Contained */
+     , (26194,  18,          1) /* UiEffects - Magical */
+     , (26194,  19,        500) /* Value */
+     , (26194,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26194,  94,         16) /* TargetType - Creature */
+     , (26194, 106,        210) /* ItemSpellcraft */
+     , (26194, 107,         50) /* ItemCurMana */
+     , (26194, 108,         50) /* ItemMaxMana */
+     , (26194, 109,          0) /* ItemDifficulty */
+     , (26194, 110,          0) /* ItemAllegianceRankLimit */
+     , (26194, 150,        103) /* HookPlacement - Hook */
+     , (26194, 151,          2) /* HookType - Wall */
+     , (26194, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26194,  15, True ) /* LightsStatus */
+     , (26194,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26194, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26194,   1, 'Hamud Cottages Portal Gem') /* Name */
+     , (26194,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26194,   1,   33556769) /* Setup */
+     , (26194,   3,  536870932) /* SoundTable */
+     , (26194,   6,   67111919) /* PaletteBase */
+     , (26194,   7,  268435723) /* ClothingBase */
+     , (26194,   8,  100675760) /* Icon */
+     , (26194,  22,  872415275) /* PhysicsEffectTable */
+     , (26194,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26194,  31,      14633) /* LinkedPortalOne - Hamud Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26195 Hand-on-Sword Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26195 Hand-on-Sword Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26195;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26195, 'gemportalhandonswordcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26195,   1,       2048) /* ItemType - Gem */
+     , (26195,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26195,   5,         10) /* EncumbranceVal */
+     , (26195,   8,         10) /* Mass */
+     , (26195,   9,          0) /* ValidLocations - None */
+     , (26195,  11,         20) /* MaxStackSize */
+     , (26195,  12,          1) /* StackSize */
+     , (26195,  13,         10) /* StackUnitEncumbrance */
+     , (26195,  14,         10) /* StackUnitMass */
+     , (26195,  15,        500) /* StackUnitValue */
+     , (26195,  16,          8) /* ItemUseable - Contained */
+     , (26195,  18,          1) /* UiEffects - Magical */
+     , (26195,  19,        500) /* Value */
+     , (26195,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26195,  94,         16) /* TargetType - Creature */
+     , (26195, 106,        210) /* ItemSpellcraft */
+     , (26195, 107,         50) /* ItemCurMana */
+     , (26195, 108,         50) /* ItemMaxMana */
+     , (26195, 109,          0) /* ItemDifficulty */
+     , (26195, 110,          0) /* ItemAllegianceRankLimit */
+     , (26195, 150,        103) /* HookPlacement - Hook */
+     , (26195, 151,          2) /* HookType - Wall */
+     , (26195, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26195,  15, True ) /* LightsStatus */
+     , (26195,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26195, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26195,   1, 'Hand-on-Sword Cottages Portal Gem') /* Name */
+     , (26195,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26195,   1,   33556769) /* Setup */
+     , (26195,   3,  536870932) /* SoundTable */
+     , (26195,   6,   67111919) /* PaletteBase */
+     , (26195,   7,  268435723) /* ClothingBase */
+     , (26195,   8,  100675760) /* Icon */
+     , (26195,  22,  872415275) /* PhysicsEffectTable */
+     , (26195,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26195,  31,      19147) /* LinkedPortalOne - Hand-on-Sword Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26196 Harmonious Blade Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26196 Harmonious Blade Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26196;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26196, 'gemportalharmoniousbladecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26196,   1,       2048) /* ItemType - Gem */
+     , (26196,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26196,   5,         10) /* EncumbranceVal */
+     , (26196,   8,         10) /* Mass */
+     , (26196,   9,          0) /* ValidLocations - None */
+     , (26196,  11,         20) /* MaxStackSize */
+     , (26196,  12,          1) /* StackSize */
+     , (26196,  13,         10) /* StackUnitEncumbrance */
+     , (26196,  14,         10) /* StackUnitMass */
+     , (26196,  15,        500) /* StackUnitValue */
+     , (26196,  16,          8) /* ItemUseable - Contained */
+     , (26196,  18,          1) /* UiEffects - Magical */
+     , (26196,  19,        500) /* Value */
+     , (26196,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26196,  94,         16) /* TargetType - Creature */
+     , (26196, 106,        210) /* ItemSpellcraft */
+     , (26196, 107,         50) /* ItemCurMana */
+     , (26196, 108,         50) /* ItemMaxMana */
+     , (26196, 109,          0) /* ItemDifficulty */
+     , (26196, 110,          0) /* ItemAllegianceRankLimit */
+     , (26196, 150,        103) /* HookPlacement - Hook */
+     , (26196, 151,          2) /* HookType - Wall */
+     , (26196, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26196,  15, True ) /* LightsStatus */
+     , (26196,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26196, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26196,   1, 'Harmonious Blade Cottages Portal Gem') /* Name */
+     , (26196,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26196,   1,   33556769) /* Setup */
+     , (26196,   3,  536870932) /* SoundTable */
+     , (26196,   6,   67111919) /* PaletteBase */
+     , (26196,   7,  268435723) /* ClothingBase */
+     , (26196,   8,  100675760) /* Icon */
+     , (26196,  22,  872415275) /* PhysicsEffectTable */
+     , (26196,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26196,  31,      15675) /* LinkedPortalOne - Harmonious Blade Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26197 Helms Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26197 Helms Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26197;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26197, 'gemportalhelmsvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26197,   1,       2048) /* ItemType - Gem */
+     , (26197,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26197,   5,         10) /* EncumbranceVal */
+     , (26197,   8,         10) /* Mass */
+     , (26197,   9,          0) /* ValidLocations - None */
+     , (26197,  11,         20) /* MaxStackSize */
+     , (26197,  12,          1) /* StackSize */
+     , (26197,  13,         10) /* StackUnitEncumbrance */
+     , (26197,  14,         10) /* StackUnitMass */
+     , (26197,  15,        500) /* StackUnitValue */
+     , (26197,  16,          8) /* ItemUseable - Contained */
+     , (26197,  18,          1) /* UiEffects - Magical */
+     , (26197,  19,        500) /* Value */
+     , (26197,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26197,  94,         16) /* TargetType - Creature */
+     , (26197, 106,        210) /* ItemSpellcraft */
+     , (26197, 107,         50) /* ItemCurMana */
+     , (26197, 108,         50) /* ItemMaxMana */
+     , (26197, 109,          0) /* ItemDifficulty */
+     , (26197, 110,          0) /* ItemAllegianceRankLimit */
+     , (26197, 150,        103) /* HookPlacement - Hook */
+     , (26197, 151,          2) /* HookType - Wall */
+     , (26197, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26197,  15, True ) /* LightsStatus */
+     , (26197,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26197, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26197,   1, 'Helms Villas Portal Gem') /* Name */
+     , (26197,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26197,   1,   33556769) /* Setup */
+     , (26197,   3,  536870932) /* SoundTable */
+     , (26197,   6,   67111919) /* PaletteBase */
+     , (26197,   7,  268435723) /* ClothingBase */
+     , (26197,   8,  100675760) /* Icon */
+     , (26197,  22,  872415275) /* PhysicsEffectTable */
+     , (26197,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26197,  31,      14264) /* LinkedPortalOne - Helms Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26198 Hermit Hill Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26198 Hermit Hill Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26198;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26198, 'gemportalhermithillcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26198,   1,       2048) /* ItemType - Gem */
+     , (26198,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26198,   5,         10) /* EncumbranceVal */
+     , (26198,   8,         10) /* Mass */
+     , (26198,   9,          0) /* ValidLocations - None */
+     , (26198,  11,         20) /* MaxStackSize */
+     , (26198,  12,          1) /* StackSize */
+     , (26198,  13,         10) /* StackUnitEncumbrance */
+     , (26198,  14,         10) /* StackUnitMass */
+     , (26198,  15,        500) /* StackUnitValue */
+     , (26198,  16,          8) /* ItemUseable - Contained */
+     , (26198,  18,          1) /* UiEffects - Magical */
+     , (26198,  19,        500) /* Value */
+     , (26198,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26198,  94,         16) /* TargetType - Creature */
+     , (26198, 106,        210) /* ItemSpellcraft */
+     , (26198, 107,         50) /* ItemCurMana */
+     , (26198, 108,         50) /* ItemMaxMana */
+     , (26198, 109,          0) /* ItemDifficulty */
+     , (26198, 110,          0) /* ItemAllegianceRankLimit */
+     , (26198, 150,        103) /* HookPlacement - Hook */
+     , (26198, 151,          2) /* HookType - Wall */
+     , (26198, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26198,  15, True ) /* LightsStatus */
+     , (26198,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26198, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26198,   1, 'Hermit Hill Cottages Portal Gem') /* Name */
+     , (26198,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26198,   1,   33556769) /* Setup */
+     , (26198,   3,  536870932) /* SoundTable */
+     , (26198,   6,   67111919) /* PaletteBase */
+     , (26198,   7,  268435723) /* ClothingBase */
+     , (26198,   8,  100675760) /* Icon */
+     , (26198,  22,  872415275) /* PhysicsEffectTable */
+     , (26198,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26198,  31,      14634) /* LinkedPortalOne - Hermit Hill Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26199 Hero's Vale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26199 Hero's Vale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26199;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26199, 'gemportalherosvale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26199,   1,       2048) /* ItemType - Gem */
+     , (26199,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26199,   5,         10) /* EncumbranceVal */
+     , (26199,   8,         10) /* Mass */
+     , (26199,   9,          0) /* ValidLocations - None */
+     , (26199,  11,         20) /* MaxStackSize */
+     , (26199,  12,          1) /* StackSize */
+     , (26199,  13,         10) /* StackUnitEncumbrance */
+     , (26199,  14,         10) /* StackUnitMass */
+     , (26199,  15,        500) /* StackUnitValue */
+     , (26199,  16,          8) /* ItemUseable - Contained */
+     , (26199,  18,          1) /* UiEffects - Magical */
+     , (26199,  19,        500) /* Value */
+     , (26199,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26199,  94,         16) /* TargetType - Creature */
+     , (26199, 106,        210) /* ItemSpellcraft */
+     , (26199, 107,         50) /* ItemCurMana */
+     , (26199, 108,         50) /* ItemMaxMana */
+     , (26199, 109,          0) /* ItemDifficulty */
+     , (26199, 110,          0) /* ItemAllegianceRankLimit */
+     , (26199, 150,        103) /* HookPlacement - Hook */
+     , (26199, 151,          2) /* HookType - Wall */
+     , (26199, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26199,  15, True ) /* LightsStatus */
+     , (26199,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26199, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26199,   1, 'Hero''s Vale Portal Gem') /* Name */
+     , (26199,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26199,   1,   33556769) /* Setup */
+     , (26199,   3,  536870932) /* SoundTable */
+     , (26199,   6,   67111919) /* PaletteBase */
+     , (26199,   7,  268435723) /* ClothingBase */
+     , (26199,   8,  100675760) /* Icon */
+     , (26199,  22,  872415275) /* PhysicsEffectTable */
+     , (26199,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26199,  31,      15676) /* LinkedPortalOne - Hero's Vale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26200 Hidden Valley Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26200 Hidden Valley Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26200;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26200, 'gemportalhiddenvalley', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26200,   1,       2048) /* ItemType - Gem */
+     , (26200,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26200,   5,         10) /* EncumbranceVal */
+     , (26200,   8,         10) /* Mass */
+     , (26200,   9,          0) /* ValidLocations - None */
+     , (26200,  11,         20) /* MaxStackSize */
+     , (26200,  12,          1) /* StackSize */
+     , (26200,  13,         10) /* StackUnitEncumbrance */
+     , (26200,  14,         10) /* StackUnitMass */
+     , (26200,  15,        500) /* StackUnitValue */
+     , (26200,  16,          8) /* ItemUseable - Contained */
+     , (26200,  18,          1) /* UiEffects - Magical */
+     , (26200,  19,        500) /* Value */
+     , (26200,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26200,  94,         16) /* TargetType - Creature */
+     , (26200, 106,        210) /* ItemSpellcraft */
+     , (26200, 107,         50) /* ItemCurMana */
+     , (26200, 108,         50) /* ItemMaxMana */
+     , (26200, 109,          0) /* ItemDifficulty */
+     , (26200, 110,          0) /* ItemAllegianceRankLimit */
+     , (26200, 150,        103) /* HookPlacement - Hook */
+     , (26200, 151,          2) /* HookType - Wall */
+     , (26200, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26200,  15, True ) /* LightsStatus */
+     , (26200,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26200, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26200,   1, 'Hidden Valley Portal Gem') /* Name */
+     , (26200,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26200,   1,   33556769) /* Setup */
+     , (26200,   3,  536870932) /* SoundTable */
+     , (26200,   6,   67111919) /* PaletteBase */
+     , (26200,   7,  268435723) /* ClothingBase */
+     , (26200,   8,  100675760) /* Icon */
+     , (26200,  22,  872415275) /* PhysicsEffectTable */
+     , (26200,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26200,  31,      14635) /* LinkedPortalOne - Hidden Valley Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26201 Highland Manors Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26201 Highland Manors Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26201;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26201, 'gemportalhighlandmanors', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26201,   1,       2048) /* ItemType - Gem */
+     , (26201,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26201,   5,         10) /* EncumbranceVal */
+     , (26201,   8,         10) /* Mass */
+     , (26201,   9,          0) /* ValidLocations - None */
+     , (26201,  11,         20) /* MaxStackSize */
+     , (26201,  12,          1) /* StackSize */
+     , (26201,  13,         10) /* StackUnitEncumbrance */
+     , (26201,  14,         10) /* StackUnitMass */
+     , (26201,  15,        500) /* StackUnitValue */
+     , (26201,  16,          8) /* ItemUseable - Contained */
+     , (26201,  18,          1) /* UiEffects - Magical */
+     , (26201,  19,        500) /* Value */
+     , (26201,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26201,  94,         16) /* TargetType - Creature */
+     , (26201, 106,        210) /* ItemSpellcraft */
+     , (26201, 107,         50) /* ItemCurMana */
+     , (26201, 108,         50) /* ItemMaxMana */
+     , (26201, 109,          0) /* ItemDifficulty */
+     , (26201, 110,          0) /* ItemAllegianceRankLimit */
+     , (26201, 150,        103) /* HookPlacement - Hook */
+     , (26201, 151,          2) /* HookType - Wall */
+     , (26201, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26201,  15, True ) /* LightsStatus */
+     , (26201,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26201, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26201,   1, 'Highland Manors Portal Gem') /* Name */
+     , (26201,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26201,   1,   33556769) /* Setup */
+     , (26201,   3,  536870932) /* SoundTable */
+     , (26201,   6,   67111919) /* PaletteBase */
+     , (26201,   7,  268435723) /* ClothingBase */
+     , (26201,   8,  100675760) /* Icon */
+     , (26201,  22,  872415275) /* PhysicsEffectTable */
+     , (26201,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26201,  31,      13108) /* LinkedPortalOne - Highland Manors Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26202 Holtburg Wilderness Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26202 Holtburg Wilderness Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26202;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26202, 'gemportalholtburgwildernesssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26202,   1,       2048) /* ItemType - Gem */
+     , (26202,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26202,   5,         10) /* EncumbranceVal */
+     , (26202,   8,         10) /* Mass */
+     , (26202,   9,          0) /* ValidLocations - None */
+     , (26202,  11,         20) /* MaxStackSize */
+     , (26202,  12,          1) /* StackSize */
+     , (26202,  13,         10) /* StackUnitEncumbrance */
+     , (26202,  14,         10) /* StackUnitMass */
+     , (26202,  15,        500) /* StackUnitValue */
+     , (26202,  16,          8) /* ItemUseable - Contained */
+     , (26202,  18,          1) /* UiEffects - Magical */
+     , (26202,  19,        500) /* Value */
+     , (26202,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26202,  94,         16) /* TargetType - Creature */
+     , (26202, 106,        210) /* ItemSpellcraft */
+     , (26202, 107,         50) /* ItemCurMana */
+     , (26202, 108,         50) /* ItemMaxMana */
+     , (26202, 109,          0) /* ItemDifficulty */
+     , (26202, 110,          0) /* ItemAllegianceRankLimit */
+     , (26202, 150,        103) /* HookPlacement - Hook */
+     , (26202, 151,          2) /* HookType - Wall */
+     , (26202, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26202,  15, True ) /* LightsStatus */
+     , (26202,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26202, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26202,   1, 'Holtburg Wilderness Settlement Portal Gem') /* Name */
+     , (26202,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26202,   1,   33556769) /* Setup */
+     , (26202,   3,  536870932) /* SoundTable */
+     , (26202,   6,   67111919) /* PaletteBase */
+     , (26202,   7,  268435723) /* ClothingBase */
+     , (26202,   8,  100675760) /* Icon */
+     , (26202,  22,  872415275) /* PhysicsEffectTable */
+     , (26202,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26202,  31,      12503) /* LinkedPortalOne - Holtburg Wilderness Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26203 Hopevale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26203 Hopevale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26203;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26203, 'gemportalhopevale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26203,   1,       2048) /* ItemType - Gem */
+     , (26203,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26203,   5,         10) /* EncumbranceVal */
+     , (26203,   8,         10) /* Mass */
+     , (26203,   9,          0) /* ValidLocations - None */
+     , (26203,  11,         20) /* MaxStackSize */
+     , (26203,  12,          1) /* StackSize */
+     , (26203,  13,         10) /* StackUnitEncumbrance */
+     , (26203,  14,         10) /* StackUnitMass */
+     , (26203,  15,        500) /* StackUnitValue */
+     , (26203,  16,          8) /* ItemUseable - Contained */
+     , (26203,  18,          1) /* UiEffects - Magical */
+     , (26203,  19,        500) /* Value */
+     , (26203,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26203,  94,         16) /* TargetType - Creature */
+     , (26203, 106,        210) /* ItemSpellcraft */
+     , (26203, 107,         50) /* ItemCurMana */
+     , (26203, 108,         50) /* ItemMaxMana */
+     , (26203, 109,          0) /* ItemDifficulty */
+     , (26203, 110,          0) /* ItemAllegianceRankLimit */
+     , (26203, 150,        103) /* HookPlacement - Hook */
+     , (26203, 151,          2) /* HookType - Wall */
+     , (26203, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26203,  15, True ) /* LightsStatus */
+     , (26203,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26203, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26203,   1, 'Hopevale Portal Gem') /* Name */
+     , (26203,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26203,   1,   33556769) /* Setup */
+     , (26203,   3,  536870932) /* SoundTable */
+     , (26203,   6,   67111919) /* PaletteBase */
+     , (26203,   7,  268435723) /* ClothingBase */
+     , (26203,   8,  100675760) /* Icon */
+     , (26203,  22,  872415275) /* PhysicsEffectTable */
+     , (26203,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26203,  31,      19148) /* LinkedPortalOne - Hopevale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26204 Howling Wolf Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26204 Howling Wolf Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26204;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26204, 'gemportalhowlingwolfvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26204,   1,       2048) /* ItemType - Gem */
+     , (26204,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26204,   5,         10) /* EncumbranceVal */
+     , (26204,   8,         10) /* Mass */
+     , (26204,   9,          0) /* ValidLocations - None */
+     , (26204,  11,         20) /* MaxStackSize */
+     , (26204,  12,          1) /* StackSize */
+     , (26204,  13,         10) /* StackUnitEncumbrance */
+     , (26204,  14,         10) /* StackUnitMass */
+     , (26204,  15,        500) /* StackUnitValue */
+     , (26204,  16,          8) /* ItemUseable - Contained */
+     , (26204,  18,          1) /* UiEffects - Magical */
+     , (26204,  19,        500) /* Value */
+     , (26204,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26204,  94,         16) /* TargetType - Creature */
+     , (26204, 106,        210) /* ItemSpellcraft */
+     , (26204, 107,         50) /* ItemCurMana */
+     , (26204, 108,         50) /* ItemMaxMana */
+     , (26204, 109,          0) /* ItemDifficulty */
+     , (26204, 110,          0) /* ItemAllegianceRankLimit */
+     , (26204, 150,        103) /* HookPlacement - Hook */
+     , (26204, 151,          2) /* HookType - Wall */
+     , (26204, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26204,  15, True ) /* LightsStatus */
+     , (26204,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26204, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26204,   1, 'Howling Wolf Villas Portal Gem') /* Name */
+     , (26204,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26204,   1,   33556769) /* Setup */
+     , (26204,   3,  536870932) /* SoundTable */
+     , (26204,   6,   67111919) /* PaletteBase */
+     , (26204,   7,  268435723) /* ClothingBase */
+     , (26204,   8,  100675760) /* Icon */
+     , (26204,  22,  872415275) /* PhysicsEffectTable */
+     , (26204,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26204,  31,      15160) /* LinkedPortalOne - Howling Wolf Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26205 Ianna Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26205 Ianna Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26205;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26205, 'gemportalianna', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26205,   1,       2048) /* ItemType - Gem */
+     , (26205,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26205,   5,         10) /* EncumbranceVal */
+     , (26205,   8,         10) /* Mass */
+     , (26205,   9,          0) /* ValidLocations - None */
+     , (26205,  11,         20) /* MaxStackSize */
+     , (26205,  12,          1) /* StackSize */
+     , (26205,  13,         10) /* StackUnitEncumbrance */
+     , (26205,  14,         10) /* StackUnitMass */
+     , (26205,  15,        500) /* StackUnitValue */
+     , (26205,  16,          8) /* ItemUseable - Contained */
+     , (26205,  18,          1) /* UiEffects - Magical */
+     , (26205,  19,        500) /* Value */
+     , (26205,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26205,  94,         16) /* TargetType - Creature */
+     , (26205, 106,        210) /* ItemSpellcraft */
+     , (26205, 107,         50) /* ItemCurMana */
+     , (26205, 108,         50) /* ItemMaxMana */
+     , (26205, 109,          0) /* ItemDifficulty */
+     , (26205, 110,          0) /* ItemAllegianceRankLimit */
+     , (26205, 150,        103) /* HookPlacement - Hook */
+     , (26205, 151,          2) /* HookType - Wall */
+     , (26205, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26205,  15, True ) /* LightsStatus */
+     , (26205,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26205, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26205,   1, 'Ianna Portal Gem') /* Name */
+     , (26205,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26205,   1,   33556769) /* Setup */
+     , (26205,   3,  536870932) /* SoundTable */
+     , (26205,   6,   67111919) /* PaletteBase */
+     , (26205,   7,  268435723) /* ClothingBase */
+     , (26205,   8,  100675760) /* Icon */
+     , (26205,  22,  872415275) /* PhysicsEffectTable */
+     , (26205,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26205,  31,      14636) /* LinkedPortalOne - Ianna Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26206 Icecliff Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26206 Icecliff Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26206;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26206, 'gemportalicecliffcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26206,   1,       2048) /* ItemType - Gem */
+     , (26206,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26206,   5,         10) /* EncumbranceVal */
+     , (26206,   8,         10) /* Mass */
+     , (26206,   9,          0) /* ValidLocations - None */
+     , (26206,  11,         20) /* MaxStackSize */
+     , (26206,  12,          1) /* StackSize */
+     , (26206,  13,         10) /* StackUnitEncumbrance */
+     , (26206,  14,         10) /* StackUnitMass */
+     , (26206,  15,        500) /* StackUnitValue */
+     , (26206,  16,          8) /* ItemUseable - Contained */
+     , (26206,  18,          1) /* UiEffects - Magical */
+     , (26206,  19,        500) /* Value */
+     , (26206,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26206,  94,         16) /* TargetType - Creature */
+     , (26206, 106,        210) /* ItemSpellcraft */
+     , (26206, 107,         50) /* ItemCurMana */
+     , (26206, 108,         50) /* ItemMaxMana */
+     , (26206, 109,          0) /* ItemDifficulty */
+     , (26206, 110,          0) /* ItemAllegianceRankLimit */
+     , (26206, 150,        103) /* HookPlacement - Hook */
+     , (26206, 151,          2) /* HookType - Wall */
+     , (26206, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26206,  15, True ) /* LightsStatus */
+     , (26206,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26206, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26206,   1, 'Icecliff Cottages Portal Gem') /* Name */
+     , (26206,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26206,   1,   33556769) /* Setup */
+     , (26206,   3,  536870932) /* SoundTable */
+     , (26206,   6,   67111919) /* PaletteBase */
+     , (26206,   7,  268435723) /* ClothingBase */
+     , (26206,   8,  100675760) /* Icon */
+     , (26206,  22,  872415275) /* PhysicsEffectTable */
+     , (26206,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26206,  31,      14265) /* LinkedPortalOne - Icecliff Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26207 Iceea Hills Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26207 Iceea Hills Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26207;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26207, 'gemportaliceeahillsestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26207,   1,       2048) /* ItemType - Gem */
+     , (26207,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26207,   5,         10) /* EncumbranceVal */
+     , (26207,   8,         10) /* Mass */
+     , (26207,   9,          0) /* ValidLocations - None */
+     , (26207,  11,         20) /* MaxStackSize */
+     , (26207,  12,          1) /* StackSize */
+     , (26207,  13,         10) /* StackUnitEncumbrance */
+     , (26207,  14,         10) /* StackUnitMass */
+     , (26207,  15,        500) /* StackUnitValue */
+     , (26207,  16,          8) /* ItemUseable - Contained */
+     , (26207,  18,          1) /* UiEffects - Magical */
+     , (26207,  19,        500) /* Value */
+     , (26207,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26207,  94,         16) /* TargetType - Creature */
+     , (26207, 106,        210) /* ItemSpellcraft */
+     , (26207, 107,         50) /* ItemCurMana */
+     , (26207, 108,         50) /* ItemMaxMana */
+     , (26207, 109,          0) /* ItemDifficulty */
+     , (26207, 110,          0) /* ItemAllegianceRankLimit */
+     , (26207, 150,        103) /* HookPlacement - Hook */
+     , (26207, 151,          2) /* HookType - Wall */
+     , (26207, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26207,  15, True ) /* LightsStatus */
+     , (26207,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26207, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26207,   1, 'Iceea Hills Estates Portal Gem') /* Name */
+     , (26207,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26207,   1,   33556769) /* Setup */
+     , (26207,   3,  536870932) /* SoundTable */
+     , (26207,   6,   67111919) /* PaletteBase */
+     , (26207,   7,  268435723) /* ClothingBase */
+     , (26207,   8,  100675760) /* Icon */
+     , (26207,  22,  872415275) /* PhysicsEffectTable */
+     , (26207,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26207,  31,      13109) /* LinkedPortalOne - Iceea Hills Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26208 Ice's Edge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26208 Ice's Edge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26208;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26208, 'gemportalicesedgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26208,   1,       2048) /* ItemType - Gem */
+     , (26208,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26208,   5,         10) /* EncumbranceVal */
+     , (26208,   8,         10) /* Mass */
+     , (26208,   9,          0) /* ValidLocations - None */
+     , (26208,  11,         20) /* MaxStackSize */
+     , (26208,  12,          1) /* StackSize */
+     , (26208,  13,         10) /* StackUnitEncumbrance */
+     , (26208,  14,         10) /* StackUnitMass */
+     , (26208,  15,        500) /* StackUnitValue */
+     , (26208,  16,          8) /* ItemUseable - Contained */
+     , (26208,  18,          1) /* UiEffects - Magical */
+     , (26208,  19,        500) /* Value */
+     , (26208,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26208,  94,         16) /* TargetType - Creature */
+     , (26208, 106,        210) /* ItemSpellcraft */
+     , (26208, 107,         50) /* ItemCurMana */
+     , (26208, 108,         50) /* ItemMaxMana */
+     , (26208, 109,          0) /* ItemDifficulty */
+     , (26208, 110,          0) /* ItemAllegianceRankLimit */
+     , (26208, 150,        103) /* HookPlacement - Hook */
+     , (26208, 151,          2) /* HookType - Wall */
+     , (26208, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26208,  15, True ) /* LightsStatus */
+     , (26208,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26208, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26208,   1, 'Ice''s Edge Cottages Portal Gem') /* Name */
+     , (26208,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26208,   1,   33556769) /* Setup */
+     , (26208,   3,  536870932) /* SoundTable */
+     , (26208,   6,   67111919) /* PaletteBase */
+     , (26208,   7,  268435723) /* ClothingBase */
+     , (26208,   8,  100675760) /* Icon */
+     , (26208,  22,  872415275) /* PhysicsEffectTable */
+     , (26208,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26208,  31,      15161) /* LinkedPortalOne - Ice's Edge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26209 Ijaniya  Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26209 Ijaniya  Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26209;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26209, 'gemportalijaniya', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26209,   1,       2048) /* ItemType - Gem */
+     , (26209,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26209,   5,         10) /* EncumbranceVal */
+     , (26209,   8,         10) /* Mass */
+     , (26209,   9,          0) /* ValidLocations - None */
+     , (26209,  11,         20) /* MaxStackSize */
+     , (26209,  12,          1) /* StackSize */
+     , (26209,  13,         10) /* StackUnitEncumbrance */
+     , (26209,  14,         10) /* StackUnitMass */
+     , (26209,  15,        500) /* StackUnitValue */
+     , (26209,  16,          8) /* ItemUseable - Contained */
+     , (26209,  18,          1) /* UiEffects - Magical */
+     , (26209,  19,        500) /* Value */
+     , (26209,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26209,  94,         16) /* TargetType - Creature */
+     , (26209, 106,        210) /* ItemSpellcraft */
+     , (26209, 107,         50) /* ItemCurMana */
+     , (26209, 108,         50) /* ItemMaxMana */
+     , (26209, 109,          0) /* ItemDifficulty */
+     , (26209, 110,          0) /* ItemAllegianceRankLimit */
+     , (26209, 150,        103) /* HookPlacement - Hook */
+     , (26209, 151,          2) /* HookType - Wall */
+     , (26209, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26209,  15, True ) /* LightsStatus */
+     , (26209,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26209, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26209,   1, 'Ijaniya  Portal Gem') /* Name */
+     , (26209,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26209,   1,   33556769) /* Setup */
+     , (26209,   3,  536870932) /* SoundTable */
+     , (26209,   6,   67111919) /* PaletteBase */
+     , (26209,   7,  268435723) /* ClothingBase */
+     , (26209,   8,  100675760) /* Icon */
+     , (26209,  22,  872415275) /* PhysicsEffectTable */
+     , (26209,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26209,  31,      12504) /* LinkedPortalOne - Ijaniya  Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26210 Ikama Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26210 Ikama Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26210;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26210, 'gemportalikamacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26210,   1,       2048) /* ItemType - Gem */
+     , (26210,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26210,   5,         10) /* EncumbranceVal */
+     , (26210,   8,         10) /* Mass */
+     , (26210,   9,          0) /* ValidLocations - None */
+     , (26210,  11,         20) /* MaxStackSize */
+     , (26210,  12,          1) /* StackSize */
+     , (26210,  13,         10) /* StackUnitEncumbrance */
+     , (26210,  14,         10) /* StackUnitMass */
+     , (26210,  15,        500) /* StackUnitValue */
+     , (26210,  16,          8) /* ItemUseable - Contained */
+     , (26210,  18,          1) /* UiEffects - Magical */
+     , (26210,  19,        500) /* Value */
+     , (26210,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26210,  94,         16) /* TargetType - Creature */
+     , (26210, 106,        210) /* ItemSpellcraft */
+     , (26210, 107,         50) /* ItemCurMana */
+     , (26210, 108,         50) /* ItemMaxMana */
+     , (26210, 109,          0) /* ItemDifficulty */
+     , (26210, 110,          0) /* ItemAllegianceRankLimit */
+     , (26210, 150,        103) /* HookPlacement - Hook */
+     , (26210, 151,          2) /* HookType - Wall */
+     , (26210, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26210,  15, True ) /* LightsStatus */
+     , (26210,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26210, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26210,   1, 'Ikama Cottages Portal Gem') /* Name */
+     , (26210,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26210,   1,   33556769) /* Setup */
+     , (26210,   3,  536870932) /* SoundTable */
+     , (26210,   6,   67111919) /* PaletteBase */
+     , (26210,   7,  268435723) /* ClothingBase */
+     , (26210,   8,  100675760) /* Icon */
+     , (26210,  22,  872415275) /* PhysicsEffectTable */
+     , (26210,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26210,  31,      14637) /* LinkedPortalOne - Ikama Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26211 Imuth Maer Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26211 Imuth Maer Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26211;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26211, 'gemportalimuthmaercottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26211,   1,       2048) /* ItemType - Gem */
+     , (26211,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26211,   5,         10) /* EncumbranceVal */
+     , (26211,   8,         10) /* Mass */
+     , (26211,   9,          0) /* ValidLocations - None */
+     , (26211,  11,         20) /* MaxStackSize */
+     , (26211,  12,          1) /* StackSize */
+     , (26211,  13,         10) /* StackUnitEncumbrance */
+     , (26211,  14,         10) /* StackUnitMass */
+     , (26211,  15,        500) /* StackUnitValue */
+     , (26211,  16,          8) /* ItemUseable - Contained */
+     , (26211,  18,          1) /* UiEffects - Magical */
+     , (26211,  19,        500) /* Value */
+     , (26211,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26211,  94,         16) /* TargetType - Creature */
+     , (26211, 106,        210) /* ItemSpellcraft */
+     , (26211, 107,         50) /* ItemCurMana */
+     , (26211, 108,         50) /* ItemMaxMana */
+     , (26211, 109,          0) /* ItemDifficulty */
+     , (26211, 110,          0) /* ItemAllegianceRankLimit */
+     , (26211, 150,        103) /* HookPlacement - Hook */
+     , (26211, 151,          2) /* HookType - Wall */
+     , (26211, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26211,  15, True ) /* LightsStatus */
+     , (26211,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26211, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26211,   1, 'Imuth Maer Cottages Portal Gem') /* Name */
+     , (26211,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26211,   1,   33556769) /* Setup */
+     , (26211,   3,  536870932) /* SoundTable */
+     , (26211,   6,   67111919) /* PaletteBase */
+     , (26211,   7,  268435723) /* ClothingBase */
+     , (26211,   8,  100675760) /* Icon */
+     , (26211,  22,  872415275) /* PhysicsEffectTable */
+     , (26211,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26211,  31,      12505) /* LinkedPortalOne - Imuth Maer Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26212 Inquisitor's Dale Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26212 Inquisitor's Dale Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26212;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26212, 'gemportalinquisitorsdalecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26212,   1,       2048) /* ItemType - Gem */
+     , (26212,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26212,   5,         10) /* EncumbranceVal */
+     , (26212,   8,         10) /* Mass */
+     , (26212,   9,          0) /* ValidLocations - None */
+     , (26212,  11,         20) /* MaxStackSize */
+     , (26212,  12,          1) /* StackSize */
+     , (26212,  13,         10) /* StackUnitEncumbrance */
+     , (26212,  14,         10) /* StackUnitMass */
+     , (26212,  15,        500) /* StackUnitValue */
+     , (26212,  16,          8) /* ItemUseable - Contained */
+     , (26212,  18,          1) /* UiEffects - Magical */
+     , (26212,  19,        500) /* Value */
+     , (26212,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26212,  94,         16) /* TargetType - Creature */
+     , (26212, 106,        210) /* ItemSpellcraft */
+     , (26212, 107,         50) /* ItemCurMana */
+     , (26212, 108,         50) /* ItemMaxMana */
+     , (26212, 109,          0) /* ItemDifficulty */
+     , (26212, 110,          0) /* ItemAllegianceRankLimit */
+     , (26212, 150,        103) /* HookPlacement - Hook */
+     , (26212, 151,          2) /* HookType - Wall */
+     , (26212, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26212,  15, True ) /* LightsStatus */
+     , (26212,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26212, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26212,   1, 'Inquisitor''s Dale Cottages Portal Gem') /* Name */
+     , (26212,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26212,   1,   33556769) /* Setup */
+     , (26212,   3,  536870932) /* SoundTable */
+     , (26212,   6,   67111919) /* PaletteBase */
+     , (26212,   7,  268435723) /* ClothingBase */
+     , (26212,   8,  100675760) /* Icon */
+     , (26212,  22,  872415275) /* PhysicsEffectTable */
+     , (26212,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26212,  31,      15162) /* LinkedPortalOne - Inquisitor's Dale Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26213 Ishilai Inlet Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26213 Ishilai Inlet Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26213;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26213, 'gemportalishilaiinletsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26213,   1,       2048) /* ItemType - Gem */
+     , (26213,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26213,   5,         10) /* EncumbranceVal */
+     , (26213,   8,         10) /* Mass */
+     , (26213,   9,          0) /* ValidLocations - None */
+     , (26213,  11,         20) /* MaxStackSize */
+     , (26213,  12,          1) /* StackSize */
+     , (26213,  13,         10) /* StackUnitEncumbrance */
+     , (26213,  14,         10) /* StackUnitMass */
+     , (26213,  15,        500) /* StackUnitValue */
+     , (26213,  16,          8) /* ItemUseable - Contained */
+     , (26213,  18,          1) /* UiEffects - Magical */
+     , (26213,  19,        500) /* Value */
+     , (26213,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26213,  94,         16) /* TargetType - Creature */
+     , (26213, 106,        210) /* ItemSpellcraft */
+     , (26213, 107,         50) /* ItemCurMana */
+     , (26213, 108,         50) /* ItemMaxMana */
+     , (26213, 109,          0) /* ItemDifficulty */
+     , (26213, 110,          0) /* ItemAllegianceRankLimit */
+     , (26213, 150,        103) /* HookPlacement - Hook */
+     , (26213, 151,          2) /* HookType - Wall */
+     , (26213, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26213,  15, True ) /* LightsStatus */
+     , (26213,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26213, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26213,   1, 'Ishilai Inlet Settlement Portal Gem') /* Name */
+     , (26213,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26213,   1,   33556769) /* Setup */
+     , (26213,   3,  536870932) /* SoundTable */
+     , (26213,   6,   67111919) /* PaletteBase */
+     , (26213,   7,  268435723) /* ClothingBase */
+     , (26213,   8,  100675760) /* Icon */
+     , (26213,  22,  872415275) /* PhysicsEffectTable */
+     , (26213,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26213,  31,      12506) /* LinkedPortalOne - Ishilai Inlet Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26214 Ishilai Inlet Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26214 Ishilai Inlet Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26214;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26214, 'gemportalishilaiinletvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26214,   1,       2048) /* ItemType - Gem */
+     , (26214,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26214,   5,         10) /* EncumbranceVal */
+     , (26214,   8,         10) /* Mass */
+     , (26214,   9,          0) /* ValidLocations - None */
+     , (26214,  11,         20) /* MaxStackSize */
+     , (26214,  12,          1) /* StackSize */
+     , (26214,  13,         10) /* StackUnitEncumbrance */
+     , (26214,  14,         10) /* StackUnitMass */
+     , (26214,  15,        500) /* StackUnitValue */
+     , (26214,  16,          8) /* ItemUseable - Contained */
+     , (26214,  18,          1) /* UiEffects - Magical */
+     , (26214,  19,        500) /* Value */
+     , (26214,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26214,  94,         16) /* TargetType - Creature */
+     , (26214, 106,        210) /* ItemSpellcraft */
+     , (26214, 107,         50) /* ItemCurMana */
+     , (26214, 108,         50) /* ItemMaxMana */
+     , (26214, 109,          0) /* ItemDifficulty */
+     , (26214, 110,          0) /* ItemAllegianceRankLimit */
+     , (26214, 150,        103) /* HookPlacement - Hook */
+     , (26214, 151,          2) /* HookType - Wall */
+     , (26214, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26214,  15, True ) /* LightsStatus */
+     , (26214,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26214, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26214,   1, 'Ishilai Inlet Villas Portal Gem') /* Name */
+     , (26214,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26214,   1,   33556769) /* Setup */
+     , (26214,   3,  536870932) /* SoundTable */
+     , (26214,   6,   67111919) /* PaletteBase */
+     , (26214,   7,  268435723) /* ClothingBase */
+     , (26214,   8,  100675760) /* Icon */
+     , (26214,  22,  872415275) /* PhysicsEffectTable */
+     , (26214,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26214,  31,      13110) /* LinkedPortalOne - Ishilai Inlet Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26215 Ispan Hill Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26215 Ispan Hill Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26215;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26215, 'gemportalispanhill', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26215,   1,       2048) /* ItemType - Gem */
+     , (26215,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26215,   5,         10) /* EncumbranceVal */
+     , (26215,   8,         10) /* Mass */
+     , (26215,   9,          0) /* ValidLocations - None */
+     , (26215,  11,         20) /* MaxStackSize */
+     , (26215,  12,          1) /* StackSize */
+     , (26215,  13,         10) /* StackUnitEncumbrance */
+     , (26215,  14,         10) /* StackUnitMass */
+     , (26215,  15,        500) /* StackUnitValue */
+     , (26215,  16,          8) /* ItemUseable - Contained */
+     , (26215,  18,          1) /* UiEffects - Magical */
+     , (26215,  19,        500) /* Value */
+     , (26215,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26215,  94,         16) /* TargetType - Creature */
+     , (26215, 106,        210) /* ItemSpellcraft */
+     , (26215, 107,         50) /* ItemCurMana */
+     , (26215, 108,         50) /* ItemMaxMana */
+     , (26215, 109,          0) /* ItemDifficulty */
+     , (26215, 110,          0) /* ItemAllegianceRankLimit */
+     , (26215, 150,        103) /* HookPlacement - Hook */
+     , (26215, 151,          2) /* HookType - Wall */
+     , (26215, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26215,  15, True ) /* LightsStatus */
+     , (26215,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26215, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26215,   1, 'Ispan Hill Portal Gem') /* Name */
+     , (26215,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26215,   1,   33556769) /* Setup */
+     , (26215,   3,  536870932) /* SoundTable */
+     , (26215,   6,   67111919) /* PaletteBase */
+     , (26215,   7,  268435723) /* ClothingBase */
+     , (26215,   8,  100675760) /* Icon */
+     , (26215,  22,  872415275) /* PhysicsEffectTable */
+     , (26215,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26215,  31,      14266) /* LinkedPortalOne - Ispan Hill Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26216 Isparian Flame Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26216 Isparian Flame Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26216;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26216, 'gemportalisparianflameestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26216,   1,       2048) /* ItemType - Gem */
+     , (26216,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26216,   5,         10) /* EncumbranceVal */
+     , (26216,   8,         10) /* Mass */
+     , (26216,   9,          0) /* ValidLocations - None */
+     , (26216,  11,         20) /* MaxStackSize */
+     , (26216,  12,          1) /* StackSize */
+     , (26216,  13,         10) /* StackUnitEncumbrance */
+     , (26216,  14,         10) /* StackUnitMass */
+     , (26216,  15,        500) /* StackUnitValue */
+     , (26216,  16,          8) /* ItemUseable - Contained */
+     , (26216,  18,          1) /* UiEffects - Magical */
+     , (26216,  19,        500) /* Value */
+     , (26216,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26216,  94,         16) /* TargetType - Creature */
+     , (26216, 106,        210) /* ItemSpellcraft */
+     , (26216, 107,         50) /* ItemCurMana */
+     , (26216, 108,         50) /* ItemMaxMana */
+     , (26216, 109,          0) /* ItemDifficulty */
+     , (26216, 110,          0) /* ItemAllegianceRankLimit */
+     , (26216, 150,        103) /* HookPlacement - Hook */
+     , (26216, 151,          2) /* HookType - Wall */
+     , (26216, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26216,  15, True ) /* LightsStatus */
+     , (26216,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26216, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26216,   1, 'Isparian Flame Estates Portal Gem') /* Name */
+     , (26216,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26216,   1,   33556769) /* Setup */
+     , (26216,   3,  536870932) /* SoundTable */
+     , (26216,   6,   67111919) /* PaletteBase */
+     , (26216,   7,  268435723) /* ClothingBase */
+     , (26216,   8,  100675760) /* Icon */
+     , (26216,  22,  872415275) /* PhysicsEffectTable */
+     , (26216,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26216,  31,      19149) /* LinkedPortalOne - Isparian Flame Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26217 Jackcat Canyon Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26217 Jackcat Canyon Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26217;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26217, 'gemportaljackcatcanyon', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26217,   1,       2048) /* ItemType - Gem */
+     , (26217,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26217,   5,         10) /* EncumbranceVal */
+     , (26217,   8,         10) /* Mass */
+     , (26217,   9,          0) /* ValidLocations - None */
+     , (26217,  11,         20) /* MaxStackSize */
+     , (26217,  12,          1) /* StackSize */
+     , (26217,  13,         10) /* StackUnitEncumbrance */
+     , (26217,  14,         10) /* StackUnitMass */
+     , (26217,  15,        500) /* StackUnitValue */
+     , (26217,  16,          8) /* ItemUseable - Contained */
+     , (26217,  18,          1) /* UiEffects - Magical */
+     , (26217,  19,        500) /* Value */
+     , (26217,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26217,  94,         16) /* TargetType - Creature */
+     , (26217, 106,        210) /* ItemSpellcraft */
+     , (26217, 107,         50) /* ItemCurMana */
+     , (26217, 108,         50) /* ItemMaxMana */
+     , (26217, 109,          0) /* ItemDifficulty */
+     , (26217, 110,          0) /* ItemAllegianceRankLimit */
+     , (26217, 150,        103) /* HookPlacement - Hook */
+     , (26217, 151,          2) /* HookType - Wall */
+     , (26217, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26217,  15, True ) /* LightsStatus */
+     , (26217,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26217, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26217,   1, 'Jackcat Canyon Portal Gem') /* Name */
+     , (26217,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26217,   1,   33556769) /* Setup */
+     , (26217,   3,  536870932) /* SoundTable */
+     , (26217,   6,   67111919) /* PaletteBase */
+     , (26217,   7,  268435723) /* ClothingBase */
+     , (26217,   8,  100675760) /* Icon */
+     , (26217,  22,  872415275) /* PhysicsEffectTable */
+     , (26217,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26217,  31,      14267) /* LinkedPortalOne - Jackcat Canyon Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26218 Jai-Tan Dale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26218 Jai-Tan Dale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26218;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26218, 'gemportaljaitandale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26218,   1,       2048) /* ItemType - Gem */
+     , (26218,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26218,   5,         10) /* EncumbranceVal */
+     , (26218,   8,         10) /* Mass */
+     , (26218,   9,          0) /* ValidLocations - None */
+     , (26218,  11,         20) /* MaxStackSize */
+     , (26218,  12,          1) /* StackSize */
+     , (26218,  13,         10) /* StackUnitEncumbrance */
+     , (26218,  14,         10) /* StackUnitMass */
+     , (26218,  15,        500) /* StackUnitValue */
+     , (26218,  16,          8) /* ItemUseable - Contained */
+     , (26218,  18,          1) /* UiEffects - Magical */
+     , (26218,  19,        500) /* Value */
+     , (26218,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26218,  94,         16) /* TargetType - Creature */
+     , (26218, 106,        210) /* ItemSpellcraft */
+     , (26218, 107,         50) /* ItemCurMana */
+     , (26218, 108,         50) /* ItemMaxMana */
+     , (26218, 109,          0) /* ItemDifficulty */
+     , (26218, 110,          0) /* ItemAllegianceRankLimit */
+     , (26218, 150,        103) /* HookPlacement - Hook */
+     , (26218, 151,          2) /* HookType - Wall */
+     , (26218, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26218,  15, True ) /* LightsStatus */
+     , (26218,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26218, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26218,   1, 'Jai-Tan Dale Portal Gem') /* Name */
+     , (26218,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26218,   1,   33556769) /* Setup */
+     , (26218,   3,  536870932) /* SoundTable */
+     , (26218,   6,   67111919) /* PaletteBase */
+     , (26218,   7,  268435723) /* ClothingBase */
+     , (26218,   8,  100675760) /* Icon */
+     , (26218,  22,  872415275) /* PhysicsEffectTable */
+     , (26218,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26218,  31,      14268) /* LinkedPortalOne - Jai-Tan Dale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26219 Janaa Ridge Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26219 Janaa Ridge Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26219;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26219, 'gemportaljanaaridgesettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26219,   1,       2048) /* ItemType - Gem */
+     , (26219,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26219,   5,         10) /* EncumbranceVal */
+     , (26219,   8,         10) /* Mass */
+     , (26219,   9,          0) /* ValidLocations - None */
+     , (26219,  11,         20) /* MaxStackSize */
+     , (26219,  12,          1) /* StackSize */
+     , (26219,  13,         10) /* StackUnitEncumbrance */
+     , (26219,  14,         10) /* StackUnitMass */
+     , (26219,  15,        500) /* StackUnitValue */
+     , (26219,  16,          8) /* ItemUseable - Contained */
+     , (26219,  18,          1) /* UiEffects - Magical */
+     , (26219,  19,        500) /* Value */
+     , (26219,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26219,  94,         16) /* TargetType - Creature */
+     , (26219, 106,        210) /* ItemSpellcraft */
+     , (26219, 107,         50) /* ItemCurMana */
+     , (26219, 108,         50) /* ItemMaxMana */
+     , (26219, 109,          0) /* ItemDifficulty */
+     , (26219, 110,          0) /* ItemAllegianceRankLimit */
+     , (26219, 150,        103) /* HookPlacement - Hook */
+     , (26219, 151,          2) /* HookType - Wall */
+     , (26219, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26219,  15, True ) /* LightsStatus */
+     , (26219,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26219, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26219,   1, 'Janaa Ridge Settlement Portal Gem') /* Name */
+     , (26219,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26219,   1,   33556769) /* Setup */
+     , (26219,   3,  536870932) /* SoundTable */
+     , (26219,   6,   67111919) /* PaletteBase */
+     , (26219,   7,  268435723) /* ClothingBase */
+     , (26219,   8,  100675760) /* Icon */
+     , (26219,  22,  872415275) /* PhysicsEffectTable */
+     , (26219,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26219,  31,      12507) /* LinkedPortalOne - Janaa Ridge Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26220 Jasmine Meadow Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26220 Jasmine Meadow Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26220;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26220, 'gemportaljasminemeadow', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26220,   1,       2048) /* ItemType - Gem */
+     , (26220,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26220,   5,         10) /* EncumbranceVal */
+     , (26220,   8,         10) /* Mass */
+     , (26220,   9,          0) /* ValidLocations - None */
+     , (26220,  11,         20) /* MaxStackSize */
+     , (26220,  12,          1) /* StackSize */
+     , (26220,  13,         10) /* StackUnitEncumbrance */
+     , (26220,  14,         10) /* StackUnitMass */
+     , (26220,  15,        500) /* StackUnitValue */
+     , (26220,  16,          8) /* ItemUseable - Contained */
+     , (26220,  18,          1) /* UiEffects - Magical */
+     , (26220,  19,        500) /* Value */
+     , (26220,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26220,  94,         16) /* TargetType - Creature */
+     , (26220, 106,        210) /* ItemSpellcraft */
+     , (26220, 107,         50) /* ItemCurMana */
+     , (26220, 108,         50) /* ItemMaxMana */
+     , (26220, 109,          0) /* ItemDifficulty */
+     , (26220, 110,          0) /* ItemAllegianceRankLimit */
+     , (26220, 150,        103) /* HookPlacement - Hook */
+     , (26220, 151,          2) /* HookType - Wall */
+     , (26220, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26220,  15, True ) /* LightsStatus */
+     , (26220,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26220, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26220,   1, 'Jasmine Meadow Portal Gem') /* Name */
+     , (26220,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26220,   1,   33556769) /* Setup */
+     , (26220,   3,  536870932) /* SoundTable */
+     , (26220,   6,   67111919) /* PaletteBase */
+     , (26220,   7,  268435723) /* ClothingBase */
+     , (26220,   8,  100675760) /* Icon */
+     , (26220,  22,  872415275) /* PhysicsEffectTable */
+     , (26220,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26220,  31,      14638) /* LinkedPortalOne - Jasmine Meadow Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26221 Jenshi Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26221 Jenshi Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26221;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26221, 'gemportaljenshicottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26221,   1,       2048) /* ItemType - Gem */
+     , (26221,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26221,   5,         10) /* EncumbranceVal */
+     , (26221,   8,         10) /* Mass */
+     , (26221,   9,          0) /* ValidLocations - None */
+     , (26221,  11,         20) /* MaxStackSize */
+     , (26221,  12,          1) /* StackSize */
+     , (26221,  13,         10) /* StackUnitEncumbrance */
+     , (26221,  14,         10) /* StackUnitMass */
+     , (26221,  15,        500) /* StackUnitValue */
+     , (26221,  16,          8) /* ItemUseable - Contained */
+     , (26221,  18,          1) /* UiEffects - Magical */
+     , (26221,  19,        500) /* Value */
+     , (26221,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26221,  94,         16) /* TargetType - Creature */
+     , (26221, 106,        210) /* ItemSpellcraft */
+     , (26221, 107,         50) /* ItemCurMana */
+     , (26221, 108,         50) /* ItemMaxMana */
+     , (26221, 109,          0) /* ItemDifficulty */
+     , (26221, 110,          0) /* ItemAllegianceRankLimit */
+     , (26221, 150,        103) /* HookPlacement - Hook */
+     , (26221, 151,          2) /* HookType - Wall */
+     , (26221, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26221,  15, True ) /* LightsStatus */
+     , (26221,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26221, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26221,   1, 'Jenshi Cottages Portal Gem') /* Name */
+     , (26221,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26221,   1,   33556769) /* Setup */
+     , (26221,   3,  536870932) /* SoundTable */
+     , (26221,   6,   67111919) /* PaletteBase */
+     , (26221,   7,  268435723) /* ClothingBase */
+     , (26221,   8,  100675760) /* Icon */
+     , (26221,  22,  872415275) /* PhysicsEffectTable */
+     , (26221,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26221,  31,      15163) /* LinkedPortalOne - Jenshi Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26222 Jeweled Thorn Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26222 Jeweled Thorn Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26222;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26222, 'gemportaljeweledthornestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26222,   1,       2048) /* ItemType - Gem */
+     , (26222,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26222,   5,         10) /* EncumbranceVal */
+     , (26222,   8,         10) /* Mass */
+     , (26222,   9,          0) /* ValidLocations - None */
+     , (26222,  11,         20) /* MaxStackSize */
+     , (26222,  12,          1) /* StackSize */
+     , (26222,  13,         10) /* StackUnitEncumbrance */
+     , (26222,  14,         10) /* StackUnitMass */
+     , (26222,  15,        500) /* StackUnitValue */
+     , (26222,  16,          8) /* ItemUseable - Contained */
+     , (26222,  18,          1) /* UiEffects - Magical */
+     , (26222,  19,        500) /* Value */
+     , (26222,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26222,  94,         16) /* TargetType - Creature */
+     , (26222, 106,        210) /* ItemSpellcraft */
+     , (26222, 107,         50) /* ItemCurMana */
+     , (26222, 108,         50) /* ItemMaxMana */
+     , (26222, 109,          0) /* ItemDifficulty */
+     , (26222, 110,          0) /* ItemAllegianceRankLimit */
+     , (26222, 150,        103) /* HookPlacement - Hook */
+     , (26222, 151,          2) /* HookType - Wall */
+     , (26222, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26222,  15, True ) /* LightsStatus */
+     , (26222,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26222, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26222,   1, 'Jeweled Thorn Estates Portal Gem') /* Name */
+     , (26222,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26222,   1,   33556769) /* Setup */
+     , (26222,   3,  536870932) /* SoundTable */
+     , (26222,   6,   67111919) /* PaletteBase */
+     , (26222,   7,  268435723) /* ClothingBase */
+     , (26222,   8,  100675760) /* Icon */
+     , (26222,  22,  872415275) /* PhysicsEffectTable */
+     , (26222,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26222,  31,      19150) /* LinkedPortalOne - Jeweled Thorn Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26223 Mirthless Dale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26223 Mirthless Dale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26223;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26223, 'gemportaljgheewidditcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26223,   1,       2048) /* ItemType - Gem */
+     , (26223,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26223,   5,         10) /* EncumbranceVal */
+     , (26223,   8,         10) /* Mass */
+     , (26223,   9,          0) /* ValidLocations - None */
+     , (26223,  11,         20) /* MaxStackSize */
+     , (26223,  12,          1) /* StackSize */
+     , (26223,  13,         10) /* StackUnitEncumbrance */
+     , (26223,  14,         10) /* StackUnitMass */
+     , (26223,  15,        500) /* StackUnitValue */
+     , (26223,  16,          8) /* ItemUseable - Contained */
+     , (26223,  18,          1) /* UiEffects - Magical */
+     , (26223,  19,        500) /* Value */
+     , (26223,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26223,  94,         16) /* TargetType - Creature */
+     , (26223, 106,        210) /* ItemSpellcraft */
+     , (26223, 107,         50) /* ItemCurMana */
+     , (26223, 108,         50) /* ItemMaxMana */
+     , (26223, 109,          0) /* ItemDifficulty */
+     , (26223, 110,          0) /* ItemAllegianceRankLimit */
+     , (26223, 150,        103) /* HookPlacement - Hook */
+     , (26223, 151,          2) /* HookType - Wall */
+     , (26223, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26223,  15, True ) /* LightsStatus */
+     , (26223,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26223, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26223,   1, 'Mirthless Dale Portal Gem') /* Name */
+     , (26223,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26223,   1,   33556769) /* Setup */
+     , (26223,   3,  536870932) /* SoundTable */
+     , (26223,   6,   67111919) /* PaletteBase */
+     , (26223,   7,  268435723) /* ClothingBase */
+     , (26223,   8,  100675760) /* Icon */
+     , (26223,  22,  872415275) /* PhysicsEffectTable */
+     , (26223,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26223,  31,      15164) /* LinkedPortalOne - Mirthless Dale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26224 Jhalalabhan Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26224 Jhalalabhan Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26224;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26224, 'gemportaljhalalabhan', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26224,   1,       2048) /* ItemType - Gem */
+     , (26224,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26224,   5,         10) /* EncumbranceVal */
+     , (26224,   8,         10) /* Mass */
+     , (26224,   9,          0) /* ValidLocations - None */
+     , (26224,  11,         20) /* MaxStackSize */
+     , (26224,  12,          1) /* StackSize */
+     , (26224,  13,         10) /* StackUnitEncumbrance */
+     , (26224,  14,         10) /* StackUnitMass */
+     , (26224,  15,        500) /* StackUnitValue */
+     , (26224,  16,          8) /* ItemUseable - Contained */
+     , (26224,  18,          1) /* UiEffects - Magical */
+     , (26224,  19,        500) /* Value */
+     , (26224,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26224,  94,         16) /* TargetType - Creature */
+     , (26224, 106,        210) /* ItemSpellcraft */
+     , (26224, 107,         50) /* ItemCurMana */
+     , (26224, 108,         50) /* ItemMaxMana */
+     , (26224, 109,          0) /* ItemDifficulty */
+     , (26224, 110,          0) /* ItemAllegianceRankLimit */
+     , (26224, 150,        103) /* HookPlacement - Hook */
+     , (26224, 151,          2) /* HookType - Wall */
+     , (26224, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26224,  15, True ) /* LightsStatus */
+     , (26224,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26224, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26224,   1, 'Jhalalabhan Portal Gem') /* Name */
+     , (26224,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26224,   1,   33556769) /* Setup */
+     , (26224,   3,  536870932) /* SoundTable */
+     , (26224,   6,   67111919) /* PaletteBase */
+     , (26224,   7,  268435723) /* ClothingBase */
+     , (26224,   8,  100675760) /* Icon */
+     , (26224,  22,  872415275) /* PhysicsEffectTable */
+     , (26224,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26224,  31,      14269) /* LinkedPortalOne - Jhalalabhan Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26225 Jinianshi Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26225 Jinianshi Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26225;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26225, 'gemportaljinianshi', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26225,   1,       2048) /* ItemType - Gem */
+     , (26225,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26225,   5,         10) /* EncumbranceVal */
+     , (26225,   8,         10) /* Mass */
+     , (26225,   9,          0) /* ValidLocations - None */
+     , (26225,  11,         20) /* MaxStackSize */
+     , (26225,  12,          1) /* StackSize */
+     , (26225,  13,         10) /* StackUnitEncumbrance */
+     , (26225,  14,         10) /* StackUnitMass */
+     , (26225,  15,        500) /* StackUnitValue */
+     , (26225,  16,          8) /* ItemUseable - Contained */
+     , (26225,  18,          1) /* UiEffects - Magical */
+     , (26225,  19,        500) /* Value */
+     , (26225,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26225,  94,         16) /* TargetType - Creature */
+     , (26225, 106,        210) /* ItemSpellcraft */
+     , (26225, 107,         50) /* ItemCurMana */
+     , (26225, 108,         50) /* ItemMaxMana */
+     , (26225, 109,          0) /* ItemDifficulty */
+     , (26225, 110,          0) /* ItemAllegianceRankLimit */
+     , (26225, 150,        103) /* HookPlacement - Hook */
+     , (26225, 151,          2) /* HookType - Wall */
+     , (26225, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26225,  15, True ) /* LightsStatus */
+     , (26225,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26225, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26225,   1, 'Jinianshi Portal Gem') /* Name */
+     , (26225,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26225,   1,   33556769) /* Setup */
+     , (26225,   3,  536870932) /* SoundTable */
+     , (26225,   6,   67111919) /* PaletteBase */
+     , (26225,   7,  268435723) /* ClothingBase */
+     , (26225,   8,  100675760) /* Icon */
+     , (26225,  22,  872415275) /* PhysicsEffectTable */
+     , (26225,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26225,  31,      12508) /* LinkedPortalOne - Jinianshi Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26226 Jin-Lai Stronghold Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26226 Jin-Lai Stronghold Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26226;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26226, 'gemportaljinlaistronghold', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26226,   1,       2048) /* ItemType - Gem */
+     , (26226,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26226,   5,         10) /* EncumbranceVal */
+     , (26226,   8,         10) /* Mass */
+     , (26226,   9,          0) /* ValidLocations - None */
+     , (26226,  11,         20) /* MaxStackSize */
+     , (26226,  12,          1) /* StackSize */
+     , (26226,  13,         10) /* StackUnitEncumbrance */
+     , (26226,  14,         10) /* StackUnitMass */
+     , (26226,  15,        500) /* StackUnitValue */
+     , (26226,  16,          8) /* ItemUseable - Contained */
+     , (26226,  18,          1) /* UiEffects - Magical */
+     , (26226,  19,        500) /* Value */
+     , (26226,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26226,  94,         16) /* TargetType - Creature */
+     , (26226, 106,        210) /* ItemSpellcraft */
+     , (26226, 107,         50) /* ItemCurMana */
+     , (26226, 108,         50) /* ItemMaxMana */
+     , (26226, 109,          0) /* ItemDifficulty */
+     , (26226, 110,          0) /* ItemAllegianceRankLimit */
+     , (26226, 150,        103) /* HookPlacement - Hook */
+     , (26226, 151,          2) /* HookType - Wall */
+     , (26226, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26226,  15, True ) /* LightsStatus */
+     , (26226,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26226, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26226,   1, 'Jin-Lai Stronghold Portal Gem') /* Name */
+     , (26226,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26226,   1,   33556769) /* Setup */
+     , (26226,   3,  536870932) /* SoundTable */
+     , (26226,   6,   67111919) /* PaletteBase */
+     , (26226,   7,  268435723) /* ClothingBase */
+     , (26226,   8,  100675760) /* Icon */
+     , (26226,  22,  872415275) /* PhysicsEffectTable */
+     , (26226,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26226,  31,      15165) /* LinkedPortalOne - Jin-Lai Stronghold Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26227 Kanasa Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26227 Kanasa Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26227;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26227, 'gemportalkanasa', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26227,   1,       2048) /* ItemType - Gem */
+     , (26227,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26227,   5,         10) /* EncumbranceVal */
+     , (26227,   8,         10) /* Mass */
+     , (26227,   9,          0) /* ValidLocations - None */
+     , (26227,  11,         20) /* MaxStackSize */
+     , (26227,  12,          1) /* StackSize */
+     , (26227,  13,         10) /* StackUnitEncumbrance */
+     , (26227,  14,         10) /* StackUnitMass */
+     , (26227,  15,        500) /* StackUnitValue */
+     , (26227,  16,          8) /* ItemUseable - Contained */
+     , (26227,  18,          1) /* UiEffects - Magical */
+     , (26227,  19,        500) /* Value */
+     , (26227,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26227,  94,         16) /* TargetType - Creature */
+     , (26227, 106,        210) /* ItemSpellcraft */
+     , (26227, 107,         50) /* ItemCurMana */
+     , (26227, 108,         50) /* ItemMaxMana */
+     , (26227, 109,          0) /* ItemDifficulty */
+     , (26227, 110,          0) /* ItemAllegianceRankLimit */
+     , (26227, 150,        103) /* HookPlacement - Hook */
+     , (26227, 151,          2) /* HookType - Wall */
+     , (26227, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26227,  15, True ) /* LightsStatus */
+     , (26227,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26227, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26227,   1, 'Kanasa Portal Gem') /* Name */
+     , (26227,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26227,   1,   33556769) /* Setup */
+     , (26227,   3,  536870932) /* SoundTable */
+     , (26227,   6,   67111919) /* PaletteBase */
+     , (26227,   7,  268435723) /* ClothingBase */
+     , (26227,   8,  100675760) /* Icon */
+     , (26227,  22,  872415275) /* PhysicsEffectTable */
+     , (26227,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26227,  31,      14270) /* LinkedPortalOne - Kanasa Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26228 Kelnen Village Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26228 Kelnen Village Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26228;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26228, 'gemportalkelnenvillage', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26228,   1,       2048) /* ItemType - Gem */
+     , (26228,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26228,   5,         10) /* EncumbranceVal */
+     , (26228,   8,         10) /* Mass */
+     , (26228,   9,          0) /* ValidLocations - None */
+     , (26228,  11,         20) /* MaxStackSize */
+     , (26228,  12,          1) /* StackSize */
+     , (26228,  13,         10) /* StackUnitEncumbrance */
+     , (26228,  14,         10) /* StackUnitMass */
+     , (26228,  15,        500) /* StackUnitValue */
+     , (26228,  16,          8) /* ItemUseable - Contained */
+     , (26228,  18,          1) /* UiEffects - Magical */
+     , (26228,  19,        500) /* Value */
+     , (26228,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26228,  94,         16) /* TargetType - Creature */
+     , (26228, 106,        210) /* ItemSpellcraft */
+     , (26228, 107,         50) /* ItemCurMana */
+     , (26228, 108,         50) /* ItemMaxMana */
+     , (26228, 109,          0) /* ItemDifficulty */
+     , (26228, 110,          0) /* ItemAllegianceRankLimit */
+     , (26228, 150,        103) /* HookPlacement - Hook */
+     , (26228, 151,          2) /* HookType - Wall */
+     , (26228, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26228,  15, True ) /* LightsStatus */
+     , (26228,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26228, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26228,   1, 'Kelnen Village Portal Gem') /* Name */
+     , (26228,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26228,   1,   33556769) /* Setup */
+     , (26228,   3,  536870932) /* SoundTable */
+     , (26228,   6,   67111919) /* PaletteBase */
+     , (26228,   7,  268435723) /* ClothingBase */
+     , (26228,   8,  100675760) /* Icon */
+     , (26228,  22,  872415275) /* PhysicsEffectTable */
+     , (26228,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26228,  31,      15166) /* LinkedPortalOne - Kelnen Village Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26229 King Pwyll Square Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26229 King Pwyll Square Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26229;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26229, 'gemportalkingpwyllsquare', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26229,   1,       2048) /* ItemType - Gem */
+     , (26229,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26229,   5,         10) /* EncumbranceVal */
+     , (26229,   8,         10) /* Mass */
+     , (26229,   9,          0) /* ValidLocations - None */
+     , (26229,  11,         20) /* MaxStackSize */
+     , (26229,  12,          1) /* StackSize */
+     , (26229,  13,         10) /* StackUnitEncumbrance */
+     , (26229,  14,         10) /* StackUnitMass */
+     , (26229,  15,        500) /* StackUnitValue */
+     , (26229,  16,          8) /* ItemUseable - Contained */
+     , (26229,  18,          1) /* UiEffects - Magical */
+     , (26229,  19,        500) /* Value */
+     , (26229,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26229,  94,         16) /* TargetType - Creature */
+     , (26229, 106,        210) /* ItemSpellcraft */
+     , (26229, 107,         50) /* ItemCurMana */
+     , (26229, 108,         50) /* ItemMaxMana */
+     , (26229, 109,          0) /* ItemDifficulty */
+     , (26229, 110,          0) /* ItemAllegianceRankLimit */
+     , (26229, 150,        103) /* HookPlacement - Hook */
+     , (26229, 151,          2) /* HookType - Wall */
+     , (26229, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26229,  15, True ) /* LightsStatus */
+     , (26229,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26229, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26229,   1, 'King Pwyll Square Portal Gem') /* Name */
+     , (26229,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26229,   1,   33556769) /* Setup */
+     , (26229,   3,  536870932) /* SoundTable */
+     , (26229,   6,   67111919) /* PaletteBase */
+     , (26229,   7,  268435723) /* ClothingBase */
+     , (26229,   8,  100675760) /* Icon */
+     , (26229,  22,  872415275) /* PhysicsEffectTable */
+     , (26229,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26229,  31,      14639) /* LinkedPortalOne - King Pwyll Square Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26230 Kuyiza Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26230 Kuyiza Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26230;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26230, 'gemportalkuyiza', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26230,   1,       2048) /* ItemType - Gem */
+     , (26230,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26230,   5,         10) /* EncumbranceVal */
+     , (26230,   8,         10) /* Mass */
+     , (26230,   9,          0) /* ValidLocations - None */
+     , (26230,  11,         20) /* MaxStackSize */
+     , (26230,  12,          1) /* StackSize */
+     , (26230,  13,         10) /* StackUnitEncumbrance */
+     , (26230,  14,         10) /* StackUnitMass */
+     , (26230,  15,        500) /* StackUnitValue */
+     , (26230,  16,          8) /* ItemUseable - Contained */
+     , (26230,  18,          1) /* UiEffects - Magical */
+     , (26230,  19,        500) /* Value */
+     , (26230,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26230,  94,         16) /* TargetType - Creature */
+     , (26230, 106,        210) /* ItemSpellcraft */
+     , (26230, 107,         50) /* ItemCurMana */
+     , (26230, 108,         50) /* ItemMaxMana */
+     , (26230, 109,          0) /* ItemDifficulty */
+     , (26230, 110,          0) /* ItemAllegianceRankLimit */
+     , (26230, 150,        103) /* HookPlacement - Hook */
+     , (26230, 151,          2) /* HookType - Wall */
+     , (26230, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26230,  15, True ) /* LightsStatus */
+     , (26230,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26230, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26230,   1, 'Kuyiza Portal Gem') /* Name */
+     , (26230,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26230,   1,   33556769) /* Setup */
+     , (26230,   3,  536870932) /* SoundTable */
+     , (26230,   6,   67111919) /* PaletteBase */
+     , (26230,   7,  268435723) /* ClothingBase */
+     , (26230,   8,  100675760) /* Icon */
+     , (26230,  22,  872415275) /* PhysicsEffectTable */
+     , (26230,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26230,  31,      15167) /* LinkedPortalOne - Kuyiza Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26231 Lady Maila Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26231 Lady Maila Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26231;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26231, 'gemportalladymailaestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26231,   1,       2048) /* ItemType - Gem */
+     , (26231,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26231,   5,         10) /* EncumbranceVal */
+     , (26231,   8,         10) /* Mass */
+     , (26231,   9,          0) /* ValidLocations - None */
+     , (26231,  11,         20) /* MaxStackSize */
+     , (26231,  12,          1) /* StackSize */
+     , (26231,  13,         10) /* StackUnitEncumbrance */
+     , (26231,  14,         10) /* StackUnitMass */
+     , (26231,  15,        500) /* StackUnitValue */
+     , (26231,  16,          8) /* ItemUseable - Contained */
+     , (26231,  18,          1) /* UiEffects - Magical */
+     , (26231,  19,        500) /* Value */
+     , (26231,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26231,  94,         16) /* TargetType - Creature */
+     , (26231, 106,        210) /* ItemSpellcraft */
+     , (26231, 107,         50) /* ItemCurMana */
+     , (26231, 108,         50) /* ItemMaxMana */
+     , (26231, 109,          0) /* ItemDifficulty */
+     , (26231, 110,          0) /* ItemAllegianceRankLimit */
+     , (26231, 150,        103) /* HookPlacement - Hook */
+     , (26231, 151,          2) /* HookType - Wall */
+     , (26231, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26231,  15, True ) /* LightsStatus */
+     , (26231,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26231, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26231,   1, 'Lady Maila Estates Portal Gem') /* Name */
+     , (26231,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26231,   1,   33556769) /* Setup */
+     , (26231,   3,  536870932) /* SoundTable */
+     , (26231,   6,   67111919) /* PaletteBase */
+     , (26231,   7,  268435723) /* ClothingBase */
+     , (26231,   8,  100675760) /* Icon */
+     , (26231,  22,  872415275) /* PhysicsEffectTable */
+     , (26231,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26231,  31,      15168) /* LinkedPortalOne - Lady Maila Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26232 Laiti's Villa Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26232 Laiti's Villa Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26232;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26232, 'gemportallaitisvilla', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26232,   1,       2048) /* ItemType - Gem */
+     , (26232,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26232,   5,         10) /* EncumbranceVal */
+     , (26232,   8,         10) /* Mass */
+     , (26232,   9,          0) /* ValidLocations - None */
+     , (26232,  11,         20) /* MaxStackSize */
+     , (26232,  12,          1) /* StackSize */
+     , (26232,  13,         10) /* StackUnitEncumbrance */
+     , (26232,  14,         10) /* StackUnitMass */
+     , (26232,  15,        500) /* StackUnitValue */
+     , (26232,  16,          8) /* ItemUseable - Contained */
+     , (26232,  18,          1) /* UiEffects - Magical */
+     , (26232,  19,        500) /* Value */
+     , (26232,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26232,  94,         16) /* TargetType - Creature */
+     , (26232, 106,        210) /* ItemSpellcraft */
+     , (26232, 107,         50) /* ItemCurMana */
+     , (26232, 108,         50) /* ItemMaxMana */
+     , (26232, 109,          0) /* ItemDifficulty */
+     , (26232, 110,          0) /* ItemAllegianceRankLimit */
+     , (26232, 150,        103) /* HookPlacement - Hook */
+     , (26232, 151,          2) /* HookType - Wall */
+     , (26232, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26232,  15, True ) /* LightsStatus */
+     , (26232,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26232, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26232,   1, 'Laiti''s Villa Portal Gem') /* Name */
+     , (26232,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26232,   1,   33556769) /* Setup */
+     , (26232,   3,  536870932) /* SoundTable */
+     , (26232,   6,   67111919) /* PaletteBase */
+     , (26232,   7,  268435723) /* ClothingBase */
+     , (26232,   8,  100675760) /* Icon */
+     , (26232,  22,  872415275) /* PhysicsEffectTable */
+     , (26232,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26232,  31,      14640) /* LinkedPortalOne - Laiti's Villa Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26233 Lake Blessed Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26233 Lake Blessed Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26233;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26233, 'gemportallakeblessedcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26233,   1,       2048) /* ItemType - Gem */
+     , (26233,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26233,   5,         10) /* EncumbranceVal */
+     , (26233,   8,         10) /* Mass */
+     , (26233,   9,          0) /* ValidLocations - None */
+     , (26233,  11,         20) /* MaxStackSize */
+     , (26233,  12,          1) /* StackSize */
+     , (26233,  13,         10) /* StackUnitEncumbrance */
+     , (26233,  14,         10) /* StackUnitMass */
+     , (26233,  15,        500) /* StackUnitValue */
+     , (26233,  16,          8) /* ItemUseable - Contained */
+     , (26233,  18,          1) /* UiEffects - Magical */
+     , (26233,  19,        500) /* Value */
+     , (26233,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26233,  94,         16) /* TargetType - Creature */
+     , (26233, 106,        210) /* ItemSpellcraft */
+     , (26233, 107,         50) /* ItemCurMana */
+     , (26233, 108,         50) /* ItemMaxMana */
+     , (26233, 109,          0) /* ItemDifficulty */
+     , (26233, 110,          0) /* ItemAllegianceRankLimit */
+     , (26233, 150,        103) /* HookPlacement - Hook */
+     , (26233, 151,          2) /* HookType - Wall */
+     , (26233, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26233,  15, True ) /* LightsStatus */
+     , (26233,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26233, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26233,   1, 'Lake Blessed Cottages Portal Gem') /* Name */
+     , (26233,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26233,   1,   33556769) /* Setup */
+     , (26233,   3,  536870932) /* SoundTable */
+     , (26233,   6,   67111919) /* PaletteBase */
+     , (26233,   7,  268435723) /* ClothingBase */
+     , (26233,   8,  100675760) /* Icon */
+     , (26233,  22,  872415275) /* PhysicsEffectTable */
+     , (26233,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26233,  31,      12509) /* LinkedPortalOne - Lake Blessed Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26234 Lake NemuelSettlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26234 Lake NemuelSettlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26234;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26234, 'gemportallakenemuelsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26234,   1,       2048) /* ItemType - Gem */
+     , (26234,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26234,   5,         10) /* EncumbranceVal */
+     , (26234,   8,         10) /* Mass */
+     , (26234,   9,          0) /* ValidLocations - None */
+     , (26234,  11,         20) /* MaxStackSize */
+     , (26234,  12,          1) /* StackSize */
+     , (26234,  13,         10) /* StackUnitEncumbrance */
+     , (26234,  14,         10) /* StackUnitMass */
+     , (26234,  15,        500) /* StackUnitValue */
+     , (26234,  16,          8) /* ItemUseable - Contained */
+     , (26234,  18,          1) /* UiEffects - Magical */
+     , (26234,  19,        500) /* Value */
+     , (26234,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26234,  94,         16) /* TargetType - Creature */
+     , (26234, 106,        210) /* ItemSpellcraft */
+     , (26234, 107,         50) /* ItemCurMana */
+     , (26234, 108,         50) /* ItemMaxMana */
+     , (26234, 109,          0) /* ItemDifficulty */
+     , (26234, 110,          0) /* ItemAllegianceRankLimit */
+     , (26234, 150,        103) /* HookPlacement - Hook */
+     , (26234, 151,          2) /* HookType - Wall */
+     , (26234, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26234,  15, True ) /* LightsStatus */
+     , (26234,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26234, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26234,   1, 'Lake NemuelSettlement Portal Gem') /* Name */
+     , (26234,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26234,   1,   33556769) /* Setup */
+     , (26234,   3,  536870932) /* SoundTable */
+     , (26234,   6,   67111919) /* PaletteBase */
+     , (26234,   7,  268435723) /* ClothingBase */
+     , (26234,   8,  100675760) /* Icon */
+     , (26234,  22,  872415275) /* PhysicsEffectTable */
+     , (26234,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26234,  31,      12510) /* LinkedPortalOne - Lake NemuelSettlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26235 Lake Thrasyl Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26235 Lake Thrasyl Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26235;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26235, 'gemportallakethrasylcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26235,   1,       2048) /* ItemType - Gem */
+     , (26235,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26235,   5,         10) /* EncumbranceVal */
+     , (26235,   8,         10) /* Mass */
+     , (26235,   9,          0) /* ValidLocations - None */
+     , (26235,  11,         20) /* MaxStackSize */
+     , (26235,  12,          1) /* StackSize */
+     , (26235,  13,         10) /* StackUnitEncumbrance */
+     , (26235,  14,         10) /* StackUnitMass */
+     , (26235,  15,        500) /* StackUnitValue */
+     , (26235,  16,          8) /* ItemUseable - Contained */
+     , (26235,  18,          1) /* UiEffects - Magical */
+     , (26235,  19,        500) /* Value */
+     , (26235,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26235,  94,         16) /* TargetType - Creature */
+     , (26235, 106,        210) /* ItemSpellcraft */
+     , (26235, 107,         50) /* ItemCurMana */
+     , (26235, 108,         50) /* ItemMaxMana */
+     , (26235, 109,          0) /* ItemDifficulty */
+     , (26235, 110,          0) /* ItemAllegianceRankLimit */
+     , (26235, 150,        103) /* HookPlacement - Hook */
+     , (26235, 151,          2) /* HookType - Wall */
+     , (26235, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26235,  15, True ) /* LightsStatus */
+     , (26235,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26235, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26235,   1, 'Lake Thrasyl Cottages Portal Gem') /* Name */
+     , (26235,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26235,   1,   33556769) /* Setup */
+     , (26235,   3,  536870932) /* SoundTable */
+     , (26235,   6,   67111919) /* PaletteBase */
+     , (26235,   7,  268435723) /* ClothingBase */
+     , (26235,   8,  100675760) /* Icon */
+     , (26235,  22,  872415275) /* PhysicsEffectTable */
+     , (26235,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26235,  31,      14641) /* LinkedPortalOne - Lake Thrasyl Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26236 Lanadryll Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26236 Lanadryll Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26236;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26236, 'gemportallanadryllcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26236,   1,       2048) /* ItemType - Gem */
+     , (26236,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26236,   5,         10) /* EncumbranceVal */
+     , (26236,   8,         10) /* Mass */
+     , (26236,   9,          0) /* ValidLocations - None */
+     , (26236,  11,         20) /* MaxStackSize */
+     , (26236,  12,          1) /* StackSize */
+     , (26236,  13,         10) /* StackUnitEncumbrance */
+     , (26236,  14,         10) /* StackUnitMass */
+     , (26236,  15,        500) /* StackUnitValue */
+     , (26236,  16,          8) /* ItemUseable - Contained */
+     , (26236,  18,          1) /* UiEffects - Magical */
+     , (26236,  19,        500) /* Value */
+     , (26236,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26236,  94,         16) /* TargetType - Creature */
+     , (26236, 106,        210) /* ItemSpellcraft */
+     , (26236, 107,         50) /* ItemCurMana */
+     , (26236, 108,         50) /* ItemMaxMana */
+     , (26236, 109,          0) /* ItemDifficulty */
+     , (26236, 110,          0) /* ItemAllegianceRankLimit */
+     , (26236, 150,        103) /* HookPlacement - Hook */
+     , (26236, 151,          2) /* HookType - Wall */
+     , (26236, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26236,  15, True ) /* LightsStatus */
+     , (26236,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26236, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26236,   1, 'Lanadryll Cottages Portal Gem') /* Name */
+     , (26236,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26236,   1,   33556769) /* Setup */
+     , (26236,   3,  536870932) /* SoundTable */
+     , (26236,   6,   67111919) /* PaletteBase */
+     , (26236,   7,  268435723) /* ClothingBase */
+     , (26236,   8,  100675760) /* Icon */
+     , (26236,  22,  872415275) /* PhysicsEffectTable */
+     , (26236,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26236,  31,      19151) /* LinkedPortalOne - Lanadryll Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26237 Land Bridge Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26237 Land Bridge Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26237;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26237, 'gemportallandbridgevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26237,   1,       2048) /* ItemType - Gem */
+     , (26237,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26237,   5,         10) /* EncumbranceVal */
+     , (26237,   8,         10) /* Mass */
+     , (26237,   9,          0) /* ValidLocations - None */
+     , (26237,  11,         20) /* MaxStackSize */
+     , (26237,  12,          1) /* StackSize */
+     , (26237,  13,         10) /* StackUnitEncumbrance */
+     , (26237,  14,         10) /* StackUnitMass */
+     , (26237,  15,        500) /* StackUnitValue */
+     , (26237,  16,          8) /* ItemUseable - Contained */
+     , (26237,  18,          1) /* UiEffects - Magical */
+     , (26237,  19,        500) /* Value */
+     , (26237,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26237,  94,         16) /* TargetType - Creature */
+     , (26237, 106,        210) /* ItemSpellcraft */
+     , (26237, 107,         50) /* ItemCurMana */
+     , (26237, 108,         50) /* ItemMaxMana */
+     , (26237, 109,          0) /* ItemDifficulty */
+     , (26237, 110,          0) /* ItemAllegianceRankLimit */
+     , (26237, 150,        103) /* HookPlacement - Hook */
+     , (26237, 151,          2) /* HookType - Wall */
+     , (26237, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26237,  15, True ) /* LightsStatus */
+     , (26237,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26237, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26237,   1, 'Land Bridge Villas Portal Gem') /* Name */
+     , (26237,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26237,   1,   33556769) /* Setup */
+     , (26237,   3,  536870932) /* SoundTable */
+     , (26237,   6,   67111919) /* PaletteBase */
+     , (26237,   7,  268435723) /* ClothingBase */
+     , (26237,   8,  100675760) /* Icon */
+     , (26237,  22,  872415275) /* PhysicsEffectTable */
+     , (26237,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26237,  31,      14642) /* LinkedPortalOne - Land Bridge Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26238 Last-Stop-Before-Dires Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26238 Last-Stop-Before-Dires Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26238;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26238, 'gemportallaststopbeforediresvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26238,   1,       2048) /* ItemType - Gem */
+     , (26238,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26238,   5,         10) /* EncumbranceVal */
+     , (26238,   8,         10) /* Mass */
+     , (26238,   9,          0) /* ValidLocations - None */
+     , (26238,  11,         20) /* MaxStackSize */
+     , (26238,  12,          1) /* StackSize */
+     , (26238,  13,         10) /* StackUnitEncumbrance */
+     , (26238,  14,         10) /* StackUnitMass */
+     , (26238,  15,        500) /* StackUnitValue */
+     , (26238,  16,          8) /* ItemUseable - Contained */
+     , (26238,  18,          1) /* UiEffects - Magical */
+     , (26238,  19,        500) /* Value */
+     , (26238,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26238,  94,         16) /* TargetType - Creature */
+     , (26238, 106,        210) /* ItemSpellcraft */
+     , (26238, 107,         50) /* ItemCurMana */
+     , (26238, 108,         50) /* ItemMaxMana */
+     , (26238, 109,          0) /* ItemDifficulty */
+     , (26238, 110,          0) /* ItemAllegianceRankLimit */
+     , (26238, 150,        103) /* HookPlacement - Hook */
+     , (26238, 151,          2) /* HookType - Wall */
+     , (26238, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26238,  15, True ) /* LightsStatus */
+     , (26238,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26238, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26238,   1, 'Last-Stop-Before-Dires Villas Portal Gem') /* Name */
+     , (26238,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26238,   1,   33556769) /* Setup */
+     , (26238,   3,  536870932) /* SoundTable */
+     , (26238,   6,   67111919) /* PaletteBase */
+     , (26238,   7,  268435723) /* ClothingBase */
+     , (26238,   8,  100675760) /* Icon */
+     , (26238,  22,  872415275) /* PhysicsEffectTable */
+     , (26238,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26238,  31,      15169) /* LinkedPortalOne - Last-Stop-Before-Dires Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26239 Leafdawning Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26239 Leafdawning Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26239;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26239, 'gemportalleafdawningsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26239,   1,       2048) /* ItemType - Gem */
+     , (26239,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26239,   5,         10) /* EncumbranceVal */
+     , (26239,   8,         10) /* Mass */
+     , (26239,   9,          0) /* ValidLocations - None */
+     , (26239,  11,         20) /* MaxStackSize */
+     , (26239,  12,          1) /* StackSize */
+     , (26239,  13,         10) /* StackUnitEncumbrance */
+     , (26239,  14,         10) /* StackUnitMass */
+     , (26239,  15,        500) /* StackUnitValue */
+     , (26239,  16,          8) /* ItemUseable - Contained */
+     , (26239,  18,          1) /* UiEffects - Magical */
+     , (26239,  19,        500) /* Value */
+     , (26239,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26239,  94,         16) /* TargetType - Creature */
+     , (26239, 106,        210) /* ItemSpellcraft */
+     , (26239, 107,         50) /* ItemCurMana */
+     , (26239, 108,         50) /* ItemMaxMana */
+     , (26239, 109,          0) /* ItemDifficulty */
+     , (26239, 110,          0) /* ItemAllegianceRankLimit */
+     , (26239, 150,        103) /* HookPlacement - Hook */
+     , (26239, 151,          2) /* HookType - Wall */
+     , (26239, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26239,  15, True ) /* LightsStatus */
+     , (26239,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26239, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26239,   1, 'Leafdawning Settlement Portal Gem') /* Name */
+     , (26239,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26239,   1,   33556769) /* Setup */
+     , (26239,   3,  536870932) /* SoundTable */
+     , (26239,   6,   67111919) /* PaletteBase */
+     , (26239,   7,  268435723) /* ClothingBase */
+     , (26239,   8,  100675760) /* Icon */
+     , (26239,  22,  872415275) /* PhysicsEffectTable */
+     , (26239,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26239,  31,      12511) /* LinkedPortalOne - Leafdawning Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26240 Liang Chi Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26240 Liang Chi Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26240;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26240, 'gemportalliangchisettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26240,   1,       2048) /* ItemType - Gem */
+     , (26240,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26240,   5,         10) /* EncumbranceVal */
+     , (26240,   8,         10) /* Mass */
+     , (26240,   9,          0) /* ValidLocations - None */
+     , (26240,  11,         20) /* MaxStackSize */
+     , (26240,  12,          1) /* StackSize */
+     , (26240,  13,         10) /* StackUnitEncumbrance */
+     , (26240,  14,         10) /* StackUnitMass */
+     , (26240,  15,        500) /* StackUnitValue */
+     , (26240,  16,          8) /* ItemUseable - Contained */
+     , (26240,  18,          1) /* UiEffects - Magical */
+     , (26240,  19,        500) /* Value */
+     , (26240,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26240,  94,         16) /* TargetType - Creature */
+     , (26240, 106,        210) /* ItemSpellcraft */
+     , (26240, 107,         50) /* ItemCurMana */
+     , (26240, 108,         50) /* ItemMaxMana */
+     , (26240, 109,          0) /* ItemDifficulty */
+     , (26240, 110,          0) /* ItemAllegianceRankLimit */
+     , (26240, 150,        103) /* HookPlacement - Hook */
+     , (26240, 151,          2) /* HookType - Wall */
+     , (26240, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26240,  15, True ) /* LightsStatus */
+     , (26240,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26240, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26240,   1, 'Liang Chi Settlement Portal Gem') /* Name */
+     , (26240,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26240,   1,   33556769) /* Setup */
+     , (26240,   3,  536870932) /* SoundTable */
+     , (26240,   6,   67111919) /* PaletteBase */
+     , (26240,   7,  268435723) /* ClothingBase */
+     , (26240,   8,  100675760) /* Icon */
+     , (26240,  22,  872415275) /* PhysicsEffectTable */
+     , (26240,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26240,  31,      12512) /* LinkedPortalOne - Liang Chi Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26241 Lightbringer Dale Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26241 Lightbringer Dale Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26241;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26241, 'gemportallightbringerdalecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26241,   1,       2048) /* ItemType - Gem */
+     , (26241,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26241,   5,         10) /* EncumbranceVal */
+     , (26241,   8,         10) /* Mass */
+     , (26241,   9,          0) /* ValidLocations - None */
+     , (26241,  11,         20) /* MaxStackSize */
+     , (26241,  12,          1) /* StackSize */
+     , (26241,  13,         10) /* StackUnitEncumbrance */
+     , (26241,  14,         10) /* StackUnitMass */
+     , (26241,  15,        500) /* StackUnitValue */
+     , (26241,  16,          8) /* ItemUseable - Contained */
+     , (26241,  18,          1) /* UiEffects - Magical */
+     , (26241,  19,        500) /* Value */
+     , (26241,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26241,  94,         16) /* TargetType - Creature */
+     , (26241, 106,        210) /* ItemSpellcraft */
+     , (26241, 107,         50) /* ItemCurMana */
+     , (26241, 108,         50) /* ItemMaxMana */
+     , (26241, 109,          0) /* ItemDifficulty */
+     , (26241, 110,          0) /* ItemAllegianceRankLimit */
+     , (26241, 150,        103) /* HookPlacement - Hook */
+     , (26241, 151,          2) /* HookType - Wall */
+     , (26241, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26241,  15, True ) /* LightsStatus */
+     , (26241,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26241, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26241,   1, 'Lightbringer Dale Cottages Portal Gem') /* Name */
+     , (26241,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26241,   1,   33556769) /* Setup */
+     , (26241,   3,  536870932) /* SoundTable */
+     , (26241,   6,   67111919) /* PaletteBase */
+     , (26241,   7,  268435723) /* ClothingBase */
+     , (26241,   8,  100675760) /* Icon */
+     , (26241,  22,  872415275) /* PhysicsEffectTable */
+     , (26241,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26241,  31,      14643) /* LinkedPortalOne - Lightbringer Dale Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26242 Lilyglen Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26242 Lilyglen Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26242;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26242, 'gemportallilyglencottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26242,   1,       2048) /* ItemType - Gem */
+     , (26242,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26242,   5,         10) /* EncumbranceVal */
+     , (26242,   8,         10) /* Mass */
+     , (26242,   9,          0) /* ValidLocations - None */
+     , (26242,  11,         20) /* MaxStackSize */
+     , (26242,  12,          1) /* StackSize */
+     , (26242,  13,         10) /* StackUnitEncumbrance */
+     , (26242,  14,         10) /* StackUnitMass */
+     , (26242,  15,        500) /* StackUnitValue */
+     , (26242,  16,          8) /* ItemUseable - Contained */
+     , (26242,  18,          1) /* UiEffects - Magical */
+     , (26242,  19,        500) /* Value */
+     , (26242,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26242,  94,         16) /* TargetType - Creature */
+     , (26242, 106,        210) /* ItemSpellcraft */
+     , (26242, 107,         50) /* ItemCurMana */
+     , (26242, 108,         50) /* ItemMaxMana */
+     , (26242, 109,          0) /* ItemDifficulty */
+     , (26242, 110,          0) /* ItemAllegianceRankLimit */
+     , (26242, 150,        103) /* HookPlacement - Hook */
+     , (26242, 151,          2) /* HookType - Wall */
+     , (26242, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26242,  15, True ) /* LightsStatus */
+     , (26242,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26242, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26242,   1, 'Lilyglen Cottages Portal Gem') /* Name */
+     , (26242,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26242,   1,   33556769) /* Setup */
+     , (26242,   3,  536870932) /* SoundTable */
+     , (26242,   6,   67111919) /* PaletteBase */
+     , (26242,   7,  268435723) /* ClothingBase */
+     , (26242,   8,  100675760) /* Icon */
+     , (26242,  22,  872415275) /* PhysicsEffectTable */
+     , (26242,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26242,  31,      12513) /* LinkedPortalOne - Lilyglen Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26243 Lin Kiln Park Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26243 Lin Kiln Park Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26243;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26243, 'gemportallinkilnpark', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26243,   1,       2048) /* ItemType - Gem */
+     , (26243,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26243,   5,         10) /* EncumbranceVal */
+     , (26243,   8,         10) /* Mass */
+     , (26243,   9,          0) /* ValidLocations - None */
+     , (26243,  11,         20) /* MaxStackSize */
+     , (26243,  12,          1) /* StackSize */
+     , (26243,  13,         10) /* StackUnitEncumbrance */
+     , (26243,  14,         10) /* StackUnitMass */
+     , (26243,  15,        500) /* StackUnitValue */
+     , (26243,  16,          8) /* ItemUseable - Contained */
+     , (26243,  18,          1) /* UiEffects - Magical */
+     , (26243,  19,        500) /* Value */
+     , (26243,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26243,  94,         16) /* TargetType - Creature */
+     , (26243, 106,        210) /* ItemSpellcraft */
+     , (26243, 107,         50) /* ItemCurMana */
+     , (26243, 108,         50) /* ItemMaxMana */
+     , (26243, 109,          0) /* ItemDifficulty */
+     , (26243, 110,          0) /* ItemAllegianceRankLimit */
+     , (26243, 150,        103) /* HookPlacement - Hook */
+     , (26243, 151,          2) /* HookType - Wall */
+     , (26243, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26243,  15, True ) /* LightsStatus */
+     , (26243,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26243, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26243,   1, 'Lin Kiln Park Portal Gem') /* Name */
+     , (26243,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26243,   1,   33556769) /* Setup */
+     , (26243,   3,  536870932) /* SoundTable */
+     , (26243,   6,   67111919) /* PaletteBase */
+     , (26243,   7,  268435723) /* ClothingBase */
+     , (26243,   8,  100675760) /* Icon */
+     , (26243,  22,  872415275) /* PhysicsEffectTable */
+     , (26243,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26243,  31,      15170) /* LinkedPortalOne - Lin Kiln Park Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26244 Linvak Tukal Foothills Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26244 Linvak Tukal Foothills Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26244;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26244, 'gemportallinvaktukalfoothillssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26244,   1,       2048) /* ItemType - Gem */
+     , (26244,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26244,   5,         10) /* EncumbranceVal */
+     , (26244,   8,         10) /* Mass */
+     , (26244,   9,          0) /* ValidLocations - None */
+     , (26244,  11,         20) /* MaxStackSize */
+     , (26244,  12,          1) /* StackSize */
+     , (26244,  13,         10) /* StackUnitEncumbrance */
+     , (26244,  14,         10) /* StackUnitMass */
+     , (26244,  15,        500) /* StackUnitValue */
+     , (26244,  16,          8) /* ItemUseable - Contained */
+     , (26244,  18,          1) /* UiEffects - Magical */
+     , (26244,  19,        500) /* Value */
+     , (26244,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26244,  94,         16) /* TargetType - Creature */
+     , (26244, 106,        210) /* ItemSpellcraft */
+     , (26244, 107,         50) /* ItemCurMana */
+     , (26244, 108,         50) /* ItemMaxMana */
+     , (26244, 109,          0) /* ItemDifficulty */
+     , (26244, 110,          0) /* ItemAllegianceRankLimit */
+     , (26244, 150,        103) /* HookPlacement - Hook */
+     , (26244, 151,          2) /* HookType - Wall */
+     , (26244, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26244,  15, True ) /* LightsStatus */
+     , (26244,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26244, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26244,   1, 'Linvak Tukal Foothills Settlement Portal Gem') /* Name */
+     , (26244,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26244,   1,   33556769) /* Setup */
+     , (26244,   3,  536870932) /* SoundTable */
+     , (26244,   6,   67111919) /* PaletteBase */
+     , (26244,   7,  268435723) /* ClothingBase */
+     , (26244,   8,  100675760) /* Icon */
+     , (26244,  22,  872415275) /* PhysicsEffectTable */
+     , (26244,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26244,  31,      14644) /* LinkedPortalOne - Linvak Tukal Foothills Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26245 Li-Po Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26245 Li-Po Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26245;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26245, 'gemportallipocottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26245,   1,       2048) /* ItemType - Gem */
+     , (26245,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26245,   5,         10) /* EncumbranceVal */
+     , (26245,   8,         10) /* Mass */
+     , (26245,   9,          0) /* ValidLocations - None */
+     , (26245,  11,         20) /* MaxStackSize */
+     , (26245,  12,          1) /* StackSize */
+     , (26245,  13,         10) /* StackUnitEncumbrance */
+     , (26245,  14,         10) /* StackUnitMass */
+     , (26245,  15,        500) /* StackUnitValue */
+     , (26245,  16,          8) /* ItemUseable - Contained */
+     , (26245,  18,          1) /* UiEffects - Magical */
+     , (26245,  19,        500) /* Value */
+     , (26245,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26245,  94,         16) /* TargetType - Creature */
+     , (26245, 106,        210) /* ItemSpellcraft */
+     , (26245, 107,         50) /* ItemCurMana */
+     , (26245, 108,         50) /* ItemMaxMana */
+     , (26245, 109,          0) /* ItemDifficulty */
+     , (26245, 110,          0) /* ItemAllegianceRankLimit */
+     , (26245, 150,        103) /* HookPlacement - Hook */
+     , (26245, 151,          2) /* HookType - Wall */
+     , (26245, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26245,  15, True ) /* LightsStatus */
+     , (26245,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26245, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26245,   1, 'Li-Po Cottages Portal Gem') /* Name */
+     , (26245,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26245,   1,   33556769) /* Setup */
+     , (26245,   3,  536870932) /* SoundTable */
+     , (26245,   6,   67111919) /* PaletteBase */
+     , (26245,   7,  268435723) /* ClothingBase */
+     , (26245,   8,  100675760) /* Icon */
+     , (26245,  22,  872415275) /* PhysicsEffectTable */
+     , (26245,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26245,  31,      14645) /* LinkedPortalOne - Li-Po Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26246 Lithaenean Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26246 Lithaenean Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26246;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26246, 'gemportallithaeneancottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26246,   1,       2048) /* ItemType - Gem */
+     , (26246,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26246,   5,         10) /* EncumbranceVal */
+     , (26246,   8,         10) /* Mass */
+     , (26246,   9,          0) /* ValidLocations - None */
+     , (26246,  11,         20) /* MaxStackSize */
+     , (26246,  12,          1) /* StackSize */
+     , (26246,  13,         10) /* StackUnitEncumbrance */
+     , (26246,  14,         10) /* StackUnitMass */
+     , (26246,  15,        500) /* StackUnitValue */
+     , (26246,  16,          8) /* ItemUseable - Contained */
+     , (26246,  18,          1) /* UiEffects - Magical */
+     , (26246,  19,        500) /* Value */
+     , (26246,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26246,  94,         16) /* TargetType - Creature */
+     , (26246, 106,        210) /* ItemSpellcraft */
+     , (26246, 107,         50) /* ItemCurMana */
+     , (26246, 108,         50) /* ItemMaxMana */
+     , (26246, 109,          0) /* ItemDifficulty */
+     , (26246, 110,          0) /* ItemAllegianceRankLimit */
+     , (26246, 150,        103) /* HookPlacement - Hook */
+     , (26246, 151,          2) /* HookType - Wall */
+     , (26246, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26246,  15, True ) /* LightsStatus */
+     , (26246,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26246, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26246,   1, 'Lithaenean Cottages Portal Gem') /* Name */
+     , (26246,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26246,   1,   33556769) /* Setup */
+     , (26246,   3,  536870932) /* SoundTable */
+     , (26246,   6,   67111919) /* PaletteBase */
+     , (26246,   7,  268435723) /* ClothingBase */
+     , (26246,   8,  100675760) /* Icon */
+     , (26246,  22,  872415275) /* PhysicsEffectTable */
+     , (26246,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26246,  31,      12514) /* LinkedPortalOne - Lithaenean Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26247 Lo-Han Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26247 Lo-Han Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26247;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26247, 'gemportallohan', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26247,   1,       2048) /* ItemType - Gem */
+     , (26247,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26247,   5,         10) /* EncumbranceVal */
+     , (26247,   8,         10) /* Mass */
+     , (26247,   9,          0) /* ValidLocations - None */
+     , (26247,  11,         20) /* MaxStackSize */
+     , (26247,  12,          1) /* StackSize */
+     , (26247,  13,         10) /* StackUnitEncumbrance */
+     , (26247,  14,         10) /* StackUnitMass */
+     , (26247,  15,        500) /* StackUnitValue */
+     , (26247,  16,          8) /* ItemUseable - Contained */
+     , (26247,  18,          1) /* UiEffects - Magical */
+     , (26247,  19,        500) /* Value */
+     , (26247,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26247,  94,         16) /* TargetType - Creature */
+     , (26247, 106,        210) /* ItemSpellcraft */
+     , (26247, 107,         50) /* ItemCurMana */
+     , (26247, 108,         50) /* ItemMaxMana */
+     , (26247, 109,          0) /* ItemDifficulty */
+     , (26247, 110,          0) /* ItemAllegianceRankLimit */
+     , (26247, 150,        103) /* HookPlacement - Hook */
+     , (26247, 151,          2) /* HookType - Wall */
+     , (26247, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26247,  15, True ) /* LightsStatus */
+     , (26247,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26247, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26247,   1, 'Lo-Han Portal Gem') /* Name */
+     , (26247,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26247,   1,   33556769) /* Setup */
+     , (26247,   3,  536870932) /* SoundTable */
+     , (26247,   6,   67111919) /* PaletteBase */
+     , (26247,   7,  268435723) /* ClothingBase */
+     , (26247,   8,  100675760) /* Icon */
+     , (26247,  22,  872415275) /* PhysicsEffectTable */
+     , (26247,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26247,  31,      14646) /* LinkedPortalOne - Lo-Han Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26248 Lord Cambarth Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26248 Lord Cambarth Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26248;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26248, 'gemportallordcambarthvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26248,   1,       2048) /* ItemType - Gem */
+     , (26248,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26248,   5,         10) /* EncumbranceVal */
+     , (26248,   8,         10) /* Mass */
+     , (26248,   9,          0) /* ValidLocations - None */
+     , (26248,  11,         20) /* MaxStackSize */
+     , (26248,  12,          1) /* StackSize */
+     , (26248,  13,         10) /* StackUnitEncumbrance */
+     , (26248,  14,         10) /* StackUnitMass */
+     , (26248,  15,        500) /* StackUnitValue */
+     , (26248,  16,          8) /* ItemUseable - Contained */
+     , (26248,  18,          1) /* UiEffects - Magical */
+     , (26248,  19,        500) /* Value */
+     , (26248,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26248,  94,         16) /* TargetType - Creature */
+     , (26248, 106,        210) /* ItemSpellcraft */
+     , (26248, 107,         50) /* ItemCurMana */
+     , (26248, 108,         50) /* ItemMaxMana */
+     , (26248, 109,          0) /* ItemDifficulty */
+     , (26248, 110,          0) /* ItemAllegianceRankLimit */
+     , (26248, 150,        103) /* HookPlacement - Hook */
+     , (26248, 151,          2) /* HookType - Wall */
+     , (26248, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26248,  15, True ) /* LightsStatus */
+     , (26248,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26248, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26248,   1, 'Lord Cambarth Villas Portal Gem') /* Name */
+     , (26248,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26248,   1,   33556769) /* Setup */
+     , (26248,   3,  536870932) /* SoundTable */
+     , (26248,   6,   67111919) /* PaletteBase */
+     , (26248,   7,  268435723) /* ClothingBase */
+     , (26248,   8,  100675760) /* Icon */
+     , (26248,  22,  872415275) /* PhysicsEffectTable */
+     , (26248,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26248,  31,      14647) /* LinkedPortalOne - Lord Cambarth Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26249 Loredane Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26249 Loredane Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26249;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26249, 'gemportalloredanevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26249,   1,       2048) /* ItemType - Gem */
+     , (26249,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26249,   5,         10) /* EncumbranceVal */
+     , (26249,   8,         10) /* Mass */
+     , (26249,   9,          0) /* ValidLocations - None */
+     , (26249,  11,         20) /* MaxStackSize */
+     , (26249,  12,          1) /* StackSize */
+     , (26249,  13,         10) /* StackUnitEncumbrance */
+     , (26249,  14,         10) /* StackUnitMass */
+     , (26249,  15,        500) /* StackUnitValue */
+     , (26249,  16,          8) /* ItemUseable - Contained */
+     , (26249,  18,          1) /* UiEffects - Magical */
+     , (26249,  19,        500) /* Value */
+     , (26249,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26249,  94,         16) /* TargetType - Creature */
+     , (26249, 106,        210) /* ItemSpellcraft */
+     , (26249, 107,         50) /* ItemCurMana */
+     , (26249, 108,         50) /* ItemMaxMana */
+     , (26249, 109,          0) /* ItemDifficulty */
+     , (26249, 110,          0) /* ItemAllegianceRankLimit */
+     , (26249, 150,        103) /* HookPlacement - Hook */
+     , (26249, 151,          2) /* HookType - Wall */
+     , (26249, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26249,  15, True ) /* LightsStatus */
+     , (26249,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26249, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26249,   1, 'Loredane Villas Portal Gem') /* Name */
+     , (26249,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26249,   1,   33556769) /* Setup */
+     , (26249,   3,  536870932) /* SoundTable */
+     , (26249,   6,   67111919) /* PaletteBase */
+     , (26249,   7,  268435723) /* ClothingBase */
+     , (26249,   8,  100675760) /* Icon */
+     , (26249,  22,  872415275) /* PhysicsEffectTable */
+     , (26249,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26249,  31,      14648) /* LinkedPortalOne - Loredane Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26250 Lost Realm Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26250 Lost Realm Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26250;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26250, 'gemportallostrealmcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26250,   1,       2048) /* ItemType - Gem */
+     , (26250,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26250,   5,         10) /* EncumbranceVal */
+     , (26250,   8,         10) /* Mass */
+     , (26250,   9,          0) /* ValidLocations - None */
+     , (26250,  11,         20) /* MaxStackSize */
+     , (26250,  12,          1) /* StackSize */
+     , (26250,  13,         10) /* StackUnitEncumbrance */
+     , (26250,  14,         10) /* StackUnitMass */
+     , (26250,  15,        500) /* StackUnitValue */
+     , (26250,  16,          8) /* ItemUseable - Contained */
+     , (26250,  18,          1) /* UiEffects - Magical */
+     , (26250,  19,        500) /* Value */
+     , (26250,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26250,  94,         16) /* TargetType - Creature */
+     , (26250, 106,        210) /* ItemSpellcraft */
+     , (26250, 107,         50) /* ItemCurMana */
+     , (26250, 108,         50) /* ItemMaxMana */
+     , (26250, 109,          0) /* ItemDifficulty */
+     , (26250, 110,          0) /* ItemAllegianceRankLimit */
+     , (26250, 150,        103) /* HookPlacement - Hook */
+     , (26250, 151,          2) /* HookType - Wall */
+     , (26250, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26250,  15, True ) /* LightsStatus */
+     , (26250,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26250, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26250,   1, 'Lost Realm Cottages Portal Gem') /* Name */
+     , (26250,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26250,   1,   33556769) /* Setup */
+     , (26250,   3,  536870932) /* SoundTable */
+     , (26250,   6,   67111919) /* PaletteBase */
+     , (26250,   7,  268435723) /* ClothingBase */
+     , (26250,   8,  100675760) /* Icon */
+     , (26250,  22,  872415275) /* PhysicsEffectTable */
+     , (26250,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26250,  31,      14649) /* LinkedPortalOne - Lost Realm Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26251 Lost Wish Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26251 Lost Wish Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26251;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26251, 'gemportallostwishcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26251,   1,       2048) /* ItemType - Gem */
+     , (26251,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26251,   5,         10) /* EncumbranceVal */
+     , (26251,   8,         10) /* Mass */
+     , (26251,   9,          0) /* ValidLocations - None */
+     , (26251,  11,         20) /* MaxStackSize */
+     , (26251,  12,          1) /* StackSize */
+     , (26251,  13,         10) /* StackUnitEncumbrance */
+     , (26251,  14,         10) /* StackUnitMass */
+     , (26251,  15,        500) /* StackUnitValue */
+     , (26251,  16,          8) /* ItemUseable - Contained */
+     , (26251,  18,          1) /* UiEffects - Magical */
+     , (26251,  19,        500) /* Value */
+     , (26251,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26251,  94,         16) /* TargetType - Creature */
+     , (26251, 106,        210) /* ItemSpellcraft */
+     , (26251, 107,         50) /* ItemCurMana */
+     , (26251, 108,         50) /* ItemMaxMana */
+     , (26251, 109,          0) /* ItemDifficulty */
+     , (26251, 110,          0) /* ItemAllegianceRankLimit */
+     , (26251, 150,        103) /* HookPlacement - Hook */
+     , (26251, 151,          2) /* HookType - Wall */
+     , (26251, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26251,  15, True ) /* LightsStatus */
+     , (26251,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26251, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26251,   1, 'Lost Wish Cottages Portal Gem') /* Name */
+     , (26251,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26251,   1,   33556769) /* Setup */
+     , (26251,   3,  536870932) /* SoundTable */
+     , (26251,   6,   67111919) /* PaletteBase */
+     , (26251,   7,  268435723) /* ClothingBase */
+     , (26251,   8,  100675760) /* Icon */
+     , (26251,  22,  872415275) /* PhysicsEffectTable */
+     , (26251,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26251,  31,      14650) /* LinkedPortalOne - Lost Wish Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26252 Lugian Meadows Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26252 Lugian Meadows Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26252;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26252, 'gemportallugianmeadowssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26252,   1,       2048) /* ItemType - Gem */
+     , (26252,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26252,   5,         10) /* EncumbranceVal */
+     , (26252,   8,         10) /* Mass */
+     , (26252,   9,          0) /* ValidLocations - None */
+     , (26252,  11,         20) /* MaxStackSize */
+     , (26252,  12,          1) /* StackSize */
+     , (26252,  13,         10) /* StackUnitEncumbrance */
+     , (26252,  14,         10) /* StackUnitMass */
+     , (26252,  15,        500) /* StackUnitValue */
+     , (26252,  16,          8) /* ItemUseable - Contained */
+     , (26252,  18,          1) /* UiEffects - Magical */
+     , (26252,  19,        500) /* Value */
+     , (26252,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26252,  94,         16) /* TargetType - Creature */
+     , (26252, 106,        210) /* ItemSpellcraft */
+     , (26252, 107,         50) /* ItemCurMana */
+     , (26252, 108,         50) /* ItemMaxMana */
+     , (26252, 109,          0) /* ItemDifficulty */
+     , (26252, 110,          0) /* ItemAllegianceRankLimit */
+     , (26252, 150,        103) /* HookPlacement - Hook */
+     , (26252, 151,          2) /* HookType - Wall */
+     , (26252, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26252,  15, True ) /* LightsStatus */
+     , (26252,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26252, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26252,   1, 'Lugian Meadows Settlement Portal Gem') /* Name */
+     , (26252,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26252,   1,   33556769) /* Setup */
+     , (26252,   3,  536870932) /* SoundTable */
+     , (26252,   6,   67111919) /* PaletteBase */
+     , (26252,   7,  268435723) /* ClothingBase */
+     , (26252,   8,  100675760) /* Icon */
+     , (26252,  22,  872415275) /* PhysicsEffectTable */
+     , (26252,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26252,  31,      12515) /* LinkedPortalOne - Lugian Meadows Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26253 Lyceum View Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26253 Lyceum View Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26253;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26253, 'gemportallyceumviewcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26253,   1,       2048) /* ItemType - Gem */
+     , (26253,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26253,   5,         10) /* EncumbranceVal */
+     , (26253,   8,         10) /* Mass */
+     , (26253,   9,          0) /* ValidLocations - None */
+     , (26253,  11,         20) /* MaxStackSize */
+     , (26253,  12,          1) /* StackSize */
+     , (26253,  13,         10) /* StackUnitEncumbrance */
+     , (26253,  14,         10) /* StackUnitMass */
+     , (26253,  15,        500) /* StackUnitValue */
+     , (26253,  16,          8) /* ItemUseable - Contained */
+     , (26253,  18,          1) /* UiEffects - Magical */
+     , (26253,  19,        500) /* Value */
+     , (26253,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26253,  94,         16) /* TargetType - Creature */
+     , (26253, 106,        210) /* ItemSpellcraft */
+     , (26253, 107,         50) /* ItemCurMana */
+     , (26253, 108,         50) /* ItemMaxMana */
+     , (26253, 109,          0) /* ItemDifficulty */
+     , (26253, 110,          0) /* ItemAllegianceRankLimit */
+     , (26253, 150,        103) /* HookPlacement - Hook */
+     , (26253, 151,          2) /* HookType - Wall */
+     , (26253, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26253,  15, True ) /* LightsStatus */
+     , (26253,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26253, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26253,   1, 'Lyceum View Cottages Portal Gem') /* Name */
+     , (26253,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26253,   1,   33556769) /* Setup */
+     , (26253,   3,  536870932) /* SoundTable */
+     , (26253,   6,   67111919) /* PaletteBase */
+     , (26253,   7,  268435723) /* ClothingBase */
+     , (26253,   8,  100675760) /* Icon */
+     , (26253,  22,  872415275) /* PhysicsEffectTable */
+     , (26253,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26253,  31,      13111) /* LinkedPortalOne - Lyceum View Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26254 Maedew Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26254 Maedew Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26254;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26254, 'gemportalmaedew', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26254,   1,       2048) /* ItemType - Gem */
+     , (26254,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26254,   5,         10) /* EncumbranceVal */
+     , (26254,   8,         10) /* Mass */
+     , (26254,   9,          0) /* ValidLocations - None */
+     , (26254,  11,         20) /* MaxStackSize */
+     , (26254,  12,          1) /* StackSize */
+     , (26254,  13,         10) /* StackUnitEncumbrance */
+     , (26254,  14,         10) /* StackUnitMass */
+     , (26254,  15,        500) /* StackUnitValue */
+     , (26254,  16,          8) /* ItemUseable - Contained */
+     , (26254,  18,          1) /* UiEffects - Magical */
+     , (26254,  19,        500) /* Value */
+     , (26254,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26254,  94,         16) /* TargetType - Creature */
+     , (26254, 106,        210) /* ItemSpellcraft */
+     , (26254, 107,         50) /* ItemCurMana */
+     , (26254, 108,         50) /* ItemMaxMana */
+     , (26254, 109,          0) /* ItemDifficulty */
+     , (26254, 110,          0) /* ItemAllegianceRankLimit */
+     , (26254, 150,        103) /* HookPlacement - Hook */
+     , (26254, 151,          2) /* HookType - Wall */
+     , (26254, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26254,  15, True ) /* LightsStatus */
+     , (26254,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26254, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26254,   1, 'Maedew Portal Gem') /* Name */
+     , (26254,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26254,   1,   33556769) /* Setup */
+     , (26254,   3,  536870932) /* SoundTable */
+     , (26254,   6,   67111919) /* PaletteBase */
+     , (26254,   7,  268435723) /* ClothingBase */
+     , (26254,   8,  100675760) /* Icon */
+     , (26254,  22,  872415275) /* PhysicsEffectTable */
+     , (26254,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26254,  31,      12516) /* LinkedPortalOne - Maedew Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26255 Mage's Pass Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26255 Mage's Pass Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26255;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26255, 'gemportalmagespass', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26255,   1,       2048) /* ItemType - Gem */
+     , (26255,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26255,   5,         10) /* EncumbranceVal */
+     , (26255,   8,         10) /* Mass */
+     , (26255,   9,          0) /* ValidLocations - None */
+     , (26255,  11,         20) /* MaxStackSize */
+     , (26255,  12,          1) /* StackSize */
+     , (26255,  13,         10) /* StackUnitEncumbrance */
+     , (26255,  14,         10) /* StackUnitMass */
+     , (26255,  15,        500) /* StackUnitValue */
+     , (26255,  16,          8) /* ItemUseable - Contained */
+     , (26255,  18,          1) /* UiEffects - Magical */
+     , (26255,  19,        500) /* Value */
+     , (26255,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26255,  94,         16) /* TargetType - Creature */
+     , (26255, 106,        210) /* ItemSpellcraft */
+     , (26255, 107,         50) /* ItemCurMana */
+     , (26255, 108,         50) /* ItemMaxMana */
+     , (26255, 109,          0) /* ItemDifficulty */
+     , (26255, 110,          0) /* ItemAllegianceRankLimit */
+     , (26255, 150,        103) /* HookPlacement - Hook */
+     , (26255, 151,          2) /* HookType - Wall */
+     , (26255, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26255,  15, True ) /* LightsStatus */
+     , (26255,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26255, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26255,   1, 'Mage''s Pass Portal Gem') /* Name */
+     , (26255,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26255,   1,   33556769) /* Setup */
+     , (26255,   3,  536870932) /* SoundTable */
+     , (26255,   6,   67111919) /* PaletteBase */
+     , (26255,   7,  268435723) /* ClothingBase */
+     , (26255,   8,  100675760) /* Icon */
+     , (26255,  22,  872415275) /* PhysicsEffectTable */
+     , (26255,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26255,  31,      14271) /* LinkedPortalOne - Mage's Pass Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26256 Mahara Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26256 Mahara Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26256;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26256, 'gemportalmaharacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26256,   1,       2048) /* ItemType - Gem */
+     , (26256,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26256,   5,         10) /* EncumbranceVal */
+     , (26256,   8,         10) /* Mass */
+     , (26256,   9,          0) /* ValidLocations - None */
+     , (26256,  11,         20) /* MaxStackSize */
+     , (26256,  12,          1) /* StackSize */
+     , (26256,  13,         10) /* StackUnitEncumbrance */
+     , (26256,  14,         10) /* StackUnitMass */
+     , (26256,  15,        500) /* StackUnitValue */
+     , (26256,  16,          8) /* ItemUseable - Contained */
+     , (26256,  18,          1) /* UiEffects - Magical */
+     , (26256,  19,        500) /* Value */
+     , (26256,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26256,  94,         16) /* TargetType - Creature */
+     , (26256, 106,        210) /* ItemSpellcraft */
+     , (26256, 107,         50) /* ItemCurMana */
+     , (26256, 108,         50) /* ItemMaxMana */
+     , (26256, 109,          0) /* ItemDifficulty */
+     , (26256, 110,          0) /* ItemAllegianceRankLimit */
+     , (26256, 150,        103) /* HookPlacement - Hook */
+     , (26256, 151,          2) /* HookType - Wall */
+     , (26256, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26256,  15, True ) /* LightsStatus */
+     , (26256,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26256, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26256,   1, 'Mahara Cottages Portal Gem') /* Name */
+     , (26256,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26256,   1,   33556769) /* Setup */
+     , (26256,   3,  536870932) /* SoundTable */
+     , (26256,   6,   67111919) /* PaletteBase */
+     , (26256,   7,  268435723) /* ClothingBase */
+     , (26256,   8,  100675760) /* Icon */
+     , (26256,  22,  872415275) /* PhysicsEffectTable */
+     , (26256,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26256,  31,      15171) /* LinkedPortalOne - Mahara Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26257 Maitland  Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26257 Maitland  Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26257;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26257, 'gemportalmaitland', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26257,   1,       2048) /* ItemType - Gem */
+     , (26257,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26257,   5,         10) /* EncumbranceVal */
+     , (26257,   8,         10) /* Mass */
+     , (26257,   9,          0) /* ValidLocations - None */
+     , (26257,  11,         20) /* MaxStackSize */
+     , (26257,  12,          1) /* StackSize */
+     , (26257,  13,         10) /* StackUnitEncumbrance */
+     , (26257,  14,         10) /* StackUnitMass */
+     , (26257,  15,        500) /* StackUnitValue */
+     , (26257,  16,          8) /* ItemUseable - Contained */
+     , (26257,  18,          1) /* UiEffects - Magical */
+     , (26257,  19,        500) /* Value */
+     , (26257,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26257,  94,         16) /* TargetType - Creature */
+     , (26257, 106,        210) /* ItemSpellcraft */
+     , (26257, 107,         50) /* ItemCurMana */
+     , (26257, 108,         50) /* ItemMaxMana */
+     , (26257, 109,          0) /* ItemDifficulty */
+     , (26257, 110,          0) /* ItemAllegianceRankLimit */
+     , (26257, 150,        103) /* HookPlacement - Hook */
+     , (26257, 151,          2) /* HookType - Wall */
+     , (26257, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26257,  15, True ) /* LightsStatus */
+     , (26257,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26257, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26257,   1, 'Maitland  Portal Gem') /* Name */
+     , (26257,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26257,   1,   33556769) /* Setup */
+     , (26257,   3,  536870932) /* SoundTable */
+     , (26257,   6,   67111919) /* PaletteBase */
+     , (26257,   7,  268435723) /* ClothingBase */
+     , (26257,   8,  100675760) /* Icon */
+     , (26257,  22,  872415275) /* PhysicsEffectTable */
+     , (26257,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26257,  31,      12517) /* LinkedPortalOne - Maitland  Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26258 Majestic Hill Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26258 Majestic Hill Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26258;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26258, 'gemportalmajestichillcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26258,   1,       2048) /* ItemType - Gem */
+     , (26258,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26258,   5,         10) /* EncumbranceVal */
+     , (26258,   8,         10) /* Mass */
+     , (26258,   9,          0) /* ValidLocations - None */
+     , (26258,  11,         20) /* MaxStackSize */
+     , (26258,  12,          1) /* StackSize */
+     , (26258,  13,         10) /* StackUnitEncumbrance */
+     , (26258,  14,         10) /* StackUnitMass */
+     , (26258,  15,        500) /* StackUnitValue */
+     , (26258,  16,          8) /* ItemUseable - Contained */
+     , (26258,  18,          1) /* UiEffects - Magical */
+     , (26258,  19,        500) /* Value */
+     , (26258,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26258,  94,         16) /* TargetType - Creature */
+     , (26258, 106,        210) /* ItemSpellcraft */
+     , (26258, 107,         50) /* ItemCurMana */
+     , (26258, 108,         50) /* ItemMaxMana */
+     , (26258, 109,          0) /* ItemDifficulty */
+     , (26258, 110,          0) /* ItemAllegianceRankLimit */
+     , (26258, 150,        103) /* HookPlacement - Hook */
+     , (26258, 151,          2) /* HookType - Wall */
+     , (26258, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26258,  15, True ) /* LightsStatus */
+     , (26258,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26258, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26258,   1, 'Majestic Hill Cottages Portal Gem') /* Name */
+     , (26258,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26258,   1,   33556769) /* Setup */
+     , (26258,   3,  536870932) /* SoundTable */
+     , (26258,   6,   67111919) /* PaletteBase */
+     , (26258,   7,  268435723) /* ClothingBase */
+     , (26258,   8,  100675760) /* Icon */
+     , (26258,  22,  872415275) /* PhysicsEffectTable */
+     , (26258,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26258,  31,      12518) /* LinkedPortalOne - Majestic Hill Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26259 Majestic Saddle Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26259 Majestic Saddle Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26259;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26259, 'gemportalmajesticsaddlecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26259,   1,       2048) /* ItemType - Gem */
+     , (26259,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26259,   5,         10) /* EncumbranceVal */
+     , (26259,   8,         10) /* Mass */
+     , (26259,   9,          0) /* ValidLocations - None */
+     , (26259,  11,         20) /* MaxStackSize */
+     , (26259,  12,          1) /* StackSize */
+     , (26259,  13,         10) /* StackUnitEncumbrance */
+     , (26259,  14,         10) /* StackUnitMass */
+     , (26259,  15,        500) /* StackUnitValue */
+     , (26259,  16,          8) /* ItemUseable - Contained */
+     , (26259,  18,          1) /* UiEffects - Magical */
+     , (26259,  19,        500) /* Value */
+     , (26259,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26259,  94,         16) /* TargetType - Creature */
+     , (26259, 106,        210) /* ItemSpellcraft */
+     , (26259, 107,         50) /* ItemCurMana */
+     , (26259, 108,         50) /* ItemMaxMana */
+     , (26259, 109,          0) /* ItemDifficulty */
+     , (26259, 110,          0) /* ItemAllegianceRankLimit */
+     , (26259, 150,        103) /* HookPlacement - Hook */
+     , (26259, 151,          2) /* HookType - Wall */
+     , (26259, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26259,  15, True ) /* LightsStatus */
+     , (26259,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26259, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26259,   1, 'Majestic Saddle Cottages Portal Gem') /* Name */
+     , (26259,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26259,   1,   33556769) /* Setup */
+     , (26259,   3,  536870932) /* SoundTable */
+     , (26259,   6,   67111919) /* PaletteBase */
+     , (26259,   7,  268435723) /* ClothingBase */
+     , (26259,   8,  100675760) /* Icon */
+     , (26259,  22,  872415275) /* PhysicsEffectTable */
+     , (26259,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26259,  31,      19152) /* LinkedPortalOne - Majestic Saddle Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26260 Mattekar Slopes Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26260 Mattekar Slopes Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26260;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26260, 'gemportalmattekarslopescottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26260,   1,       2048) /* ItemType - Gem */
+     , (26260,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26260,   5,         10) /* EncumbranceVal */
+     , (26260,   8,         10) /* Mass */
+     , (26260,   9,          0) /* ValidLocations - None */
+     , (26260,  11,         20) /* MaxStackSize */
+     , (26260,  12,          1) /* StackSize */
+     , (26260,  13,         10) /* StackUnitEncumbrance */
+     , (26260,  14,         10) /* StackUnitMass */
+     , (26260,  15,        500) /* StackUnitValue */
+     , (26260,  16,          8) /* ItemUseable - Contained */
+     , (26260,  18,          1) /* UiEffects - Magical */
+     , (26260,  19,        500) /* Value */
+     , (26260,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26260,  94,         16) /* TargetType - Creature */
+     , (26260, 106,        210) /* ItemSpellcraft */
+     , (26260, 107,         50) /* ItemCurMana */
+     , (26260, 108,         50) /* ItemMaxMana */
+     , (26260, 109,          0) /* ItemDifficulty */
+     , (26260, 110,          0) /* ItemAllegianceRankLimit */
+     , (26260, 150,        103) /* HookPlacement - Hook */
+     , (26260, 151,          2) /* HookType - Wall */
+     , (26260, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26260,  15, True ) /* LightsStatus */
+     , (26260,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26260, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26260,   1, 'Mattekar Slopes Cottages Portal Gem') /* Name */
+     , (26260,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26260,   1,   33556769) /* Setup */
+     , (26260,   3,  536870932) /* SoundTable */
+     , (26260,   6,   67111919) /* PaletteBase */
+     , (26260,   7,  268435723) /* ClothingBase */
+     , (26260,   8,  100675760) /* Icon */
+     , (26260,  22,  872415275) /* PhysicsEffectTable */
+     , (26260,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26260,  31,      15172) /* LinkedPortalOne - Mattekar Slopes Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26261 Maythen Geroyu Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26261 Maythen Geroyu Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26261;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26261, 'gemportalmaythengeroyuvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26261,   1,       2048) /* ItemType - Gem */
+     , (26261,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26261,   5,         10) /* EncumbranceVal */
+     , (26261,   8,         10) /* Mass */
+     , (26261,   9,          0) /* ValidLocations - None */
+     , (26261,  11,         20) /* MaxStackSize */
+     , (26261,  12,          1) /* StackSize */
+     , (26261,  13,         10) /* StackUnitEncumbrance */
+     , (26261,  14,         10) /* StackUnitMass */
+     , (26261,  15,        500) /* StackUnitValue */
+     , (26261,  16,          8) /* ItemUseable - Contained */
+     , (26261,  18,          1) /* UiEffects - Magical */
+     , (26261,  19,        500) /* Value */
+     , (26261,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26261,  94,         16) /* TargetType - Creature */
+     , (26261, 106,        210) /* ItemSpellcraft */
+     , (26261, 107,         50) /* ItemCurMana */
+     , (26261, 108,         50) /* ItemMaxMana */
+     , (26261, 109,          0) /* ItemDifficulty */
+     , (26261, 110,          0) /* ItemAllegianceRankLimit */
+     , (26261, 150,        103) /* HookPlacement - Hook */
+     , (26261, 151,          2) /* HookType - Wall */
+     , (26261, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26261,  15, True ) /* LightsStatus */
+     , (26261,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26261, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26261,   1, 'Maythen Geroyu Villas Portal Gem') /* Name */
+     , (26261,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26261,   1,   33556769) /* Setup */
+     , (26261,   3,  536870932) /* SoundTable */
+     , (26261,   6,   67111919) /* PaletteBase */
+     , (26261,   7,  268435723) /* ClothingBase */
+     , (26261,   8,  100675760) /* Icon */
+     , (26261,  22,  872415275) /* PhysicsEffectTable */
+     , (26261,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26261,  31,      15173) /* LinkedPortalOne - Maythen Geroyu Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26262 Meditation Meadow Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26262 Meditation Meadow Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26262;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26262, 'gemportalmeditationmeadownortheastnanto', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26262,   1,       2048) /* ItemType - Gem */
+     , (26262,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26262,   5,         10) /* EncumbranceVal */
+     , (26262,   8,         10) /* Mass */
+     , (26262,   9,          0) /* ValidLocations - None */
+     , (26262,  11,         20) /* MaxStackSize */
+     , (26262,  12,          1) /* StackSize */
+     , (26262,  13,         10) /* StackUnitEncumbrance */
+     , (26262,  14,         10) /* StackUnitMass */
+     , (26262,  15,        500) /* StackUnitValue */
+     , (26262,  16,          8) /* ItemUseable - Contained */
+     , (26262,  18,          1) /* UiEffects - Magical */
+     , (26262,  19,        500) /* Value */
+     , (26262,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26262,  94,         16) /* TargetType - Creature */
+     , (26262, 106,        210) /* ItemSpellcraft */
+     , (26262, 107,         50) /* ItemCurMana */
+     , (26262, 108,         50) /* ItemMaxMana */
+     , (26262, 109,          0) /* ItemDifficulty */
+     , (26262, 110,          0) /* ItemAllegianceRankLimit */
+     , (26262, 150,        103) /* HookPlacement - Hook */
+     , (26262, 151,          2) /* HookType - Wall */
+     , (26262, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26262,  15, True ) /* LightsStatus */
+     , (26262,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26262, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26262,   1, 'Meditation Meadow Portal Gem') /* Name */
+     , (26262,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26262,   1,   33556769) /* Setup */
+     , (26262,   3,  536870932) /* SoundTable */
+     , (26262,   6,   67111919) /* PaletteBase */
+     , (26262,   7,  268435723) /* ClothingBase */
+     , (26262,   8,  100675760) /* Icon */
+     , (26262,  22,  872415275) /* PhysicsEffectTable */
+     , (26262,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26262,  31,      12519) /* LinkedPortalOne - Meditation Meadow Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26263 Meerthus Square Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26263 Meerthus Square Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26263;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26263, 'gemportalmeerthussquare', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26263,   1,       2048) /* ItemType - Gem */
+     , (26263,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26263,   5,         10) /* EncumbranceVal */
+     , (26263,   8,         10) /* Mass */
+     , (26263,   9,          0) /* ValidLocations - None */
+     , (26263,  11,         20) /* MaxStackSize */
+     , (26263,  12,          1) /* StackSize */
+     , (26263,  13,         10) /* StackUnitEncumbrance */
+     , (26263,  14,         10) /* StackUnitMass */
+     , (26263,  15,        500) /* StackUnitValue */
+     , (26263,  16,          8) /* ItemUseable - Contained */
+     , (26263,  18,          1) /* UiEffects - Magical */
+     , (26263,  19,        500) /* Value */
+     , (26263,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26263,  94,         16) /* TargetType - Creature */
+     , (26263, 106,        210) /* ItemSpellcraft */
+     , (26263, 107,         50) /* ItemCurMana */
+     , (26263, 108,         50) /* ItemMaxMana */
+     , (26263, 109,          0) /* ItemDifficulty */
+     , (26263, 110,          0) /* ItemAllegianceRankLimit */
+     , (26263, 150,        103) /* HookPlacement - Hook */
+     , (26263, 151,          2) /* HookType - Wall */
+     , (26263, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26263,  15, True ) /* LightsStatus */
+     , (26263,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26263, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26263,   1, 'Meerthus Square Portal Gem') /* Name */
+     , (26263,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26263,   1,   33556769) /* Setup */
+     , (26263,   3,  536870932) /* SoundTable */
+     , (26263,   6,   67111919) /* PaletteBase */
+     , (26263,   7,  268435723) /* ClothingBase */
+     , (26263,   8,  100675760) /* Icon */
+     , (26263,  22,  872415275) /* PhysicsEffectTable */
+     , (26263,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26263,  31,      14651) /* LinkedPortalOne - Meerthus Square Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26264 Merak Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26264 Merak Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26264;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26264, 'gemportalmerak', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26264,   1,       2048) /* ItemType - Gem */
+     , (26264,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26264,   5,         10) /* EncumbranceVal */
+     , (26264,   8,         10) /* Mass */
+     , (26264,   9,          0) /* ValidLocations - None */
+     , (26264,  11,         20) /* MaxStackSize */
+     , (26264,  12,          1) /* StackSize */
+     , (26264,  13,         10) /* StackUnitEncumbrance */
+     , (26264,  14,         10) /* StackUnitMass */
+     , (26264,  15,        500) /* StackUnitValue */
+     , (26264,  16,          8) /* ItemUseable - Contained */
+     , (26264,  18,          1) /* UiEffects - Magical */
+     , (26264,  19,        500) /* Value */
+     , (26264,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26264,  94,         16) /* TargetType - Creature */
+     , (26264, 106,        210) /* ItemSpellcraft */
+     , (26264, 107,         50) /* ItemCurMana */
+     , (26264, 108,         50) /* ItemMaxMana */
+     , (26264, 109,          0) /* ItemDifficulty */
+     , (26264, 110,          0) /* ItemAllegianceRankLimit */
+     , (26264, 150,        103) /* HookPlacement - Hook */
+     , (26264, 151,          2) /* HookType - Wall */
+     , (26264, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26264,  15, True ) /* LightsStatus */
+     , (26264,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26264, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26264,   1, 'Merak Portal Gem') /* Name */
+     , (26264,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26264,   1,   33556769) /* Setup */
+     , (26264,   3,  536870932) /* SoundTable */
+     , (26264,   6,   67111919) /* PaletteBase */
+     , (26264,   7,  268435723) /* ClothingBase */
+     , (26264,   8,  100675760) /* Icon */
+     , (26264,  22,  872415275) /* PhysicsEffectTable */
+     , (26264,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26264,  31,      15174) /* LinkedPortalOne - Merak Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26265 Meridian Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26265 Meridian Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26265;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26265, 'gemportalmeridiancottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26265,   1,       2048) /* ItemType - Gem */
+     , (26265,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26265,   5,         10) /* EncumbranceVal */
+     , (26265,   8,         10) /* Mass */
+     , (26265,   9,          0) /* ValidLocations - None */
+     , (26265,  11,         20) /* MaxStackSize */
+     , (26265,  12,          1) /* StackSize */
+     , (26265,  13,         10) /* StackUnitEncumbrance */
+     , (26265,  14,         10) /* StackUnitMass */
+     , (26265,  15,        500) /* StackUnitValue */
+     , (26265,  16,          8) /* ItemUseable - Contained */
+     , (26265,  18,          1) /* UiEffects - Magical */
+     , (26265,  19,        500) /* Value */
+     , (26265,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26265,  94,         16) /* TargetType - Creature */
+     , (26265, 106,        210) /* ItemSpellcraft */
+     , (26265, 107,         50) /* ItemCurMana */
+     , (26265, 108,         50) /* ItemMaxMana */
+     , (26265, 109,          0) /* ItemDifficulty */
+     , (26265, 110,          0) /* ItemAllegianceRankLimit */
+     , (26265, 150,        103) /* HookPlacement - Hook */
+     , (26265, 151,          2) /* HookType - Wall */
+     , (26265, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26265,  15, True ) /* LightsStatus */
+     , (26265,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26265, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26265,   1, 'Meridian Cottages Portal Gem') /* Name */
+     , (26265,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26265,   1,   33556769) /* Setup */
+     , (26265,   3,  536870932) /* SoundTable */
+     , (26265,   6,   67111919) /* PaletteBase */
+     , (26265,   7,  268435723) /* ClothingBase */
+     , (26265,   8,  100675760) /* Icon */
+     , (26265,  22,  872415275) /* PhysicsEffectTable */
+     , (26265,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26265,  31,      12520) /* LinkedPortalOne - Meridian Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26266 Midhill Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26266 Midhill Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26266;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26266, 'gemportalmidhillcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26266,   1,       2048) /* ItemType - Gem */
+     , (26266,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26266,   5,         10) /* EncumbranceVal */
+     , (26266,   8,         10) /* Mass */
+     , (26266,   9,          0) /* ValidLocations - None */
+     , (26266,  11,         20) /* MaxStackSize */
+     , (26266,  12,          1) /* StackSize */
+     , (26266,  13,         10) /* StackUnitEncumbrance */
+     , (26266,  14,         10) /* StackUnitMass */
+     , (26266,  15,        500) /* StackUnitValue */
+     , (26266,  16,          8) /* ItemUseable - Contained */
+     , (26266,  18,          1) /* UiEffects - Magical */
+     , (26266,  19,        500) /* Value */
+     , (26266,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26266,  94,         16) /* TargetType - Creature */
+     , (26266, 106,        210) /* ItemSpellcraft */
+     , (26266, 107,         50) /* ItemCurMana */
+     , (26266, 108,         50) /* ItemMaxMana */
+     , (26266, 109,          0) /* ItemDifficulty */
+     , (26266, 110,          0) /* ItemAllegianceRankLimit */
+     , (26266, 150,        103) /* HookPlacement - Hook */
+     , (26266, 151,          2) /* HookType - Wall */
+     , (26266, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26266,  15, True ) /* LightsStatus */
+     , (26266,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26266, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26266,   1, 'Midhill Cottages Portal Gem') /* Name */
+     , (26266,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26266,   1,   33556769) /* Setup */
+     , (26266,   3,  536870932) /* SoundTable */
+     , (26266,   6,   67111919) /* PaletteBase */
+     , (26266,   7,  268435723) /* ClothingBase */
+     , (26266,   8,  100675760) /* Icon */
+     , (26266,  22,  872415275) /* PhysicsEffectTable */
+     , (26266,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26266,  31,      15175) /* LinkedPortalOne - Midhill Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26267 Midsong Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26267 Midsong Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26267;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26267, 'gemportalmidsongcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26267,   1,       2048) /* ItemType - Gem */
+     , (26267,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26267,   5,         10) /* EncumbranceVal */
+     , (26267,   8,         10) /* Mass */
+     , (26267,   9,          0) /* ValidLocations - None */
+     , (26267,  11,         20) /* MaxStackSize */
+     , (26267,  12,          1) /* StackSize */
+     , (26267,  13,         10) /* StackUnitEncumbrance */
+     , (26267,  14,         10) /* StackUnitMass */
+     , (26267,  15,        500) /* StackUnitValue */
+     , (26267,  16,          8) /* ItemUseable - Contained */
+     , (26267,  18,          1) /* UiEffects - Magical */
+     , (26267,  19,        500) /* Value */
+     , (26267,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26267,  94,         16) /* TargetType - Creature */
+     , (26267, 106,        210) /* ItemSpellcraft */
+     , (26267, 107,         50) /* ItemCurMana */
+     , (26267, 108,         50) /* ItemMaxMana */
+     , (26267, 109,          0) /* ItemDifficulty */
+     , (26267, 110,          0) /* ItemAllegianceRankLimit */
+     , (26267, 150,        103) /* HookPlacement - Hook */
+     , (26267, 151,          2) /* HookType - Wall */
+     , (26267, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26267,  15, True ) /* LightsStatus */
+     , (26267,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26267, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26267,   1, 'Midsong Cottages Portal Gem') /* Name */
+     , (26267,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26267,   1,   33556769) /* Setup */
+     , (26267,   3,  536870932) /* SoundTable */
+     , (26267,   6,   67111919) /* PaletteBase */
+     , (26267,   7,  268435723) /* ClothingBase */
+     , (26267,   8,  100675760) /* Icon */
+     , (26267,  22,  872415275) /* PhysicsEffectTable */
+     , (26267,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26267,  31,      14272) /* LinkedPortalOne - Midsong Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26268 Mimiana Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26268 Mimiana Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26268;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26268, 'gemportalmimianavillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26268,   1,       2048) /* ItemType - Gem */
+     , (26268,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26268,   5,         10) /* EncumbranceVal */
+     , (26268,   8,         10) /* Mass */
+     , (26268,   9,          0) /* ValidLocations - None */
+     , (26268,  11,         20) /* MaxStackSize */
+     , (26268,  12,          1) /* StackSize */
+     , (26268,  13,         10) /* StackUnitEncumbrance */
+     , (26268,  14,         10) /* StackUnitMass */
+     , (26268,  15,        500) /* StackUnitValue */
+     , (26268,  16,          8) /* ItemUseable - Contained */
+     , (26268,  18,          1) /* UiEffects - Magical */
+     , (26268,  19,        500) /* Value */
+     , (26268,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26268,  94,         16) /* TargetType - Creature */
+     , (26268, 106,        210) /* ItemSpellcraft */
+     , (26268, 107,         50) /* ItemCurMana */
+     , (26268, 108,         50) /* ItemMaxMana */
+     , (26268, 109,          0) /* ItemDifficulty */
+     , (26268, 110,          0) /* ItemAllegianceRankLimit */
+     , (26268, 150,        103) /* HookPlacement - Hook */
+     , (26268, 151,          2) /* HookType - Wall */
+     , (26268, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26268,  15, True ) /* LightsStatus */
+     , (26268,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26268, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26268,   1, 'Mimiana Villas Portal Gem') /* Name */
+     , (26268,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26268,   1,   33556769) /* Setup */
+     , (26268,   3,  536870932) /* SoundTable */
+     , (26268,   6,   67111919) /* PaletteBase */
+     , (26268,   7,  268435723) /* ClothingBase */
+     , (26268,   8,  100675760) /* Icon */
+     , (26268,  22,  872415275) /* PhysicsEffectTable */
+     , (26268,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26268,  31,      15176) /* LinkedPortalOne - Mimiana Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26269 Mire Hill Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26269 Mire Hill Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26269;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26269, 'gemportalmirehill', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26269,   1,       2048) /* ItemType - Gem */
+     , (26269,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26269,   5,         10) /* EncumbranceVal */
+     , (26269,   8,         10) /* Mass */
+     , (26269,   9,          0) /* ValidLocations - None */
+     , (26269,  11,         20) /* MaxStackSize */
+     , (26269,  12,          1) /* StackSize */
+     , (26269,  13,         10) /* StackUnitEncumbrance */
+     , (26269,  14,         10) /* StackUnitMass */
+     , (26269,  15,        500) /* StackUnitValue */
+     , (26269,  16,          8) /* ItemUseable - Contained */
+     , (26269,  18,          1) /* UiEffects - Magical */
+     , (26269,  19,        500) /* Value */
+     , (26269,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26269,  94,         16) /* TargetType - Creature */
+     , (26269, 106,        210) /* ItemSpellcraft */
+     , (26269, 107,         50) /* ItemCurMana */
+     , (26269, 108,         50) /* ItemMaxMana */
+     , (26269, 109,          0) /* ItemDifficulty */
+     , (26269, 110,          0) /* ItemAllegianceRankLimit */
+     , (26269, 150,        103) /* HookPlacement - Hook */
+     , (26269, 151,          2) /* HookType - Wall */
+     , (26269, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26269,  15, True ) /* LightsStatus */
+     , (26269,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26269, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26269,   1, 'Mire Hill Portal Gem') /* Name */
+     , (26269,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26269,   1,   33556769) /* Setup */
+     , (26269,   3,  536870932) /* SoundTable */
+     , (26269,   6,   67111919) /* PaletteBase */
+     , (26269,   7,  268435723) /* ClothingBase */
+     , (26269,   8,  100675760) /* Icon */
+     , (26269,  22,  872415275) /* PhysicsEffectTable */
+     , (26269,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26269,  31,      14273) /* LinkedPortalOne - Mire Hill Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26270 Mistdweller Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26270 Mistdweller Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26270;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26270, 'gemportalmistdwellervillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26270,   1,       2048) /* ItemType - Gem */
+     , (26270,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26270,   5,         10) /* EncumbranceVal */
+     , (26270,   8,         10) /* Mass */
+     , (26270,   9,          0) /* ValidLocations - None */
+     , (26270,  11,         20) /* MaxStackSize */
+     , (26270,  12,          1) /* StackSize */
+     , (26270,  13,         10) /* StackUnitEncumbrance */
+     , (26270,  14,         10) /* StackUnitMass */
+     , (26270,  15,        500) /* StackUnitValue */
+     , (26270,  16,          8) /* ItemUseable - Contained */
+     , (26270,  18,          1) /* UiEffects - Magical */
+     , (26270,  19,        500) /* Value */
+     , (26270,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26270,  94,         16) /* TargetType - Creature */
+     , (26270, 106,        210) /* ItemSpellcraft */
+     , (26270, 107,         50) /* ItemCurMana */
+     , (26270, 108,         50) /* ItemMaxMana */
+     , (26270, 109,          0) /* ItemDifficulty */
+     , (26270, 110,          0) /* ItemAllegianceRankLimit */
+     , (26270, 150,        103) /* HookPlacement - Hook */
+     , (26270, 151,          2) /* HookType - Wall */
+     , (26270, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26270,  15, True ) /* LightsStatus */
+     , (26270,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26270, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26270,   1, 'Mistdweller Villas Portal Gem') /* Name */
+     , (26270,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26270,   1,   33556769) /* Setup */
+     , (26270,   3,  536870932) /* SoundTable */
+     , (26270,   6,   67111919) /* PaletteBase */
+     , (26270,   7,  268435723) /* ClothingBase */
+     , (26270,   8,  100675760) /* Icon */
+     , (26270,  22,  872415275) /* PhysicsEffectTable */
+     , (26270,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26270,  31,      14652) /* LinkedPortalOne - Mistdweller Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26271 Monument Sands Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26271 Monument Sands Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26271;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26271, 'gemportalmonumentsandssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26271,   1,       2048) /* ItemType - Gem */
+     , (26271,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26271,   5,         10) /* EncumbranceVal */
+     , (26271,   8,         10) /* Mass */
+     , (26271,   9,          0) /* ValidLocations - None */
+     , (26271,  11,         20) /* MaxStackSize */
+     , (26271,  12,          1) /* StackSize */
+     , (26271,  13,         10) /* StackUnitEncumbrance */
+     , (26271,  14,         10) /* StackUnitMass */
+     , (26271,  15,        500) /* StackUnitValue */
+     , (26271,  16,          8) /* ItemUseable - Contained */
+     , (26271,  18,          1) /* UiEffects - Magical */
+     , (26271,  19,        500) /* Value */
+     , (26271,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26271,  94,         16) /* TargetType - Creature */
+     , (26271, 106,        210) /* ItemSpellcraft */
+     , (26271, 107,         50) /* ItemCurMana */
+     , (26271, 108,         50) /* ItemMaxMana */
+     , (26271, 109,          0) /* ItemDifficulty */
+     , (26271, 110,          0) /* ItemAllegianceRankLimit */
+     , (26271, 150,        103) /* HookPlacement - Hook */
+     , (26271, 151,          2) /* HookType - Wall */
+     , (26271, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26271,  15, True ) /* LightsStatus */
+     , (26271,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26271, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26271,   1, 'Monument Sands Settlement Portal Gem') /* Name */
+     , (26271,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26271,   1,   33556769) /* Setup */
+     , (26271,   3,  536870932) /* SoundTable */
+     , (26271,   6,   67111919) /* PaletteBase */
+     , (26271,   7,  268435723) /* ClothingBase */
+     , (26271,   8,  100675760) /* Icon */
+     , (26271,  22,  872415275) /* PhysicsEffectTable */
+     , (26271,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26271,  31,      12521) /* LinkedPortalOne - Monument Sands Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26272 Morntide Ascent Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26272 Morntide Ascent Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26272;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26272, 'gemportalmorntideascentcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26272,   1,       2048) /* ItemType - Gem */
+     , (26272,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26272,   5,         10) /* EncumbranceVal */
+     , (26272,   8,         10) /* Mass */
+     , (26272,   9,          0) /* ValidLocations - None */
+     , (26272,  11,         20) /* MaxStackSize */
+     , (26272,  12,          1) /* StackSize */
+     , (26272,  13,         10) /* StackUnitEncumbrance */
+     , (26272,  14,         10) /* StackUnitMass */
+     , (26272,  15,        500) /* StackUnitValue */
+     , (26272,  16,          8) /* ItemUseable - Contained */
+     , (26272,  18,          1) /* UiEffects - Magical */
+     , (26272,  19,        500) /* Value */
+     , (26272,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26272,  94,         16) /* TargetType - Creature */
+     , (26272, 106,        210) /* ItemSpellcraft */
+     , (26272, 107,         50) /* ItemCurMana */
+     , (26272, 108,         50) /* ItemMaxMana */
+     , (26272, 109,          0) /* ItemDifficulty */
+     , (26272, 110,          0) /* ItemAllegianceRankLimit */
+     , (26272, 150,        103) /* HookPlacement - Hook */
+     , (26272, 151,          2) /* HookType - Wall */
+     , (26272, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26272,  15, True ) /* LightsStatus */
+     , (26272,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26272, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26272,   1, 'Morntide Ascent Cottages Portal Gem') /* Name */
+     , (26272,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26272,   1,   33556769) /* Setup */
+     , (26272,   3,  536870932) /* SoundTable */
+     , (26272,   6,   67111919) /* PaletteBase */
+     , (26272,   7,  268435723) /* ClothingBase */
+     , (26272,   8,  100675760) /* Icon */
+     , (26272,  22,  872415275) /* PhysicsEffectTable */
+     , (26272,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26272,  31,      19153) /* LinkedPortalOne - Morntide Ascent Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26273 Mosswart Place Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26273 Mosswart Place Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26273;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26273, 'gemportalmosswartplacecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26273,   1,       2048) /* ItemType - Gem */
+     , (26273,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26273,   5,         10) /* EncumbranceVal */
+     , (26273,   8,         10) /* Mass */
+     , (26273,   9,          0) /* ValidLocations - None */
+     , (26273,  11,         20) /* MaxStackSize */
+     , (26273,  12,          1) /* StackSize */
+     , (26273,  13,         10) /* StackUnitEncumbrance */
+     , (26273,  14,         10) /* StackUnitMass */
+     , (26273,  15,        500) /* StackUnitValue */
+     , (26273,  16,          8) /* ItemUseable - Contained */
+     , (26273,  18,          1) /* UiEffects - Magical */
+     , (26273,  19,        500) /* Value */
+     , (26273,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26273,  94,         16) /* TargetType - Creature */
+     , (26273, 106,        210) /* ItemSpellcraft */
+     , (26273, 107,         50) /* ItemCurMana */
+     , (26273, 108,         50) /* ItemMaxMana */
+     , (26273, 109,          0) /* ItemDifficulty */
+     , (26273, 110,          0) /* ItemAllegianceRankLimit */
+     , (26273, 150,        103) /* HookPlacement - Hook */
+     , (26273, 151,          2) /* HookType - Wall */
+     , (26273, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26273,  15, True ) /* LightsStatus */
+     , (26273,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26273, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26273,   1, 'Mosswart Place Cottages Portal Gem') /* Name */
+     , (26273,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26273,   1,   33556769) /* Setup */
+     , (26273,   3,  536870932) /* SoundTable */
+     , (26273,   6,   67111919) /* PaletteBase */
+     , (26273,   7,  268435723) /* ClothingBase */
+     , (26273,   8,  100675760) /* Icon */
+     , (26273,  22,  872415275) /* PhysicsEffectTable */
+     , (26273,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26273,  31,      12522) /* LinkedPortalOne - Mosswart Place Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26274 Mountain Keep Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26274 Mountain Keep Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26274;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26274, 'gemportalmountainkeepcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26274,   1,       2048) /* ItemType - Gem */
+     , (26274,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26274,   5,         10) /* EncumbranceVal */
+     , (26274,   8,         10) /* Mass */
+     , (26274,   9,          0) /* ValidLocations - None */
+     , (26274,  11,         20) /* MaxStackSize */
+     , (26274,  12,          1) /* StackSize */
+     , (26274,  13,         10) /* StackUnitEncumbrance */
+     , (26274,  14,         10) /* StackUnitMass */
+     , (26274,  15,        500) /* StackUnitValue */
+     , (26274,  16,          8) /* ItemUseable - Contained */
+     , (26274,  18,          1) /* UiEffects - Magical */
+     , (26274,  19,        500) /* Value */
+     , (26274,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26274,  94,         16) /* TargetType - Creature */
+     , (26274, 106,        210) /* ItemSpellcraft */
+     , (26274, 107,         50) /* ItemCurMana */
+     , (26274, 108,         50) /* ItemMaxMana */
+     , (26274, 109,          0) /* ItemDifficulty */
+     , (26274, 110,          0) /* ItemAllegianceRankLimit */
+     , (26274, 150,        103) /* HookPlacement - Hook */
+     , (26274, 151,          2) /* HookType - Wall */
+     , (26274, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26274,  15, True ) /* LightsStatus */
+     , (26274,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26274, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26274,   1, 'Mountain Keep Cottages Portal Gem') /* Name */
+     , (26274,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26274,   1,   33556769) /* Setup */
+     , (26274,   3,  536870932) /* SoundTable */
+     , (26274,   6,   67111919) /* PaletteBase */
+     , (26274,   7,  268435723) /* ClothingBase */
+     , (26274,   8,  100675760) /* Icon */
+     , (26274,  22,  872415275) /* PhysicsEffectTable */
+     , (26274,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26274,  31,      12523) /* LinkedPortalOne - Mountain Keep Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26275 Mountain Retreat Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26275 Mountain Retreat Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26275;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26275, 'gemportalmountainretreatcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26275,   1,       2048) /* ItemType - Gem */
+     , (26275,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26275,   5,         10) /* EncumbranceVal */
+     , (26275,   8,         10) /* Mass */
+     , (26275,   9,          0) /* ValidLocations - None */
+     , (26275,  11,         20) /* MaxStackSize */
+     , (26275,  12,          1) /* StackSize */
+     , (26275,  13,         10) /* StackUnitEncumbrance */
+     , (26275,  14,         10) /* StackUnitMass */
+     , (26275,  15,        500) /* StackUnitValue */
+     , (26275,  16,          8) /* ItemUseable - Contained */
+     , (26275,  18,          1) /* UiEffects - Magical */
+     , (26275,  19,        500) /* Value */
+     , (26275,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26275,  94,         16) /* TargetType - Creature */
+     , (26275, 106,        210) /* ItemSpellcraft */
+     , (26275, 107,         50) /* ItemCurMana */
+     , (26275, 108,         50) /* ItemMaxMana */
+     , (26275, 109,          0) /* ItemDifficulty */
+     , (26275, 110,          0) /* ItemAllegianceRankLimit */
+     , (26275, 150,        103) /* HookPlacement - Hook */
+     , (26275, 151,          2) /* HookType - Wall */
+     , (26275, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26275,  15, True ) /* LightsStatus */
+     , (26275,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26275, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26275,   1, 'Mountain Retreat Cottages Portal Gem') /* Name */
+     , (26275,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26275,   1,   33556769) /* Setup */
+     , (26275,   3,  536870932) /* SoundTable */
+     , (26275,   6,   67111919) /* PaletteBase */
+     , (26275,   7,  268435723) /* ClothingBase */
+     , (26275,   8,  100675760) /* Icon */
+     , (26275,  22,  872415275) /* PhysicsEffectTable */
+     , (26275,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26275,  31,      15677) /* LinkedPortalOne - Mountain Retreat Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26276 Mountain Ridge Abodes Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26276 Mountain Ridge Abodes Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26276;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26276, 'gemportalmountainridgeabodes', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26276,   1,       2048) /* ItemType - Gem */
+     , (26276,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26276,   5,         10) /* EncumbranceVal */
+     , (26276,   8,         10) /* Mass */
+     , (26276,   9,          0) /* ValidLocations - None */
+     , (26276,  11,         20) /* MaxStackSize */
+     , (26276,  12,          1) /* StackSize */
+     , (26276,  13,         10) /* StackUnitEncumbrance */
+     , (26276,  14,         10) /* StackUnitMass */
+     , (26276,  15,        500) /* StackUnitValue */
+     , (26276,  16,          8) /* ItemUseable - Contained */
+     , (26276,  18,          1) /* UiEffects - Magical */
+     , (26276,  19,        500) /* Value */
+     , (26276,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26276,  94,         16) /* TargetType - Creature */
+     , (26276, 106,        210) /* ItemSpellcraft */
+     , (26276, 107,         50) /* ItemCurMana */
+     , (26276, 108,         50) /* ItemMaxMana */
+     , (26276, 109,          0) /* ItemDifficulty */
+     , (26276, 110,          0) /* ItemAllegianceRankLimit */
+     , (26276, 150,        103) /* HookPlacement - Hook */
+     , (26276, 151,          2) /* HookType - Wall */
+     , (26276, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26276,  15, True ) /* LightsStatus */
+     , (26276,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26276, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26276,   1, 'Mountain Ridge Abodes Portal Gem') /* Name */
+     , (26276,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26276,   1,   33556769) /* Setup */
+     , (26276,   3,  536870932) /* SoundTable */
+     , (26276,   6,   67111919) /* PaletteBase */
+     , (26276,   7,  268435723) /* ClothingBase */
+     , (26276,   8,  100675760) /* Icon */
+     , (26276,  22,  872415275) /* PhysicsEffectTable */
+     , (26276,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26276,  31,      12524) /* LinkedPortalOne - Mountain Ridge Abodes Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26277 Mt Sylph View Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26277 Mt Sylph View Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26277;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26277, 'gemportalmtsylphviewcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26277,   1,       2048) /* ItemType - Gem */
+     , (26277,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26277,   5,         10) /* EncumbranceVal */
+     , (26277,   8,         10) /* Mass */
+     , (26277,   9,          0) /* ValidLocations - None */
+     , (26277,  11,         20) /* MaxStackSize */
+     , (26277,  12,          1) /* StackSize */
+     , (26277,  13,         10) /* StackUnitEncumbrance */
+     , (26277,  14,         10) /* StackUnitMass */
+     , (26277,  15,        500) /* StackUnitValue */
+     , (26277,  16,          8) /* ItemUseable - Contained */
+     , (26277,  18,          1) /* UiEffects - Magical */
+     , (26277,  19,        500) /* Value */
+     , (26277,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26277,  94,         16) /* TargetType - Creature */
+     , (26277, 106,        210) /* ItemSpellcraft */
+     , (26277, 107,         50) /* ItemCurMana */
+     , (26277, 108,         50) /* ItemMaxMana */
+     , (26277, 109,          0) /* ItemDifficulty */
+     , (26277, 110,          0) /* ItemAllegianceRankLimit */
+     , (26277, 150,        103) /* HookPlacement - Hook */
+     , (26277, 151,          2) /* HookType - Wall */
+     , (26277, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26277,  15, True ) /* LightsStatus */
+     , (26277,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26277, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26277,   1, 'Mt Sylph View Cottages Portal Gem') /* Name */
+     , (26277,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26277,   1,   33556769) /* Setup */
+     , (26277,   3,  536870932) /* SoundTable */
+     , (26277,   6,   67111919) /* PaletteBase */
+     , (26277,   7,  268435723) /* ClothingBase */
+     , (26277,   8,  100675760) /* Icon */
+     , (26277,  22,  872415275) /* PhysicsEffectTable */
+     , (26277,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26277,  31,      14274) /* LinkedPortalOne - Mt Sylph View Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26278 Musansayn Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26278 Musansayn Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26278;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26278, 'gemportalmusansayn', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26278,   1,       2048) /* ItemType - Gem */
+     , (26278,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26278,   5,         10) /* EncumbranceVal */
+     , (26278,   8,         10) /* Mass */
+     , (26278,   9,          0) /* ValidLocations - None */
+     , (26278,  11,         20) /* MaxStackSize */
+     , (26278,  12,          1) /* StackSize */
+     , (26278,  13,         10) /* StackUnitEncumbrance */
+     , (26278,  14,         10) /* StackUnitMass */
+     , (26278,  15,        500) /* StackUnitValue */
+     , (26278,  16,          8) /* ItemUseable - Contained */
+     , (26278,  18,          1) /* UiEffects - Magical */
+     , (26278,  19,        500) /* Value */
+     , (26278,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26278,  94,         16) /* TargetType - Creature */
+     , (26278, 106,        210) /* ItemSpellcraft */
+     , (26278, 107,         50) /* ItemCurMana */
+     , (26278, 108,         50) /* ItemMaxMana */
+     , (26278, 109,          0) /* ItemDifficulty */
+     , (26278, 110,          0) /* ItemAllegianceRankLimit */
+     , (26278, 150,        103) /* HookPlacement - Hook */
+     , (26278, 151,          2) /* HookType - Wall */
+     , (26278, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26278,  15, True ) /* LightsStatus */
+     , (26278,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26278, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26278,   1, 'Musansayn Portal Gem') /* Name */
+     , (26278,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26278,   1,   33556769) /* Setup */
+     , (26278,   3,  536870932) /* SoundTable */
+     , (26278,   6,   67111919) /* PaletteBase */
+     , (26278,   7,  268435723) /* ClothingBase */
+     , (26278,   8,  100675760) /* Icon */
+     , (26278,  22,  872415275) /* PhysicsEffectTable */
+     , (26278,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26278,  31,      12525) /* LinkedPortalOne - Musansayn Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26279 Nalib Cavana Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26279 Nalib Cavana Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26279;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26279, 'gemportalnalibcavanasettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26279,   1,       2048) /* ItemType - Gem */
+     , (26279,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26279,   5,         10) /* EncumbranceVal */
+     , (26279,   8,         10) /* Mass */
+     , (26279,   9,          0) /* ValidLocations - None */
+     , (26279,  11,         20) /* MaxStackSize */
+     , (26279,  12,          1) /* StackSize */
+     , (26279,  13,         10) /* StackUnitEncumbrance */
+     , (26279,  14,         10) /* StackUnitMass */
+     , (26279,  15,        500) /* StackUnitValue */
+     , (26279,  16,          8) /* ItemUseable - Contained */
+     , (26279,  18,          1) /* UiEffects - Magical */
+     , (26279,  19,        500) /* Value */
+     , (26279,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26279,  94,         16) /* TargetType - Creature */
+     , (26279, 106,        210) /* ItemSpellcraft */
+     , (26279, 107,         50) /* ItemCurMana */
+     , (26279, 108,         50) /* ItemMaxMana */
+     , (26279, 109,          0) /* ItemDifficulty */
+     , (26279, 110,          0) /* ItemAllegianceRankLimit */
+     , (26279, 150,        103) /* HookPlacement - Hook */
+     , (26279, 151,          2) /* HookType - Wall */
+     , (26279, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26279,  15, True ) /* LightsStatus */
+     , (26279,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26279, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26279,   1, 'Nalib Cavana Settlement Portal Gem') /* Name */
+     , (26279,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26279,   1,   33556769) /* Setup */
+     , (26279,   3,  536870932) /* SoundTable */
+     , (26279,   6,   67111919) /* PaletteBase */
+     , (26279,   7,  268435723) /* ClothingBase */
+     , (26279,   8,  100675760) /* Icon */
+     , (26279,  22,  872415275) /* PhysicsEffectTable */
+     , (26279,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26279,  31,      15177) /* LinkedPortalOne - Nalib Cavana Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26280 Nal Wadi Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26280 Nal Wadi Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26280;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26280, 'gemportalnalwadicottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26280,   1,       2048) /* ItemType - Gem */
+     , (26280,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26280,   5,         10) /* EncumbranceVal */
+     , (26280,   8,         10) /* Mass */
+     , (26280,   9,          0) /* ValidLocations - None */
+     , (26280,  11,         20) /* MaxStackSize */
+     , (26280,  12,          1) /* StackSize */
+     , (26280,  13,         10) /* StackUnitEncumbrance */
+     , (26280,  14,         10) /* StackUnitMass */
+     , (26280,  15,        500) /* StackUnitValue */
+     , (26280,  16,          8) /* ItemUseable - Contained */
+     , (26280,  18,          1) /* UiEffects - Magical */
+     , (26280,  19,        500) /* Value */
+     , (26280,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26280,  94,         16) /* TargetType - Creature */
+     , (26280, 106,        210) /* ItemSpellcraft */
+     , (26280, 107,         50) /* ItemCurMana */
+     , (26280, 108,         50) /* ItemMaxMana */
+     , (26280, 109,          0) /* ItemDifficulty */
+     , (26280, 110,          0) /* ItemAllegianceRankLimit */
+     , (26280, 150,        103) /* HookPlacement - Hook */
+     , (26280, 151,          2) /* HookType - Wall */
+     , (26280, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26280,  15, True ) /* LightsStatus */
+     , (26280,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26280, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26280,   1, 'Nal Wadi Cottages Portal Gem') /* Name */
+     , (26280,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26280,   1,   33556769) /* Setup */
+     , (26280,   3,  536870932) /* SoundTable */
+     , (26280,   6,   67111919) /* PaletteBase */
+     , (26280,   7,  268435723) /* ClothingBase */
+     , (26280,   8,  100675760) /* Icon */
+     , (26280,  22,  872415275) /* PhysicsEffectTable */
+     , (26280,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26280,  31,      14275) /* LinkedPortalOne - Nal Wadi Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26281 Nan-Zari Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26281 Nan-Zari Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26281;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26281, 'gemportalnanzari', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26281,   1,       2048) /* ItemType - Gem */
+     , (26281,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26281,   5,         10) /* EncumbranceVal */
+     , (26281,   8,         10) /* Mass */
+     , (26281,   9,          0) /* ValidLocations - None */
+     , (26281,  11,         20) /* MaxStackSize */
+     , (26281,  12,          1) /* StackSize */
+     , (26281,  13,         10) /* StackUnitEncumbrance */
+     , (26281,  14,         10) /* StackUnitMass */
+     , (26281,  15,        500) /* StackUnitValue */
+     , (26281,  16,          8) /* ItemUseable - Contained */
+     , (26281,  18,          1) /* UiEffects - Magical */
+     , (26281,  19,        500) /* Value */
+     , (26281,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26281,  94,         16) /* TargetType - Creature */
+     , (26281, 106,        210) /* ItemSpellcraft */
+     , (26281, 107,         50) /* ItemCurMana */
+     , (26281, 108,         50) /* ItemMaxMana */
+     , (26281, 109,          0) /* ItemDifficulty */
+     , (26281, 110,          0) /* ItemAllegianceRankLimit */
+     , (26281, 150,        103) /* HookPlacement - Hook */
+     , (26281, 151,          2) /* HookType - Wall */
+     , (26281, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26281,  15, True ) /* LightsStatus */
+     , (26281,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26281, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26281,   1, 'Nan-Zari Portal Gem') /* Name */
+     , (26281,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26281,   1,   33556769) /* Setup */
+     , (26281,   3,  536870932) /* SoundTable */
+     , (26281,   6,   67111919) /* PaletteBase */
+     , (26281,   7,  268435723) /* ClothingBase */
+     , (26281,   8,  100675760) /* Icon */
+     , (26281,  22,  872415275) /* PhysicsEffectTable */
+     , (26281,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26281,  31,      13112) /* LinkedPortalOne - Nan-Zari Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26282 Naqut Dreams Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26282 Naqut Dreams Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26282;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26282, 'gemportalnaqutdreamsvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26282,   1,       2048) /* ItemType - Gem */
+     , (26282,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26282,   5,         10) /* EncumbranceVal */
+     , (26282,   8,         10) /* Mass */
+     , (26282,   9,          0) /* ValidLocations - None */
+     , (26282,  11,         20) /* MaxStackSize */
+     , (26282,  12,          1) /* StackSize */
+     , (26282,  13,         10) /* StackUnitEncumbrance */
+     , (26282,  14,         10) /* StackUnitMass */
+     , (26282,  15,        500) /* StackUnitValue */
+     , (26282,  16,          8) /* ItemUseable - Contained */
+     , (26282,  18,          1) /* UiEffects - Magical */
+     , (26282,  19,        500) /* Value */
+     , (26282,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26282,  94,         16) /* TargetType - Creature */
+     , (26282, 106,        210) /* ItemSpellcraft */
+     , (26282, 107,         50) /* ItemCurMana */
+     , (26282, 108,         50) /* ItemMaxMana */
+     , (26282, 109,          0) /* ItemDifficulty */
+     , (26282, 110,          0) /* ItemAllegianceRankLimit */
+     , (26282, 150,        103) /* HookPlacement - Hook */
+     , (26282, 151,          2) /* HookType - Wall */
+     , (26282, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26282,  15, True ) /* LightsStatus */
+     , (26282,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26282, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26282,   1, 'Naqut Dreams Villas Portal Gem') /* Name */
+     , (26282,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26282,   1,   33556769) /* Setup */
+     , (26282,   3,  536870932) /* SoundTable */
+     , (26282,   6,   67111919) /* PaletteBase */
+     , (26282,   7,  268435723) /* ClothingBase */
+     , (26282,   8,  100675760) /* Icon */
+     , (26282,  22,  872415275) /* PhysicsEffectTable */
+     , (26282,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26282,  31,      13113) /* LinkedPortalOne - Naqut Dreams Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26283 Narsys Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26283 Narsys Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26283;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26283, 'gemportalnarsys', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26283,   1,       2048) /* ItemType - Gem */
+     , (26283,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26283,   5,         10) /* EncumbranceVal */
+     , (26283,   8,         10) /* Mass */
+     , (26283,   9,          0) /* ValidLocations - None */
+     , (26283,  11,         20) /* MaxStackSize */
+     , (26283,  12,          1) /* StackSize */
+     , (26283,  13,         10) /* StackUnitEncumbrance */
+     , (26283,  14,         10) /* StackUnitMass */
+     , (26283,  15,        500) /* StackUnitValue */
+     , (26283,  16,          8) /* ItemUseable - Contained */
+     , (26283,  18,          1) /* UiEffects - Magical */
+     , (26283,  19,        500) /* Value */
+     , (26283,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26283,  94,         16) /* TargetType - Creature */
+     , (26283, 106,        210) /* ItemSpellcraft */
+     , (26283, 107,         50) /* ItemCurMana */
+     , (26283, 108,         50) /* ItemMaxMana */
+     , (26283, 109,          0) /* ItemDifficulty */
+     , (26283, 110,          0) /* ItemAllegianceRankLimit */
+     , (26283, 150,        103) /* HookPlacement - Hook */
+     , (26283, 151,          2) /* HookType - Wall */
+     , (26283, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26283,  15, True ) /* LightsStatus */
+     , (26283,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26283, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26283,   1, 'Narsys Portal Gem') /* Name */
+     , (26283,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26283,   1,   33556769) /* Setup */
+     , (26283,   3,  536870932) /* SoundTable */
+     , (26283,   6,   67111919) /* PaletteBase */
+     , (26283,   7,  268435723) /* ClothingBase */
+     , (26283,   8,  100675760) /* Icon */
+     , (26283,  22,  872415275) /* PhysicsEffectTable */
+     , (26283,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26283,  31,      14276) /* LinkedPortalOne - Narsys Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26284 Narziz Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26284 Narziz Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26284;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26284, 'gemportalnarzizcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26284,   1,       2048) /* ItemType - Gem */
+     , (26284,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26284,   5,         10) /* EncumbranceVal */
+     , (26284,   8,         10) /* Mass */
+     , (26284,   9,          0) /* ValidLocations - None */
+     , (26284,  11,         20) /* MaxStackSize */
+     , (26284,  12,          1) /* StackSize */
+     , (26284,  13,         10) /* StackUnitEncumbrance */
+     , (26284,  14,         10) /* StackUnitMass */
+     , (26284,  15,        500) /* StackUnitValue */
+     , (26284,  16,          8) /* ItemUseable - Contained */
+     , (26284,  18,          1) /* UiEffects - Magical */
+     , (26284,  19,        500) /* Value */
+     , (26284,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26284,  94,         16) /* TargetType - Creature */
+     , (26284, 106,        210) /* ItemSpellcraft */
+     , (26284, 107,         50) /* ItemCurMana */
+     , (26284, 108,         50) /* ItemMaxMana */
+     , (26284, 109,          0) /* ItemDifficulty */
+     , (26284, 110,          0) /* ItemAllegianceRankLimit */
+     , (26284, 150,        103) /* HookPlacement - Hook */
+     , (26284, 151,          2) /* HookType - Wall */
+     , (26284, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26284,  15, True ) /* LightsStatus */
+     , (26284,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26284, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26284,   1, 'Narziz Cottages Portal Gem') /* Name */
+     , (26284,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26284,   1,   33556769) /* Setup */
+     , (26284,   3,  536870932) /* SoundTable */
+     , (26284,   6,   67111919) /* PaletteBase */
+     , (26284,   7,  268435723) /* ClothingBase */
+     , (26284,   8,  100675760) /* Icon */
+     , (26284,  22,  872415275) /* PhysicsEffectTable */
+     , (26284,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26284,  31,      12526) /* LinkedPortalOne - Narziz Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26285 Neu Gerz Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26285 Neu Gerz Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26285;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26285, 'gemportalneugerzvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26285,   1,       2048) /* ItemType - Gem */
+     , (26285,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26285,   5,         10) /* EncumbranceVal */
+     , (26285,   8,         10) /* Mass */
+     , (26285,   9,          0) /* ValidLocations - None */
+     , (26285,  11,         20) /* MaxStackSize */
+     , (26285,  12,          1) /* StackSize */
+     , (26285,  13,         10) /* StackUnitEncumbrance */
+     , (26285,  14,         10) /* StackUnitMass */
+     , (26285,  15,        500) /* StackUnitValue */
+     , (26285,  16,          8) /* ItemUseable - Contained */
+     , (26285,  18,          1) /* UiEffects - Magical */
+     , (26285,  19,        500) /* Value */
+     , (26285,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26285,  94,         16) /* TargetType - Creature */
+     , (26285, 106,        210) /* ItemSpellcraft */
+     , (26285, 107,         50) /* ItemCurMana */
+     , (26285, 108,         50) /* ItemMaxMana */
+     , (26285, 109,          0) /* ItemDifficulty */
+     , (26285, 110,          0) /* ItemAllegianceRankLimit */
+     , (26285, 150,        103) /* HookPlacement - Hook */
+     , (26285, 151,          2) /* HookType - Wall */
+     , (26285, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26285,  15, True ) /* LightsStatus */
+     , (26285,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26285, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26285,   1, 'Neu Gerz Villas Portal Gem') /* Name */
+     , (26285,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26285,   1,   33556769) /* Setup */
+     , (26285,   3,  536870932) /* SoundTable */
+     , (26285,   6,   67111919) /* PaletteBase */
+     , (26285,   7,  268435723) /* ClothingBase */
+     , (26285,   8,  100675760) /* Icon */
+     , (26285,  22,  872415275) /* PhysicsEffectTable */
+     , (26285,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26285,  31,      13114) /* LinkedPortalOne - Neu Gerz Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26286 New Cannthalo Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26286 New Cannthalo Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26286;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26286, 'gemportalnewcannthalo', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26286,   1,       2048) /* ItemType - Gem */
+     , (26286,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26286,   5,         10) /* EncumbranceVal */
+     , (26286,   8,         10) /* Mass */
+     , (26286,   9,          0) /* ValidLocations - None */
+     , (26286,  11,         20) /* MaxStackSize */
+     , (26286,  12,          1) /* StackSize */
+     , (26286,  13,         10) /* StackUnitEncumbrance */
+     , (26286,  14,         10) /* StackUnitMass */
+     , (26286,  15,        500) /* StackUnitValue */
+     , (26286,  16,          8) /* ItemUseable - Contained */
+     , (26286,  18,          1) /* UiEffects - Magical */
+     , (26286,  19,        500) /* Value */
+     , (26286,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26286,  94,         16) /* TargetType - Creature */
+     , (26286, 106,        210) /* ItemSpellcraft */
+     , (26286, 107,         50) /* ItemCurMana */
+     , (26286, 108,         50) /* ItemMaxMana */
+     , (26286, 109,          0) /* ItemDifficulty */
+     , (26286, 110,          0) /* ItemAllegianceRankLimit */
+     , (26286, 150,        103) /* HookPlacement - Hook */
+     , (26286, 151,          2) /* HookType - Wall */
+     , (26286, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26286,  15, True ) /* LightsStatus */
+     , (26286,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26286, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26286,   1, 'New Cannthalo Portal Gem') /* Name */
+     , (26286,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26286,   1,   33556769) /* Setup */
+     , (26286,   3,  536870932) /* SoundTable */
+     , (26286,   6,   67111919) /* PaletteBase */
+     , (26286,   7,  268435723) /* ClothingBase */
+     , (26286,   8,  100675760) /* Icon */
+     , (26286,  22,  872415275) /* PhysicsEffectTable */
+     , (26286,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26286,  31,      15178) /* LinkedPortalOne - New Cannthalo Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26287 New Colier Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26287 New Colier Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26287;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26287, 'gemportalnewcolier', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26287,   1,       2048) /* ItemType - Gem */
+     , (26287,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26287,   5,         10) /* EncumbranceVal */
+     , (26287,   8,         10) /* Mass */
+     , (26287,   9,          0) /* ValidLocations - None */
+     , (26287,  11,         20) /* MaxStackSize */
+     , (26287,  12,          1) /* StackSize */
+     , (26287,  13,         10) /* StackUnitEncumbrance */
+     , (26287,  14,         10) /* StackUnitMass */
+     , (26287,  15,        500) /* StackUnitValue */
+     , (26287,  16,          8) /* ItemUseable - Contained */
+     , (26287,  18,          1) /* UiEffects - Magical */
+     , (26287,  19,        500) /* Value */
+     , (26287,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26287,  94,         16) /* TargetType - Creature */
+     , (26287, 106,        210) /* ItemSpellcraft */
+     , (26287, 107,         50) /* ItemCurMana */
+     , (26287, 108,         50) /* ItemMaxMana */
+     , (26287, 109,          0) /* ItemDifficulty */
+     , (26287, 110,          0) /* ItemAllegianceRankLimit */
+     , (26287, 150,        103) /* HookPlacement - Hook */
+     , (26287, 151,          2) /* HookType - Wall */
+     , (26287, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26287,  15, True ) /* LightsStatus */
+     , (26287,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26287, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26287,   1, 'New Colier Portal Gem') /* Name */
+     , (26287,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26287,   1,   33556769) /* Setup */
+     , (26287,   3,  536870932) /* SoundTable */
+     , (26287,   6,   67111919) /* PaletteBase */
+     , (26287,   7,  268435723) /* ClothingBase */
+     , (26287,   8,  100675760) /* Icon */
+     , (26287,  22,  872415275) /* PhysicsEffectTable */
+     , (26287,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26287,  31,      12527) /* LinkedPortalOne - New Colier Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26288 New Nesortania Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26288 New Nesortania Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26288;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26288, 'gemportalnewnesortania', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26288,   1,       2048) /* ItemType - Gem */
+     , (26288,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26288,   5,         10) /* EncumbranceVal */
+     , (26288,   8,         10) /* Mass */
+     , (26288,   9,          0) /* ValidLocations - None */
+     , (26288,  11,         20) /* MaxStackSize */
+     , (26288,  12,          1) /* StackSize */
+     , (26288,  13,         10) /* StackUnitEncumbrance */
+     , (26288,  14,         10) /* StackUnitMass */
+     , (26288,  15,        500) /* StackUnitValue */
+     , (26288,  16,          8) /* ItemUseable - Contained */
+     , (26288,  18,          1) /* UiEffects - Magical */
+     , (26288,  19,        500) /* Value */
+     , (26288,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26288,  94,         16) /* TargetType - Creature */
+     , (26288, 106,        210) /* ItemSpellcraft */
+     , (26288, 107,         50) /* ItemCurMana */
+     , (26288, 108,         50) /* ItemMaxMana */
+     , (26288, 109,          0) /* ItemDifficulty */
+     , (26288, 110,          0) /* ItemAllegianceRankLimit */
+     , (26288, 150,        103) /* HookPlacement - Hook */
+     , (26288, 151,          2) /* HookType - Wall */
+     , (26288, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26288,  15, True ) /* LightsStatus */
+     , (26288,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26288, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26288,   1, 'New Nesortania Portal Gem') /* Name */
+     , (26288,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26288,   1,   33556769) /* Setup */
+     , (26288,   3,  536870932) /* SoundTable */
+     , (26288,   6,   67111919) /* PaletteBase */
+     , (26288,   7,  268435723) /* ClothingBase */
+     , (26288,   8,  100675760) /* Icon */
+     , (26288,  22,  872415275) /* PhysicsEffectTable */
+     , (26288,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26288,  31,      15179) /* LinkedPortalOne - New Nesortania Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26289 New Suntik Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26289 New Suntik Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26289;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26289, 'gemportalnewsuntik', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26289,   1,       2048) /* ItemType - Gem */
+     , (26289,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26289,   5,         10) /* EncumbranceVal */
+     , (26289,   8,         10) /* Mass */
+     , (26289,   9,          0) /* ValidLocations - None */
+     , (26289,  11,         20) /* MaxStackSize */
+     , (26289,  12,          1) /* StackSize */
+     , (26289,  13,         10) /* StackUnitEncumbrance */
+     , (26289,  14,         10) /* StackUnitMass */
+     , (26289,  15,        500) /* StackUnitValue */
+     , (26289,  16,          8) /* ItemUseable - Contained */
+     , (26289,  18,          1) /* UiEffects - Magical */
+     , (26289,  19,        500) /* Value */
+     , (26289,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26289,  94,         16) /* TargetType - Creature */
+     , (26289, 106,        210) /* ItemSpellcraft */
+     , (26289, 107,         50) /* ItemCurMana */
+     , (26289, 108,         50) /* ItemMaxMana */
+     , (26289, 109,          0) /* ItemDifficulty */
+     , (26289, 110,          0) /* ItemAllegianceRankLimit */
+     , (26289, 150,        103) /* HookPlacement - Hook */
+     , (26289, 151,          2) /* HookType - Wall */
+     , (26289, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26289,  15, True ) /* LightsStatus */
+     , (26289,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26289, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26289,   1, 'New Suntik Portal Gem') /* Name */
+     , (26289,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26289,   1,   33556769) /* Setup */
+     , (26289,   3,  536870932) /* SoundTable */
+     , (26289,   6,   67111919) /* PaletteBase */
+     , (26289,   7,  268435723) /* ClothingBase */
+     , (26289,   8,  100675760) /* Icon */
+     , (26289,  22,  872415275) /* PhysicsEffectTable */
+     , (26289,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26289,  31,      12528) /* LinkedPortalOne - New Suntik Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26290 Neydisa Village Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26290 Neydisa Village Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26290;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26290, 'gemportalneydisavillage', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26290,   1,       2048) /* ItemType - Gem */
+     , (26290,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26290,   5,         10) /* EncumbranceVal */
+     , (26290,   8,         10) /* Mass */
+     , (26290,   9,          0) /* ValidLocations - None */
+     , (26290,  11,         20) /* MaxStackSize */
+     , (26290,  12,          1) /* StackSize */
+     , (26290,  13,         10) /* StackUnitEncumbrance */
+     , (26290,  14,         10) /* StackUnitMass */
+     , (26290,  15,        500) /* StackUnitValue */
+     , (26290,  16,          8) /* ItemUseable - Contained */
+     , (26290,  18,          1) /* UiEffects - Magical */
+     , (26290,  19,        500) /* Value */
+     , (26290,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26290,  94,         16) /* TargetType - Creature */
+     , (26290, 106,        210) /* ItemSpellcraft */
+     , (26290, 107,         50) /* ItemCurMana */
+     , (26290, 108,         50) /* ItemMaxMana */
+     , (26290, 109,          0) /* ItemDifficulty */
+     , (26290, 110,          0) /* ItemAllegianceRankLimit */
+     , (26290, 150,        103) /* HookPlacement - Hook */
+     , (26290, 151,          2) /* HookType - Wall */
+     , (26290, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26290,  15, True ) /* LightsStatus */
+     , (26290,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26290, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26290,   1, 'Neydisa Village Portal Gem') /* Name */
+     , (26290,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26290,   1,   33556769) /* Setup */
+     , (26290,   3,  536870932) /* SoundTable */
+     , (26290,   6,   67111919) /* PaletteBase */
+     , (26290,   7,  268435723) /* ClothingBase */
+     , (26290,   8,  100675760) /* Icon */
+     , (26290,  22,  872415275) /* PhysicsEffectTable */
+     , (26290,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26290,  31,      12529) /* LinkedPortalOne - Neydisa Village Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26291 Nidal-Taraq Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26291 Nidal-Taraq Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26291;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26291, 'gemportalnidaltaraqvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26291,   1,       2048) /* ItemType - Gem */
+     , (26291,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26291,   5,         10) /* EncumbranceVal */
+     , (26291,   8,         10) /* Mass */
+     , (26291,   9,          0) /* ValidLocations - None */
+     , (26291,  11,         20) /* MaxStackSize */
+     , (26291,  12,          1) /* StackSize */
+     , (26291,  13,         10) /* StackUnitEncumbrance */
+     , (26291,  14,         10) /* StackUnitMass */
+     , (26291,  15,        500) /* StackUnitValue */
+     , (26291,  16,          8) /* ItemUseable - Contained */
+     , (26291,  18,          1) /* UiEffects - Magical */
+     , (26291,  19,        500) /* Value */
+     , (26291,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26291,  94,         16) /* TargetType - Creature */
+     , (26291, 106,        210) /* ItemSpellcraft */
+     , (26291, 107,         50) /* ItemCurMana */
+     , (26291, 108,         50) /* ItemMaxMana */
+     , (26291, 109,          0) /* ItemDifficulty */
+     , (26291, 110,          0) /* ItemAllegianceRankLimit */
+     , (26291, 150,        103) /* HookPlacement - Hook */
+     , (26291, 151,          2) /* HookType - Wall */
+     , (26291, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26291,  15, True ) /* LightsStatus */
+     , (26291,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26291, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26291,   1, 'Nidal-Taraq Villas Portal Gem') /* Name */
+     , (26291,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26291,   1,   33556769) /* Setup */
+     , (26291,   3,  536870932) /* SoundTable */
+     , (26291,   6,   67111919) /* PaletteBase */
+     , (26291,   7,  268435723) /* ClothingBase */
+     , (26291,   8,  100675760) /* Icon */
+     , (26291,  22,  872415275) /* PhysicsEffectTable */
+     , (26291,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26291,  31,      15678) /* LinkedPortalOne - Nidal-Taraq Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26292 Norstead Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26292 Norstead Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26292;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26292, 'gemportalnorstead', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26292,   1,       2048) /* ItemType - Gem */
+     , (26292,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26292,   5,         10) /* EncumbranceVal */
+     , (26292,   8,         10) /* Mass */
+     , (26292,   9,          0) /* ValidLocations - None */
+     , (26292,  11,         20) /* MaxStackSize */
+     , (26292,  12,          1) /* StackSize */
+     , (26292,  13,         10) /* StackUnitEncumbrance */
+     , (26292,  14,         10) /* StackUnitMass */
+     , (26292,  15,        500) /* StackUnitValue */
+     , (26292,  16,          8) /* ItemUseable - Contained */
+     , (26292,  18,          1) /* UiEffects - Magical */
+     , (26292,  19,        500) /* Value */
+     , (26292,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26292,  94,         16) /* TargetType - Creature */
+     , (26292, 106,        210) /* ItemSpellcraft */
+     , (26292, 107,         50) /* ItemCurMana */
+     , (26292, 108,         50) /* ItemMaxMana */
+     , (26292, 109,          0) /* ItemDifficulty */
+     , (26292, 110,          0) /* ItemAllegianceRankLimit */
+     , (26292, 150,        103) /* HookPlacement - Hook */
+     , (26292, 151,          2) /* HookType - Wall */
+     , (26292, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26292,  15, True ) /* LightsStatus */
+     , (26292,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26292, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26292,   1, 'Norstead Portal Gem') /* Name */
+     , (26292,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26292,   1,   33556769) /* Setup */
+     , (26292,   3,  536870932) /* SoundTable */
+     , (26292,   6,   67111919) /* PaletteBase */
+     , (26292,   7,  268435723) /* ClothingBase */
+     , (26292,   8,  100675760) /* Icon */
+     , (26292,  22,  872415275) /* PhysicsEffectTable */
+     , (26292,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26292,  31,      12530) /* LinkedPortalOne - Norstead Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26293 North Adjamaer Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26293 North Adjamaer Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26293;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26293, 'gemportalnorthadjamaercottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26293,   1,       2048) /* ItemType - Gem */
+     , (26293,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26293,   5,         10) /* EncumbranceVal */
+     , (26293,   8,         10) /* Mass */
+     , (26293,   9,          0) /* ValidLocations - None */
+     , (26293,  11,         20) /* MaxStackSize */
+     , (26293,  12,          1) /* StackSize */
+     , (26293,  13,         10) /* StackUnitEncumbrance */
+     , (26293,  14,         10) /* StackUnitMass */
+     , (26293,  15,        500) /* StackUnitValue */
+     , (26293,  16,          8) /* ItemUseable - Contained */
+     , (26293,  18,          1) /* UiEffects - Magical */
+     , (26293,  19,        500) /* Value */
+     , (26293,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26293,  94,         16) /* TargetType - Creature */
+     , (26293, 106,        210) /* ItemSpellcraft */
+     , (26293, 107,         50) /* ItemCurMana */
+     , (26293, 108,         50) /* ItemMaxMana */
+     , (26293, 109,          0) /* ItemDifficulty */
+     , (26293, 110,          0) /* ItemAllegianceRankLimit */
+     , (26293, 150,        103) /* HookPlacement - Hook */
+     , (26293, 151,          2) /* HookType - Wall */
+     , (26293, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26293,  15, True ) /* LightsStatus */
+     , (26293,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26293, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26293,   1, 'North Adjamaer Cottages Portal Gem') /* Name */
+     , (26293,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26293,   1,   33556769) /* Setup */
+     , (26293,   3,  536870932) /* SoundTable */
+     , (26293,   6,   67111919) /* PaletteBase */
+     , (26293,   7,  268435723) /* ClothingBase */
+     , (26293,   8,  100675760) /* Icon */
+     , (26293,  22,  872415275) /* PhysicsEffectTable */
+     , (26293,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26293,  31,      12531) /* LinkedPortalOne - North Adjamaer Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26294 North Baishi Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26294 North Baishi Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26294;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26294, 'gemportalnorthbaishicottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26294,   1,       2048) /* ItemType - Gem */
+     , (26294,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26294,   5,         10) /* EncumbranceVal */
+     , (26294,   8,         10) /* Mass */
+     , (26294,   9,          0) /* ValidLocations - None */
+     , (26294,  11,         20) /* MaxStackSize */
+     , (26294,  12,          1) /* StackSize */
+     , (26294,  13,         10) /* StackUnitEncumbrance */
+     , (26294,  14,         10) /* StackUnitMass */
+     , (26294,  15,        500) /* StackUnitValue */
+     , (26294,  16,          8) /* ItemUseable - Contained */
+     , (26294,  18,          1) /* UiEffects - Magical */
+     , (26294,  19,        500) /* Value */
+     , (26294,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26294,  94,         16) /* TargetType - Creature */
+     , (26294, 106,        210) /* ItemSpellcraft */
+     , (26294, 107,         50) /* ItemCurMana */
+     , (26294, 108,         50) /* ItemMaxMana */
+     , (26294, 109,          0) /* ItemDifficulty */
+     , (26294, 110,          0) /* ItemAllegianceRankLimit */
+     , (26294, 150,        103) /* HookPlacement - Hook */
+     , (26294, 151,          2) /* HookType - Wall */
+     , (26294, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26294,  15, True ) /* LightsStatus */
+     , (26294,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26294, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26294,   1, 'North Baishi Cottages Portal Gem') /* Name */
+     , (26294,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26294,   1,   33556769) /* Setup */
+     , (26294,   3,  536870932) /* SoundTable */
+     , (26294,   6,   67111919) /* PaletteBase */
+     , (26294,   7,  268435723) /* ClothingBase */
+     , (26294,   8,  100675760) /* Icon */
+     , (26294,  22,  872415275) /* PhysicsEffectTable */
+     , (26294,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26294,  31,      12532) /* LinkedPortalOne - North Baishi Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26295 North Eastham Meadow Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26295 North Eastham Meadow Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26295;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26295, 'gemportalnortheasthammeadow', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26295,   1,       2048) /* ItemType - Gem */
+     , (26295,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26295,   5,         10) /* EncumbranceVal */
+     , (26295,   8,         10) /* Mass */
+     , (26295,   9,          0) /* ValidLocations - None */
+     , (26295,  11,         20) /* MaxStackSize */
+     , (26295,  12,          1) /* StackSize */
+     , (26295,  13,         10) /* StackUnitEncumbrance */
+     , (26295,  14,         10) /* StackUnitMass */
+     , (26295,  15,        500) /* StackUnitValue */
+     , (26295,  16,          8) /* ItemUseable - Contained */
+     , (26295,  18,          1) /* UiEffects - Magical */
+     , (26295,  19,        500) /* Value */
+     , (26295,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26295,  94,         16) /* TargetType - Creature */
+     , (26295, 106,        210) /* ItemSpellcraft */
+     , (26295, 107,         50) /* ItemCurMana */
+     , (26295, 108,         50) /* ItemMaxMana */
+     , (26295, 109,          0) /* ItemDifficulty */
+     , (26295, 110,          0) /* ItemAllegianceRankLimit */
+     , (26295, 150,        103) /* HookPlacement - Hook */
+     , (26295, 151,          2) /* HookType - Wall */
+     , (26295, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26295,  15, True ) /* LightsStatus */
+     , (26295,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26295, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26295,   1, 'North Eastham Meadow Portal Gem') /* Name */
+     , (26295,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26295,   1,   33556769) /* Setup */
+     , (26295,   3,  536870932) /* SoundTable */
+     , (26295,   6,   67111919) /* PaletteBase */
+     , (26295,   7,  268435723) /* ClothingBase */
+     , (26295,   8,  100675760) /* Icon */
+     , (26295,  22,  872415275) /* PhysicsEffectTable */
+     , (26295,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26295,  31,      12533) /* LinkedPortalOne - North Eastham Meadow Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26296 Northfire Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26296 Northfire Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26296;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26296, 'gemportalnorthfireestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26296,   1,       2048) /* ItemType - Gem */
+     , (26296,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26296,   5,         10) /* EncumbranceVal */
+     , (26296,   8,         10) /* Mass */
+     , (26296,   9,          0) /* ValidLocations - None */
+     , (26296,  11,         20) /* MaxStackSize */
+     , (26296,  12,          1) /* StackSize */
+     , (26296,  13,         10) /* StackUnitEncumbrance */
+     , (26296,  14,         10) /* StackUnitMass */
+     , (26296,  15,        500) /* StackUnitValue */
+     , (26296,  16,          8) /* ItemUseable - Contained */
+     , (26296,  18,          1) /* UiEffects - Magical */
+     , (26296,  19,        500) /* Value */
+     , (26296,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26296,  94,         16) /* TargetType - Creature */
+     , (26296, 106,        210) /* ItemSpellcraft */
+     , (26296, 107,         50) /* ItemCurMana */
+     , (26296, 108,         50) /* ItemMaxMana */
+     , (26296, 109,          0) /* ItemDifficulty */
+     , (26296, 110,          0) /* ItemAllegianceRankLimit */
+     , (26296, 150,        103) /* HookPlacement - Hook */
+     , (26296, 151,          2) /* HookType - Wall */
+     , (26296, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26296,  15, True ) /* LightsStatus */
+     , (26296,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26296, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26296,   1, 'Northfire Estates Portal Gem') /* Name */
+     , (26296,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26296,   1,   33556769) /* Setup */
+     , (26296,   3,  536870932) /* SoundTable */
+     , (26296,   6,   67111919) /* PaletteBase */
+     , (26296,   7,  268435723) /* ClothingBase */
+     , (26296,   8,  100675760) /* Icon */
+     , (26296,  22,  872415275) /* PhysicsEffectTable */
+     , (26296,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26296,  31,      15180) /* LinkedPortalOne - Northfire Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26297 North Lytelthorpe Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26297 North Lytelthorpe Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26297;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26297, 'gemportalnorthlytelthorpevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26297,   1,       2048) /* ItemType - Gem */
+     , (26297,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26297,   5,         10) /* EncumbranceVal */
+     , (26297,   8,         10) /* Mass */
+     , (26297,   9,          0) /* ValidLocations - None */
+     , (26297,  11,         20) /* MaxStackSize */
+     , (26297,  12,          1) /* StackSize */
+     , (26297,  13,         10) /* StackUnitEncumbrance */
+     , (26297,  14,         10) /* StackUnitMass */
+     , (26297,  15,        500) /* StackUnitValue */
+     , (26297,  16,          8) /* ItemUseable - Contained */
+     , (26297,  18,          1) /* UiEffects - Magical */
+     , (26297,  19,        500) /* Value */
+     , (26297,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26297,  94,         16) /* TargetType - Creature */
+     , (26297, 106,        210) /* ItemSpellcraft */
+     , (26297, 107,         50) /* ItemCurMana */
+     , (26297, 108,         50) /* ItemMaxMana */
+     , (26297, 109,          0) /* ItemDifficulty */
+     , (26297, 110,          0) /* ItemAllegianceRankLimit */
+     , (26297, 150,        103) /* HookPlacement - Hook */
+     , (26297, 151,          2) /* HookType - Wall */
+     , (26297, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26297,  15, True ) /* LightsStatus */
+     , (26297,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26297, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26297,   1, 'North Lytelthorpe Villas Portal Gem') /* Name */
+     , (26297,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26297,   1,   33556769) /* Setup */
+     , (26297,   3,  536870932) /* SoundTable */
+     , (26297,   6,   67111919) /* PaletteBase */
+     , (26297,   7,  268435723) /* ClothingBase */
+     , (26297,   8,  100675760) /* Icon */
+     , (26297,  22,  872415275) /* PhysicsEffectTable */
+     , (26297,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26297,  31,      13115) /* LinkedPortalOne - North Lytelthorpe Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26298 North Pass Hollow Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26298 North Pass Hollow Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26298;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26298, 'gemportalnorthpasshollowcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26298,   1,       2048) /* ItemType - Gem */
+     , (26298,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26298,   5,         10) /* EncumbranceVal */
+     , (26298,   8,         10) /* Mass */
+     , (26298,   9,          0) /* ValidLocations - None */
+     , (26298,  11,         20) /* MaxStackSize */
+     , (26298,  12,          1) /* StackSize */
+     , (26298,  13,         10) /* StackUnitEncumbrance */
+     , (26298,  14,         10) /* StackUnitMass */
+     , (26298,  15,        500) /* StackUnitValue */
+     , (26298,  16,          8) /* ItemUseable - Contained */
+     , (26298,  18,          1) /* UiEffects - Magical */
+     , (26298,  19,        500) /* Value */
+     , (26298,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26298,  94,         16) /* TargetType - Creature */
+     , (26298, 106,        210) /* ItemSpellcraft */
+     , (26298, 107,         50) /* ItemCurMana */
+     , (26298, 108,         50) /* ItemMaxMana */
+     , (26298, 109,          0) /* ItemDifficulty */
+     , (26298, 110,          0) /* ItemAllegianceRankLimit */
+     , (26298, 150,        103) /* HookPlacement - Hook */
+     , (26298, 151,          2) /* HookType - Wall */
+     , (26298, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26298,  15, True ) /* LightsStatus */
+     , (26298,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26298, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26298,   1, 'North Pass Hollow Cottages Portal Gem') /* Name */
+     , (26298,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26298,   1,   33556769) /* Setup */
+     , (26298,   3,  536870932) /* SoundTable */
+     , (26298,   6,   67111919) /* PaletteBase */
+     , (26298,   7,  268435723) /* ClothingBase */
+     , (26298,   8,  100675760) /* Icon */
+     , (26298,  22,  872415275) /* PhysicsEffectTable */
+     , (26298,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26298,  31,      19154) /* LinkedPortalOne - North Pass Hollow Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26299 Northreach Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26299 Northreach Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26299;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26299, 'gemportalnorthreach', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26299,   1,       2048) /* ItemType - Gem */
+     , (26299,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26299,   5,         10) /* EncumbranceVal */
+     , (26299,   8,         10) /* Mass */
+     , (26299,   9,          0) /* ValidLocations - None */
+     , (26299,  11,         20) /* MaxStackSize */
+     , (26299,  12,          1) /* StackSize */
+     , (26299,  13,         10) /* StackUnitEncumbrance */
+     , (26299,  14,         10) /* StackUnitMass */
+     , (26299,  15,        500) /* StackUnitValue */
+     , (26299,  16,          8) /* ItemUseable - Contained */
+     , (26299,  18,          1) /* UiEffects - Magical */
+     , (26299,  19,        500) /* Value */
+     , (26299,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26299,  94,         16) /* TargetType - Creature */
+     , (26299, 106,        210) /* ItemSpellcraft */
+     , (26299, 107,         50) /* ItemCurMana */
+     , (26299, 108,         50) /* ItemMaxMana */
+     , (26299, 109,          0) /* ItemDifficulty */
+     , (26299, 110,          0) /* ItemAllegianceRankLimit */
+     , (26299, 150,        103) /* HookPlacement - Hook */
+     , (26299, 151,          2) /* HookType - Wall */
+     , (26299, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26299,  15, True ) /* LightsStatus */
+     , (26299,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26299, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26299,   1, 'Northreach Portal Gem') /* Name */
+     , (26299,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26299,   1,   33556769) /* Setup */
+     , (26299,   3,  536870932) /* SoundTable */
+     , (26299,   6,   67111919) /* PaletteBase */
+     , (26299,   7,  268435723) /* ClothingBase */
+     , (26299,   8,  100675760) /* Icon */
+     , (26299,  22,  872415275) /* PhysicsEffectTable */
+     , (26299,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26299,  31,      14653) /* LinkedPortalOne - Northreach Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26300 North Sawato Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26300 North Sawato Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26300;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26300, 'gemportalnorthsawatovillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26300,   1,       2048) /* ItemType - Gem */
+     , (26300,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26300,   5,         10) /* EncumbranceVal */
+     , (26300,   8,         10) /* Mass */
+     , (26300,   9,          0) /* ValidLocations - None */
+     , (26300,  11,         20) /* MaxStackSize */
+     , (26300,  12,          1) /* StackSize */
+     , (26300,  13,         10) /* StackUnitEncumbrance */
+     , (26300,  14,         10) /* StackUnitMass */
+     , (26300,  15,        500) /* StackUnitValue */
+     , (26300,  16,          8) /* ItemUseable - Contained */
+     , (26300,  18,          1) /* UiEffects - Magical */
+     , (26300,  19,        500) /* Value */
+     , (26300,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26300,  94,         16) /* TargetType - Creature */
+     , (26300, 106,        210) /* ItemSpellcraft */
+     , (26300, 107,         50) /* ItemCurMana */
+     , (26300, 108,         50) /* ItemMaxMana */
+     , (26300, 109,          0) /* ItemDifficulty */
+     , (26300, 110,          0) /* ItemAllegianceRankLimit */
+     , (26300, 150,        103) /* HookPlacement - Hook */
+     , (26300, 151,          2) /* HookType - Wall */
+     , (26300, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26300,  15, True ) /* LightsStatus */
+     , (26300,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26300, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26300,   1, 'North Sawato Villas Portal Gem') /* Name */
+     , (26300,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26300,   1,   33556769) /* Setup */
+     , (26300,   3,  536870932) /* SoundTable */
+     , (26300,   6,   67111919) /* PaletteBase */
+     , (26300,   7,  268435723) /* ClothingBase */
+     , (26300,   8,  100675760) /* Icon */
+     , (26300,  22,  872415275) /* PhysicsEffectTable */
+     , (26300,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26300,  31,      13116) /* LinkedPortalOne - North Sawato Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26301 North Uziz Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26301 North Uziz Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26301;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26301, 'gemportalnorthuzizsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26301,   1,       2048) /* ItemType - Gem */
+     , (26301,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26301,   5,         10) /* EncumbranceVal */
+     , (26301,   8,         10) /* Mass */
+     , (26301,   9,          0) /* ValidLocations - None */
+     , (26301,  11,         20) /* MaxStackSize */
+     , (26301,  12,          1) /* StackSize */
+     , (26301,  13,         10) /* StackUnitEncumbrance */
+     , (26301,  14,         10) /* StackUnitMass */
+     , (26301,  15,        500) /* StackUnitValue */
+     , (26301,  16,          8) /* ItemUseable - Contained */
+     , (26301,  18,          1) /* UiEffects - Magical */
+     , (26301,  19,        500) /* Value */
+     , (26301,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26301,  94,         16) /* TargetType - Creature */
+     , (26301, 106,        210) /* ItemSpellcraft */
+     , (26301, 107,         50) /* ItemCurMana */
+     , (26301, 108,         50) /* ItemMaxMana */
+     , (26301, 109,          0) /* ItemDifficulty */
+     , (26301, 110,          0) /* ItemAllegianceRankLimit */
+     , (26301, 150,        103) /* HookPlacement - Hook */
+     , (26301, 151,          2) /* HookType - Wall */
+     , (26301, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26301,  15, True ) /* LightsStatus */
+     , (26301,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26301, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26301,   1, 'North Uziz Settlement Portal Gem') /* Name */
+     , (26301,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26301,   1,   33556769) /* Setup */
+     , (26301,   3,  536870932) /* SoundTable */
+     , (26301,   6,   67111919) /* PaletteBase */
+     , (26301,   7,  268435723) /* ClothingBase */
+     , (26301,   8,  100675760) /* Icon */
+     , (26301,  22,  872415275) /* PhysicsEffectTable */
+     , (26301,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26301,  31,      12534) /* LinkedPortalOne - North Uziz Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26302 Northwater Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26302 Northwater Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26302;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26302, 'gemportalnorthwatercottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26302,   1,       2048) /* ItemType - Gem */
+     , (26302,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26302,   5,         10) /* EncumbranceVal */
+     , (26302,   8,         10) /* Mass */
+     , (26302,   9,          0) /* ValidLocations - None */
+     , (26302,  11,         20) /* MaxStackSize */
+     , (26302,  12,          1) /* StackSize */
+     , (26302,  13,         10) /* StackUnitEncumbrance */
+     , (26302,  14,         10) /* StackUnitMass */
+     , (26302,  15,        500) /* StackUnitValue */
+     , (26302,  16,          8) /* ItemUseable - Contained */
+     , (26302,  18,          1) /* UiEffects - Magical */
+     , (26302,  19,        500) /* Value */
+     , (26302,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26302,  94,         16) /* TargetType - Creature */
+     , (26302, 106,        210) /* ItemSpellcraft */
+     , (26302, 107,         50) /* ItemCurMana */
+     , (26302, 108,         50) /* ItemMaxMana */
+     , (26302, 109,          0) /* ItemDifficulty */
+     , (26302, 110,          0) /* ItemAllegianceRankLimit */
+     , (26302, 150,        103) /* HookPlacement - Hook */
+     , (26302, 151,          2) /* HookType - Wall */
+     , (26302, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26302,  15, True ) /* LightsStatus */
+     , (26302,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26302, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26302,   1, 'Northwater Cottages Portal Gem') /* Name */
+     , (26302,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26302,   1,   33556769) /* Setup */
+     , (26302,   3,  536870932) /* SoundTable */
+     , (26302,   6,   67111919) /* PaletteBase */
+     , (26302,   7,  268435723) /* ClothingBase */
+     , (26302,   8,  100675760) /* Icon */
+     , (26302,  22,  872415275) /* PhysicsEffectTable */
+     , (26302,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26302,  31,      13117) /* LinkedPortalOne - Northwater Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26303 North Yanshi Plains Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26303 North Yanshi Plains Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26303;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26303, 'gemportalnorthyanshiplainssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26303,   1,       2048) /* ItemType - Gem */
+     , (26303,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26303,   5,         10) /* EncumbranceVal */
+     , (26303,   8,         10) /* Mass */
+     , (26303,   9,          0) /* ValidLocations - None */
+     , (26303,  11,         20) /* MaxStackSize */
+     , (26303,  12,          1) /* StackSize */
+     , (26303,  13,         10) /* StackUnitEncumbrance */
+     , (26303,  14,         10) /* StackUnitMass */
+     , (26303,  15,        500) /* StackUnitValue */
+     , (26303,  16,          8) /* ItemUseable - Contained */
+     , (26303,  18,          1) /* UiEffects - Magical */
+     , (26303,  19,        500) /* Value */
+     , (26303,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26303,  94,         16) /* TargetType - Creature */
+     , (26303, 106,        210) /* ItemSpellcraft */
+     , (26303, 107,         50) /* ItemCurMana */
+     , (26303, 108,         50) /* ItemMaxMana */
+     , (26303, 109,          0) /* ItemDifficulty */
+     , (26303, 110,          0) /* ItemAllegianceRankLimit */
+     , (26303, 150,        103) /* HookPlacement - Hook */
+     , (26303, 151,          2) /* HookType - Wall */
+     , (26303, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26303,  15, True ) /* LightsStatus */
+     , (26303,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26303, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26303,   1, 'North Yanshi Plains Settlement Portal Gem') /* Name */
+     , (26303,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26303,   1,   33556769) /* Setup */
+     , (26303,   3,  536870932) /* SoundTable */
+     , (26303,   6,   67111919) /* PaletteBase */
+     , (26303,   7,  268435723) /* ClothingBase */
+     , (26303,   8,  100675760) /* Icon */
+     , (26303,  22,  872415275) /* PhysicsEffectTable */
+     , (26303,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26303,  31,      12535) /* LinkedPortalOne - North Yanshi Plains Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26304 North Yaraq Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26304 North Yaraq Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26304;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26304, 'gemportalnorthyaraqvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26304,   1,       2048) /* ItemType - Gem */
+     , (26304,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26304,   5,         10) /* EncumbranceVal */
+     , (26304,   8,         10) /* Mass */
+     , (26304,   9,          0) /* ValidLocations - None */
+     , (26304,  11,         20) /* MaxStackSize */
+     , (26304,  12,          1) /* StackSize */
+     , (26304,  13,         10) /* StackUnitEncumbrance */
+     , (26304,  14,         10) /* StackUnitMass */
+     , (26304,  15,        500) /* StackUnitValue */
+     , (26304,  16,          8) /* ItemUseable - Contained */
+     , (26304,  18,          1) /* UiEffects - Magical */
+     , (26304,  19,        500) /* Value */
+     , (26304,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26304,  94,         16) /* TargetType - Creature */
+     , (26304, 106,        210) /* ItemSpellcraft */
+     , (26304, 107,         50) /* ItemCurMana */
+     , (26304, 108,         50) /* ItemMaxMana */
+     , (26304, 109,          0) /* ItemDifficulty */
+     , (26304, 110,          0) /* ItemAllegianceRankLimit */
+     , (26304, 150,        103) /* HookPlacement - Hook */
+     , (26304, 151,          2) /* HookType - Wall */
+     , (26304, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26304,  15, True ) /* LightsStatus */
+     , (26304,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26304, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26304,   1, 'North Yaraq Villas Portal Gem') /* Name */
+     , (26304,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26304,   1,   33556769) /* Setup */
+     , (26304,   3,  536870932) /* SoundTable */
+     , (26304,   6,   67111919) /* PaletteBase */
+     , (26304,   7,  268435723) /* ClothingBase */
+     , (26304,   8,  100675760) /* Icon */
+     , (26304,  22,  872415275) /* PhysicsEffectTable */
+     , (26304,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26304,  31,      13118) /* LinkedPortalOne - North Yaraq Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26305 Norvale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26305 Norvale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26305;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26305, 'gemportalnorvale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26305,   1,       2048) /* ItemType - Gem */
+     , (26305,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26305,   5,         10) /* EncumbranceVal */
+     , (26305,   8,         10) /* Mass */
+     , (26305,   9,          0) /* ValidLocations - None */
+     , (26305,  11,         20) /* MaxStackSize */
+     , (26305,  12,          1) /* StackSize */
+     , (26305,  13,         10) /* StackUnitEncumbrance */
+     , (26305,  14,         10) /* StackUnitMass */
+     , (26305,  15,        500) /* StackUnitValue */
+     , (26305,  16,          8) /* ItemUseable - Contained */
+     , (26305,  18,          1) /* UiEffects - Magical */
+     , (26305,  19,        500) /* Value */
+     , (26305,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26305,  94,         16) /* TargetType - Creature */
+     , (26305, 106,        210) /* ItemSpellcraft */
+     , (26305, 107,         50) /* ItemCurMana */
+     , (26305, 108,         50) /* ItemMaxMana */
+     , (26305, 109,          0) /* ItemDifficulty */
+     , (26305, 110,          0) /* ItemAllegianceRankLimit */
+     , (26305, 150,        103) /* HookPlacement - Hook */
+     , (26305, 151,          2) /* HookType - Wall */
+     , (26305, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26305,  15, True ) /* LightsStatus */
+     , (26305,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26305, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26305,   1, 'Norvale Portal Gem') /* Name */
+     , (26305,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26305,   1,   33556769) /* Setup */
+     , (26305,   3,  536870932) /* SoundTable */
+     , (26305,   6,   67111919) /* PaletteBase */
+     , (26305,   7,  268435723) /* ClothingBase */
+     , (26305,   8,  100675760) /* Icon */
+     , (26305,  22,  872415275) /* PhysicsEffectTable */
+     , (26305,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26305,  31,      14654) /* LinkedPortalOne - Norvale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26306 Oboro Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26306 Oboro Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26306;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26306, 'gemportaloboro', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26306,   1,       2048) /* ItemType - Gem */
+     , (26306,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26306,   5,         10) /* EncumbranceVal */
+     , (26306,   8,         10) /* Mass */
+     , (26306,   9,          0) /* ValidLocations - None */
+     , (26306,  11,         20) /* MaxStackSize */
+     , (26306,  12,          1) /* StackSize */
+     , (26306,  13,         10) /* StackUnitEncumbrance */
+     , (26306,  14,         10) /* StackUnitMass */
+     , (26306,  15,        500) /* StackUnitValue */
+     , (26306,  16,          8) /* ItemUseable - Contained */
+     , (26306,  18,          1) /* UiEffects - Magical */
+     , (26306,  19,        500) /* Value */
+     , (26306,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26306,  94,         16) /* TargetType - Creature */
+     , (26306, 106,        210) /* ItemSpellcraft */
+     , (26306, 107,         50) /* ItemCurMana */
+     , (26306, 108,         50) /* ItemMaxMana */
+     , (26306, 109,          0) /* ItemDifficulty */
+     , (26306, 110,          0) /* ItemAllegianceRankLimit */
+     , (26306, 150,        103) /* HookPlacement - Hook */
+     , (26306, 151,          2) /* HookType - Wall */
+     , (26306, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26306,  15, True ) /* LightsStatus */
+     , (26306,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26306, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26306,   1, 'Oboro Portal Gem') /* Name */
+     , (26306,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26306,   1,   33556769) /* Setup */
+     , (26306,   3,  536870932) /* SoundTable */
+     , (26306,   6,   67111919) /* PaletteBase */
+     , (26306,   7,  268435723) /* ClothingBase */
+     , (26306,   8,  100675760) /* Icon */
+     , (26306,  22,  872415275) /* PhysicsEffectTable */
+     , (26306,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26306,  31,      12536) /* LinkedPortalOne - Oboro Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26307 Ong-Hau Village Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26307 Ong-Hau Village Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26307;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26307, 'gemportalonghauvillage', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26307,   1,       2048) /* ItemType - Gem */
+     , (26307,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26307,   5,         10) /* EncumbranceVal */
+     , (26307,   8,         10) /* Mass */
+     , (26307,   9,          0) /* ValidLocations - None */
+     , (26307,  11,         20) /* MaxStackSize */
+     , (26307,  12,          1) /* StackSize */
+     , (26307,  13,         10) /* StackUnitEncumbrance */
+     , (26307,  14,         10) /* StackUnitMass */
+     , (26307,  15,        500) /* StackUnitValue */
+     , (26307,  16,          8) /* ItemUseable - Contained */
+     , (26307,  18,          1) /* UiEffects - Magical */
+     , (26307,  19,        500) /* Value */
+     , (26307,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26307,  94,         16) /* TargetType - Creature */
+     , (26307, 106,        210) /* ItemSpellcraft */
+     , (26307, 107,         50) /* ItemCurMana */
+     , (26307, 108,         50) /* ItemMaxMana */
+     , (26307, 109,          0) /* ItemDifficulty */
+     , (26307, 110,          0) /* ItemAllegianceRankLimit */
+     , (26307, 150,        103) /* HookPlacement - Hook */
+     , (26307, 151,          2) /* HookType - Wall */
+     , (26307, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26307,  15, True ) /* LightsStatus */
+     , (26307,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26307, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26307,   1, 'Ong-Hau Village Portal Gem') /* Name */
+     , (26307,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26307,   1,   33556769) /* Setup */
+     , (26307,   3,  536870932) /* SoundTable */
+     , (26307,   6,   67111919) /* PaletteBase */
+     , (26307,   7,  268435723) /* ClothingBase */
+     , (26307,   8,  100675760) /* Icon */
+     , (26307,  22,  872415275) /* PhysicsEffectTable */
+     , (26307,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26307,  31,      14655) /* LinkedPortalOne - Ong-Hau Village Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26308 Osric Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26308 Osric Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26308;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26308, 'gemportalosriccottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26308,   1,       2048) /* ItemType - Gem */
+     , (26308,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26308,   5,         10) /* EncumbranceVal */
+     , (26308,   8,         10) /* Mass */
+     , (26308,   9,          0) /* ValidLocations - None */
+     , (26308,  11,         20) /* MaxStackSize */
+     , (26308,  12,          1) /* StackSize */
+     , (26308,  13,         10) /* StackUnitEncumbrance */
+     , (26308,  14,         10) /* StackUnitMass */
+     , (26308,  15,        500) /* StackUnitValue */
+     , (26308,  16,          8) /* ItemUseable - Contained */
+     , (26308,  18,          1) /* UiEffects - Magical */
+     , (26308,  19,        500) /* Value */
+     , (26308,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26308,  94,         16) /* TargetType - Creature */
+     , (26308, 106,        210) /* ItemSpellcraft */
+     , (26308, 107,         50) /* ItemCurMana */
+     , (26308, 108,         50) /* ItemMaxMana */
+     , (26308, 109,          0) /* ItemDifficulty */
+     , (26308, 110,          0) /* ItemAllegianceRankLimit */
+     , (26308, 150,        103) /* HookPlacement - Hook */
+     , (26308, 151,          2) /* HookType - Wall */
+     , (26308, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26308,  15, True ) /* LightsStatus */
+     , (26308,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26308, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26308,   1, 'Osric Cottages Portal Gem') /* Name */
+     , (26308,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26308,   1,   33556769) /* Setup */
+     , (26308,   3,  536870932) /* SoundTable */
+     , (26308,   6,   67111919) /* PaletteBase */
+     , (26308,   7,  268435723) /* ClothingBase */
+     , (26308,   8,  100675760) /* Icon */
+     , (26308,  22,  872415275) /* PhysicsEffectTable */
+     , (26308,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26308,  31,      15181) /* LinkedPortalOne - Osric Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26309 Palm-of-Stone Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26309 Palm-of-Stone Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26309;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26309, 'gemportalpalmofstonevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26309,   1,       2048) /* ItemType - Gem */
+     , (26309,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26309,   5,         10) /* EncumbranceVal */
+     , (26309,   8,         10) /* Mass */
+     , (26309,   9,          0) /* ValidLocations - None */
+     , (26309,  11,         20) /* MaxStackSize */
+     , (26309,  12,          1) /* StackSize */
+     , (26309,  13,         10) /* StackUnitEncumbrance */
+     , (26309,  14,         10) /* StackUnitMass */
+     , (26309,  15,        500) /* StackUnitValue */
+     , (26309,  16,          8) /* ItemUseable - Contained */
+     , (26309,  18,          1) /* UiEffects - Magical */
+     , (26309,  19,        500) /* Value */
+     , (26309,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26309,  94,         16) /* TargetType - Creature */
+     , (26309, 106,        210) /* ItemSpellcraft */
+     , (26309, 107,         50) /* ItemCurMana */
+     , (26309, 108,         50) /* ItemMaxMana */
+     , (26309, 109,          0) /* ItemDifficulty */
+     , (26309, 110,          0) /* ItemAllegianceRankLimit */
+     , (26309, 150,        103) /* HookPlacement - Hook */
+     , (26309, 151,          2) /* HookType - Wall */
+     , (26309, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26309,  15, True ) /* LightsStatus */
+     , (26309,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26309, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26309,   1, 'Palm-of-Stone Villas Portal Gem') /* Name */
+     , (26309,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26309,   1,   33556769) /* Setup */
+     , (26309,   3,  536870932) /* SoundTable */
+     , (26309,   6,   67111919) /* PaletteBase */
+     , (26309,   7,  268435723) /* ClothingBase */
+     , (26309,   8,  100675760) /* Icon */
+     , (26309,  22,  872415275) /* PhysicsEffectTable */
+     , (26309,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26309,  31,      15182) /* LinkedPortalOne - Palm-of-Stone Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26310 Patron's Honor Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26310 Patron's Honor Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26310;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26310, 'gemportalpatronshonorcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26310,   1,       2048) /* ItemType - Gem */
+     , (26310,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26310,   5,         10) /* EncumbranceVal */
+     , (26310,   8,         10) /* Mass */
+     , (26310,   9,          0) /* ValidLocations - None */
+     , (26310,  11,         20) /* MaxStackSize */
+     , (26310,  12,          1) /* StackSize */
+     , (26310,  13,         10) /* StackUnitEncumbrance */
+     , (26310,  14,         10) /* StackUnitMass */
+     , (26310,  15,        500) /* StackUnitValue */
+     , (26310,  16,          8) /* ItemUseable - Contained */
+     , (26310,  18,          1) /* UiEffects - Magical */
+     , (26310,  19,        500) /* Value */
+     , (26310,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26310,  94,         16) /* TargetType - Creature */
+     , (26310, 106,        210) /* ItemSpellcraft */
+     , (26310, 107,         50) /* ItemCurMana */
+     , (26310, 108,         50) /* ItemMaxMana */
+     , (26310, 109,          0) /* ItemDifficulty */
+     , (26310, 110,          0) /* ItemAllegianceRankLimit */
+     , (26310, 150,        103) /* HookPlacement - Hook */
+     , (26310, 151,          2) /* HookType - Wall */
+     , (26310, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26310,  15, True ) /* LightsStatus */
+     , (26310,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26310, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26310,   1, 'Patron''s Honor Cottages Portal Gem') /* Name */
+     , (26310,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26310,   1,   33556769) /* Setup */
+     , (26310,   3,  536870932) /* SoundTable */
+     , (26310,   6,   67111919) /* PaletteBase */
+     , (26310,   7,  268435723) /* ClothingBase */
+     , (26310,   8,  100675760) /* Icon */
+     , (26310,  22,  872415275) /* PhysicsEffectTable */
+     , (26310,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26310,  31,      15679) /* LinkedPortalOne - Patron's Honor Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26311 Pavanne Vale Freehold Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26311 Pavanne Vale Freehold Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26311;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26311, 'gemportalpavannevalefreehold', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26311,   1,       2048) /* ItemType - Gem */
+     , (26311,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26311,   5,         10) /* EncumbranceVal */
+     , (26311,   8,         10) /* Mass */
+     , (26311,   9,          0) /* ValidLocations - None */
+     , (26311,  11,         20) /* MaxStackSize */
+     , (26311,  12,          1) /* StackSize */
+     , (26311,  13,         10) /* StackUnitEncumbrance */
+     , (26311,  14,         10) /* StackUnitMass */
+     , (26311,  15,        500) /* StackUnitValue */
+     , (26311,  16,          8) /* ItemUseable - Contained */
+     , (26311,  18,          1) /* UiEffects - Magical */
+     , (26311,  19,        500) /* Value */
+     , (26311,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26311,  94,         16) /* TargetType - Creature */
+     , (26311, 106,        210) /* ItemSpellcraft */
+     , (26311, 107,         50) /* ItemCurMana */
+     , (26311, 108,         50) /* ItemMaxMana */
+     , (26311, 109,          0) /* ItemDifficulty */
+     , (26311, 110,          0) /* ItemAllegianceRankLimit */
+     , (26311, 150,        103) /* HookPlacement - Hook */
+     , (26311, 151,          2) /* HookType - Wall */
+     , (26311, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26311,  15, True ) /* LightsStatus */
+     , (26311,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26311, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26311,   1, 'Pavanne Vale Freehold Portal Gem') /* Name */
+     , (26311,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26311,   1,   33556769) /* Setup */
+     , (26311,   3,  536870932) /* SoundTable */
+     , (26311,   6,   67111919) /* PaletteBase */
+     , (26311,   7,  268435723) /* ClothingBase */
+     , (26311,   8,  100675760) /* Icon */
+     , (26311,  22,  872415275) /* PhysicsEffectTable */
+     , (26311,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26311,  31,      12537) /* LinkedPortalOne - Pavanne Vale Freehold Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26312 Peril's Edge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26312 Peril's Edge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26312;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26312, 'gemportalperilsedgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26312,   1,       2048) /* ItemType - Gem */
+     , (26312,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26312,   5,         10) /* EncumbranceVal */
+     , (26312,   8,         10) /* Mass */
+     , (26312,   9,          0) /* ValidLocations - None */
+     , (26312,  11,         20) /* MaxStackSize */
+     , (26312,  12,          1) /* StackSize */
+     , (26312,  13,         10) /* StackUnitEncumbrance */
+     , (26312,  14,         10) /* StackUnitMass */
+     , (26312,  15,        500) /* StackUnitValue */
+     , (26312,  16,          8) /* ItemUseable - Contained */
+     , (26312,  18,          1) /* UiEffects - Magical */
+     , (26312,  19,        500) /* Value */
+     , (26312,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26312,  94,         16) /* TargetType - Creature */
+     , (26312, 106,        210) /* ItemSpellcraft */
+     , (26312, 107,         50) /* ItemCurMana */
+     , (26312, 108,         50) /* ItemMaxMana */
+     , (26312, 109,          0) /* ItemDifficulty */
+     , (26312, 110,          0) /* ItemAllegianceRankLimit */
+     , (26312, 150,        103) /* HookPlacement - Hook */
+     , (26312, 151,          2) /* HookType - Wall */
+     , (26312, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26312,  15, True ) /* LightsStatus */
+     , (26312,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26312, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26312,   1, 'Peril''s Edge Cottages Portal Gem') /* Name */
+     , (26312,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26312,   1,   33556769) /* Setup */
+     , (26312,   3,  536870932) /* SoundTable */
+     , (26312,   6,   67111919) /* PaletteBase */
+     , (26312,   7,  268435723) /* ClothingBase */
+     , (26312,   8,  100675760) /* Icon */
+     , (26312,  22,  872415275) /* PhysicsEffectTable */
+     , (26312,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26312,  31,      15680) /* LinkedPortalOne - Peril's Edge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26313 Pillars-on-the-Sea Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26313 Pillars-on-the-Sea Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26313;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26313, 'gemportalpillarsontheseacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26313,   1,       2048) /* ItemType - Gem */
+     , (26313,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26313,   5,         10) /* EncumbranceVal */
+     , (26313,   8,         10) /* Mass */
+     , (26313,   9,          0) /* ValidLocations - None */
+     , (26313,  11,         20) /* MaxStackSize */
+     , (26313,  12,          1) /* StackSize */
+     , (26313,  13,         10) /* StackUnitEncumbrance */
+     , (26313,  14,         10) /* StackUnitMass */
+     , (26313,  15,        500) /* StackUnitValue */
+     , (26313,  16,          8) /* ItemUseable - Contained */
+     , (26313,  18,          1) /* UiEffects - Magical */
+     , (26313,  19,        500) /* Value */
+     , (26313,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26313,  94,         16) /* TargetType - Creature */
+     , (26313, 106,        210) /* ItemSpellcraft */
+     , (26313, 107,         50) /* ItemCurMana */
+     , (26313, 108,         50) /* ItemMaxMana */
+     , (26313, 109,          0) /* ItemDifficulty */
+     , (26313, 110,          0) /* ItemAllegianceRankLimit */
+     , (26313, 150,        103) /* HookPlacement - Hook */
+     , (26313, 151,          2) /* HookType - Wall */
+     , (26313, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26313,  15, True ) /* LightsStatus */
+     , (26313,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26313, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26313,   1, 'Pillars-on-the-Sea Cottages Portal Gem') /* Name */
+     , (26313,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26313,   1,   33556769) /* Setup */
+     , (26313,   3,  536870932) /* SoundTable */
+     , (26313,   6,   67111919) /* PaletteBase */
+     , (26313,   7,  268435723) /* ClothingBase */
+     , (26313,   8,  100675760) /* Icon */
+     , (26313,  22,  872415275) /* PhysicsEffectTable */
+     , (26313,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26313,  31,      14277) /* LinkedPortalOne - Pillars-on-the-Sea Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26314 Pine Deep Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26314 Pine Deep Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26314;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26314, 'gemportalpinedeep', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26314,   1,       2048) /* ItemType - Gem */
+     , (26314,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26314,   5,         10) /* EncumbranceVal */
+     , (26314,   8,         10) /* Mass */
+     , (26314,   9,          0) /* ValidLocations - None */
+     , (26314,  11,         20) /* MaxStackSize */
+     , (26314,  12,          1) /* StackSize */
+     , (26314,  13,         10) /* StackUnitEncumbrance */
+     , (26314,  14,         10) /* StackUnitMass */
+     , (26314,  15,        500) /* StackUnitValue */
+     , (26314,  16,          8) /* ItemUseable - Contained */
+     , (26314,  18,          1) /* UiEffects - Magical */
+     , (26314,  19,        500) /* Value */
+     , (26314,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26314,  94,         16) /* TargetType - Creature */
+     , (26314, 106,        210) /* ItemSpellcraft */
+     , (26314, 107,         50) /* ItemCurMana */
+     , (26314, 108,         50) /* ItemMaxMana */
+     , (26314, 109,          0) /* ItemDifficulty */
+     , (26314, 110,          0) /* ItemAllegianceRankLimit */
+     , (26314, 150,        103) /* HookPlacement - Hook */
+     , (26314, 151,          2) /* HookType - Wall */
+     , (26314, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26314,  15, True ) /* LightsStatus */
+     , (26314,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26314, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26314,   1, 'Pine Deep Portal Gem') /* Name */
+     , (26314,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26314,   1,   33556769) /* Setup */
+     , (26314,   3,  536870932) /* SoundTable */
+     , (26314,   6,   67111919) /* PaletteBase */
+     , (26314,   7,  268435723) /* ClothingBase */
+     , (26314,   8,  100675760) /* Icon */
+     , (26314,  22,  872415275) /* PhysicsEffectTable */
+     , (26314,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26314,  31,      14656) /* LinkedPortalOne - Pine Deep Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26315 Pine Hillock Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26315 Pine Hillock Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26315;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26315, 'gemportalpinehillocksettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26315,   1,       2048) /* ItemType - Gem */
+     , (26315,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26315,   5,         10) /* EncumbranceVal */
+     , (26315,   8,         10) /* Mass */
+     , (26315,   9,          0) /* ValidLocations - None */
+     , (26315,  11,         20) /* MaxStackSize */
+     , (26315,  12,          1) /* StackSize */
+     , (26315,  13,         10) /* StackUnitEncumbrance */
+     , (26315,  14,         10) /* StackUnitMass */
+     , (26315,  15,        500) /* StackUnitValue */
+     , (26315,  16,          8) /* ItemUseable - Contained */
+     , (26315,  18,          1) /* UiEffects - Magical */
+     , (26315,  19,        500) /* Value */
+     , (26315,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26315,  94,         16) /* TargetType - Creature */
+     , (26315, 106,        210) /* ItemSpellcraft */
+     , (26315, 107,         50) /* ItemCurMana */
+     , (26315, 108,         50) /* ItemMaxMana */
+     , (26315, 109,          0) /* ItemDifficulty */
+     , (26315, 110,          0) /* ItemAllegianceRankLimit */
+     , (26315, 150,        103) /* HookPlacement - Hook */
+     , (26315, 151,          2) /* HookType - Wall */
+     , (26315, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26315,  15, True ) /* LightsStatus */
+     , (26315,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26315, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26315,   1, 'Pine Hillock Settlement Portal Gem') /* Name */
+     , (26315,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26315,   1,   33556769) /* Setup */
+     , (26315,   3,  536870932) /* SoundTable */
+     , (26315,   6,   67111919) /* PaletteBase */
+     , (26315,   7,  268435723) /* ClothingBase */
+     , (26315,   8,  100675760) /* Icon */
+     , (26315,  22,  872415275) /* PhysicsEffectTable */
+     , (26315,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26315,  31,      14657) /* LinkedPortalOne - Pine Hillock Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26316 Plainsview Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26316 Plainsview Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26316;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26316, 'gemportalplainsviewcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26316,   1,       2048) /* ItemType - Gem */
+     , (26316,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26316,   5,         10) /* EncumbranceVal */
+     , (26316,   8,         10) /* Mass */
+     , (26316,   9,          0) /* ValidLocations - None */
+     , (26316,  11,         20) /* MaxStackSize */
+     , (26316,  12,          1) /* StackSize */
+     , (26316,  13,         10) /* StackUnitEncumbrance */
+     , (26316,  14,         10) /* StackUnitMass */
+     , (26316,  15,        500) /* StackUnitValue */
+     , (26316,  16,          8) /* ItemUseable - Contained */
+     , (26316,  18,          1) /* UiEffects - Magical */
+     , (26316,  19,        500) /* Value */
+     , (26316,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26316,  94,         16) /* TargetType - Creature */
+     , (26316, 106,        210) /* ItemSpellcraft */
+     , (26316, 107,         50) /* ItemCurMana */
+     , (26316, 108,         50) /* ItemMaxMana */
+     , (26316, 109,          0) /* ItemDifficulty */
+     , (26316, 110,          0) /* ItemAllegianceRankLimit */
+     , (26316, 150,        103) /* HookPlacement - Hook */
+     , (26316, 151,          2) /* HookType - Wall */
+     , (26316, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26316,  15, True ) /* LightsStatus */
+     , (26316,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26316, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26316,   1, 'Plainsview Cottages Portal Gem') /* Name */
+     , (26316,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26316,   1,   33556769) /* Setup */
+     , (26316,   3,  536870932) /* SoundTable */
+     , (26316,   6,   67111919) /* PaletteBase */
+     , (26316,   7,  268435723) /* ClothingBase */
+     , (26316,   8,  100675760) /* Icon */
+     , (26316,  22,  872415275) /* PhysicsEffectTable */
+     , (26316,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26316,  31,      14278) /* LinkedPortalOne - Plainsview Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26317 Plateau Hollow Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26317 Plateau Hollow Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26317;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26317, 'gemportalplateauhollowsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26317,   1,       2048) /* ItemType - Gem */
+     , (26317,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26317,   5,         10) /* EncumbranceVal */
+     , (26317,   8,         10) /* Mass */
+     , (26317,   9,          0) /* ValidLocations - None */
+     , (26317,  11,         20) /* MaxStackSize */
+     , (26317,  12,          1) /* StackSize */
+     , (26317,  13,         10) /* StackUnitEncumbrance */
+     , (26317,  14,         10) /* StackUnitMass */
+     , (26317,  15,        500) /* StackUnitValue */
+     , (26317,  16,          8) /* ItemUseable - Contained */
+     , (26317,  18,          1) /* UiEffects - Magical */
+     , (26317,  19,        500) /* Value */
+     , (26317,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26317,  94,         16) /* TargetType - Creature */
+     , (26317, 106,        210) /* ItemSpellcraft */
+     , (26317, 107,         50) /* ItemCurMana */
+     , (26317, 108,         50) /* ItemMaxMana */
+     , (26317, 109,          0) /* ItemDifficulty */
+     , (26317, 110,          0) /* ItemAllegianceRankLimit */
+     , (26317, 150,        103) /* HookPlacement - Hook */
+     , (26317, 151,          2) /* HookType - Wall */
+     , (26317, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26317,  15, True ) /* LightsStatus */
+     , (26317,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26317, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26317,   1, 'Plateau Hollow Settlement Portal Gem') /* Name */
+     , (26317,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26317,   1,   33556769) /* Setup */
+     , (26317,   3,  536870932) /* SoundTable */
+     , (26317,   6,   67111919) /* PaletteBase */
+     , (26317,   7,  268435723) /* ClothingBase */
+     , (26317,   8,  100675760) /* Icon */
+     , (26317,  22,  872415275) /* PhysicsEffectTable */
+     , (26317,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26317,  31,      12538) /* LinkedPortalOne - Plateau Hollow Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26318 Point Tremblant Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26318 Point Tremblant Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26318;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26318, 'gemportalpointtremblant', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26318,   1,       2048) /* ItemType - Gem */
+     , (26318,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26318,   5,         10) /* EncumbranceVal */
+     , (26318,   8,         10) /* Mass */
+     , (26318,   9,          0) /* ValidLocations - None */
+     , (26318,  11,         20) /* MaxStackSize */
+     , (26318,  12,          1) /* StackSize */
+     , (26318,  13,         10) /* StackUnitEncumbrance */
+     , (26318,  14,         10) /* StackUnitMass */
+     , (26318,  15,        500) /* StackUnitValue */
+     , (26318,  16,          8) /* ItemUseable - Contained */
+     , (26318,  18,          1) /* UiEffects - Magical */
+     , (26318,  19,        500) /* Value */
+     , (26318,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26318,  94,         16) /* TargetType - Creature */
+     , (26318, 106,        210) /* ItemSpellcraft */
+     , (26318, 107,         50) /* ItemCurMana */
+     , (26318, 108,         50) /* ItemMaxMana */
+     , (26318, 109,          0) /* ItemDifficulty */
+     , (26318, 110,          0) /* ItemAllegianceRankLimit */
+     , (26318, 150,        103) /* HookPlacement - Hook */
+     , (26318, 151,          2) /* HookType - Wall */
+     , (26318, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26318,  15, True ) /* LightsStatus */
+     , (26318,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26318, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26318,   1, 'Point Tremblant Portal Gem') /* Name */
+     , (26318,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26318,   1,   33556769) /* Setup */
+     , (26318,   3,  536870932) /* SoundTable */
+     , (26318,   6,   67111919) /* PaletteBase */
+     , (26318,   7,  268435723) /* ClothingBase */
+     , (26318,   8,  100675760) /* Icon */
+     , (26318,  22,  872415275) /* PhysicsEffectTable */
+     , (26318,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26318,  31,      14658) /* LinkedPortalOne - Point Tremblant Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26319 P'rnelle Acres Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26319 P'rnelle Acres Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26319;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26319, 'gemportalprnelleacres', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26319,   1,       2048) /* ItemType - Gem */
+     , (26319,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26319,   5,         10) /* EncumbranceVal */
+     , (26319,   8,         10) /* Mass */
+     , (26319,   9,          0) /* ValidLocations - None */
+     , (26319,  11,         20) /* MaxStackSize */
+     , (26319,  12,          1) /* StackSize */
+     , (26319,  13,         10) /* StackUnitEncumbrance */
+     , (26319,  14,         10) /* StackUnitMass */
+     , (26319,  15,        500) /* StackUnitValue */
+     , (26319,  16,          8) /* ItemUseable - Contained */
+     , (26319,  18,          1) /* UiEffects - Magical */
+     , (26319,  19,        500) /* Value */
+     , (26319,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26319,  94,         16) /* TargetType - Creature */
+     , (26319, 106,        210) /* ItemSpellcraft */
+     , (26319, 107,         50) /* ItemCurMana */
+     , (26319, 108,         50) /* ItemMaxMana */
+     , (26319, 109,          0) /* ItemDifficulty */
+     , (26319, 110,          0) /* ItemAllegianceRankLimit */
+     , (26319, 150,        103) /* HookPlacement - Hook */
+     , (26319, 151,          2) /* HookType - Wall */
+     , (26319, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26319,  15, True ) /* LightsStatus */
+     , (26319,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26319, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26319,   1, 'P''rnelle Acres Portal Gem') /* Name */
+     , (26319,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26319,   1,   33556769) /* Setup */
+     , (26319,   3,  536870932) /* SoundTable */
+     , (26319,   6,   67111919) /* PaletteBase */
+     , (26319,   7,  268435723) /* ClothingBase */
+     , (26319,   8,  100675760) /* Icon */
+     , (26319,  22,  872415275) /* PhysicsEffectTable */
+     , (26319,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26319,  31,      15183) /* LinkedPortalOne - P'rnelle Acres Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26320 Prosper River Headwaters Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26320 Prosper River Headwaters Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26320;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26320, 'gemportalprosperriverheadwaters', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26320,   1,       2048) /* ItemType - Gem */
+     , (26320,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26320,   5,         10) /* EncumbranceVal */
+     , (26320,   8,         10) /* Mass */
+     , (26320,   9,          0) /* ValidLocations - None */
+     , (26320,  11,         20) /* MaxStackSize */
+     , (26320,  12,          1) /* StackSize */
+     , (26320,  13,         10) /* StackUnitEncumbrance */
+     , (26320,  14,         10) /* StackUnitMass */
+     , (26320,  15,        500) /* StackUnitValue */
+     , (26320,  16,          8) /* ItemUseable - Contained */
+     , (26320,  18,          1) /* UiEffects - Magical */
+     , (26320,  19,        500) /* Value */
+     , (26320,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26320,  94,         16) /* TargetType - Creature */
+     , (26320, 106,        210) /* ItemSpellcraft */
+     , (26320, 107,         50) /* ItemCurMana */
+     , (26320, 108,         50) /* ItemMaxMana */
+     , (26320, 109,          0) /* ItemDifficulty */
+     , (26320, 110,          0) /* ItemAllegianceRankLimit */
+     , (26320, 150,        103) /* HookPlacement - Hook */
+     , (26320, 151,          2) /* HookType - Wall */
+     , (26320, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26320,  15, True ) /* LightsStatus */
+     , (26320,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26320, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26320,   1, 'Prosper River Headwaters Portal Gem') /* Name */
+     , (26320,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26320,   1,   33556769) /* Setup */
+     , (26320,   3,  536870932) /* SoundTable */
+     , (26320,   6,   67111919) /* PaletteBase */
+     , (26320,   7,  268435723) /* ClothingBase */
+     , (26320,   8,  100675760) /* Icon */
+     , (26320,  22,  872415275) /* PhysicsEffectTable */
+     , (26320,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26320,  31,      12539) /* LinkedPortalOne - Prosper River Headwaters Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26321 Qalabar Oasis Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26321 Qalabar Oasis Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26321;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26321, 'gemportalqalabaroasissettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26321,   1,       2048) /* ItemType - Gem */
+     , (26321,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26321,   5,         10) /* EncumbranceVal */
+     , (26321,   8,         10) /* Mass */
+     , (26321,   9,          0) /* ValidLocations - None */
+     , (26321,  11,         20) /* MaxStackSize */
+     , (26321,  12,          1) /* StackSize */
+     , (26321,  13,         10) /* StackUnitEncumbrance */
+     , (26321,  14,         10) /* StackUnitMass */
+     , (26321,  15,        500) /* StackUnitValue */
+     , (26321,  16,          8) /* ItemUseable - Contained */
+     , (26321,  18,          1) /* UiEffects - Magical */
+     , (26321,  19,        500) /* Value */
+     , (26321,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26321,  94,         16) /* TargetType - Creature */
+     , (26321, 106,        210) /* ItemSpellcraft */
+     , (26321, 107,         50) /* ItemCurMana */
+     , (26321, 108,         50) /* ItemMaxMana */
+     , (26321, 109,          0) /* ItemDifficulty */
+     , (26321, 110,          0) /* ItemAllegianceRankLimit */
+     , (26321, 150,        103) /* HookPlacement - Hook */
+     , (26321, 151,          2) /* HookType - Wall */
+     , (26321, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26321,  15, True ) /* LightsStatus */
+     , (26321,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26321, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26321,   1, 'Qalabar Oasis Settlement Portal Gem') /* Name */
+     , (26321,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26321,   1,   33556769) /* Setup */
+     , (26321,   3,  536870932) /* SoundTable */
+     , (26321,   6,   67111919) /* PaletteBase */
+     , (26321,   7,  268435723) /* ClothingBase */
+     , (26321,   8,  100675760) /* Icon */
+     , (26321,  22,  872415275) /* PhysicsEffectTable */
+     , (26321,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26321,  31,      13119) /* LinkedPortalOne - Qalabar Oasis Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26322 Qalaba'r Seaside Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26322 Qalaba'r Seaside Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26322;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26322, 'gemportalqalabarseasidevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26322,   1,       2048) /* ItemType - Gem */
+     , (26322,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26322,   5,         10) /* EncumbranceVal */
+     , (26322,   8,         10) /* Mass */
+     , (26322,   9,          0) /* ValidLocations - None */
+     , (26322,  11,         20) /* MaxStackSize */
+     , (26322,  12,          1) /* StackSize */
+     , (26322,  13,         10) /* StackUnitEncumbrance */
+     , (26322,  14,         10) /* StackUnitMass */
+     , (26322,  15,        500) /* StackUnitValue */
+     , (26322,  16,          8) /* ItemUseable - Contained */
+     , (26322,  18,          1) /* UiEffects - Magical */
+     , (26322,  19,        500) /* Value */
+     , (26322,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26322,  94,         16) /* TargetType - Creature */
+     , (26322, 106,        210) /* ItemSpellcraft */
+     , (26322, 107,         50) /* ItemCurMana */
+     , (26322, 108,         50) /* ItemMaxMana */
+     , (26322, 109,          0) /* ItemDifficulty */
+     , (26322, 110,          0) /* ItemAllegianceRankLimit */
+     , (26322, 150,        103) /* HookPlacement - Hook */
+     , (26322, 151,          2) /* HookType - Wall */
+     , (26322, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26322,  15, True ) /* LightsStatus */
+     , (26322,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26322, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26322,   1, 'Qalaba''r Seaside Villas Portal Gem') /* Name */
+     , (26322,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26322,   1,   33556769) /* Setup */
+     , (26322,   3,  536870932) /* SoundTable */
+     , (26322,   6,   67111919) /* PaletteBase */
+     , (26322,   7,  268435723) /* ClothingBase */
+     , (26322,   8,  100675760) /* Icon */
+     , (26322,  22,  872415275) /* PhysicsEffectTable */
+     , (26322,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26322,  31,      13120) /* LinkedPortalOne - Qalaba'r Seaside Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26323 Rahvard Square Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26323 Rahvard Square Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26323;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26323, 'gemportalrahvardsquare', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26323,   1,       2048) /* ItemType - Gem */
+     , (26323,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26323,   5,         10) /* EncumbranceVal */
+     , (26323,   8,         10) /* Mass */
+     , (26323,   9,          0) /* ValidLocations - None */
+     , (26323,  11,         20) /* MaxStackSize */
+     , (26323,  12,          1) /* StackSize */
+     , (26323,  13,         10) /* StackUnitEncumbrance */
+     , (26323,  14,         10) /* StackUnitMass */
+     , (26323,  15,        500) /* StackUnitValue */
+     , (26323,  16,          8) /* ItemUseable - Contained */
+     , (26323,  18,          1) /* UiEffects - Magical */
+     , (26323,  19,        500) /* Value */
+     , (26323,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26323,  94,         16) /* TargetType - Creature */
+     , (26323, 106,        210) /* ItemSpellcraft */
+     , (26323, 107,         50) /* ItemCurMana */
+     , (26323, 108,         50) /* ItemMaxMana */
+     , (26323, 109,          0) /* ItemDifficulty */
+     , (26323, 110,          0) /* ItemAllegianceRankLimit */
+     , (26323, 150,        103) /* HookPlacement - Hook */
+     , (26323, 151,          2) /* HookType - Wall */
+     , (26323, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26323,  15, True ) /* LightsStatus */
+     , (26323,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26323, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26323,   1, 'Rahvard Square Portal Gem') /* Name */
+     , (26323,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26323,   1,   33556769) /* Setup */
+     , (26323,   3,  536870932) /* SoundTable */
+     , (26323,   6,   67111919) /* PaletteBase */
+     , (26323,   7,  268435723) /* ClothingBase */
+     , (26323,   8,  100675760) /* Icon */
+     , (26323,  22,  872415275) /* PhysicsEffectTable */
+     , (26323,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26323,  31,      14659) /* LinkedPortalOne - Rahvard Square Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26324 Redrock Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26324 Redrock Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26324;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26324, 'gemportalredrockcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26324,   1,       2048) /* ItemType - Gem */
+     , (26324,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26324,   5,         10) /* EncumbranceVal */
+     , (26324,   8,         10) /* Mass */
+     , (26324,   9,          0) /* ValidLocations - None */
+     , (26324,  11,         20) /* MaxStackSize */
+     , (26324,  12,          1) /* StackSize */
+     , (26324,  13,         10) /* StackUnitEncumbrance */
+     , (26324,  14,         10) /* StackUnitMass */
+     , (26324,  15,        500) /* StackUnitValue */
+     , (26324,  16,          8) /* ItemUseable - Contained */
+     , (26324,  18,          1) /* UiEffects - Magical */
+     , (26324,  19,        500) /* Value */
+     , (26324,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26324,  94,         16) /* TargetType - Creature */
+     , (26324, 106,        210) /* ItemSpellcraft */
+     , (26324, 107,         50) /* ItemCurMana */
+     , (26324, 108,         50) /* ItemMaxMana */
+     , (26324, 109,          0) /* ItemDifficulty */
+     , (26324, 110,          0) /* ItemAllegianceRankLimit */
+     , (26324, 150,        103) /* HookPlacement - Hook */
+     , (26324, 151,          2) /* HookType - Wall */
+     , (26324, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26324,  15, True ) /* LightsStatus */
+     , (26324,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26324, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26324,   1, 'Redrock Cottages Portal Gem') /* Name */
+     , (26324,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26324,   1,   33556769) /* Setup */
+     , (26324,   3,  536870932) /* SoundTable */
+     , (26324,   6,   67111919) /* PaletteBase */
+     , (26324,   7,  268435723) /* ClothingBase */
+     , (26324,   8,  100675760) /* Icon */
+     , (26324,  22,  872415275) /* PhysicsEffectTable */
+     , (26324,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26324,  31,      14660) /* LinkedPortalOne - Redrock Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26325 Regina Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26325 Regina Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26325;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26325, 'gemportalreginacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26325,   1,       2048) /* ItemType - Gem */
+     , (26325,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26325,   5,         10) /* EncumbranceVal */
+     , (26325,   8,         10) /* Mass */
+     , (26325,   9,          0) /* ValidLocations - None */
+     , (26325,  11,         20) /* MaxStackSize */
+     , (26325,  12,          1) /* StackSize */
+     , (26325,  13,         10) /* StackUnitEncumbrance */
+     , (26325,  14,         10) /* StackUnitMass */
+     , (26325,  15,        500) /* StackUnitValue */
+     , (26325,  16,          8) /* ItemUseable - Contained */
+     , (26325,  18,          1) /* UiEffects - Magical */
+     , (26325,  19,        500) /* Value */
+     , (26325,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26325,  94,         16) /* TargetType - Creature */
+     , (26325, 106,        210) /* ItemSpellcraft */
+     , (26325, 107,         50) /* ItemCurMana */
+     , (26325, 108,         50) /* ItemMaxMana */
+     , (26325, 109,          0) /* ItemDifficulty */
+     , (26325, 110,          0) /* ItemAllegianceRankLimit */
+     , (26325, 150,        103) /* HookPlacement - Hook */
+     , (26325, 151,          2) /* HookType - Wall */
+     , (26325, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26325,  15, True ) /* LightsStatus */
+     , (26325,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26325, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26325,   1, 'Regina Cottages Portal Gem') /* Name */
+     , (26325,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26325,   1,   33556769) /* Setup */
+     , (26325,   3,  536870932) /* SoundTable */
+     , (26325,   6,   67111919) /* PaletteBase */
+     , (26325,   7,  268435723) /* ClothingBase */
+     , (26325,   8,  100675760) /* Icon */
+     , (26325,  22,  872415275) /* PhysicsEffectTable */
+     , (26325,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26325,  31,      15184) /* LinkedPortalOne - Regina Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26326 Rending Talon Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26326 Rending Talon Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26326;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26326, 'gemportalrendingtaloncottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26326,   1,       2048) /* ItemType - Gem */
+     , (26326,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26326,   5,         10) /* EncumbranceVal */
+     , (26326,   8,         10) /* Mass */
+     , (26326,   9,          0) /* ValidLocations - None */
+     , (26326,  11,         20) /* MaxStackSize */
+     , (26326,  12,          1) /* StackSize */
+     , (26326,  13,         10) /* StackUnitEncumbrance */
+     , (26326,  14,         10) /* StackUnitMass */
+     , (26326,  15,        500) /* StackUnitValue */
+     , (26326,  16,          8) /* ItemUseable - Contained */
+     , (26326,  18,          1) /* UiEffects - Magical */
+     , (26326,  19,        500) /* Value */
+     , (26326,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26326,  94,         16) /* TargetType - Creature */
+     , (26326, 106,        210) /* ItemSpellcraft */
+     , (26326, 107,         50) /* ItemCurMana */
+     , (26326, 108,         50) /* ItemMaxMana */
+     , (26326, 109,          0) /* ItemDifficulty */
+     , (26326, 110,          0) /* ItemAllegianceRankLimit */
+     , (26326, 150,        103) /* HookPlacement - Hook */
+     , (26326, 151,          2) /* HookType - Wall */
+     , (26326, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26326,  15, True ) /* LightsStatus */
+     , (26326,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26326, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26326,   1, 'Rending Talon Cottages Portal Gem') /* Name */
+     , (26326,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26326,   1,   33556769) /* Setup */
+     , (26326,   3,  536870932) /* SoundTable */
+     , (26326,   6,   67111919) /* PaletteBase */
+     , (26326,   7,  268435723) /* ClothingBase */
+     , (26326,   8,  100675760) /* Icon */
+     , (26326,  22,  872415275) /* PhysicsEffectTable */
+     , (26326,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26326,  31,      19155) /* LinkedPortalOne - Rending Talon Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26327 Rethux Vale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26327 Rethux Vale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26327;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26327, 'gemportalrethuxvale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26327,   1,       2048) /* ItemType - Gem */
+     , (26327,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26327,   5,         10) /* EncumbranceVal */
+     , (26327,   8,         10) /* Mass */
+     , (26327,   9,          0) /* ValidLocations - None */
+     , (26327,  11,         20) /* MaxStackSize */
+     , (26327,  12,          1) /* StackSize */
+     , (26327,  13,         10) /* StackUnitEncumbrance */
+     , (26327,  14,         10) /* StackUnitMass */
+     , (26327,  15,        500) /* StackUnitValue */
+     , (26327,  16,          8) /* ItemUseable - Contained */
+     , (26327,  18,          1) /* UiEffects - Magical */
+     , (26327,  19,        500) /* Value */
+     , (26327,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26327,  94,         16) /* TargetType - Creature */
+     , (26327, 106,        210) /* ItemSpellcraft */
+     , (26327, 107,         50) /* ItemCurMana */
+     , (26327, 108,         50) /* ItemMaxMana */
+     , (26327, 109,          0) /* ItemDifficulty */
+     , (26327, 110,          0) /* ItemAllegianceRankLimit */
+     , (26327, 150,        103) /* HookPlacement - Hook */
+     , (26327, 151,          2) /* HookType - Wall */
+     , (26327, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26327,  15, True ) /* LightsStatus */
+     , (26327,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26327, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26327,   1, 'Rethux Vale Portal Gem') /* Name */
+     , (26327,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26327,   1,   33556769) /* Setup */
+     , (26327,   3,  536870932) /* SoundTable */
+     , (26327,   6,   67111919) /* PaletteBase */
+     , (26327,   7,  268435723) /* ClothingBase */
+     , (26327,   8,  100675760) /* Icon */
+     , (26327,  22,  872415275) /* PhysicsEffectTable */
+     , (26327,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26327,  31,      15185) /* LinkedPortalOne - Rethux Vale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26328 Return of Mumiyah Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26328 Return of Mumiyah Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26328;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26328, 'gemportalreturnofmumiyahcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26328,   1,       2048) /* ItemType - Gem */
+     , (26328,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26328,   5,         10) /* EncumbranceVal */
+     , (26328,   8,         10) /* Mass */
+     , (26328,   9,          0) /* ValidLocations - None */
+     , (26328,  11,         20) /* MaxStackSize */
+     , (26328,  12,          1) /* StackSize */
+     , (26328,  13,         10) /* StackUnitEncumbrance */
+     , (26328,  14,         10) /* StackUnitMass */
+     , (26328,  15,        500) /* StackUnitValue */
+     , (26328,  16,          8) /* ItemUseable - Contained */
+     , (26328,  18,          1) /* UiEffects - Magical */
+     , (26328,  19,        500) /* Value */
+     , (26328,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26328,  94,         16) /* TargetType - Creature */
+     , (26328, 106,        210) /* ItemSpellcraft */
+     , (26328, 107,         50) /* ItemCurMana */
+     , (26328, 108,         50) /* ItemMaxMana */
+     , (26328, 109,          0) /* ItemDifficulty */
+     , (26328, 110,          0) /* ItemAllegianceRankLimit */
+     , (26328, 150,        103) /* HookPlacement - Hook */
+     , (26328, 151,          2) /* HookType - Wall */
+     , (26328, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26328,  15, True ) /* LightsStatus */
+     , (26328,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26328, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26328,   1, 'Return of Mumiyah Cottages Portal Gem') /* Name */
+     , (26328,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26328,   1,   33556769) /* Setup */
+     , (26328,   3,  536870932) /* SoundTable */
+     , (26328,   6,   67111919) /* PaletteBase */
+     , (26328,   7,  268435723) /* ClothingBase */
+     , (26328,   8,  100675760) /* Icon */
+     , (26328,  22,  872415275) /* PhysicsEffectTable */
+     , (26328,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26328,  31,      15186) /* LinkedPortalOne - Return of Mumiyah Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26329 Reviled Maw Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26329 Reviled Maw Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26329;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26329, 'gemportalreviledmawcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26329,   1,       2048) /* ItemType - Gem */
+     , (26329,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26329,   5,         10) /* EncumbranceVal */
+     , (26329,   8,         10) /* Mass */
+     , (26329,   9,          0) /* ValidLocations - None */
+     , (26329,  11,         20) /* MaxStackSize */
+     , (26329,  12,          1) /* StackSize */
+     , (26329,  13,         10) /* StackUnitEncumbrance */
+     , (26329,  14,         10) /* StackUnitMass */
+     , (26329,  15,        500) /* StackUnitValue */
+     , (26329,  16,          8) /* ItemUseable - Contained */
+     , (26329,  18,          1) /* UiEffects - Magical */
+     , (26329,  19,        500) /* Value */
+     , (26329,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26329,  94,         16) /* TargetType - Creature */
+     , (26329, 106,        210) /* ItemSpellcraft */
+     , (26329, 107,         50) /* ItemCurMana */
+     , (26329, 108,         50) /* ItemMaxMana */
+     , (26329, 109,          0) /* ItemDifficulty */
+     , (26329, 110,          0) /* ItemAllegianceRankLimit */
+     , (26329, 150,        103) /* HookPlacement - Hook */
+     , (26329, 151,          2) /* HookType - Wall */
+     , (26329, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26329,  15, True ) /* LightsStatus */
+     , (26329,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26329, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26329,   1, 'Reviled Maw Cottages Portal Gem') /* Name */
+     , (26329,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26329,   1,   33556769) /* Setup */
+     , (26329,   3,  536870932) /* SoundTable */
+     , (26329,   6,   67111919) /* PaletteBase */
+     , (26329,   7,  268435723) /* ClothingBase */
+     , (26329,   8,  100675760) /* Icon */
+     , (26329,  22,  872415275) /* PhysicsEffectTable */
+     , (26329,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26329,  31,      19156) /* LinkedPortalOne - Reviled Maw Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26330 Rhynntal Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26330 Rhynntal Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26330;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26330, 'gemportalrhynntalcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26330,   1,       2048) /* ItemType - Gem */
+     , (26330,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26330,   5,         10) /* EncumbranceVal */
+     , (26330,   8,         10) /* Mass */
+     , (26330,   9,          0) /* ValidLocations - None */
+     , (26330,  11,         20) /* MaxStackSize */
+     , (26330,  12,          1) /* StackSize */
+     , (26330,  13,         10) /* StackUnitEncumbrance */
+     , (26330,  14,         10) /* StackUnitMass */
+     , (26330,  15,        500) /* StackUnitValue */
+     , (26330,  16,          8) /* ItemUseable - Contained */
+     , (26330,  18,          1) /* UiEffects - Magical */
+     , (26330,  19,        500) /* Value */
+     , (26330,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26330,  94,         16) /* TargetType - Creature */
+     , (26330, 106,        210) /* ItemSpellcraft */
+     , (26330, 107,         50) /* ItemCurMana */
+     , (26330, 108,         50) /* ItemMaxMana */
+     , (26330, 109,          0) /* ItemDifficulty */
+     , (26330, 110,          0) /* ItemAllegianceRankLimit */
+     , (26330, 150,        103) /* HookPlacement - Hook */
+     , (26330, 151,          2) /* HookType - Wall */
+     , (26330, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26330,  15, True ) /* LightsStatus */
+     , (26330,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26330, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26330,   1, 'Rhynntal Cottages Portal Gem') /* Name */
+     , (26330,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26330,   1,   33556769) /* Setup */
+     , (26330,   3,  536870932) /* SoundTable */
+     , (26330,   6,   67111919) /* PaletteBase */
+     , (26330,   7,  268435723) /* ClothingBase */
+     , (26330,   8,  100675760) /* Icon */
+     , (26330,  22,  872415275) /* PhysicsEffectTable */
+     , (26330,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26330,  31,      14661) /* LinkedPortalOne - Rhynntal Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26331 Ring of Crystals Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26331 Ring of Crystals Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26331;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26331, 'gemportalringofcrystalsestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26331,   1,       2048) /* ItemType - Gem */
+     , (26331,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26331,   5,         10) /* EncumbranceVal */
+     , (26331,   8,         10) /* Mass */
+     , (26331,   9,          0) /* ValidLocations - None */
+     , (26331,  11,         20) /* MaxStackSize */
+     , (26331,  12,          1) /* StackSize */
+     , (26331,  13,         10) /* StackUnitEncumbrance */
+     , (26331,  14,         10) /* StackUnitMass */
+     , (26331,  15,        500) /* StackUnitValue */
+     , (26331,  16,          8) /* ItemUseable - Contained */
+     , (26331,  18,          1) /* UiEffects - Magical */
+     , (26331,  19,        500) /* Value */
+     , (26331,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26331,  94,         16) /* TargetType - Creature */
+     , (26331, 106,        210) /* ItemSpellcraft */
+     , (26331, 107,         50) /* ItemCurMana */
+     , (26331, 108,         50) /* ItemMaxMana */
+     , (26331, 109,          0) /* ItemDifficulty */
+     , (26331, 110,          0) /* ItemAllegianceRankLimit */
+     , (26331, 150,        103) /* HookPlacement - Hook */
+     , (26331, 151,          2) /* HookType - Wall */
+     , (26331, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26331,  15, True ) /* LightsStatus */
+     , (26331,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26331, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26331,   1, 'Ring of Crystals Estates Portal Gem') /* Name */
+     , (26331,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26331,   1,   33556769) /* Setup */
+     , (26331,   3,  536870932) /* SoundTable */
+     , (26331,   6,   67111919) /* PaletteBase */
+     , (26331,   7,  268435723) /* ClothingBase */
+     , (26331,   8,  100675760) /* Icon */
+     , (26331,  22,  872415275) /* PhysicsEffectTable */
+     , (26331,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26331,  31,      13121) /* LinkedPortalOne - Ring of Crystals Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26332 Riverbend Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26332 Riverbend Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26332;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26332, 'gemportalriverbendcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26332,   1,       2048) /* ItemType - Gem */
+     , (26332,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26332,   5,         10) /* EncumbranceVal */
+     , (26332,   8,         10) /* Mass */
+     , (26332,   9,          0) /* ValidLocations - None */
+     , (26332,  11,         20) /* MaxStackSize */
+     , (26332,  12,          1) /* StackSize */
+     , (26332,  13,         10) /* StackUnitEncumbrance */
+     , (26332,  14,         10) /* StackUnitMass */
+     , (26332,  15,        500) /* StackUnitValue */
+     , (26332,  16,          8) /* ItemUseable - Contained */
+     , (26332,  18,          1) /* UiEffects - Magical */
+     , (26332,  19,        500) /* Value */
+     , (26332,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26332,  94,         16) /* TargetType - Creature */
+     , (26332, 106,        210) /* ItemSpellcraft */
+     , (26332, 107,         50) /* ItemCurMana */
+     , (26332, 108,         50) /* ItemMaxMana */
+     , (26332, 109,          0) /* ItemDifficulty */
+     , (26332, 110,          0) /* ItemAllegianceRankLimit */
+     , (26332, 150,        103) /* HookPlacement - Hook */
+     , (26332, 151,          2) /* HookType - Wall */
+     , (26332, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26332,  15, True ) /* LightsStatus */
+     , (26332,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26332, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26332,   1, 'Riverbend Cottages Portal Gem') /* Name */
+     , (26332,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26332,   1,   33556769) /* Setup */
+     , (26332,   3,  536870932) /* SoundTable */
+     , (26332,   6,   67111919) /* PaletteBase */
+     , (26332,   7,  268435723) /* ClothingBase */
+     , (26332,   8,  100675760) /* Icon */
+     , (26332,  22,  872415275) /* PhysicsEffectTable */
+     , (26332,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26332,  31,      13122) /* LinkedPortalOne - Riverbend Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26333 Rivermouth Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26333 Rivermouth Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26333;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26333, 'gemportalrivermouthvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26333,   1,       2048) /* ItemType - Gem */
+     , (26333,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26333,   5,         10) /* EncumbranceVal */
+     , (26333,   8,         10) /* Mass */
+     , (26333,   9,          0) /* ValidLocations - None */
+     , (26333,  11,         20) /* MaxStackSize */
+     , (26333,  12,          1) /* StackSize */
+     , (26333,  13,         10) /* StackUnitEncumbrance */
+     , (26333,  14,         10) /* StackUnitMass */
+     , (26333,  15,        500) /* StackUnitValue */
+     , (26333,  16,          8) /* ItemUseable - Contained */
+     , (26333,  18,          1) /* UiEffects - Magical */
+     , (26333,  19,        500) /* Value */
+     , (26333,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26333,  94,         16) /* TargetType - Creature */
+     , (26333, 106,        210) /* ItemSpellcraft */
+     , (26333, 107,         50) /* ItemCurMana */
+     , (26333, 108,         50) /* ItemMaxMana */
+     , (26333, 109,          0) /* ItemDifficulty */
+     , (26333, 110,          0) /* ItemAllegianceRankLimit */
+     , (26333, 150,        103) /* HookPlacement - Hook */
+     , (26333, 151,          2) /* HookType - Wall */
+     , (26333, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26333,  15, True ) /* LightsStatus */
+     , (26333,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26333, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26333,   1, 'Rivermouth Villas Portal Gem') /* Name */
+     , (26333,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26333,   1,   33556769) /* Setup */
+     , (26333,   3,  536870932) /* SoundTable */
+     , (26333,   6,   67111919) /* PaletteBase */
+     , (26333,   7,  268435723) /* ClothingBase */
+     , (26333,   8,  100675760) /* Icon */
+     , (26333,  22,  872415275) /* PhysicsEffectTable */
+     , (26333,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26333,  31,      13123) /* LinkedPortalOne - Rivermouth Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26334 Ro-Nan Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26334 Ro-Nan Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26334;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26334, 'gemportalronan', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26334,   1,       2048) /* ItemType - Gem */
+     , (26334,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26334,   5,         10) /* EncumbranceVal */
+     , (26334,   8,         10) /* Mass */
+     , (26334,   9,          0) /* ValidLocations - None */
+     , (26334,  11,         20) /* MaxStackSize */
+     , (26334,  12,          1) /* StackSize */
+     , (26334,  13,         10) /* StackUnitEncumbrance */
+     , (26334,  14,         10) /* StackUnitMass */
+     , (26334,  15,        500) /* StackUnitValue */
+     , (26334,  16,          8) /* ItemUseable - Contained */
+     , (26334,  18,          1) /* UiEffects - Magical */
+     , (26334,  19,        500) /* Value */
+     , (26334,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26334,  94,         16) /* TargetType - Creature */
+     , (26334, 106,        210) /* ItemSpellcraft */
+     , (26334, 107,         50) /* ItemCurMana */
+     , (26334, 108,         50) /* ItemMaxMana */
+     , (26334, 109,          0) /* ItemDifficulty */
+     , (26334, 110,          0) /* ItemAllegianceRankLimit */
+     , (26334, 150,        103) /* HookPlacement - Hook */
+     , (26334, 151,          2) /* HookType - Wall */
+     , (26334, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26334,  15, True ) /* LightsStatus */
+     , (26334,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26334, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26334,   1, 'Ro-Nan Portal Gem') /* Name */
+     , (26334,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26334,   1,   33556769) /* Setup */
+     , (26334,   3,  536870932) /* SoundTable */
+     , (26334,   6,   67111919) /* PaletteBase */
+     , (26334,   7,  268435723) /* ClothingBase */
+     , (26334,   8,  100675760) /* Icon */
+     , (26334,  22,  872415275) /* PhysicsEffectTable */
+     , (26334,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26334,  31,      14279) /* LinkedPortalOne - Ro-Nan Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26335 Rytheran Dale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26335 Rytheran Dale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26335;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26335, 'gemportalrytherandale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26335,   1,       2048) /* ItemType - Gem */
+     , (26335,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26335,   5,         10) /* EncumbranceVal */
+     , (26335,   8,         10) /* Mass */
+     , (26335,   9,          0) /* ValidLocations - None */
+     , (26335,  11,         20) /* MaxStackSize */
+     , (26335,  12,          1) /* StackSize */
+     , (26335,  13,         10) /* StackUnitEncumbrance */
+     , (26335,  14,         10) /* StackUnitMass */
+     , (26335,  15,        500) /* StackUnitValue */
+     , (26335,  16,          8) /* ItemUseable - Contained */
+     , (26335,  18,          1) /* UiEffects - Magical */
+     , (26335,  19,        500) /* Value */
+     , (26335,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26335,  94,         16) /* TargetType - Creature */
+     , (26335, 106,        210) /* ItemSpellcraft */
+     , (26335, 107,         50) /* ItemCurMana */
+     , (26335, 108,         50) /* ItemMaxMana */
+     , (26335, 109,          0) /* ItemDifficulty */
+     , (26335, 110,          0) /* ItemAllegianceRankLimit */
+     , (26335, 150,        103) /* HookPlacement - Hook */
+     , (26335, 151,          2) /* HookType - Wall */
+     , (26335, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26335,  15, True ) /* LightsStatus */
+     , (26335,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26335, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26335,   1, 'Rytheran Dale Portal Gem') /* Name */
+     , (26335,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26335,   1,   33556769) /* Setup */
+     , (26335,   3,  536870932) /* SoundTable */
+     , (26335,   6,   67111919) /* PaletteBase */
+     , (26335,   7,  268435723) /* ClothingBase */
+     , (26335,   8,  100675760) /* Icon */
+     , (26335,  22,  872415275) /* PhysicsEffectTable */
+     , (26335,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26335,  31,      15681) /* LinkedPortalOne - Rytheran Dale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26336 Sai-Nan Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26336 Sai-Nan Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26336;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26336, 'gemportalsainan', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26336,   1,       2048) /* ItemType - Gem */
+     , (26336,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26336,   5,         10) /* EncumbranceVal */
+     , (26336,   8,         10) /* Mass */
+     , (26336,   9,          0) /* ValidLocations - None */
+     , (26336,  11,         20) /* MaxStackSize */
+     , (26336,  12,          1) /* StackSize */
+     , (26336,  13,         10) /* StackUnitEncumbrance */
+     , (26336,  14,         10) /* StackUnitMass */
+     , (26336,  15,        500) /* StackUnitValue */
+     , (26336,  16,          8) /* ItemUseable - Contained */
+     , (26336,  18,          1) /* UiEffects - Magical */
+     , (26336,  19,        500) /* Value */
+     , (26336,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26336,  94,         16) /* TargetType - Creature */
+     , (26336, 106,        210) /* ItemSpellcraft */
+     , (26336, 107,         50) /* ItemCurMana */
+     , (26336, 108,         50) /* ItemMaxMana */
+     , (26336, 109,          0) /* ItemDifficulty */
+     , (26336, 110,          0) /* ItemAllegianceRankLimit */
+     , (26336, 150,        103) /* HookPlacement - Hook */
+     , (26336, 151,          2) /* HookType - Wall */
+     , (26336, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26336,  15, True ) /* LightsStatus */
+     , (26336,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26336, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26336,   1, 'Sai-Nan Portal Gem') /* Name */
+     , (26336,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26336,   1,   33556769) /* Setup */
+     , (26336,   3,  536870932) /* SoundTable */
+     , (26336,   6,   67111919) /* PaletteBase */
+     , (26336,   7,  268435723) /* ClothingBase */
+     , (26336,   8,  100675760) /* Icon */
+     , (26336,  22,  872415275) /* PhysicsEffectTable */
+     , (26336,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26336,  31,      14280) /* LinkedPortalOne - Sai-Nan Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26337 Samsur Butte Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26337 Samsur Butte Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26337;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26337, 'gemportalsamsurbuttecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26337,   1,       2048) /* ItemType - Gem */
+     , (26337,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26337,   5,         10) /* EncumbranceVal */
+     , (26337,   8,         10) /* Mass */
+     , (26337,   9,          0) /* ValidLocations - None */
+     , (26337,  11,         20) /* MaxStackSize */
+     , (26337,  12,          1) /* StackSize */
+     , (26337,  13,         10) /* StackUnitEncumbrance */
+     , (26337,  14,         10) /* StackUnitMass */
+     , (26337,  15,        500) /* StackUnitValue */
+     , (26337,  16,          8) /* ItemUseable - Contained */
+     , (26337,  18,          1) /* UiEffects - Magical */
+     , (26337,  19,        500) /* Value */
+     , (26337,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26337,  94,         16) /* TargetType - Creature */
+     , (26337, 106,        210) /* ItemSpellcraft */
+     , (26337, 107,         50) /* ItemCurMana */
+     , (26337, 108,         50) /* ItemMaxMana */
+     , (26337, 109,          0) /* ItemDifficulty */
+     , (26337, 110,          0) /* ItemAllegianceRankLimit */
+     , (26337, 150,        103) /* HookPlacement - Hook */
+     , (26337, 151,          2) /* HookType - Wall */
+     , (26337, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26337,  15, True ) /* LightsStatus */
+     , (26337,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26337, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26337,   1, 'Samsur Butte Cottages Portal Gem') /* Name */
+     , (26337,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26337,   1,   33556769) /* Setup */
+     , (26337,   3,  536870932) /* SoundTable */
+     , (26337,   6,   67111919) /* PaletteBase */
+     , (26337,   7,  268435723) /* ClothingBase */
+     , (26337,   8,  100675760) /* Icon */
+     , (26337,  22,  872415275) /* PhysicsEffectTable */
+     , (26337,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26337,  31,      12540) /* LinkedPortalOne - Samsur Butte Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26338 Sanai Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26338 Sanai Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26338;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26338, 'gemportalsanai', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26338,   1,       2048) /* ItemType - Gem */
+     , (26338,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26338,   5,         10) /* EncumbranceVal */
+     , (26338,   8,         10) /* Mass */
+     , (26338,   9,          0) /* ValidLocations - None */
+     , (26338,  11,         20) /* MaxStackSize */
+     , (26338,  12,          1) /* StackSize */
+     , (26338,  13,         10) /* StackUnitEncumbrance */
+     , (26338,  14,         10) /* StackUnitMass */
+     , (26338,  15,        500) /* StackUnitValue */
+     , (26338,  16,          8) /* ItemUseable - Contained */
+     , (26338,  18,          1) /* UiEffects - Magical */
+     , (26338,  19,        500) /* Value */
+     , (26338,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26338,  94,         16) /* TargetType - Creature */
+     , (26338, 106,        210) /* ItemSpellcraft */
+     , (26338, 107,         50) /* ItemCurMana */
+     , (26338, 108,         50) /* ItemMaxMana */
+     , (26338, 109,          0) /* ItemDifficulty */
+     , (26338, 110,          0) /* ItemAllegianceRankLimit */
+     , (26338, 150,        103) /* HookPlacement - Hook */
+     , (26338, 151,          2) /* HookType - Wall */
+     , (26338, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26338,  15, True ) /* LightsStatus */
+     , (26338,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26338, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26338,   1, 'Sanai Portal Gem') /* Name */
+     , (26338,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26338,   1,   33556769) /* Setup */
+     , (26338,   3,  536870932) /* SoundTable */
+     , (26338,   6,   67111919) /* PaletteBase */
+     , (26338,   7,  268435723) /* ClothingBase */
+     , (26338,   8,  100675760) /* Icon */
+     , (26338,  22,  872415275) /* PhysicsEffectTable */
+     , (26338,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26338,  31,      12541) /* LinkedPortalOne - Sanai Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26339 Sanam Batal Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26339 Sanam Batal Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26339;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26339, 'gemportalsanamtalibvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26339,   1,       2048) /* ItemType - Gem */
+     , (26339,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26339,   5,         10) /* EncumbranceVal */
+     , (26339,   8,         10) /* Mass */
+     , (26339,   9,          0) /* ValidLocations - None */
+     , (26339,  11,         20) /* MaxStackSize */
+     , (26339,  12,          1) /* StackSize */
+     , (26339,  13,         10) /* StackUnitEncumbrance */
+     , (26339,  14,         10) /* StackUnitMass */
+     , (26339,  15,        500) /* StackUnitValue */
+     , (26339,  16,          8) /* ItemUseable - Contained */
+     , (26339,  18,          1) /* UiEffects - Magical */
+     , (26339,  19,        500) /* Value */
+     , (26339,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26339,  94,         16) /* TargetType - Creature */
+     , (26339, 106,        210) /* ItemSpellcraft */
+     , (26339, 107,         50) /* ItemCurMana */
+     , (26339, 108,         50) /* ItemMaxMana */
+     , (26339, 109,          0) /* ItemDifficulty */
+     , (26339, 110,          0) /* ItemAllegianceRankLimit */
+     , (26339, 150,        103) /* HookPlacement - Hook */
+     , (26339, 151,          2) /* HookType - Wall */
+     , (26339, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26339,  15, True ) /* LightsStatus */
+     , (26339,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26339, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26339,   1, 'Sanam Batal Villas Portal Gem') /* Name */
+     , (26339,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26339,   1,   33556769) /* Setup */
+     , (26339,   3,  536870932) /* SoundTable */
+     , (26339,   6,   67111919) /* PaletteBase */
+     , (26339,   7,  268435723) /* ClothingBase */
+     , (26339,   8,  100675760) /* Icon */
+     , (26339,  22,  872415275) /* PhysicsEffectTable */
+     , (26339,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26339,  31,      19157) /* LinkedPortalOne - Sanam Batal Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26340 San-Chin Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26340 San-Chin Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26340;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26340, 'gemportalsanchin', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26340,   1,       2048) /* ItemType - Gem */
+     , (26340,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26340,   5,         10) /* EncumbranceVal */
+     , (26340,   8,         10) /* Mass */
+     , (26340,   9,          0) /* ValidLocations - None */
+     , (26340,  11,         20) /* MaxStackSize */
+     , (26340,  12,          1) /* StackSize */
+     , (26340,  13,         10) /* StackUnitEncumbrance */
+     , (26340,  14,         10) /* StackUnitMass */
+     , (26340,  15,        500) /* StackUnitValue */
+     , (26340,  16,          8) /* ItemUseable - Contained */
+     , (26340,  18,          1) /* UiEffects - Magical */
+     , (26340,  19,        500) /* Value */
+     , (26340,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26340,  94,         16) /* TargetType - Creature */
+     , (26340, 106,        210) /* ItemSpellcraft */
+     , (26340, 107,         50) /* ItemCurMana */
+     , (26340, 108,         50) /* ItemMaxMana */
+     , (26340, 109,          0) /* ItemDifficulty */
+     , (26340, 110,          0) /* ItemAllegianceRankLimit */
+     , (26340, 150,        103) /* HookPlacement - Hook */
+     , (26340, 151,          2) /* HookType - Wall */
+     , (26340, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26340,  15, True ) /* LightsStatus */
+     , (26340,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26340, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26340,   1, 'San-Chin Portal Gem') /* Name */
+     , (26340,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26340,   1,   33556769) /* Setup */
+     , (26340,   3,  536870932) /* SoundTable */
+     , (26340,   6,   67111919) /* PaletteBase */
+     , (26340,   7,  268435723) /* ClothingBase */
+     , (26340,   8,  100675760) /* Icon */
+     , (26340,  22,  872415275) /* PhysicsEffectTable */
+     , (26340,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26340,  31,      14662) /* LinkedPortalOne - San-Chin Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26341 Sand Kings Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26341 Sand Kings Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26341;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26341, 'gemportalsandkingscottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26341,   1,       2048) /* ItemType - Gem */
+     , (26341,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26341,   5,         10) /* EncumbranceVal */
+     , (26341,   8,         10) /* Mass */
+     , (26341,   9,          0) /* ValidLocations - None */
+     , (26341,  11,         20) /* MaxStackSize */
+     , (26341,  12,          1) /* StackSize */
+     , (26341,  13,         10) /* StackUnitEncumbrance */
+     , (26341,  14,         10) /* StackUnitMass */
+     , (26341,  15,        500) /* StackUnitValue */
+     , (26341,  16,          8) /* ItemUseable - Contained */
+     , (26341,  18,          1) /* UiEffects - Magical */
+     , (26341,  19,        500) /* Value */
+     , (26341,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26341,  94,         16) /* TargetType - Creature */
+     , (26341, 106,        210) /* ItemSpellcraft */
+     , (26341, 107,         50) /* ItemCurMana */
+     , (26341, 108,         50) /* ItemMaxMana */
+     , (26341, 109,          0) /* ItemDifficulty */
+     , (26341, 110,          0) /* ItemAllegianceRankLimit */
+     , (26341, 150,        103) /* HookPlacement - Hook */
+     , (26341, 151,          2) /* HookType - Wall */
+     , (26341, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26341,  15, True ) /* LightsStatus */
+     , (26341,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26341, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26341,   1, 'Sand Kings Cottages Portal Gem') /* Name */
+     , (26341,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26341,   1,   33556769) /* Setup */
+     , (26341,   3,  536870932) /* SoundTable */
+     , (26341,   6,   67111919) /* PaletteBase */
+     , (26341,   7,  268435723) /* ClothingBase */
+     , (26341,   8,  100675760) /* Icon */
+     , (26341,  22,  872415275) /* PhysicsEffectTable */
+     , (26341,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26341,  31,      14663) /* LinkedPortalOne - Sand Kings Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26342 Sand's Edge Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26342 Sand's Edge Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26342;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26342, 'gemportalsandsedge', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26342,   1,       2048) /* ItemType - Gem */
+     , (26342,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26342,   5,         10) /* EncumbranceVal */
+     , (26342,   8,         10) /* Mass */
+     , (26342,   9,          0) /* ValidLocations - None */
+     , (26342,  11,         20) /* MaxStackSize */
+     , (26342,  12,          1) /* StackSize */
+     , (26342,  13,         10) /* StackUnitEncumbrance */
+     , (26342,  14,         10) /* StackUnitMass */
+     , (26342,  15,        500) /* StackUnitValue */
+     , (26342,  16,          8) /* ItemUseable - Contained */
+     , (26342,  18,          1) /* UiEffects - Magical */
+     , (26342,  19,        500) /* Value */
+     , (26342,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26342,  94,         16) /* TargetType - Creature */
+     , (26342, 106,        210) /* ItemSpellcraft */
+     , (26342, 107,         50) /* ItemCurMana */
+     , (26342, 108,         50) /* ItemMaxMana */
+     , (26342, 109,          0) /* ItemDifficulty */
+     , (26342, 110,          0) /* ItemAllegianceRankLimit */
+     , (26342, 150,        103) /* HookPlacement - Hook */
+     , (26342, 151,          2) /* HookType - Wall */
+     , (26342, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26342,  15, True ) /* LightsStatus */
+     , (26342,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26342, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26342,   1, 'Sand''s Edge Portal Gem') /* Name */
+     , (26342,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26342,   1,   33556769) /* Setup */
+     , (26342,   3,  536870932) /* SoundTable */
+     , (26342,   6,   67111919) /* PaletteBase */
+     , (26342,   7,  268435723) /* ClothingBase */
+     , (26342,   8,  100675760) /* Icon */
+     , (26342,  22,  872415275) /* PhysicsEffectTable */
+     , (26342,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26342,  31,      13124) /* LinkedPortalOne - Sand's Edge Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26343 Sand Shallow Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26343 Sand Shallow Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26343;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26343, 'gemportalsandshallowcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26343,   1,       2048) /* ItemType - Gem */
+     , (26343,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26343,   5,         10) /* EncumbranceVal */
+     , (26343,   8,         10) /* Mass */
+     , (26343,   9,          0) /* ValidLocations - None */
+     , (26343,  11,         20) /* MaxStackSize */
+     , (26343,  12,          1) /* StackSize */
+     , (26343,  13,         10) /* StackUnitEncumbrance */
+     , (26343,  14,         10) /* StackUnitMass */
+     , (26343,  15,        500) /* StackUnitValue */
+     , (26343,  16,          8) /* ItemUseable - Contained */
+     , (26343,  18,          1) /* UiEffects - Magical */
+     , (26343,  19,        500) /* Value */
+     , (26343,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26343,  94,         16) /* TargetType - Creature */
+     , (26343, 106,        210) /* ItemSpellcraft */
+     , (26343, 107,         50) /* ItemCurMana */
+     , (26343, 108,         50) /* ItemMaxMana */
+     , (26343, 109,          0) /* ItemDifficulty */
+     , (26343, 110,          0) /* ItemAllegianceRankLimit */
+     , (26343, 150,        103) /* HookPlacement - Hook */
+     , (26343, 151,          2) /* HookType - Wall */
+     , (26343, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26343,  15, True ) /* LightsStatus */
+     , (26343,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26343, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26343,   1, 'Sand Shallow Cottages Portal Gem') /* Name */
+     , (26343,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26343,   1,   33556769) /* Setup */
+     , (26343,   3,  536870932) /* SoundTable */
+     , (26343,   6,   67111919) /* PaletteBase */
+     , (26343,   7,  268435723) /* ClothingBase */
+     , (26343,   8,  100675760) /* Icon */
+     , (26343,  22,  872415275) /* PhysicsEffectTable */
+     , (26343,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26343,  31,      15187) /* LinkedPortalOne - Sand Shallow Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26344 Sands-of-the-Skull Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26344 Sands-of-the-Skull Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26344;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26344, 'gemportalsandsoftheskullcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26344,   1,       2048) /* ItemType - Gem */
+     , (26344,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26344,   5,         10) /* EncumbranceVal */
+     , (26344,   8,         10) /* Mass */
+     , (26344,   9,          0) /* ValidLocations - None */
+     , (26344,  11,         20) /* MaxStackSize */
+     , (26344,  12,          1) /* StackSize */
+     , (26344,  13,         10) /* StackUnitEncumbrance */
+     , (26344,  14,         10) /* StackUnitMass */
+     , (26344,  15,        500) /* StackUnitValue */
+     , (26344,  16,          8) /* ItemUseable - Contained */
+     , (26344,  18,          1) /* UiEffects - Magical */
+     , (26344,  19,        500) /* Value */
+     , (26344,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26344,  94,         16) /* TargetType - Creature */
+     , (26344, 106,        210) /* ItemSpellcraft */
+     , (26344, 107,         50) /* ItemCurMana */
+     , (26344, 108,         50) /* ItemMaxMana */
+     , (26344, 109,          0) /* ItemDifficulty */
+     , (26344, 110,          0) /* ItemAllegianceRankLimit */
+     , (26344, 150,        103) /* HookPlacement - Hook */
+     , (26344, 151,          2) /* HookType - Wall */
+     , (26344, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26344,  15, True ) /* LightsStatus */
+     , (26344,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26344, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26344,   1, 'Sands-of-the-Skull Cottages Portal Gem') /* Name */
+     , (26344,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26344,   1,   33556769) /* Setup */
+     , (26344,   3,  536870932) /* SoundTable */
+     , (26344,   6,   67111919) /* PaletteBase */
+     , (26344,   7,  268435723) /* ClothingBase */
+     , (26344,   8,  100675760) /* Icon */
+     , (26344,  22,  872415275) /* PhysicsEffectTable */
+     , (26344,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26344,  31,      14664) /* LinkedPortalOne - Sands-of-the-Skull Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26345 Sawato Foothills Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26345 Sawato Foothills Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26345;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26345, 'gemportalsawatofoothillssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26345,   1,       2048) /* ItemType - Gem */
+     , (26345,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26345,   5,         10) /* EncumbranceVal */
+     , (26345,   8,         10) /* Mass */
+     , (26345,   9,          0) /* ValidLocations - None */
+     , (26345,  11,         20) /* MaxStackSize */
+     , (26345,  12,          1) /* StackSize */
+     , (26345,  13,         10) /* StackUnitEncumbrance */
+     , (26345,  14,         10) /* StackUnitMass */
+     , (26345,  15,        500) /* StackUnitValue */
+     , (26345,  16,          8) /* ItemUseable - Contained */
+     , (26345,  18,          1) /* UiEffects - Magical */
+     , (26345,  19,        500) /* Value */
+     , (26345,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26345,  94,         16) /* TargetType - Creature */
+     , (26345, 106,        210) /* ItemSpellcraft */
+     , (26345, 107,         50) /* ItemCurMana */
+     , (26345, 108,         50) /* ItemMaxMana */
+     , (26345, 109,          0) /* ItemDifficulty */
+     , (26345, 110,          0) /* ItemAllegianceRankLimit */
+     , (26345, 150,        103) /* HookPlacement - Hook */
+     , (26345, 151,          2) /* HookType - Wall */
+     , (26345, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26345,  15, True ) /* LightsStatus */
+     , (26345,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26345, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26345,   1, 'Sawato Foothills Settlement Portal Gem') /* Name */
+     , (26345,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26345,   1,   33556769) /* Setup */
+     , (26345,   3,  536870932) /* SoundTable */
+     , (26345,   6,   67111919) /* PaletteBase */
+     , (26345,   7,  268435723) /* ClothingBase */
+     , (26345,   8,  100675760) /* Icon */
+     , (26345,  22,  872415275) /* PhysicsEffectTable */
+     , (26345,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26345,  31,      12542) /* LinkedPortalOne - Sawato Foothills Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26346 Scimitar Lake Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26346 Scimitar Lake Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26346;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26346, 'gemportalscimitarlakecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26346,   1,       2048) /* ItemType - Gem */
+     , (26346,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26346,   5,         10) /* EncumbranceVal */
+     , (26346,   8,         10) /* Mass */
+     , (26346,   9,          0) /* ValidLocations - None */
+     , (26346,  11,         20) /* MaxStackSize */
+     , (26346,  12,          1) /* StackSize */
+     , (26346,  13,         10) /* StackUnitEncumbrance */
+     , (26346,  14,         10) /* StackUnitMass */
+     , (26346,  15,        500) /* StackUnitValue */
+     , (26346,  16,          8) /* ItemUseable - Contained */
+     , (26346,  18,          1) /* UiEffects - Magical */
+     , (26346,  19,        500) /* Value */
+     , (26346,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26346,  94,         16) /* TargetType - Creature */
+     , (26346, 106,        210) /* ItemSpellcraft */
+     , (26346, 107,         50) /* ItemCurMana */
+     , (26346, 108,         50) /* ItemMaxMana */
+     , (26346, 109,          0) /* ItemDifficulty */
+     , (26346, 110,          0) /* ItemAllegianceRankLimit */
+     , (26346, 150,        103) /* HookPlacement - Hook */
+     , (26346, 151,          2) /* HookType - Wall */
+     , (26346, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26346,  15, True ) /* LightsStatus */
+     , (26346,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26346, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26346,   1, 'Scimitar Lake Cottages Portal Gem') /* Name */
+     , (26346,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26346,   1,   33556769) /* Setup */
+     , (26346,   3,  536870932) /* SoundTable */
+     , (26346,   6,   67111919) /* PaletteBase */
+     , (26346,   7,  268435723) /* ClothingBase */
+     , (26346,   8,  100675760) /* Icon */
+     , (26346,  22,  872415275) /* PhysicsEffectTable */
+     , (26346,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26346,  31,      15188) /* LinkedPortalOne - Scimitar Lake Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26347 Sclavavania Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26347 Sclavavania Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26347;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26347, 'gemportalsclavavania', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26347,   1,       2048) /* ItemType - Gem */
+     , (26347,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26347,   5,         10) /* EncumbranceVal */
+     , (26347,   8,         10) /* Mass */
+     , (26347,   9,          0) /* ValidLocations - None */
+     , (26347,  11,         20) /* MaxStackSize */
+     , (26347,  12,          1) /* StackSize */
+     , (26347,  13,         10) /* StackUnitEncumbrance */
+     , (26347,  14,         10) /* StackUnitMass */
+     , (26347,  15,        500) /* StackUnitValue */
+     , (26347,  16,          8) /* ItemUseable - Contained */
+     , (26347,  18,          1) /* UiEffects - Magical */
+     , (26347,  19,        500) /* Value */
+     , (26347,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26347,  94,         16) /* TargetType - Creature */
+     , (26347, 106,        210) /* ItemSpellcraft */
+     , (26347, 107,         50) /* ItemCurMana */
+     , (26347, 108,         50) /* ItemMaxMana */
+     , (26347, 109,          0) /* ItemDifficulty */
+     , (26347, 110,          0) /* ItemAllegianceRankLimit */
+     , (26347, 150,        103) /* HookPlacement - Hook */
+     , (26347, 151,          2) /* HookType - Wall */
+     , (26347, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26347,  15, True ) /* LightsStatus */
+     , (26347,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26347, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26347,   1, 'Sclavavania Portal Gem') /* Name */
+     , (26347,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26347,   1,   33556769) /* Setup */
+     , (26347,   3,  536870932) /* SoundTable */
+     , (26347,   6,   67111919) /* PaletteBase */
+     , (26347,   7,  268435723) /* ClothingBase */
+     , (26347,   8,  100675760) /* Icon */
+     , (26347,  22,  872415275) /* PhysicsEffectTable */
+     , (26347,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26347,  31,      14281) /* LinkedPortalOne - Sclavavania Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26348 Seaview Ridge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26348 Seaview Ridge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26348;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26348, 'gemportalseaviewridgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26348,   1,       2048) /* ItemType - Gem */
+     , (26348,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26348,   5,         10) /* EncumbranceVal */
+     , (26348,   8,         10) /* Mass */
+     , (26348,   9,          0) /* ValidLocations - None */
+     , (26348,  11,         20) /* MaxStackSize */
+     , (26348,  12,          1) /* StackSize */
+     , (26348,  13,         10) /* StackUnitEncumbrance */
+     , (26348,  14,         10) /* StackUnitMass */
+     , (26348,  15,        500) /* StackUnitValue */
+     , (26348,  16,          8) /* ItemUseable - Contained */
+     , (26348,  18,          1) /* UiEffects - Magical */
+     , (26348,  19,        500) /* Value */
+     , (26348,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26348,  94,         16) /* TargetType - Creature */
+     , (26348, 106,        210) /* ItemSpellcraft */
+     , (26348, 107,         50) /* ItemCurMana */
+     , (26348, 108,         50) /* ItemMaxMana */
+     , (26348, 109,          0) /* ItemDifficulty */
+     , (26348, 110,          0) /* ItemAllegianceRankLimit */
+     , (26348, 150,        103) /* HookPlacement - Hook */
+     , (26348, 151,          2) /* HookType - Wall */
+     , (26348, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26348,  15, True ) /* LightsStatus */
+     , (26348,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26348, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26348,   1, 'Seaview Ridge Cottages Portal Gem') /* Name */
+     , (26348,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26348,   1,   33556769) /* Setup */
+     , (26348,   3,  536870932) /* SoundTable */
+     , (26348,   6,   67111919) /* PaletteBase */
+     , (26348,   7,  268435723) /* ClothingBase */
+     , (26348,   8,  100675760) /* Icon */
+     , (26348,  22,  872415275) /* PhysicsEffectTable */
+     , (26348,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26348,  31,      13125) /* LinkedPortalOne - Seaview Ridge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26349 Secluded Valley Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26349 Secluded Valley Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26349;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26349, 'gemportalsecludedvalleycottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26349,   1,       2048) /* ItemType - Gem */
+     , (26349,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26349,   5,         10) /* EncumbranceVal */
+     , (26349,   8,         10) /* Mass */
+     , (26349,   9,          0) /* ValidLocations - None */
+     , (26349,  11,         20) /* MaxStackSize */
+     , (26349,  12,          1) /* StackSize */
+     , (26349,  13,         10) /* StackUnitEncumbrance */
+     , (26349,  14,         10) /* StackUnitMass */
+     , (26349,  15,        500) /* StackUnitValue */
+     , (26349,  16,          8) /* ItemUseable - Contained */
+     , (26349,  18,          1) /* UiEffects - Magical */
+     , (26349,  19,        500) /* Value */
+     , (26349,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26349,  94,         16) /* TargetType - Creature */
+     , (26349, 106,        210) /* ItemSpellcraft */
+     , (26349, 107,         50) /* ItemCurMana */
+     , (26349, 108,         50) /* ItemMaxMana */
+     , (26349, 109,          0) /* ItemDifficulty */
+     , (26349, 110,          0) /* ItemAllegianceRankLimit */
+     , (26349, 150,        103) /* HookPlacement - Hook */
+     , (26349, 151,          2) /* HookType - Wall */
+     , (26349, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26349,  15, True ) /* LightsStatus */
+     , (26349,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26349, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26349,   1, 'Secluded Valley Cottages Portal Gem') /* Name */
+     , (26349,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26349,   1,   33556769) /* Setup */
+     , (26349,   3,  536870932) /* SoundTable */
+     , (26349,   6,   67111919) /* PaletteBase */
+     , (26349,   7,  268435723) /* ClothingBase */
+     , (26349,   8,  100675760) /* Icon */
+     , (26349,  22,  872415275) /* PhysicsEffectTable */
+     , (26349,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26349,  31,      19158) /* LinkedPortalOne - Secluded Valley Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26350 Sennon Valley Retreat Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26350 Sennon Valley Retreat Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26350;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26350, 'gemportalsennonvalleyretreat', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26350,   1,       2048) /* ItemType - Gem */
+     , (26350,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26350,   5,         10) /* EncumbranceVal */
+     , (26350,   8,         10) /* Mass */
+     , (26350,   9,          0) /* ValidLocations - None */
+     , (26350,  11,         20) /* MaxStackSize */
+     , (26350,  12,          1) /* StackSize */
+     , (26350,  13,         10) /* StackUnitEncumbrance */
+     , (26350,  14,         10) /* StackUnitMass */
+     , (26350,  15,        500) /* StackUnitValue */
+     , (26350,  16,          8) /* ItemUseable - Contained */
+     , (26350,  18,          1) /* UiEffects - Magical */
+     , (26350,  19,        500) /* Value */
+     , (26350,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26350,  94,         16) /* TargetType - Creature */
+     , (26350, 106,        210) /* ItemSpellcraft */
+     , (26350, 107,         50) /* ItemCurMana */
+     , (26350, 108,         50) /* ItemMaxMana */
+     , (26350, 109,          0) /* ItemDifficulty */
+     , (26350, 110,          0) /* ItemAllegianceRankLimit */
+     , (26350, 150,        103) /* HookPlacement - Hook */
+     , (26350, 151,          2) /* HookType - Wall */
+     , (26350, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26350,  15, True ) /* LightsStatus */
+     , (26350,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26350, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26350,   1, 'Sennon Valley Retreat Portal Gem') /* Name */
+     , (26350,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26350,   1,   33556769) /* Setup */
+     , (26350,   3,  536870932) /* SoundTable */
+     , (26350,   6,   67111919) /* PaletteBase */
+     , (26350,   7,  268435723) /* ClothingBase */
+     , (26350,   8,  100675760) /* Icon */
+     , (26350,  22,  872415275) /* PhysicsEffectTable */
+     , (26350,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26350,  31,      12543) /* LinkedPortalOne - Sennon Valley Retreat Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26351 Serpent Hills Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26351 Serpent Hills Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26351;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26351, 'gemportalserpenthillssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26351,   1,       2048) /* ItemType - Gem */
+     , (26351,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26351,   5,         10) /* EncumbranceVal */
+     , (26351,   8,         10) /* Mass */
+     , (26351,   9,          0) /* ValidLocations - None */
+     , (26351,  11,         20) /* MaxStackSize */
+     , (26351,  12,          1) /* StackSize */
+     , (26351,  13,         10) /* StackUnitEncumbrance */
+     , (26351,  14,         10) /* StackUnitMass */
+     , (26351,  15,        500) /* StackUnitValue */
+     , (26351,  16,          8) /* ItemUseable - Contained */
+     , (26351,  18,          1) /* UiEffects - Magical */
+     , (26351,  19,        500) /* Value */
+     , (26351,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26351,  94,         16) /* TargetType - Creature */
+     , (26351, 106,        210) /* ItemSpellcraft */
+     , (26351, 107,         50) /* ItemCurMana */
+     , (26351, 108,         50) /* ItemMaxMana */
+     , (26351, 109,          0) /* ItemDifficulty */
+     , (26351, 110,          0) /* ItemAllegianceRankLimit */
+     , (26351, 150,        103) /* HookPlacement - Hook */
+     , (26351, 151,          2) /* HookType - Wall */
+     , (26351, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26351,  15, True ) /* LightsStatus */
+     , (26351,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26351, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26351,   1, 'Serpent Hills Settlement Portal Gem') /* Name */
+     , (26351,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26351,   1,   33556769) /* Setup */
+     , (26351,   3,  536870932) /* SoundTable */
+     , (26351,   6,   67111919) /* PaletteBase */
+     , (26351,   7,  268435723) /* ClothingBase */
+     , (26351,   8,  100675760) /* Icon */
+     , (26351,  22,  872415275) /* PhysicsEffectTable */
+     , (26351,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26351,  31,      12544) /* LinkedPortalOne - Serpent Hills Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26352 Shaky Ledge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26352 Shaky Ledge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26352;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26352, 'gemportalshakyledgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26352,   1,       2048) /* ItemType - Gem */
+     , (26352,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26352,   5,         10) /* EncumbranceVal */
+     , (26352,   8,         10) /* Mass */
+     , (26352,   9,          0) /* ValidLocations - None */
+     , (26352,  11,         20) /* MaxStackSize */
+     , (26352,  12,          1) /* StackSize */
+     , (26352,  13,         10) /* StackUnitEncumbrance */
+     , (26352,  14,         10) /* StackUnitMass */
+     , (26352,  15,        500) /* StackUnitValue */
+     , (26352,  16,          8) /* ItemUseable - Contained */
+     , (26352,  18,          1) /* UiEffects - Magical */
+     , (26352,  19,        500) /* Value */
+     , (26352,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26352,  94,         16) /* TargetType - Creature */
+     , (26352, 106,        210) /* ItemSpellcraft */
+     , (26352, 107,         50) /* ItemCurMana */
+     , (26352, 108,         50) /* ItemMaxMana */
+     , (26352, 109,          0) /* ItemDifficulty */
+     , (26352, 110,          0) /* ItemAllegianceRankLimit */
+     , (26352, 150,        103) /* HookPlacement - Hook */
+     , (26352, 151,          2) /* HookType - Wall */
+     , (26352, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26352,  15, True ) /* LightsStatus */
+     , (26352,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26352, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26352,   1, 'Shaky Ledge Cottages Portal Gem') /* Name */
+     , (26352,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26352,   1,   33556769) /* Setup */
+     , (26352,   3,  536870932) /* SoundTable */
+     , (26352,   6,   67111919) /* PaletteBase */
+     , (26352,   7,  268435723) /* ClothingBase */
+     , (26352,   8,  100675760) /* Icon */
+     , (26352,  22,  872415275) /* PhysicsEffectTable */
+     , (26352,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26352,  31,      19159) /* LinkedPortalOne - Shaky Ledge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26353 Shara Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26353 Shara Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26353;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26353, 'gemportalshara', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26353,   1,       2048) /* ItemType - Gem */
+     , (26353,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26353,   5,         10) /* EncumbranceVal */
+     , (26353,   8,         10) /* Mass */
+     , (26353,   9,          0) /* ValidLocations - None */
+     , (26353,  11,         20) /* MaxStackSize */
+     , (26353,  12,          1) /* StackSize */
+     , (26353,  13,         10) /* StackUnitEncumbrance */
+     , (26353,  14,         10) /* StackUnitMass */
+     , (26353,  15,        500) /* StackUnitValue */
+     , (26353,  16,          8) /* ItemUseable - Contained */
+     , (26353,  18,          1) /* UiEffects - Magical */
+     , (26353,  19,        500) /* Value */
+     , (26353,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26353,  94,         16) /* TargetType - Creature */
+     , (26353, 106,        210) /* ItemSpellcraft */
+     , (26353, 107,         50) /* ItemCurMana */
+     , (26353, 108,         50) /* ItemMaxMana */
+     , (26353, 109,          0) /* ItemDifficulty */
+     , (26353, 110,          0) /* ItemAllegianceRankLimit */
+     , (26353, 150,        103) /* HookPlacement - Hook */
+     , (26353, 151,          2) /* HookType - Wall */
+     , (26353, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26353,  15, True ) /* LightsStatus */
+     , (26353,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26353, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26353,   1, 'Shara Portal Gem') /* Name */
+     , (26353,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26353,   1,   33556769) /* Setup */
+     , (26353,   3,  536870932) /* SoundTable */
+     , (26353,   6,   67111919) /* PaletteBase */
+     , (26353,   7,  268435723) /* ClothingBase */
+     , (26353,   8,  100675760) /* Icon */
+     , (26353,  22,  872415275) /* PhysicsEffectTable */
+     , (26353,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26353,  31,      14665) /* LinkedPortalOne - Shara Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26354 Sharvale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26354 Sharvale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26354;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26354, 'gemportalsharvale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26354,   1,       2048) /* ItemType - Gem */
+     , (26354,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26354,   5,         10) /* EncumbranceVal */
+     , (26354,   8,         10) /* Mass */
+     , (26354,   9,          0) /* ValidLocations - None */
+     , (26354,  11,         20) /* MaxStackSize */
+     , (26354,  12,          1) /* StackSize */
+     , (26354,  13,         10) /* StackUnitEncumbrance */
+     , (26354,  14,         10) /* StackUnitMass */
+     , (26354,  15,        500) /* StackUnitValue */
+     , (26354,  16,          8) /* ItemUseable - Contained */
+     , (26354,  18,          1) /* UiEffects - Magical */
+     , (26354,  19,        500) /* Value */
+     , (26354,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26354,  94,         16) /* TargetType - Creature */
+     , (26354, 106,        210) /* ItemSpellcraft */
+     , (26354, 107,         50) /* ItemCurMana */
+     , (26354, 108,         50) /* ItemMaxMana */
+     , (26354, 109,          0) /* ItemDifficulty */
+     , (26354, 110,          0) /* ItemAllegianceRankLimit */
+     , (26354, 150,        103) /* HookPlacement - Hook */
+     , (26354, 151,          2) /* HookType - Wall */
+     , (26354, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26354,  15, True ) /* LightsStatus */
+     , (26354,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26354, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26354,   1, 'Sharvale Portal Gem') /* Name */
+     , (26354,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26354,   1,   33556769) /* Setup */
+     , (26354,   3,  536870932) /* SoundTable */
+     , (26354,   6,   67111919) /* PaletteBase */
+     , (26354,   7,  268435723) /* ClothingBase */
+     , (26354,   8,  100675760) /* Icon */
+     , (26354,  22,  872415275) /* PhysicsEffectTable */
+     , (26354,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26354,  31,      13126) /* LinkedPortalOne - Sharvale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26355 Shian-To Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26355 Shian-To Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26355;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26355, 'gemportalshiantocottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26355,   1,       2048) /* ItemType - Gem */
+     , (26355,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26355,   5,         10) /* EncumbranceVal */
+     , (26355,   8,         10) /* Mass */
+     , (26355,   9,          0) /* ValidLocations - None */
+     , (26355,  11,         20) /* MaxStackSize */
+     , (26355,  12,          1) /* StackSize */
+     , (26355,  13,         10) /* StackUnitEncumbrance */
+     , (26355,  14,         10) /* StackUnitMass */
+     , (26355,  15,        500) /* StackUnitValue */
+     , (26355,  16,          8) /* ItemUseable - Contained */
+     , (26355,  18,          1) /* UiEffects - Magical */
+     , (26355,  19,        500) /* Value */
+     , (26355,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26355,  94,         16) /* TargetType - Creature */
+     , (26355, 106,        210) /* ItemSpellcraft */
+     , (26355, 107,         50) /* ItemCurMana */
+     , (26355, 108,         50) /* ItemMaxMana */
+     , (26355, 109,          0) /* ItemDifficulty */
+     , (26355, 110,          0) /* ItemAllegianceRankLimit */
+     , (26355, 150,        103) /* HookPlacement - Hook */
+     , (26355, 151,          2) /* HookType - Wall */
+     , (26355, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26355,  15, True ) /* LightsStatus */
+     , (26355,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26355, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26355,   1, 'Shian-To Cottages Portal Gem') /* Name */
+     , (26355,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26355,   1,   33556769) /* Setup */
+     , (26355,   3,  536870932) /* SoundTable */
+     , (26355,   6,   67111919) /* PaletteBase */
+     , (26355,   7,  268435723) /* ClothingBase */
+     , (26355,   8,  100675760) /* Icon */
+     , (26355,  22,  872415275) /* PhysicsEffectTable */
+     , (26355,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26355,  31,      12545) /* LinkedPortalOne - Shian-To Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26356 Shield of Ispar Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26356 Shield of Ispar Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26356;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26356, 'gemportalshieldofisparvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26356,   1,       2048) /* ItemType - Gem */
+     , (26356,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26356,   5,         10) /* EncumbranceVal */
+     , (26356,   8,         10) /* Mass */
+     , (26356,   9,          0) /* ValidLocations - None */
+     , (26356,  11,         20) /* MaxStackSize */
+     , (26356,  12,          1) /* StackSize */
+     , (26356,  13,         10) /* StackUnitEncumbrance */
+     , (26356,  14,         10) /* StackUnitMass */
+     , (26356,  15,        500) /* StackUnitValue */
+     , (26356,  16,          8) /* ItemUseable - Contained */
+     , (26356,  18,          1) /* UiEffects - Magical */
+     , (26356,  19,        500) /* Value */
+     , (26356,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26356,  94,         16) /* TargetType - Creature */
+     , (26356, 106,        210) /* ItemSpellcraft */
+     , (26356, 107,         50) /* ItemCurMana */
+     , (26356, 108,         50) /* ItemMaxMana */
+     , (26356, 109,          0) /* ItemDifficulty */
+     , (26356, 110,          0) /* ItemAllegianceRankLimit */
+     , (26356, 150,        103) /* HookPlacement - Hook */
+     , (26356, 151,          2) /* HookType - Wall */
+     , (26356, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26356,  15, True ) /* LightsStatus */
+     , (26356,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26356, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26356,   1, 'Shield of Ispar Villas Portal Gem') /* Name */
+     , (26356,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26356,   1,   33556769) /* Setup */
+     , (26356,   3,  536870932) /* SoundTable */
+     , (26356,   6,   67111919) /* PaletteBase */
+     , (26356,   7,  268435723) /* ClothingBase */
+     , (26356,   8,  100675760) /* Icon */
+     , (26356,  22,  872415275) /* PhysicsEffectTable */
+     , (26356,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26356,  31,      15682) /* LinkedPortalOne - Shield of Ispar Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26357 Shield of Valor Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26357 Shield of Valor Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26357;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26357, 'gemportalshieldofvalorcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26357,   1,       2048) /* ItemType - Gem */
+     , (26357,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26357,   5,         10) /* EncumbranceVal */
+     , (26357,   8,         10) /* Mass */
+     , (26357,   9,          0) /* ValidLocations - None */
+     , (26357,  11,         20) /* MaxStackSize */
+     , (26357,  12,          1) /* StackSize */
+     , (26357,  13,         10) /* StackUnitEncumbrance */
+     , (26357,  14,         10) /* StackUnitMass */
+     , (26357,  15,        500) /* StackUnitValue */
+     , (26357,  16,          8) /* ItemUseable - Contained */
+     , (26357,  18,          1) /* UiEffects - Magical */
+     , (26357,  19,        500) /* Value */
+     , (26357,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26357,  94,         16) /* TargetType - Creature */
+     , (26357, 106,        210) /* ItemSpellcraft */
+     , (26357, 107,         50) /* ItemCurMana */
+     , (26357, 108,         50) /* ItemMaxMana */
+     , (26357, 109,          0) /* ItemDifficulty */
+     , (26357, 110,          0) /* ItemAllegianceRankLimit */
+     , (26357, 150,        103) /* HookPlacement - Hook */
+     , (26357, 151,          2) /* HookType - Wall */
+     , (26357, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26357,  15, True ) /* LightsStatus */
+     , (26357,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26357, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26357,   1, 'Shield of Valor Cottages Portal Gem') /* Name */
+     , (26357,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26357,   1,   33556769) /* Setup */
+     , (26357,   3,  536870932) /* SoundTable */
+     , (26357,   6,   67111919) /* PaletteBase */
+     , (26357,   7,  268435723) /* ClothingBase */
+     , (26357,   8,  100675760) /* Icon */
+     , (26357,  22,  872415275) /* PhysicsEffectTable */
+     , (26357,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26357,  31,      15683) /* LinkedPortalOne - Shield of Valor Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26358 Shore Vista Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26358 Shore Vista Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26358;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26358, 'gemportalshorevistacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26358,   1,       2048) /* ItemType - Gem */
+     , (26358,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26358,   5,         10) /* EncumbranceVal */
+     , (26358,   8,         10) /* Mass */
+     , (26358,   9,          0) /* ValidLocations - None */
+     , (26358,  11,         20) /* MaxStackSize */
+     , (26358,  12,          1) /* StackSize */
+     , (26358,  13,         10) /* StackUnitEncumbrance */
+     , (26358,  14,         10) /* StackUnitMass */
+     , (26358,  15,        500) /* StackUnitValue */
+     , (26358,  16,          8) /* ItemUseable - Contained */
+     , (26358,  18,          1) /* UiEffects - Magical */
+     , (26358,  19,        500) /* Value */
+     , (26358,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26358,  94,         16) /* TargetType - Creature */
+     , (26358, 106,        210) /* ItemSpellcraft */
+     , (26358, 107,         50) /* ItemCurMana */
+     , (26358, 108,         50) /* ItemMaxMana */
+     , (26358, 109,          0) /* ItemDifficulty */
+     , (26358, 110,          0) /* ItemAllegianceRankLimit */
+     , (26358, 150,        103) /* HookPlacement - Hook */
+     , (26358, 151,          2) /* HookType - Wall */
+     , (26358, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26358,  15, True ) /* LightsStatus */
+     , (26358,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26358, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26358,   1, 'Shore Vista Cottages Portal Gem') /* Name */
+     , (26358,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26358,   1,   33556769) /* Setup */
+     , (26358,   3,  536870932) /* SoundTable */
+     , (26358,   6,   67111919) /* PaletteBase */
+     , (26358,   7,  268435723) /* ClothingBase */
+     , (26358,   8,  100675760) /* Icon */
+     , (26358,  22,  872415275) /* PhysicsEffectTable */
+     , (26358,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26358,  31,      15189) /* LinkedPortalOne - Shore Vista Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26359 Shou-Zin Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26359 Shou-Zin Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26359;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26359, 'gemportalshouzin', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26359,   1,       2048) /* ItemType - Gem */
+     , (26359,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26359,   5,         10) /* EncumbranceVal */
+     , (26359,   8,         10) /* Mass */
+     , (26359,   9,          0) /* ValidLocations - None */
+     , (26359,  11,         20) /* MaxStackSize */
+     , (26359,  12,          1) /* StackSize */
+     , (26359,  13,         10) /* StackUnitEncumbrance */
+     , (26359,  14,         10) /* StackUnitMass */
+     , (26359,  15,        500) /* StackUnitValue */
+     , (26359,  16,          8) /* ItemUseable - Contained */
+     , (26359,  18,          1) /* UiEffects - Magical */
+     , (26359,  19,        500) /* Value */
+     , (26359,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26359,  94,         16) /* TargetType - Creature */
+     , (26359, 106,        210) /* ItemSpellcraft */
+     , (26359, 107,         50) /* ItemCurMana */
+     , (26359, 108,         50) /* ItemMaxMana */
+     , (26359, 109,          0) /* ItemDifficulty */
+     , (26359, 110,          0) /* ItemAllegianceRankLimit */
+     , (26359, 150,        103) /* HookPlacement - Hook */
+     , (26359, 151,          2) /* HookType - Wall */
+     , (26359, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26359,  15, True ) /* LightsStatus */
+     , (26359,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26359, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26359,   1, 'Shou-Zin Portal Gem') /* Name */
+     , (26359,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26359,   1,   33556769) /* Setup */
+     , (26359,   3,  536870932) /* SoundTable */
+     , (26359,   6,   67111919) /* PaletteBase */
+     , (26359,   7,  268435723) /* ClothingBase */
+     , (26359,   8,  100675760) /* Icon */
+     , (26359,  22,  872415275) /* PhysicsEffectTable */
+     , (26359,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26359,  31,      13127) /* LinkedPortalOne - Shou-Zin Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26360 Siege Road Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26360 Siege Road Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26360;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26360, 'gemportalsiegeroadsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26360,   1,       2048) /* ItemType - Gem */
+     , (26360,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26360,   5,         10) /* EncumbranceVal */
+     , (26360,   8,         10) /* Mass */
+     , (26360,   9,          0) /* ValidLocations - None */
+     , (26360,  11,         20) /* MaxStackSize */
+     , (26360,  12,          1) /* StackSize */
+     , (26360,  13,         10) /* StackUnitEncumbrance */
+     , (26360,  14,         10) /* StackUnitMass */
+     , (26360,  15,        500) /* StackUnitValue */
+     , (26360,  16,          8) /* ItemUseable - Contained */
+     , (26360,  18,          1) /* UiEffects - Magical */
+     , (26360,  19,        500) /* Value */
+     , (26360,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26360,  94,         16) /* TargetType - Creature */
+     , (26360, 106,        210) /* ItemSpellcraft */
+     , (26360, 107,         50) /* ItemCurMana */
+     , (26360, 108,         50) /* ItemMaxMana */
+     , (26360, 109,          0) /* ItemDifficulty */
+     , (26360, 110,          0) /* ItemAllegianceRankLimit */
+     , (26360, 150,        103) /* HookPlacement - Hook */
+     , (26360, 151,          2) /* HookType - Wall */
+     , (26360, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26360,  15, True ) /* LightsStatus */
+     , (26360,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26360, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26360,   1, 'Siege Road Settlement Portal Gem') /* Name */
+     , (26360,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26360,   1,   33556769) /* Setup */
+     , (26360,   3,  536870932) /* SoundTable */
+     , (26360,   6,   67111919) /* PaletteBase */
+     , (26360,   7,  268435723) /* ClothingBase */
+     , (26360,   8,  100675760) /* Icon */
+     , (26360,  22,  872415275) /* PhysicsEffectTable */
+     , (26360,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26360,  31,      12546) /* LinkedPortalOne - Siege Road Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26361 Siege Road Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26361 Siege Road Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26361;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26361, 'gemportalsiegeroadvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26361,   1,       2048) /* ItemType - Gem */
+     , (26361,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26361,   5,         10) /* EncumbranceVal */
+     , (26361,   8,         10) /* Mass */
+     , (26361,   9,          0) /* ValidLocations - None */
+     , (26361,  11,         20) /* MaxStackSize */
+     , (26361,  12,          1) /* StackSize */
+     , (26361,  13,         10) /* StackUnitEncumbrance */
+     , (26361,  14,         10) /* StackUnitMass */
+     , (26361,  15,        500) /* StackUnitValue */
+     , (26361,  16,          8) /* ItemUseable - Contained */
+     , (26361,  18,          1) /* UiEffects - Magical */
+     , (26361,  19,        500) /* Value */
+     , (26361,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26361,  94,         16) /* TargetType - Creature */
+     , (26361, 106,        210) /* ItemSpellcraft */
+     , (26361, 107,         50) /* ItemCurMana */
+     , (26361, 108,         50) /* ItemMaxMana */
+     , (26361, 109,          0) /* ItemDifficulty */
+     , (26361, 110,          0) /* ItemAllegianceRankLimit */
+     , (26361, 150,        103) /* HookPlacement - Hook */
+     , (26361, 151,          2) /* HookType - Wall */
+     , (26361, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26361,  15, True ) /* LightsStatus */
+     , (26361,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26361, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26361,   1, 'Siege Road Villas Portal Gem') /* Name */
+     , (26361,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26361,   1,   33556769) /* Setup */
+     , (26361,   3,  536870932) /* SoundTable */
+     , (26361,   6,   67111919) /* PaletteBase */
+     , (26361,   7,  268435723) /* ClothingBase */
+     , (26361,   8,  100675760) /* Icon */
+     , (26361,  22,  872415275) /* PhysicsEffectTable */
+     , (26361,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26361,  31,      14282) /* LinkedPortalOne - Siege Road Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26362 Simda'r Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26362 Simda'r Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26362;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26362, 'gemportalsimdarvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26362,   1,       2048) /* ItemType - Gem */
+     , (26362,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26362,   5,         10) /* EncumbranceVal */
+     , (26362,   8,         10) /* Mass */
+     , (26362,   9,          0) /* ValidLocations - None */
+     , (26362,  11,         20) /* MaxStackSize */
+     , (26362,  12,          1) /* StackSize */
+     , (26362,  13,         10) /* StackUnitEncumbrance */
+     , (26362,  14,         10) /* StackUnitMass */
+     , (26362,  15,        500) /* StackUnitValue */
+     , (26362,  16,          8) /* ItemUseable - Contained */
+     , (26362,  18,          1) /* UiEffects - Magical */
+     , (26362,  19,        500) /* Value */
+     , (26362,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26362,  94,         16) /* TargetType - Creature */
+     , (26362, 106,        210) /* ItemSpellcraft */
+     , (26362, 107,         50) /* ItemCurMana */
+     , (26362, 108,         50) /* ItemMaxMana */
+     , (26362, 109,          0) /* ItemDifficulty */
+     , (26362, 110,          0) /* ItemAllegianceRankLimit */
+     , (26362, 150,        103) /* HookPlacement - Hook */
+     , (26362, 151,          2) /* HookType - Wall */
+     , (26362, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26362,  15, True ) /* LightsStatus */
+     , (26362,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26362, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26362,   1, 'Simda''r Villas Portal Gem') /* Name */
+     , (26362,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26362,   1,   33556769) /* Setup */
+     , (26362,   3,  536870932) /* SoundTable */
+     , (26362,   6,   67111919) /* PaletteBase */
+     , (26362,   7,  268435723) /* ClothingBase */
+     , (26362,   8,  100675760) /* Icon */
+     , (26362,  22,  872415275) /* PhysicsEffectTable */
+     , (26362,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26362,  31,      13128) /* LinkedPortalOne - Simda'r Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26363 Slidara Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26363 Slidara Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26363;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26363, 'gemportalslidaracottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26363,   1,       2048) /* ItemType - Gem */
+     , (26363,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26363,   5,         10) /* EncumbranceVal */
+     , (26363,   8,         10) /* Mass */
+     , (26363,   9,          0) /* ValidLocations - None */
+     , (26363,  11,         20) /* MaxStackSize */
+     , (26363,  12,          1) /* StackSize */
+     , (26363,  13,         10) /* StackUnitEncumbrance */
+     , (26363,  14,         10) /* StackUnitMass */
+     , (26363,  15,        500) /* StackUnitValue */
+     , (26363,  16,          8) /* ItemUseable - Contained */
+     , (26363,  18,          1) /* UiEffects - Magical */
+     , (26363,  19,        500) /* Value */
+     , (26363,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26363,  94,         16) /* TargetType - Creature */
+     , (26363, 106,        210) /* ItemSpellcraft */
+     , (26363, 107,         50) /* ItemCurMana */
+     , (26363, 108,         50) /* ItemMaxMana */
+     , (26363, 109,          0) /* ItemDifficulty */
+     , (26363, 110,          0) /* ItemAllegianceRankLimit */
+     , (26363, 150,        103) /* HookPlacement - Hook */
+     , (26363, 151,          2) /* HookType - Wall */
+     , (26363, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26363,  15, True ) /* LightsStatus */
+     , (26363,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26363, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26363,   1, 'Slidara Cottages Portal Gem') /* Name */
+     , (26363,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26363,   1,   33556769) /* Setup */
+     , (26363,   3,  536870932) /* SoundTable */
+     , (26363,   6,   67111919) /* PaletteBase */
+     , (26363,   7,  268435723) /* ClothingBase */
+     , (26363,   8,  100675760) /* Icon */
+     , (26363,  22,  872415275) /* PhysicsEffectTable */
+     , (26363,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26363,  31,      14283) /* LinkedPortalOne - Slidara Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26364 Slinker Meadows Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26364 Slinker Meadows Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26364;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26364, 'gemportalslinkermeadows', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26364,   1,       2048) /* ItemType - Gem */
+     , (26364,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26364,   5,         10) /* EncumbranceVal */
+     , (26364,   8,         10) /* Mass */
+     , (26364,   9,          0) /* ValidLocations - None */
+     , (26364,  11,         20) /* MaxStackSize */
+     , (26364,  12,          1) /* StackSize */
+     , (26364,  13,         10) /* StackUnitEncumbrance */
+     , (26364,  14,         10) /* StackUnitMass */
+     , (26364,  15,        500) /* StackUnitValue */
+     , (26364,  16,          8) /* ItemUseable - Contained */
+     , (26364,  18,          1) /* UiEffects - Magical */
+     , (26364,  19,        500) /* Value */
+     , (26364,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26364,  94,         16) /* TargetType - Creature */
+     , (26364, 106,        210) /* ItemSpellcraft */
+     , (26364, 107,         50) /* ItemCurMana */
+     , (26364, 108,         50) /* ItemMaxMana */
+     , (26364, 109,          0) /* ItemDifficulty */
+     , (26364, 110,          0) /* ItemAllegianceRankLimit */
+     , (26364, 150,        103) /* HookPlacement - Hook */
+     , (26364, 151,          2) /* HookType - Wall */
+     , (26364, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26364,  15, True ) /* LightsStatus */
+     , (26364,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26364, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26364,   1, 'Slinker Meadows Portal Gem') /* Name */
+     , (26364,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26364,   1,   33556769) /* Setup */
+     , (26364,   3,  536870932) /* SoundTable */
+     , (26364,   6,   67111919) /* PaletteBase */
+     , (26364,   7,  268435723) /* ClothingBase */
+     , (26364,   8,  100675760) /* Icon */
+     , (26364,  22,  872415275) /* PhysicsEffectTable */
+     , (26364,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26364,  31,      13129) /* LinkedPortalOne - Slinker Meadows Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26365 Sliver-of-BlueCottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26365 Sliver-of-BlueCottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26365;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26365, 'gemportalsliverofbluecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26365,   1,       2048) /* ItemType - Gem */
+     , (26365,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26365,   5,         10) /* EncumbranceVal */
+     , (26365,   8,         10) /* Mass */
+     , (26365,   9,          0) /* ValidLocations - None */
+     , (26365,  11,         20) /* MaxStackSize */
+     , (26365,  12,          1) /* StackSize */
+     , (26365,  13,         10) /* StackUnitEncumbrance */
+     , (26365,  14,         10) /* StackUnitMass */
+     , (26365,  15,        500) /* StackUnitValue */
+     , (26365,  16,          8) /* ItemUseable - Contained */
+     , (26365,  18,          1) /* UiEffects - Magical */
+     , (26365,  19,        500) /* Value */
+     , (26365,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26365,  94,         16) /* TargetType - Creature */
+     , (26365, 106,        210) /* ItemSpellcraft */
+     , (26365, 107,         50) /* ItemCurMana */
+     , (26365, 108,         50) /* ItemMaxMana */
+     , (26365, 109,          0) /* ItemDifficulty */
+     , (26365, 110,          0) /* ItemAllegianceRankLimit */
+     , (26365, 150,        103) /* HookPlacement - Hook */
+     , (26365, 151,          2) /* HookType - Wall */
+     , (26365, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26365,  15, True ) /* LightsStatus */
+     , (26365,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26365, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26365,   1, 'Sliver-of-BlueCottages Portal Gem') /* Name */
+     , (26365,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26365,   1,   33556769) /* Setup */
+     , (26365,   3,  536870932) /* SoundTable */
+     , (26365,   6,   67111919) /* PaletteBase */
+     , (26365,   7,  268435723) /* ClothingBase */
+     , (26365,   8,  100675760) /* Icon */
+     , (26365,  22,  872415275) /* PhysicsEffectTable */
+     , (26365,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26365,  31,      15190) /* LinkedPortalOne - Sliver-of-BlueCottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26366 Snakehead Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26366 Snakehead Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26366;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26366, 'gemportalsnakehead', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26366,   1,       2048) /* ItemType - Gem */
+     , (26366,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26366,   5,         10) /* EncumbranceVal */
+     , (26366,   8,         10) /* Mass */
+     , (26366,   9,          0) /* ValidLocations - None */
+     , (26366,  11,         20) /* MaxStackSize */
+     , (26366,  12,          1) /* StackSize */
+     , (26366,  13,         10) /* StackUnitEncumbrance */
+     , (26366,  14,         10) /* StackUnitMass */
+     , (26366,  15,        500) /* StackUnitValue */
+     , (26366,  16,          8) /* ItemUseable - Contained */
+     , (26366,  18,          1) /* UiEffects - Magical */
+     , (26366,  19,        500) /* Value */
+     , (26366,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26366,  94,         16) /* TargetType - Creature */
+     , (26366, 106,        210) /* ItemSpellcraft */
+     , (26366, 107,         50) /* ItemCurMana */
+     , (26366, 108,         50) /* ItemMaxMana */
+     , (26366, 109,          0) /* ItemDifficulty */
+     , (26366, 110,          0) /* ItemAllegianceRankLimit */
+     , (26366, 150,        103) /* HookPlacement - Hook */
+     , (26366, 151,          2) /* HookType - Wall */
+     , (26366, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26366,  15, True ) /* LightsStatus */
+     , (26366,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26366, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26366,   1, 'Snakehead Portal Gem') /* Name */
+     , (26366,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26366,   1,   33556769) /* Setup */
+     , (26366,   3,  536870932) /* SoundTable */
+     , (26366,   6,   67111919) /* PaletteBase */
+     , (26366,   7,  268435723) /* ClothingBase */
+     , (26366,   8,  100675760) /* Icon */
+     , (26366,  22,  872415275) /* PhysicsEffectTable */
+     , (26366,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26366,  31,      14284) /* LinkedPortalOne - Snakehead Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26367 Snowy Valley Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26367 Snowy Valley Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26367;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26367, 'gemportalsnowyvalley', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26367,   1,       2048) /* ItemType - Gem */
+     , (26367,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26367,   5,         10) /* EncumbranceVal */
+     , (26367,   8,         10) /* Mass */
+     , (26367,   9,          0) /* ValidLocations - None */
+     , (26367,  11,         20) /* MaxStackSize */
+     , (26367,  12,          1) /* StackSize */
+     , (26367,  13,         10) /* StackUnitEncumbrance */
+     , (26367,  14,         10) /* StackUnitMass */
+     , (26367,  15,        500) /* StackUnitValue */
+     , (26367,  16,          8) /* ItemUseable - Contained */
+     , (26367,  18,          1) /* UiEffects - Magical */
+     , (26367,  19,        500) /* Value */
+     , (26367,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26367,  94,         16) /* TargetType - Creature */
+     , (26367, 106,        210) /* ItemSpellcraft */
+     , (26367, 107,         50) /* ItemCurMana */
+     , (26367, 108,         50) /* ItemMaxMana */
+     , (26367, 109,          0) /* ItemDifficulty */
+     , (26367, 110,          0) /* ItemAllegianceRankLimit */
+     , (26367, 150,        103) /* HookPlacement - Hook */
+     , (26367, 151,          2) /* HookType - Wall */
+     , (26367, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26367,  15, True ) /* LightsStatus */
+     , (26367,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26367, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26367,   1, 'Snowy Valley Portal Gem') /* Name */
+     , (26367,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26367,   1,   33556769) /* Setup */
+     , (26367,   3,  536870932) /* SoundTable */
+     , (26367,   6,   67111919) /* PaletteBase */
+     , (26367,   7,  268435723) /* ClothingBase */
+     , (26367,   8,  100675760) /* Icon */
+     , (26367,  22,  872415275) /* PhysicsEffectTable */
+     , (26367,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26367,  31,      13130) /* LinkedPortalOne - Snowy Valley Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26368 Solstice Hill Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26368 Solstice Hill Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26368;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26368, 'gemportalsolsticehill', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26368,   1,       2048) /* ItemType - Gem */
+     , (26368,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26368,   5,         10) /* EncumbranceVal */
+     , (26368,   8,         10) /* Mass */
+     , (26368,   9,          0) /* ValidLocations - None */
+     , (26368,  11,         20) /* MaxStackSize */
+     , (26368,  12,          1) /* StackSize */
+     , (26368,  13,         10) /* StackUnitEncumbrance */
+     , (26368,  14,         10) /* StackUnitMass */
+     , (26368,  15,        500) /* StackUnitValue */
+     , (26368,  16,          8) /* ItemUseable - Contained */
+     , (26368,  18,          1) /* UiEffects - Magical */
+     , (26368,  19,        500) /* Value */
+     , (26368,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26368,  94,         16) /* TargetType - Creature */
+     , (26368, 106,        210) /* ItemSpellcraft */
+     , (26368, 107,         50) /* ItemCurMana */
+     , (26368, 108,         50) /* ItemMaxMana */
+     , (26368, 109,          0) /* ItemDifficulty */
+     , (26368, 110,          0) /* ItemAllegianceRankLimit */
+     , (26368, 150,        103) /* HookPlacement - Hook */
+     , (26368, 151,          2) /* HookType - Wall */
+     , (26368, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26368,  15, True ) /* LightsStatus */
+     , (26368,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26368, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26368,   1, 'Solstice Hill Portal Gem') /* Name */
+     , (26368,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26368,   1,   33556769) /* Setup */
+     , (26368,   3,  536870932) /* SoundTable */
+     , (26368,   6,   67111919) /* PaletteBase */
+     , (26368,   7,  268435723) /* ClothingBase */
+     , (26368,   8,  100675760) /* Icon */
+     , (26368,  22,  872415275) /* PhysicsEffectTable */
+     , (26368,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26368,  31,      14666) /* LinkedPortalOne - Solstice Hill Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26369 Soltan Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26369 Soltan Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26369;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26369, 'gemportalsoltanvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26369,   1,       2048) /* ItemType - Gem */
+     , (26369,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26369,   5,         10) /* EncumbranceVal */
+     , (26369,   8,         10) /* Mass */
+     , (26369,   9,          0) /* ValidLocations - None */
+     , (26369,  11,         20) /* MaxStackSize */
+     , (26369,  12,          1) /* StackSize */
+     , (26369,  13,         10) /* StackUnitEncumbrance */
+     , (26369,  14,         10) /* StackUnitMass */
+     , (26369,  15,        500) /* StackUnitValue */
+     , (26369,  16,          8) /* ItemUseable - Contained */
+     , (26369,  18,          1) /* UiEffects - Magical */
+     , (26369,  19,        500) /* Value */
+     , (26369,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26369,  94,         16) /* TargetType - Creature */
+     , (26369, 106,        210) /* ItemSpellcraft */
+     , (26369, 107,         50) /* ItemCurMana */
+     , (26369, 108,         50) /* ItemMaxMana */
+     , (26369, 109,          0) /* ItemDifficulty */
+     , (26369, 110,          0) /* ItemAllegianceRankLimit */
+     , (26369, 150,        103) /* HookPlacement - Hook */
+     , (26369, 151,          2) /* HookType - Wall */
+     , (26369, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26369,  15, True ) /* LightsStatus */
+     , (26369,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26369, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26369,   1, 'Soltan Villas Portal Gem') /* Name */
+     , (26369,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26369,   1,   33556769) /* Setup */
+     , (26369,   3,  536870932) /* SoundTable */
+     , (26369,   6,   67111919) /* PaletteBase */
+     , (26369,   7,  268435723) /* ClothingBase */
+     , (26369,   8,  100675760) /* Icon */
+     , (26369,  22,  872415275) /* PhysicsEffectTable */
+     , (26369,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26369,  31,      15191) /* LinkedPortalOne - Soltan Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26370 Sonel Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26370 Sonel Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26370;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26370, 'gemportalsonel', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26370,   1,       2048) /* ItemType - Gem */
+     , (26370,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26370,   5,         10) /* EncumbranceVal */
+     , (26370,   8,         10) /* Mass */
+     , (26370,   9,          0) /* ValidLocations - None */
+     , (26370,  11,         20) /* MaxStackSize */
+     , (26370,  12,          1) /* StackSize */
+     , (26370,  13,         10) /* StackUnitEncumbrance */
+     , (26370,  14,         10) /* StackUnitMass */
+     , (26370,  15,        500) /* StackUnitValue */
+     , (26370,  16,          8) /* ItemUseable - Contained */
+     , (26370,  18,          1) /* UiEffects - Magical */
+     , (26370,  19,        500) /* Value */
+     , (26370,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26370,  94,         16) /* TargetType - Creature */
+     , (26370, 106,        210) /* ItemSpellcraft */
+     , (26370, 107,         50) /* ItemCurMana */
+     , (26370, 108,         50) /* ItemMaxMana */
+     , (26370, 109,          0) /* ItemDifficulty */
+     , (26370, 110,          0) /* ItemAllegianceRankLimit */
+     , (26370, 150,        103) /* HookPlacement - Hook */
+     , (26370, 151,          2) /* HookType - Wall */
+     , (26370, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26370,  15, True ) /* LightsStatus */
+     , (26370,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26370, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26370,   1, 'Sonel Portal Gem') /* Name */
+     , (26370,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26370,   1,   33556769) /* Setup */
+     , (26370,   3,  536870932) /* SoundTable */
+     , (26370,   6,   67111919) /* PaletteBase */
+     , (26370,   7,  268435723) /* ClothingBase */
+     , (26370,   8,  100675760) /* Icon */
+     , (26370,  22,  872415275) /* PhysicsEffectTable */
+     , (26370,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26370,  31,      12547) /* LinkedPortalOne - Sonel Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26371 Songview Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26371 Songview Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26371;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26371, 'gemportalsongview', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26371,   1,       2048) /* ItemType - Gem */
+     , (26371,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26371,   5,         10) /* EncumbranceVal */
+     , (26371,   8,         10) /* Mass */
+     , (26371,   9,          0) /* ValidLocations - None */
+     , (26371,  11,         20) /* MaxStackSize */
+     , (26371,  12,          1) /* StackSize */
+     , (26371,  13,         10) /* StackUnitEncumbrance */
+     , (26371,  14,         10) /* StackUnitMass */
+     , (26371,  15,        500) /* StackUnitValue */
+     , (26371,  16,          8) /* ItemUseable - Contained */
+     , (26371,  18,          1) /* UiEffects - Magical */
+     , (26371,  19,        500) /* Value */
+     , (26371,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26371,  94,         16) /* TargetType - Creature */
+     , (26371, 106,        210) /* ItemSpellcraft */
+     , (26371, 107,         50) /* ItemCurMana */
+     , (26371, 108,         50) /* ItemMaxMana */
+     , (26371, 109,          0) /* ItemDifficulty */
+     , (26371, 110,          0) /* ItemAllegianceRankLimit */
+     , (26371, 150,        103) /* HookPlacement - Hook */
+     , (26371, 151,          2) /* HookType - Wall */
+     , (26371, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26371,  15, True ) /* LightsStatus */
+     , (26371,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26371, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26371,   1, 'Songview Portal Gem') /* Name */
+     , (26371,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26371,   1,   33556769) /* Setup */
+     , (26371,   3,  536870932) /* SoundTable */
+     , (26371,   6,   67111919) /* PaletteBase */
+     , (26371,   7,  268435723) /* ClothingBase */
+     , (26371,   8,  100675760) /* Icon */
+     , (26371,  22,  872415275) /* PhysicsEffectTable */
+     , (26371,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26371,  31,      15684) /* LinkedPortalOne - Songview Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26372 Sonpay Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26372 Sonpay Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26372;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26372, 'gemportalsonpay', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26372,   1,       2048) /* ItemType - Gem */
+     , (26372,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26372,   5,         10) /* EncumbranceVal */
+     , (26372,   8,         10) /* Mass */
+     , (26372,   9,          0) /* ValidLocations - None */
+     , (26372,  11,         20) /* MaxStackSize */
+     , (26372,  12,          1) /* StackSize */
+     , (26372,  13,         10) /* StackUnitEncumbrance */
+     , (26372,  14,         10) /* StackUnitMass */
+     , (26372,  15,        500) /* StackUnitValue */
+     , (26372,  16,          8) /* ItemUseable - Contained */
+     , (26372,  18,          1) /* UiEffects - Magical */
+     , (26372,  19,        500) /* Value */
+     , (26372,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26372,  94,         16) /* TargetType - Creature */
+     , (26372, 106,        210) /* ItemSpellcraft */
+     , (26372, 107,         50) /* ItemCurMana */
+     , (26372, 108,         50) /* ItemMaxMana */
+     , (26372, 109,          0) /* ItemDifficulty */
+     , (26372, 110,          0) /* ItemAllegianceRankLimit */
+     , (26372, 150,        103) /* HookPlacement - Hook */
+     , (26372, 151,          2) /* HookType - Wall */
+     , (26372, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26372,  15, True ) /* LightsStatus */
+     , (26372,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26372, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26372,   1, 'Sonpay Portal Gem') /* Name */
+     , (26372,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26372,   1,   33556769) /* Setup */
+     , (26372,   3,  536870932) /* SoundTable */
+     , (26372,   6,   67111919) /* PaletteBase */
+     , (26372,   7,  268435723) /* ClothingBase */
+     , (26372,   8,  100675760) /* Icon */
+     , (26372,  22,  872415275) /* PhysicsEffectTable */
+     , (26372,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26372,  31,      15192) /* LinkedPortalOne - Sonpay Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26373 South Adjamaer Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26373 South Adjamaer Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26373;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26373, 'gemportalsouthadjamaercottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26373,   1,       2048) /* ItemType - Gem */
+     , (26373,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26373,   5,         10) /* EncumbranceVal */
+     , (26373,   8,         10) /* Mass */
+     , (26373,   9,          0) /* ValidLocations - None */
+     , (26373,  11,         20) /* MaxStackSize */
+     , (26373,  12,          1) /* StackSize */
+     , (26373,  13,         10) /* StackUnitEncumbrance */
+     , (26373,  14,         10) /* StackUnitMass */
+     , (26373,  15,        500) /* StackUnitValue */
+     , (26373,  16,          8) /* ItemUseable - Contained */
+     , (26373,  18,          1) /* UiEffects - Magical */
+     , (26373,  19,        500) /* Value */
+     , (26373,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26373,  94,         16) /* TargetType - Creature */
+     , (26373, 106,        210) /* ItemSpellcraft */
+     , (26373, 107,         50) /* ItemCurMana */
+     , (26373, 108,         50) /* ItemMaxMana */
+     , (26373, 109,          0) /* ItemDifficulty */
+     , (26373, 110,          0) /* ItemAllegianceRankLimit */
+     , (26373, 150,        103) /* HookPlacement - Hook */
+     , (26373, 151,          2) /* HookType - Wall */
+     , (26373, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26373,  15, True ) /* LightsStatus */
+     , (26373,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26373, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26373,   1, 'South Adjamaer Cottages Portal Gem') /* Name */
+     , (26373,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26373,   1,   33556769) /* Setup */
+     , (26373,   3,  536870932) /* SoundTable */
+     , (26373,   6,   67111919) /* PaletteBase */
+     , (26373,   7,  268435723) /* ClothingBase */
+     , (26373,   8,  100675760) /* Icon */
+     , (26373,  22,  872415275) /* PhysicsEffectTable */
+     , (26373,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26373,  31,      12548) /* LinkedPortalOne - South Adjamaer Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26374 South Beach Pass Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26374 South Beach Pass Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26374;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26374, 'gemportalsouthbeachpassvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26374,   1,       2048) /* ItemType - Gem */
+     , (26374,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26374,   5,         10) /* EncumbranceVal */
+     , (26374,   8,         10) /* Mass */
+     , (26374,   9,          0) /* ValidLocations - None */
+     , (26374,  11,         20) /* MaxStackSize */
+     , (26374,  12,          1) /* StackSize */
+     , (26374,  13,         10) /* StackUnitEncumbrance */
+     , (26374,  14,         10) /* StackUnitMass */
+     , (26374,  15,        500) /* StackUnitValue */
+     , (26374,  16,          8) /* ItemUseable - Contained */
+     , (26374,  18,          1) /* UiEffects - Magical */
+     , (26374,  19,        500) /* Value */
+     , (26374,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26374,  94,         16) /* TargetType - Creature */
+     , (26374, 106,        210) /* ItemSpellcraft */
+     , (26374, 107,         50) /* ItemCurMana */
+     , (26374, 108,         50) /* ItemMaxMana */
+     , (26374, 109,          0) /* ItemDifficulty */
+     , (26374, 110,          0) /* ItemAllegianceRankLimit */
+     , (26374, 150,        103) /* HookPlacement - Hook */
+     , (26374, 151,          2) /* HookType - Wall */
+     , (26374, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26374,  15, True ) /* LightsStatus */
+     , (26374,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26374, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26374,   1, 'South Beach Pass Villas Portal Gem') /* Name */
+     , (26374,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26374,   1,   33556769) /* Setup */
+     , (26374,   3,  536870932) /* SoundTable */
+     , (26374,   6,   67111919) /* PaletteBase */
+     , (26374,   7,  268435723) /* ClothingBase */
+     , (26374,   8,  100675760) /* Icon */
+     , (26374,  22,  872415275) /* PhysicsEffectTable */
+     , (26374,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26374,  31,      13090) /* LinkedPortalOne - South Beach Pass Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26375 Southeast Arwic Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26375 Southeast Arwic Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26375;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26375, 'gemportalsoutheastarwicsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26375,   1,       2048) /* ItemType - Gem */
+     , (26375,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26375,   5,         10) /* EncumbranceVal */
+     , (26375,   8,         10) /* Mass */
+     , (26375,   9,          0) /* ValidLocations - None */
+     , (26375,  11,         20) /* MaxStackSize */
+     , (26375,  12,          1) /* StackSize */
+     , (26375,  13,         10) /* StackUnitEncumbrance */
+     , (26375,  14,         10) /* StackUnitMass */
+     , (26375,  15,        500) /* StackUnitValue */
+     , (26375,  16,          8) /* ItemUseable - Contained */
+     , (26375,  18,          1) /* UiEffects - Magical */
+     , (26375,  19,        500) /* Value */
+     , (26375,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26375,  94,         16) /* TargetType - Creature */
+     , (26375, 106,        210) /* ItemSpellcraft */
+     , (26375, 107,         50) /* ItemCurMana */
+     , (26375, 108,         50) /* ItemMaxMana */
+     , (26375, 109,          0) /* ItemDifficulty */
+     , (26375, 110,          0) /* ItemAllegianceRankLimit */
+     , (26375, 150,        103) /* HookPlacement - Hook */
+     , (26375, 151,          2) /* HookType - Wall */
+     , (26375, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26375,  15, True ) /* LightsStatus */
+     , (26375,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26375, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26375,   1, 'Southeast Arwic Settlement Portal Gem') /* Name */
+     , (26375,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26375,   1,   33556769) /* Setup */
+     , (26375,   3,  536870932) /* SoundTable */
+     , (26375,   6,   67111919) /* PaletteBase */
+     , (26375,   7,  268435723) /* ClothingBase */
+     , (26375,   8,  100675760) /* Icon */
+     , (26375,  22,  872415275) /* PhysicsEffectTable */
+     , (26375,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26375,  31,      12549) /* LinkedPortalOne - Southeast Arwic Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26376 Southern Park Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26376 Southern Park Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26376;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26376, 'gemportalsouthernpark', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26376,   1,       2048) /* ItemType - Gem */
+     , (26376,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26376,   5,         10) /* EncumbranceVal */
+     , (26376,   8,         10) /* Mass */
+     , (26376,   9,          0) /* ValidLocations - None */
+     , (26376,  11,         20) /* MaxStackSize */
+     , (26376,  12,          1) /* StackSize */
+     , (26376,  13,         10) /* StackUnitEncumbrance */
+     , (26376,  14,         10) /* StackUnitMass */
+     , (26376,  15,        500) /* StackUnitValue */
+     , (26376,  16,          8) /* ItemUseable - Contained */
+     , (26376,  18,          1) /* UiEffects - Magical */
+     , (26376,  19,        500) /* Value */
+     , (26376,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26376,  94,         16) /* TargetType - Creature */
+     , (26376, 106,        210) /* ItemSpellcraft */
+     , (26376, 107,         50) /* ItemCurMana */
+     , (26376, 108,         50) /* ItemMaxMana */
+     , (26376, 109,          0) /* ItemDifficulty */
+     , (26376, 110,          0) /* ItemAllegianceRankLimit */
+     , (26376, 150,        103) /* HookPlacement - Hook */
+     , (26376, 151,          2) /* HookType - Wall */
+     , (26376, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26376,  15, True ) /* LightsStatus */
+     , (26376,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26376, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26376,   1, 'Southern Park Portal Gem') /* Name */
+     , (26376,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26376,   1,   33556769) /* Setup */
+     , (26376,   3,  536870932) /* SoundTable */
+     , (26376,   6,   67111919) /* PaletteBase */
+     , (26376,   7,  268435723) /* ClothingBase */
+     , (26376,   8,  100675760) /* Icon */
+     , (26376,  22,  872415275) /* PhysicsEffectTable */
+     , (26376,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26376,  31,      14667) /* LinkedPortalOne - Southern Park Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26377 South Hebian-To Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26377 South Hebian-To Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26377;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26377, 'gemportalsouthhebiantocottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26377,   1,       2048) /* ItemType - Gem */
+     , (26377,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26377,   5,         10) /* EncumbranceVal */
+     , (26377,   8,         10) /* Mass */
+     , (26377,   9,          0) /* ValidLocations - None */
+     , (26377,  11,         20) /* MaxStackSize */
+     , (26377,  12,          1) /* StackSize */
+     , (26377,  13,         10) /* StackUnitEncumbrance */
+     , (26377,  14,         10) /* StackUnitMass */
+     , (26377,  15,        500) /* StackUnitValue */
+     , (26377,  16,          8) /* ItemUseable - Contained */
+     , (26377,  18,          1) /* UiEffects - Magical */
+     , (26377,  19,        500) /* Value */
+     , (26377,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26377,  94,         16) /* TargetType - Creature */
+     , (26377, 106,        210) /* ItemSpellcraft */
+     , (26377, 107,         50) /* ItemCurMana */
+     , (26377, 108,         50) /* ItemMaxMana */
+     , (26377, 109,          0) /* ItemDifficulty */
+     , (26377, 110,          0) /* ItemAllegianceRankLimit */
+     , (26377, 150,        103) /* HookPlacement - Hook */
+     , (26377, 151,          2) /* HookType - Wall */
+     , (26377, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26377,  15, True ) /* LightsStatus */
+     , (26377,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26377, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26377,   1, 'South Hebian-To Cottages Portal Gem') /* Name */
+     , (26377,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26377,   1,   33556769) /* Setup */
+     , (26377,   3,  536870932) /* SoundTable */
+     , (26377,   6,   67111919) /* PaletteBase */
+     , (26377,   7,  268435723) /* ClothingBase */
+     , (26377,   8,  100675760) /* Icon */
+     , (26377,  22,  872415275) /* PhysicsEffectTable */
+     , (26377,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26377,  31,      12550) /* LinkedPortalOne - South Hebian-To Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26378 South Hebian-To Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26378 South Hebian-To Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26378;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26378, 'gemportalsouthhebiantoestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26378,   1,       2048) /* ItemType - Gem */
+     , (26378,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26378,   5,         10) /* EncumbranceVal */
+     , (26378,   8,         10) /* Mass */
+     , (26378,   9,          0) /* ValidLocations - None */
+     , (26378,  11,         20) /* MaxStackSize */
+     , (26378,  12,          1) /* StackSize */
+     , (26378,  13,         10) /* StackUnitEncumbrance */
+     , (26378,  14,         10) /* StackUnitMass */
+     , (26378,  15,        500) /* StackUnitValue */
+     , (26378,  16,          8) /* ItemUseable - Contained */
+     , (26378,  18,          1) /* UiEffects - Magical */
+     , (26378,  19,        500) /* Value */
+     , (26378,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26378,  94,         16) /* TargetType - Creature */
+     , (26378, 106,        210) /* ItemSpellcraft */
+     , (26378, 107,         50) /* ItemCurMana */
+     , (26378, 108,         50) /* ItemMaxMana */
+     , (26378, 109,          0) /* ItemDifficulty */
+     , (26378, 110,          0) /* ItemAllegianceRankLimit */
+     , (26378, 150,        103) /* HookPlacement - Hook */
+     , (26378, 151,          2) /* HookType - Wall */
+     , (26378, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26378,  15, True ) /* LightsStatus */
+     , (26378,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26378, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26378,   1, 'South Hebian-To Estates Portal Gem') /* Name */
+     , (26378,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26378,   1,   33556769) /* Setup */
+     , (26378,   3,  536870932) /* SoundTable */
+     , (26378,   6,   67111919) /* PaletteBase */
+     , (26378,   7,  268435723) /* ClothingBase */
+     , (26378,   8,  100675760) /* Icon */
+     , (26378,  22,  872415275) /* PhysicsEffectTable */
+     , (26378,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26378,  31,      13132) /* LinkedPortalOne - South Hebian-To Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26379 South Khayyaban Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26379 South Khayyaban Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26379;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26379, 'gemportalsouthkhayyabancottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26379,   1,       2048) /* ItemType - Gem */
+     , (26379,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26379,   5,         10) /* EncumbranceVal */
+     , (26379,   8,         10) /* Mass */
+     , (26379,   9,          0) /* ValidLocations - None */
+     , (26379,  11,         20) /* MaxStackSize */
+     , (26379,  12,          1) /* StackSize */
+     , (26379,  13,         10) /* StackUnitEncumbrance */
+     , (26379,  14,         10) /* StackUnitMass */
+     , (26379,  15,        500) /* StackUnitValue */
+     , (26379,  16,          8) /* ItemUseable - Contained */
+     , (26379,  18,          1) /* UiEffects - Magical */
+     , (26379,  19,        500) /* Value */
+     , (26379,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26379,  94,         16) /* TargetType - Creature */
+     , (26379, 106,        210) /* ItemSpellcraft */
+     , (26379, 107,         50) /* ItemCurMana */
+     , (26379, 108,         50) /* ItemMaxMana */
+     , (26379, 109,          0) /* ItemDifficulty */
+     , (26379, 110,          0) /* ItemAllegianceRankLimit */
+     , (26379, 150,        103) /* HookPlacement - Hook */
+     , (26379, 151,          2) /* HookType - Wall */
+     , (26379, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26379,  15, True ) /* LightsStatus */
+     , (26379,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26379, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26379,   1, 'South Khayyaban Cottages Portal Gem') /* Name */
+     , (26379,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26379,   1,   33556769) /* Setup */
+     , (26379,   3,  536870932) /* SoundTable */
+     , (26379,   6,   67111919) /* PaletteBase */
+     , (26379,   7,  268435723) /* ClothingBase */
+     , (26379,   8,  100675760) /* Icon */
+     , (26379,  22,  872415275) /* PhysicsEffectTable */
+     , (26379,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26379,  31,      12551) /* LinkedPortalOne - South Khayyaban Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26380 South Lytelthorpe  Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26380 South Lytelthorpe  Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26380;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26380, 'gemportalsouthlytelthorpe', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26380,   1,       2048) /* ItemType - Gem */
+     , (26380,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26380,   5,         10) /* EncumbranceVal */
+     , (26380,   8,         10) /* Mass */
+     , (26380,   9,          0) /* ValidLocations - None */
+     , (26380,  11,         20) /* MaxStackSize */
+     , (26380,  12,          1) /* StackSize */
+     , (26380,  13,         10) /* StackUnitEncumbrance */
+     , (26380,  14,         10) /* StackUnitMass */
+     , (26380,  15,        500) /* StackUnitValue */
+     , (26380,  16,          8) /* ItemUseable - Contained */
+     , (26380,  18,          1) /* UiEffects - Magical */
+     , (26380,  19,        500) /* Value */
+     , (26380,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26380,  94,         16) /* TargetType - Creature */
+     , (26380, 106,        210) /* ItemSpellcraft */
+     , (26380, 107,         50) /* ItemCurMana */
+     , (26380, 108,         50) /* ItemMaxMana */
+     , (26380, 109,          0) /* ItemDifficulty */
+     , (26380, 110,          0) /* ItemAllegianceRankLimit */
+     , (26380, 150,        103) /* HookPlacement - Hook */
+     , (26380, 151,          2) /* HookType - Wall */
+     , (26380, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26380,  15, True ) /* LightsStatus */
+     , (26380,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26380, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26380,   1, 'South Lytelthorpe  Portal Gem') /* Name */
+     , (26380,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26380,   1,   33556769) /* Setup */
+     , (26380,   3,  536870932) /* SoundTable */
+     , (26380,   6,   67111919) /* PaletteBase */
+     , (26380,   7,  268435723) /* ClothingBase */
+     , (26380,   8,  100675760) /* Icon */
+     , (26380,  22,  872415275) /* PhysicsEffectTable */
+     , (26380,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26380,  31,      12552) /* LinkedPortalOne - South Lytelthorpe  Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26381 South Shoushi Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26381 South Shoushi Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26381;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26381, 'gemportalsouthshoushivillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26381,   1,       2048) /* ItemType - Gem */
+     , (26381,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26381,   5,         10) /* EncumbranceVal */
+     , (26381,   8,         10) /* Mass */
+     , (26381,   9,          0) /* ValidLocations - None */
+     , (26381,  11,         20) /* MaxStackSize */
+     , (26381,  12,          1) /* StackSize */
+     , (26381,  13,         10) /* StackUnitEncumbrance */
+     , (26381,  14,         10) /* StackUnitMass */
+     , (26381,  15,        500) /* StackUnitValue */
+     , (26381,  16,          8) /* ItemUseable - Contained */
+     , (26381,  18,          1) /* UiEffects - Magical */
+     , (26381,  19,        500) /* Value */
+     , (26381,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26381,  94,         16) /* TargetType - Creature */
+     , (26381, 106,        210) /* ItemSpellcraft */
+     , (26381, 107,         50) /* ItemCurMana */
+     , (26381, 108,         50) /* ItemMaxMana */
+     , (26381, 109,          0) /* ItemDifficulty */
+     , (26381, 110,          0) /* ItemAllegianceRankLimit */
+     , (26381, 150,        103) /* HookPlacement - Hook */
+     , (26381, 151,          2) /* HookType - Wall */
+     , (26381, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26381,  15, True ) /* LightsStatus */
+     , (26381,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26381, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26381,   1, 'South Shoushi Villas Portal Gem') /* Name */
+     , (26381,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26381,   1,   33556769) /* Setup */
+     , (26381,   3,  536870932) /* SoundTable */
+     , (26381,   6,   67111919) /* PaletteBase */
+     , (26381,   7,  268435723) /* ClothingBase */
+     , (26381,   8,  100675760) /* Icon */
+     , (26381,  22,  872415275) /* PhysicsEffectTable */
+     , (26381,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26381,  31,      13133) /* LinkedPortalOne - South Shoushi Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26382 South Siege Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26382 South Siege Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26382;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26382, 'gemportalsouthsiegevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26382,   1,       2048) /* ItemType - Gem */
+     , (26382,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26382,   5,         10) /* EncumbranceVal */
+     , (26382,   8,         10) /* Mass */
+     , (26382,   9,          0) /* ValidLocations - None */
+     , (26382,  11,         20) /* MaxStackSize */
+     , (26382,  12,          1) /* StackSize */
+     , (26382,  13,         10) /* StackUnitEncumbrance */
+     , (26382,  14,         10) /* StackUnitMass */
+     , (26382,  15,        500) /* StackUnitValue */
+     , (26382,  16,          8) /* ItemUseable - Contained */
+     , (26382,  18,          1) /* UiEffects - Magical */
+     , (26382,  19,        500) /* Value */
+     , (26382,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26382,  94,         16) /* TargetType - Creature */
+     , (26382, 106,        210) /* ItemSpellcraft */
+     , (26382, 107,         50) /* ItemCurMana */
+     , (26382, 108,         50) /* ItemMaxMana */
+     , (26382, 109,          0) /* ItemDifficulty */
+     , (26382, 110,          0) /* ItemAllegianceRankLimit */
+     , (26382, 150,        103) /* HookPlacement - Hook */
+     , (26382, 151,          2) /* HookType - Wall */
+     , (26382, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26382,  15, True ) /* LightsStatus */
+     , (26382,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26382, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26382,   1, 'South Siege Villas Portal Gem') /* Name */
+     , (26382,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26382,   1,   33556769) /* Setup */
+     , (26382,   3,  536870932) /* SoundTable */
+     , (26382,   6,   67111919) /* PaletteBase */
+     , (26382,   7,  268435723) /* ClothingBase */
+     , (26382,   8,  100675760) /* Icon */
+     , (26382,  22,  872415275) /* PhysicsEffectTable */
+     , (26382,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26382,  31,      15193) /* LinkedPortalOne - South Siege Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26383 South Uzis Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26383 South Uzis Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26383;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26383, 'gemportalsouthuzisvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26383,   1,       2048) /* ItemType - Gem */
+     , (26383,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26383,   5,         10) /* EncumbranceVal */
+     , (26383,   8,         10) /* Mass */
+     , (26383,   9,          0) /* ValidLocations - None */
+     , (26383,  11,         20) /* MaxStackSize */
+     , (26383,  12,          1) /* StackSize */
+     , (26383,  13,         10) /* StackUnitEncumbrance */
+     , (26383,  14,         10) /* StackUnitMass */
+     , (26383,  15,        500) /* StackUnitValue */
+     , (26383,  16,          8) /* ItemUseable - Contained */
+     , (26383,  18,          1) /* UiEffects - Magical */
+     , (26383,  19,        500) /* Value */
+     , (26383,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26383,  94,         16) /* TargetType - Creature */
+     , (26383, 106,        210) /* ItemSpellcraft */
+     , (26383, 107,         50) /* ItemCurMana */
+     , (26383, 108,         50) /* ItemMaxMana */
+     , (26383, 109,          0) /* ItemDifficulty */
+     , (26383, 110,          0) /* ItemAllegianceRankLimit */
+     , (26383, 150,        103) /* HookPlacement - Hook */
+     , (26383, 151,          2) /* HookType - Wall */
+     , (26383, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26383,  15, True ) /* LightsStatus */
+     , (26383,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26383, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26383,   1, 'South Uzis Villas Portal Gem') /* Name */
+     , (26383,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26383,   1,   33556769) /* Setup */
+     , (26383,   3,  536870932) /* SoundTable */
+     , (26383,   6,   67111919) /* PaletteBase */
+     , (26383,   7,  268435723) /* ClothingBase */
+     , (26383,   8,  100675760) /* Icon */
+     , (26383,  22,  872415275) /* PhysicsEffectTable */
+     , (26383,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26383,  31,      14668) /* LinkedPortalOne - South Uzis Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26384 South Victory Harbor Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26384 South Victory Harbor Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26384;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26384, 'gemportalsouthvictoryharbor', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26384,   1,       2048) /* ItemType - Gem */
+     , (26384,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26384,   5,         10) /* EncumbranceVal */
+     , (26384,   8,         10) /* Mass */
+     , (26384,   9,          0) /* ValidLocations - None */
+     , (26384,  11,         20) /* MaxStackSize */
+     , (26384,  12,          1) /* StackSize */
+     , (26384,  13,         10) /* StackUnitEncumbrance */
+     , (26384,  14,         10) /* StackUnitMass */
+     , (26384,  15,        500) /* StackUnitValue */
+     , (26384,  16,          8) /* ItemUseable - Contained */
+     , (26384,  18,          1) /* UiEffects - Magical */
+     , (26384,  19,        500) /* Value */
+     , (26384,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26384,  94,         16) /* TargetType - Creature */
+     , (26384, 106,        210) /* ItemSpellcraft */
+     , (26384, 107,         50) /* ItemCurMana */
+     , (26384, 108,         50) /* ItemMaxMana */
+     , (26384, 109,          0) /* ItemDifficulty */
+     , (26384, 110,          0) /* ItemAllegianceRankLimit */
+     , (26384, 150,        103) /* HookPlacement - Hook */
+     , (26384, 151,          2) /* HookType - Wall */
+     , (26384, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26384,  15, True ) /* LightsStatus */
+     , (26384,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26384, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26384,   1, 'South Victory Harbor Portal Gem') /* Name */
+     , (26384,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26384,   1,   33556769) /* Setup */
+     , (26384,   3,  536870932) /* SoundTable */
+     , (26384,   6,   67111919) /* PaletteBase */
+     , (26384,   7,  268435723) /* ClothingBase */
+     , (26384,   8,  100675760) /* Icon */
+     , (26384,  22,  872415275) /* PhysicsEffectTable */
+     , (26384,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26384,  31,      12553) /* LinkedPortalOne - South Victory Harbor Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26385 Southwest Hebian-To Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26385 Southwest Hebian-To Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26385;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26385, 'gemportalsouthwesthebiantosettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26385,   1,       2048) /* ItemType - Gem */
+     , (26385,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26385,   5,         10) /* EncumbranceVal */
+     , (26385,   8,         10) /* Mass */
+     , (26385,   9,          0) /* ValidLocations - None */
+     , (26385,  11,         20) /* MaxStackSize */
+     , (26385,  12,          1) /* StackSize */
+     , (26385,  13,         10) /* StackUnitEncumbrance */
+     , (26385,  14,         10) /* StackUnitMass */
+     , (26385,  15,        500) /* StackUnitValue */
+     , (26385,  16,          8) /* ItemUseable - Contained */
+     , (26385,  18,          1) /* UiEffects - Magical */
+     , (26385,  19,        500) /* Value */
+     , (26385,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26385,  94,         16) /* TargetType - Creature */
+     , (26385, 106,        210) /* ItemSpellcraft */
+     , (26385, 107,         50) /* ItemCurMana */
+     , (26385, 108,         50) /* ItemMaxMana */
+     , (26385, 109,          0) /* ItemDifficulty */
+     , (26385, 110,          0) /* ItemAllegianceRankLimit */
+     , (26385, 150,        103) /* HookPlacement - Hook */
+     , (26385, 151,          2) /* HookType - Wall */
+     , (26385, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26385,  15, True ) /* LightsStatus */
+     , (26385,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26385, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26385,   1, 'Southwest Hebian-To Settlement Portal Gem') /* Name */
+     , (26385,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26385,   1,   33556769) /* Setup */
+     , (26385,   3,  536870932) /* SoundTable */
+     , (26385,   6,   67111919) /* PaletteBase */
+     , (26385,   7,  268435723) /* ClothingBase */
+     , (26385,   8,  100675760) /* Icon */
+     , (26385,  22,  872415275) /* PhysicsEffectTable */
+     , (26385,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26385,  31,      12554) /* LinkedPortalOne - Southwest Hebian-To Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26386 South Yaraq Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26386 South Yaraq Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26386;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26386, 'gemportalsouthyaraqcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26386,   1,       2048) /* ItemType - Gem */
+     , (26386,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26386,   5,         10) /* EncumbranceVal */
+     , (26386,   8,         10) /* Mass */
+     , (26386,   9,          0) /* ValidLocations - None */
+     , (26386,  11,         20) /* MaxStackSize */
+     , (26386,  12,          1) /* StackSize */
+     , (26386,  13,         10) /* StackUnitEncumbrance */
+     , (26386,  14,         10) /* StackUnitMass */
+     , (26386,  15,        500) /* StackUnitValue */
+     , (26386,  16,          8) /* ItemUseable - Contained */
+     , (26386,  18,          1) /* UiEffects - Magical */
+     , (26386,  19,        500) /* Value */
+     , (26386,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26386,  94,         16) /* TargetType - Creature */
+     , (26386, 106,        210) /* ItemSpellcraft */
+     , (26386, 107,         50) /* ItemCurMana */
+     , (26386, 108,         50) /* ItemMaxMana */
+     , (26386, 109,          0) /* ItemDifficulty */
+     , (26386, 110,          0) /* ItemAllegianceRankLimit */
+     , (26386, 150,        103) /* HookPlacement - Hook */
+     , (26386, 151,          2) /* HookType - Wall */
+     , (26386, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26386,  15, True ) /* LightsStatus */
+     , (26386,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26386, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26386,   1, 'South Yaraq Cottages Portal Gem') /* Name */
+     , (26386,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26386,   1,   33556769) /* Setup */
+     , (26386,   3,  536870932) /* SoundTable */
+     , (26386,   6,   67111919) /* PaletteBase */
+     , (26386,   7,  268435723) /* ClothingBase */
+     , (26386,   8,  100675760) /* Icon */
+     , (26386,  22,  872415275) /* PhysicsEffectTable */
+     , (26386,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26386,  31,      12555) /* LinkedPortalOne - South Yaraq Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26387 Spire Hills Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26387 Spire Hills Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26387;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26387, 'gemportalspirehillssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26387,   1,       2048) /* ItemType - Gem */
+     , (26387,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26387,   5,         10) /* EncumbranceVal */
+     , (26387,   8,         10) /* Mass */
+     , (26387,   9,          0) /* ValidLocations - None */
+     , (26387,  11,         20) /* MaxStackSize */
+     , (26387,  12,          1) /* StackSize */
+     , (26387,  13,         10) /* StackUnitEncumbrance */
+     , (26387,  14,         10) /* StackUnitMass */
+     , (26387,  15,        500) /* StackUnitValue */
+     , (26387,  16,          8) /* ItemUseable - Contained */
+     , (26387,  18,          1) /* UiEffects - Magical */
+     , (26387,  19,        500) /* Value */
+     , (26387,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26387,  94,         16) /* TargetType - Creature */
+     , (26387, 106,        210) /* ItemSpellcraft */
+     , (26387, 107,         50) /* ItemCurMana */
+     , (26387, 108,         50) /* ItemMaxMana */
+     , (26387, 109,          0) /* ItemDifficulty */
+     , (26387, 110,          0) /* ItemAllegianceRankLimit */
+     , (26387, 150,        103) /* HookPlacement - Hook */
+     , (26387, 151,          2) /* HookType - Wall */
+     , (26387, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26387,  15, True ) /* LightsStatus */
+     , (26387,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26387, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26387,   1, 'Spire Hills Settlement Portal Gem') /* Name */
+     , (26387,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26387,   1,   33556769) /* Setup */
+     , (26387,   3,  536870932) /* SoundTable */
+     , (26387,   6,   67111919) /* PaletteBase */
+     , (26387,   7,  268435723) /* ClothingBase */
+     , (26387,   8,  100675760) /* Icon */
+     , (26387,  22,  872415275) /* PhysicsEffectTable */
+     , (26387,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26387,  31,      12556) /* LinkedPortalOne - Spire Hills Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26388 Stonebend Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26388 Stonebend Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26388;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26388, 'gemportalstonebendcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26388,   1,       2048) /* ItemType - Gem */
+     , (26388,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26388,   5,         10) /* EncumbranceVal */
+     , (26388,   8,         10) /* Mass */
+     , (26388,   9,          0) /* ValidLocations - None */
+     , (26388,  11,         20) /* MaxStackSize */
+     , (26388,  12,          1) /* StackSize */
+     , (26388,  13,         10) /* StackUnitEncumbrance */
+     , (26388,  14,         10) /* StackUnitMass */
+     , (26388,  15,        500) /* StackUnitValue */
+     , (26388,  16,          8) /* ItemUseable - Contained */
+     , (26388,  18,          1) /* UiEffects - Magical */
+     , (26388,  19,        500) /* Value */
+     , (26388,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26388,  94,         16) /* TargetType - Creature */
+     , (26388, 106,        210) /* ItemSpellcraft */
+     , (26388, 107,         50) /* ItemCurMana */
+     , (26388, 108,         50) /* ItemMaxMana */
+     , (26388, 109,          0) /* ItemDifficulty */
+     , (26388, 110,          0) /* ItemAllegianceRankLimit */
+     , (26388, 150,        103) /* HookPlacement - Hook */
+     , (26388, 151,          2) /* HookType - Wall */
+     , (26388, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26388,  15, True ) /* LightsStatus */
+     , (26388,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26388, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26388,   1, 'Stonebend Cottages Portal Gem') /* Name */
+     , (26388,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26388,   1,   33556769) /* Setup */
+     , (26388,   3,  536870932) /* SoundTable */
+     , (26388,   6,   67111919) /* PaletteBase */
+     , (26388,   7,  268435723) /* ClothingBase */
+     , (26388,   8,  100675760) /* Icon */
+     , (26388,  22,  872415275) /* PhysicsEffectTable */
+     , (26388,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26388,  31,      14669) /* LinkedPortalOne - Stonebend Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26389 Stone Face Oasis Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26389 Stone Face Oasis Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26389;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26389, 'gemportalstonefaceoasisvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26389,   1,       2048) /* ItemType - Gem */
+     , (26389,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26389,   5,         10) /* EncumbranceVal */
+     , (26389,   8,         10) /* Mass */
+     , (26389,   9,          0) /* ValidLocations - None */
+     , (26389,  11,         20) /* MaxStackSize */
+     , (26389,  12,          1) /* StackSize */
+     , (26389,  13,         10) /* StackUnitEncumbrance */
+     , (26389,  14,         10) /* StackUnitMass */
+     , (26389,  15,        500) /* StackUnitValue */
+     , (26389,  16,          8) /* ItemUseable - Contained */
+     , (26389,  18,          1) /* UiEffects - Magical */
+     , (26389,  19,        500) /* Value */
+     , (26389,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26389,  94,         16) /* TargetType - Creature */
+     , (26389, 106,        210) /* ItemSpellcraft */
+     , (26389, 107,         50) /* ItemCurMana */
+     , (26389, 108,         50) /* ItemMaxMana */
+     , (26389, 109,          0) /* ItemDifficulty */
+     , (26389, 110,          0) /* ItemAllegianceRankLimit */
+     , (26389, 150,        103) /* HookPlacement - Hook */
+     , (26389, 151,          2) /* HookType - Wall */
+     , (26389, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26389,  15, True ) /* LightsStatus */
+     , (26389,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26389, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26389,   1, 'Stone Face Oasis Villas Portal Gem') /* Name */
+     , (26389,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26389,   1,   33556769) /* Setup */
+     , (26389,   3,  536870932) /* SoundTable */
+     , (26389,   6,   67111919) /* PaletteBase */
+     , (26389,   7,  268435723) /* ClothingBase */
+     , (26389,   8,  100675760) /* Icon */
+     , (26389,  22,  872415275) /* PhysicsEffectTable */
+     , (26389,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26389,  31,      14670) /* LinkedPortalOne - Stone Face Oasis Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26390 Stone Hollow Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26390 Stone Hollow Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26390;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26390, 'gemportalstonehollow', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26390,   1,       2048) /* ItemType - Gem */
+     , (26390,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26390,   5,         10) /* EncumbranceVal */
+     , (26390,   8,         10) /* Mass */
+     , (26390,   9,          0) /* ValidLocations - None */
+     , (26390,  11,         20) /* MaxStackSize */
+     , (26390,  12,          1) /* StackSize */
+     , (26390,  13,         10) /* StackUnitEncumbrance */
+     , (26390,  14,         10) /* StackUnitMass */
+     , (26390,  15,        500) /* StackUnitValue */
+     , (26390,  16,          8) /* ItemUseable - Contained */
+     , (26390,  18,          1) /* UiEffects - Magical */
+     , (26390,  19,        500) /* Value */
+     , (26390,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26390,  94,         16) /* TargetType - Creature */
+     , (26390, 106,        210) /* ItemSpellcraft */
+     , (26390, 107,         50) /* ItemCurMana */
+     , (26390, 108,         50) /* ItemMaxMana */
+     , (26390, 109,          0) /* ItemDifficulty */
+     , (26390, 110,          0) /* ItemAllegianceRankLimit */
+     , (26390, 150,        103) /* HookPlacement - Hook */
+     , (26390, 151,          2) /* HookType - Wall */
+     , (26390, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26390,  15, True ) /* LightsStatus */
+     , (26390,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26390, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26390,   1, 'Stone Hollow Portal Gem') /* Name */
+     , (26390,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26390,   1,   33556769) /* Setup */
+     , (26390,   3,  536870932) /* SoundTable */
+     , (26390,   6,   67111919) /* PaletteBase */
+     , (26390,   7,  268435723) /* ClothingBase */
+     , (26390,   8,  100675760) /* Icon */
+     , (26390,  22,  872415275) /* PhysicsEffectTable */
+     , (26390,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26390,  31,      14671) /* LinkedPortalOne - Stone Hollow Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26391 Stoneport Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26391 Stoneport Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26391;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26391, 'gemportalstoneportvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26391,   1,       2048) /* ItemType - Gem */
+     , (26391,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26391,   5,         10) /* EncumbranceVal */
+     , (26391,   8,         10) /* Mass */
+     , (26391,   9,          0) /* ValidLocations - None */
+     , (26391,  11,         20) /* MaxStackSize */
+     , (26391,  12,          1) /* StackSize */
+     , (26391,  13,         10) /* StackUnitEncumbrance */
+     , (26391,  14,         10) /* StackUnitMass */
+     , (26391,  15,        500) /* StackUnitValue */
+     , (26391,  16,          8) /* ItemUseable - Contained */
+     , (26391,  18,          1) /* UiEffects - Magical */
+     , (26391,  19,        500) /* Value */
+     , (26391,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26391,  94,         16) /* TargetType - Creature */
+     , (26391, 106,        210) /* ItemSpellcraft */
+     , (26391, 107,         50) /* ItemCurMana */
+     , (26391, 108,         50) /* ItemMaxMana */
+     , (26391, 109,          0) /* ItemDifficulty */
+     , (26391, 110,          0) /* ItemAllegianceRankLimit */
+     , (26391, 150,        103) /* HookPlacement - Hook */
+     , (26391, 151,          2) /* HookType - Wall */
+     , (26391, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26391,  15, True ) /* LightsStatus */
+     , (26391,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26391, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26391,   1, 'Stoneport Villas Portal Gem') /* Name */
+     , (26391,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26391,   1,   33556769) /* Setup */
+     , (26391,   3,  536870932) /* SoundTable */
+     , (26391,   6,   67111919) /* PaletteBase */
+     , (26391,   7,  268435723) /* ClothingBase */
+     , (26391,   8,  100675760) /* Icon */
+     , (26391,  22,  872415275) /* PhysicsEffectTable */
+     , (26391,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26391,  31,      13134) /* LinkedPortalOne - Stoneport Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26392 Stonerune Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26392 Stonerune Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26392;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26392, 'gemportalstonerunecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26392,   1,       2048) /* ItemType - Gem */
+     , (26392,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26392,   5,         10) /* EncumbranceVal */
+     , (26392,   8,         10) /* Mass */
+     , (26392,   9,          0) /* ValidLocations - None */
+     , (26392,  11,         20) /* MaxStackSize */
+     , (26392,  12,          1) /* StackSize */
+     , (26392,  13,         10) /* StackUnitEncumbrance */
+     , (26392,  14,         10) /* StackUnitMass */
+     , (26392,  15,        500) /* StackUnitValue */
+     , (26392,  16,          8) /* ItemUseable - Contained */
+     , (26392,  18,          1) /* UiEffects - Magical */
+     , (26392,  19,        500) /* Value */
+     , (26392,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26392,  94,         16) /* TargetType - Creature */
+     , (26392, 106,        210) /* ItemSpellcraft */
+     , (26392, 107,         50) /* ItemCurMana */
+     , (26392, 108,         50) /* ItemMaxMana */
+     , (26392, 109,          0) /* ItemDifficulty */
+     , (26392, 110,          0) /* ItemAllegianceRankLimit */
+     , (26392, 150,        103) /* HookPlacement - Hook */
+     , (26392, 151,          2) /* HookType - Wall */
+     , (26392, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26392,  15, True ) /* LightsStatus */
+     , (26392,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26392, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26392,   1, 'Stonerune Cottages Portal Gem') /* Name */
+     , (26392,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26392,   1,   33556769) /* Setup */
+     , (26392,   3,  536870932) /* SoundTable */
+     , (26392,   6,   67111919) /* PaletteBase */
+     , (26392,   7,  268435723) /* ClothingBase */
+     , (26392,   8,  100675760) /* Icon */
+     , (26392,  22,  872415275) /* PhysicsEffectTable */
+     , (26392,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26392,  31,      19160) /* LinkedPortalOne - Stonerune Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26393 Stone Scar Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26393 Stone Scar Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26393;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26393, 'gemportalstonescarsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26393,   1,       2048) /* ItemType - Gem */
+     , (26393,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26393,   5,         10) /* EncumbranceVal */
+     , (26393,   8,         10) /* Mass */
+     , (26393,   9,          0) /* ValidLocations - None */
+     , (26393,  11,         20) /* MaxStackSize */
+     , (26393,  12,          1) /* StackSize */
+     , (26393,  13,         10) /* StackUnitEncumbrance */
+     , (26393,  14,         10) /* StackUnitMass */
+     , (26393,  15,        500) /* StackUnitValue */
+     , (26393,  16,          8) /* ItemUseable - Contained */
+     , (26393,  18,          1) /* UiEffects - Magical */
+     , (26393,  19,        500) /* Value */
+     , (26393,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26393,  94,         16) /* TargetType - Creature */
+     , (26393, 106,        210) /* ItemSpellcraft */
+     , (26393, 107,         50) /* ItemCurMana */
+     , (26393, 108,         50) /* ItemMaxMana */
+     , (26393, 109,          0) /* ItemDifficulty */
+     , (26393, 110,          0) /* ItemAllegianceRankLimit */
+     , (26393, 150,        103) /* HookPlacement - Hook */
+     , (26393, 151,          2) /* HookType - Wall */
+     , (26393, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26393,  15, True ) /* LightsStatus */
+     , (26393,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26393, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26393,   1, 'Stone Scar Settlement Portal Gem') /* Name */
+     , (26393,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26393,   1,   33556769) /* Setup */
+     , (26393,   3,  536870932) /* SoundTable */
+     , (26393,   6,   67111919) /* PaletteBase */
+     , (26393,   7,  268435723) /* ClothingBase */
+     , (26393,   8,  100675760) /* Icon */
+     , (26393,  22,  872415275) /* PhysicsEffectTable */
+     , (26393,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26393,  31,      14285) /* LinkedPortalOne - Stone Scar Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26394 Stone Scythe Stronghold Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26394 Stone Scythe Stronghold Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26394;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26394, 'gemportalstonescythestronghold', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26394,   1,       2048) /* ItemType - Gem */
+     , (26394,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26394,   5,         10) /* EncumbranceVal */
+     , (26394,   8,         10) /* Mass */
+     , (26394,   9,          0) /* ValidLocations - None */
+     , (26394,  11,         20) /* MaxStackSize */
+     , (26394,  12,          1) /* StackSize */
+     , (26394,  13,         10) /* StackUnitEncumbrance */
+     , (26394,  14,         10) /* StackUnitMass */
+     , (26394,  15,        500) /* StackUnitValue */
+     , (26394,  16,          8) /* ItemUseable - Contained */
+     , (26394,  18,          1) /* UiEffects - Magical */
+     , (26394,  19,        500) /* Value */
+     , (26394,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26394,  94,         16) /* TargetType - Creature */
+     , (26394, 106,        210) /* ItemSpellcraft */
+     , (26394, 107,         50) /* ItemCurMana */
+     , (26394, 108,         50) /* ItemMaxMana */
+     , (26394, 109,          0) /* ItemDifficulty */
+     , (26394, 110,          0) /* ItemAllegianceRankLimit */
+     , (26394, 150,        103) /* HookPlacement - Hook */
+     , (26394, 151,          2) /* HookType - Wall */
+     , (26394, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26394,  15, True ) /* LightsStatus */
+     , (26394,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26394, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26394,   1, 'Stone Scythe Stronghold Portal Gem') /* Name */
+     , (26394,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26394,   1,   33556769) /* Setup */
+     , (26394,   3,  536870932) /* SoundTable */
+     , (26394,   6,   67111919) /* PaletteBase */
+     , (26394,   7,  268435723) /* ClothingBase */
+     , (26394,   8,  100675760) /* Icon */
+     , (26394,  22,  872415275) /* PhysicsEffectTable */
+     , (26394,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26394,  31,      19161) /* LinkedPortalOne - Stone Scythe Stronghold Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26395 Stone Triad Dell Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26395 Stone Triad Dell Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26395;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26395, 'gemportalstonetriaddell', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26395,   1,       2048) /* ItemType - Gem */
+     , (26395,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26395,   5,         10) /* EncumbranceVal */
+     , (26395,   8,         10) /* Mass */
+     , (26395,   9,          0) /* ValidLocations - None */
+     , (26395,  11,         20) /* MaxStackSize */
+     , (26395,  12,          1) /* StackSize */
+     , (26395,  13,         10) /* StackUnitEncumbrance */
+     , (26395,  14,         10) /* StackUnitMass */
+     , (26395,  15,        500) /* StackUnitValue */
+     , (26395,  16,          8) /* ItemUseable - Contained */
+     , (26395,  18,          1) /* UiEffects - Magical */
+     , (26395,  19,        500) /* Value */
+     , (26395,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26395,  94,         16) /* TargetType - Creature */
+     , (26395, 106,        210) /* ItemSpellcraft */
+     , (26395, 107,         50) /* ItemCurMana */
+     , (26395, 108,         50) /* ItemMaxMana */
+     , (26395, 109,          0) /* ItemDifficulty */
+     , (26395, 110,          0) /* ItemAllegianceRankLimit */
+     , (26395, 150,        103) /* HookPlacement - Hook */
+     , (26395, 151,          2) /* HookType - Wall */
+     , (26395, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26395,  15, True ) /* LightsStatus */
+     , (26395,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26395, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26395,   1, 'Stone Triad Dell Portal Gem') /* Name */
+     , (26395,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26395,   1,   33556769) /* Setup */
+     , (26395,   3,  536870932) /* SoundTable */
+     , (26395,   6,   67111919) /* PaletteBase */
+     , (26395,   7,  268435723) /* ClothingBase */
+     , (26395,   8,  100675760) /* Icon */
+     , (26395,  22,  872415275) /* PhysicsEffectTable */
+     , (26395,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26395,  31,      13135) /* LinkedPortalOne - Stone Triad Dell Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26396 Stormbrow Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26396 Stormbrow Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26396;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26396, 'gemportalstormbrow', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26396,   1,       2048) /* ItemType - Gem */
+     , (26396,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26396,   5,         10) /* EncumbranceVal */
+     , (26396,   8,         10) /* Mass */
+     , (26396,   9,          0) /* ValidLocations - None */
+     , (26396,  11,         20) /* MaxStackSize */
+     , (26396,  12,          1) /* StackSize */
+     , (26396,  13,         10) /* StackUnitEncumbrance */
+     , (26396,  14,         10) /* StackUnitMass */
+     , (26396,  15,        500) /* StackUnitValue */
+     , (26396,  16,          8) /* ItemUseable - Contained */
+     , (26396,  18,          1) /* UiEffects - Magical */
+     , (26396,  19,        500) /* Value */
+     , (26396,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26396,  94,         16) /* TargetType - Creature */
+     , (26396, 106,        210) /* ItemSpellcraft */
+     , (26396, 107,         50) /* ItemCurMana */
+     , (26396, 108,         50) /* ItemMaxMana */
+     , (26396, 109,          0) /* ItemDifficulty */
+     , (26396, 110,          0) /* ItemAllegianceRankLimit */
+     , (26396, 150,        103) /* HookPlacement - Hook */
+     , (26396, 151,          2) /* HookType - Wall */
+     , (26396, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26396,  15, True ) /* LightsStatus */
+     , (26396,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26396, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26396,   1, 'Stormbrow Portal Gem') /* Name */
+     , (26396,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26396,   1,   33556769) /* Setup */
+     , (26396,   3,  536870932) /* SoundTable */
+     , (26396,   6,   67111919) /* PaletteBase */
+     , (26396,   7,  268435723) /* ClothingBase */
+     , (26396,   8,  100675760) /* Icon */
+     , (26396,  22,  872415275) /* PhysicsEffectTable */
+     , (26396,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26396,  31,      14672) /* LinkedPortalOne - Stormbrow Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26397 Stormtree Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26397 Stormtree Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26397;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26397, 'gemportalstormtreevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26397,   1,       2048) /* ItemType - Gem */
+     , (26397,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26397,   5,         10) /* EncumbranceVal */
+     , (26397,   8,         10) /* Mass */
+     , (26397,   9,          0) /* ValidLocations - None */
+     , (26397,  11,         20) /* MaxStackSize */
+     , (26397,  12,          1) /* StackSize */
+     , (26397,  13,         10) /* StackUnitEncumbrance */
+     , (26397,  14,         10) /* StackUnitMass */
+     , (26397,  15,        500) /* StackUnitValue */
+     , (26397,  16,          8) /* ItemUseable - Contained */
+     , (26397,  18,          1) /* UiEffects - Magical */
+     , (26397,  19,        500) /* Value */
+     , (26397,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26397,  94,         16) /* TargetType - Creature */
+     , (26397, 106,        210) /* ItemSpellcraft */
+     , (26397, 107,         50) /* ItemCurMana */
+     , (26397, 108,         50) /* ItemMaxMana */
+     , (26397, 109,          0) /* ItemDifficulty */
+     , (26397, 110,          0) /* ItemAllegianceRankLimit */
+     , (26397, 150,        103) /* HookPlacement - Hook */
+     , (26397, 151,          2) /* HookType - Wall */
+     , (26397, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26397,  15, True ) /* LightsStatus */
+     , (26397,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26397, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26397,   1, 'Stormtree Villas Portal Gem') /* Name */
+     , (26397,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26397,   1,   33556769) /* Setup */
+     , (26397,   3,  536870932) /* SoundTable */
+     , (26397,   6,   67111919) /* PaletteBase */
+     , (26397,   7,  268435723) /* ClothingBase */
+     , (26397,   8,  100675760) /* Icon */
+     , (26397,  22,  872415275) /* PhysicsEffectTable */
+     , (26397,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26397,  31,      15194) /* LinkedPortalOne - Stormtree Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26398 Strathelar's Watch Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26398 Strathelar's Watch Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26398;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26398, 'gemportalstrathelarswatchcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26398,   1,       2048) /* ItemType - Gem */
+     , (26398,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26398,   5,         10) /* EncumbranceVal */
+     , (26398,   8,         10) /* Mass */
+     , (26398,   9,          0) /* ValidLocations - None */
+     , (26398,  11,         20) /* MaxStackSize */
+     , (26398,  12,          1) /* StackSize */
+     , (26398,  13,         10) /* StackUnitEncumbrance */
+     , (26398,  14,         10) /* StackUnitMass */
+     , (26398,  15,        500) /* StackUnitValue */
+     , (26398,  16,          8) /* ItemUseable - Contained */
+     , (26398,  18,          1) /* UiEffects - Magical */
+     , (26398,  19,        500) /* Value */
+     , (26398,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26398,  94,         16) /* TargetType - Creature */
+     , (26398, 106,        210) /* ItemSpellcraft */
+     , (26398, 107,         50) /* ItemCurMana */
+     , (26398, 108,         50) /* ItemMaxMana */
+     , (26398, 109,          0) /* ItemDifficulty */
+     , (26398, 110,          0) /* ItemAllegianceRankLimit */
+     , (26398, 150,        103) /* HookPlacement - Hook */
+     , (26398, 151,          2) /* HookType - Wall */
+     , (26398, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26398,  15, True ) /* LightsStatus */
+     , (26398,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26398, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26398,   1, 'Strathelar''s Watch Cottages Portal Gem') /* Name */
+     , (26398,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26398,   1,   33556769) /* Setup */
+     , (26398,   3,  536870932) /* SoundTable */
+     , (26398,   6,   67111919) /* PaletteBase */
+     , (26398,   7,  268435723) /* ClothingBase */
+     , (26398,   8,  100675760) /* Icon */
+     , (26398,  22,  872415275) /* PhysicsEffectTable */
+     , (26398,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26398,  31,      12557) /* LinkedPortalOne - Strathelar's Watch Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26399 Swamp Temple Place Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26399 Swamp Temple Place Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26399;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26399, 'gemportalswamptempleplace', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26399,   1,       2048) /* ItemType - Gem */
+     , (26399,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26399,   5,         10) /* EncumbranceVal */
+     , (26399,   8,         10) /* Mass */
+     , (26399,   9,          0) /* ValidLocations - None */
+     , (26399,  11,         20) /* MaxStackSize */
+     , (26399,  12,          1) /* StackSize */
+     , (26399,  13,         10) /* StackUnitEncumbrance */
+     , (26399,  14,         10) /* StackUnitMass */
+     , (26399,  15,        500) /* StackUnitValue */
+     , (26399,  16,          8) /* ItemUseable - Contained */
+     , (26399,  18,          1) /* UiEffects - Magical */
+     , (26399,  19,        500) /* Value */
+     , (26399,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26399,  94,         16) /* TargetType - Creature */
+     , (26399, 106,        210) /* ItemSpellcraft */
+     , (26399, 107,         50) /* ItemCurMana */
+     , (26399, 108,         50) /* ItemMaxMana */
+     , (26399, 109,          0) /* ItemDifficulty */
+     , (26399, 110,          0) /* ItemAllegianceRankLimit */
+     , (26399, 150,        103) /* HookPlacement - Hook */
+     , (26399, 151,          2) /* HookType - Wall */
+     , (26399, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26399,  15, True ) /* LightsStatus */
+     , (26399,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26399, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26399,   1, 'Swamp Temple Place Portal Gem') /* Name */
+     , (26399,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26399,   1,   33556769) /* Setup */
+     , (26399,   3,  536870932) /* SoundTable */
+     , (26399,   6,   67111919) /* PaletteBase */
+     , (26399,   7,  268435723) /* ClothingBase */
+     , (26399,   8,  100675760) /* Icon */
+     , (26399,  22,  872415275) /* PhysicsEffectTable */
+     , (26399,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26399,  31,      12558) /* LinkedPortalOne - Swamp Temple Place Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26400 Sweet Maple Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26400 Sweet Maple Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26400;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26400, 'gemportalsweetmaplecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26400,   1,       2048) /* ItemType - Gem */
+     , (26400,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26400,   5,         10) /* EncumbranceVal */
+     , (26400,   8,         10) /* Mass */
+     , (26400,   9,          0) /* ValidLocations - None */
+     , (26400,  11,         20) /* MaxStackSize */
+     , (26400,  12,          1) /* StackSize */
+     , (26400,  13,         10) /* StackUnitEncumbrance */
+     , (26400,  14,         10) /* StackUnitMass */
+     , (26400,  15,        500) /* StackUnitValue */
+     , (26400,  16,          8) /* ItemUseable - Contained */
+     , (26400,  18,          1) /* UiEffects - Magical */
+     , (26400,  19,        500) /* Value */
+     , (26400,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26400,  94,         16) /* TargetType - Creature */
+     , (26400, 106,        210) /* ItemSpellcraft */
+     , (26400, 107,         50) /* ItemCurMana */
+     , (26400, 108,         50) /* ItemMaxMana */
+     , (26400, 109,          0) /* ItemDifficulty */
+     , (26400, 110,          0) /* ItemAllegianceRankLimit */
+     , (26400, 150,        103) /* HookPlacement - Hook */
+     , (26400, 151,          2) /* HookType - Wall */
+     , (26400, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26400,  15, True ) /* LightsStatus */
+     , (26400,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26400, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26400,   1, 'Sweet Maple Cottages Portal Gem') /* Name */
+     , (26400,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26400,   1,   33556769) /* Setup */
+     , (26400,   3,  536870932) /* SoundTable */
+     , (26400,   6,   67111919) /* PaletteBase */
+     , (26400,   7,  268435723) /* ClothingBase */
+     , (26400,   8,  100675760) /* Icon */
+     , (26400,  22,  872415275) /* PhysicsEffectTable */
+     , (26400,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26400,  31,      15685) /* LinkedPortalOne - Sweet Maple Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26401 Taklihuan Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26401 Taklihuan Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26401;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26401, 'gemportaltaklihuansettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26401,   1,       2048) /* ItemType - Gem */
+     , (26401,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26401,   5,         10) /* EncumbranceVal */
+     , (26401,   8,         10) /* Mass */
+     , (26401,   9,          0) /* ValidLocations - None */
+     , (26401,  11,         20) /* MaxStackSize */
+     , (26401,  12,          1) /* StackSize */
+     , (26401,  13,         10) /* StackUnitEncumbrance */
+     , (26401,  14,         10) /* StackUnitMass */
+     , (26401,  15,        500) /* StackUnitValue */
+     , (26401,  16,          8) /* ItemUseable - Contained */
+     , (26401,  18,          1) /* UiEffects - Magical */
+     , (26401,  19,        500) /* Value */
+     , (26401,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26401,  94,         16) /* TargetType - Creature */
+     , (26401, 106,        210) /* ItemSpellcraft */
+     , (26401, 107,         50) /* ItemCurMana */
+     , (26401, 108,         50) /* ItemMaxMana */
+     , (26401, 109,          0) /* ItemDifficulty */
+     , (26401, 110,          0) /* ItemAllegianceRankLimit */
+     , (26401, 150,        103) /* HookPlacement - Hook */
+     , (26401, 151,          2) /* HookType - Wall */
+     , (26401, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26401,  15, True ) /* LightsStatus */
+     , (26401,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26401, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26401,   1, 'Taklihuan Settlement Portal Gem') /* Name */
+     , (26401,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26401,   1,   33556769) /* Setup */
+     , (26401,   3,  536870932) /* SoundTable */
+     , (26401,   6,   67111919) /* PaletteBase */
+     , (26401,   7,  268435723) /* ClothingBase */
+     , (26401,   8,  100675760) /* Icon */
+     , (26401,  22,  872415275) /* PhysicsEffectTable */
+     , (26401,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26401,  31,      12559) /* LinkedPortalOne - Taklihuan Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26402 Tanshi Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26402 Tanshi Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26402;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26402, 'gemportaltanshi', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26402,   1,       2048) /* ItemType - Gem */
+     , (26402,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26402,   5,         10) /* EncumbranceVal */
+     , (26402,   8,         10) /* Mass */
+     , (26402,   9,          0) /* ValidLocations - None */
+     , (26402,  11,         20) /* MaxStackSize */
+     , (26402,  12,          1) /* StackSize */
+     , (26402,  13,         10) /* StackUnitEncumbrance */
+     , (26402,  14,         10) /* StackUnitMass */
+     , (26402,  15,        500) /* StackUnitValue */
+     , (26402,  16,          8) /* ItemUseable - Contained */
+     , (26402,  18,          1) /* UiEffects - Magical */
+     , (26402,  19,        500) /* Value */
+     , (26402,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26402,  94,         16) /* TargetType - Creature */
+     , (26402, 106,        210) /* ItemSpellcraft */
+     , (26402, 107,         50) /* ItemCurMana */
+     , (26402, 108,         50) /* ItemMaxMana */
+     , (26402, 109,          0) /* ItemDifficulty */
+     , (26402, 110,          0) /* ItemAllegianceRankLimit */
+     , (26402, 150,        103) /* HookPlacement - Hook */
+     , (26402, 151,          2) /* HookType - Wall */
+     , (26402, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26402,  15, True ) /* LightsStatus */
+     , (26402,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26402, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26402,   1, 'Tanshi Portal Gem') /* Name */
+     , (26402,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26402,   1,   33556769) /* Setup */
+     , (26402,   3,  536870932) /* SoundTable */
+     , (26402,   6,   67111919) /* PaletteBase */
+     , (26402,   7,  268435723) /* ClothingBase */
+     , (26402,   8,  100675760) /* Icon */
+     , (26402,  22,  872415275) /* PhysicsEffectTable */
+     , (26402,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26402,  31,      13136) /* LinkedPortalOne - Tanshi Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26403 Taralla Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26403 Taralla Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26403;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26403, 'gemportaltaralla', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26403,   1,       2048) /* ItemType - Gem */
+     , (26403,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26403,   5,         10) /* EncumbranceVal */
+     , (26403,   8,         10) /* Mass */
+     , (26403,   9,          0) /* ValidLocations - None */
+     , (26403,  11,         20) /* MaxStackSize */
+     , (26403,  12,          1) /* StackSize */
+     , (26403,  13,         10) /* StackUnitEncumbrance */
+     , (26403,  14,         10) /* StackUnitMass */
+     , (26403,  15,        500) /* StackUnitValue */
+     , (26403,  16,          8) /* ItemUseable - Contained */
+     , (26403,  18,          1) /* UiEffects - Magical */
+     , (26403,  19,        500) /* Value */
+     , (26403,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26403,  94,         16) /* TargetType - Creature */
+     , (26403, 106,        210) /* ItemSpellcraft */
+     , (26403, 107,         50) /* ItemCurMana */
+     , (26403, 108,         50) /* ItemMaxMana */
+     , (26403, 109,          0) /* ItemDifficulty */
+     , (26403, 110,          0) /* ItemAllegianceRankLimit */
+     , (26403, 150,        103) /* HookPlacement - Hook */
+     , (26403, 151,          2) /* HookType - Wall */
+     , (26403, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26403,  15, True ) /* LightsStatus */
+     , (26403,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26403, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26403,   1, 'Taralla Portal Gem') /* Name */
+     , (26403,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26403,   1,   33556769) /* Setup */
+     , (26403,   3,  536870932) /* SoundTable */
+     , (26403,   6,   67111919) /* PaletteBase */
+     , (26403,   7,  268435723) /* ClothingBase */
+     , (26403,   8,  100675760) /* Icon */
+     , (26403,  22,  872415275) /* PhysicsEffectTable */
+     , (26403,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26403,  31,      14286) /* LinkedPortalOne - Taralla Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26404 Tarn Vinara Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26404 Tarn Vinara Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26404;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26404, 'gemportaltarnvinaravillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26404,   1,       2048) /* ItemType - Gem */
+     , (26404,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26404,   5,         10) /* EncumbranceVal */
+     , (26404,   8,         10) /* Mass */
+     , (26404,   9,          0) /* ValidLocations - None */
+     , (26404,  11,         20) /* MaxStackSize */
+     , (26404,  12,          1) /* StackSize */
+     , (26404,  13,         10) /* StackUnitEncumbrance */
+     , (26404,  14,         10) /* StackUnitMass */
+     , (26404,  15,        500) /* StackUnitValue */
+     , (26404,  16,          8) /* ItemUseable - Contained */
+     , (26404,  18,          1) /* UiEffects - Magical */
+     , (26404,  19,        500) /* Value */
+     , (26404,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26404,  94,         16) /* TargetType - Creature */
+     , (26404, 106,        210) /* ItemSpellcraft */
+     , (26404, 107,         50) /* ItemCurMana */
+     , (26404, 108,         50) /* ItemMaxMana */
+     , (26404, 109,          0) /* ItemDifficulty */
+     , (26404, 110,          0) /* ItemAllegianceRankLimit */
+     , (26404, 150,        103) /* HookPlacement - Hook */
+     , (26404, 151,          2) /* HookType - Wall */
+     , (26404, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26404,  15, True ) /* LightsStatus */
+     , (26404,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26404, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26404,   1, 'Tarn Vinara Villas Portal Gem') /* Name */
+     , (26404,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26404,   1,   33556769) /* Setup */
+     , (26404,   3,  536870932) /* SoundTable */
+     , (26404,   6,   67111919) /* PaletteBase */
+     , (26404,   7,  268435723) /* ClothingBase */
+     , (26404,   8,  100675760) /* Icon */
+     , (26404,  22,  872415275) /* PhysicsEffectTable */
+     , (26404,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26404,  31,      14673) /* LinkedPortalOne - Tarn Vinara Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26405 Tattered Ridge Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26405 Tattered Ridge Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26405;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26405, 'gemportaltatteredridge', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26405,   1,       2048) /* ItemType - Gem */
+     , (26405,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26405,   5,         10) /* EncumbranceVal */
+     , (26405,   8,         10) /* Mass */
+     , (26405,   9,          0) /* ValidLocations - None */
+     , (26405,  11,         20) /* MaxStackSize */
+     , (26405,  12,          1) /* StackSize */
+     , (26405,  13,         10) /* StackUnitEncumbrance */
+     , (26405,  14,         10) /* StackUnitMass */
+     , (26405,  15,        500) /* StackUnitValue */
+     , (26405,  16,          8) /* ItemUseable - Contained */
+     , (26405,  18,          1) /* UiEffects - Magical */
+     , (26405,  19,        500) /* Value */
+     , (26405,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26405,  94,         16) /* TargetType - Creature */
+     , (26405, 106,        210) /* ItemSpellcraft */
+     , (26405, 107,         50) /* ItemCurMana */
+     , (26405, 108,         50) /* ItemMaxMana */
+     , (26405, 109,          0) /* ItemDifficulty */
+     , (26405, 110,          0) /* ItemAllegianceRankLimit */
+     , (26405, 150,        103) /* HookPlacement - Hook */
+     , (26405, 151,          2) /* HookType - Wall */
+     , (26405, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26405,  15, True ) /* LightsStatus */
+     , (26405,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26405, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26405,   1, 'Tattered Ridge Portal Gem') /* Name */
+     , (26405,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26405,   1,   33556769) /* Setup */
+     , (26405,   3,  536870932) /* SoundTable */
+     , (26405,   6,   67111919) /* PaletteBase */
+     , (26405,   7,  268435723) /* ClothingBase */
+     , (26405,   8,  100675760) /* Icon */
+     , (26405,  22,  872415275) /* PhysicsEffectTable */
+     , (26405,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26405,  31,      14287) /* LinkedPortalOne - Tattered Ridge Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26406 Tharesun Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26406 Tharesun Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26406;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26406, 'gemportaltharesun', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26406,   1,       2048) /* ItemType - Gem */
+     , (26406,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26406,   5,         10) /* EncumbranceVal */
+     , (26406,   8,         10) /* Mass */
+     , (26406,   9,          0) /* ValidLocations - None */
+     , (26406,  11,         20) /* MaxStackSize */
+     , (26406,  12,          1) /* StackSize */
+     , (26406,  13,         10) /* StackUnitEncumbrance */
+     , (26406,  14,         10) /* StackUnitMass */
+     , (26406,  15,        500) /* StackUnitValue */
+     , (26406,  16,          8) /* ItemUseable - Contained */
+     , (26406,  18,          1) /* UiEffects - Magical */
+     , (26406,  19,        500) /* Value */
+     , (26406,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26406,  94,         16) /* TargetType - Creature */
+     , (26406, 106,        210) /* ItemSpellcraft */
+     , (26406, 107,         50) /* ItemCurMana */
+     , (26406, 108,         50) /* ItemMaxMana */
+     , (26406, 109,          0) /* ItemDifficulty */
+     , (26406, 110,          0) /* ItemAllegianceRankLimit */
+     , (26406, 150,        103) /* HookPlacement - Hook */
+     , (26406, 151,          2) /* HookType - Wall */
+     , (26406, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26406,  15, True ) /* LightsStatus */
+     , (26406,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26406, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26406,   1, 'Tharesun Portal Gem') /* Name */
+     , (26406,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26406,   1,   33556769) /* Setup */
+     , (26406,   3,  536870932) /* SoundTable */
+     , (26406,   6,   67111919) /* PaletteBase */
+     , (26406,   7,  268435723) /* ClothingBase */
+     , (26406,   8,  100675760) /* Icon */
+     , (26406,  22,  872415275) /* PhysicsEffectTable */
+     , (26406,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26406,  31,      15195) /* LinkedPortalOne - Tharesun Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26407 Thasali Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26407 Thasali Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26407;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26407, 'gemportalthasalicottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26407,   1,       2048) /* ItemType - Gem */
+     , (26407,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26407,   5,         10) /* EncumbranceVal */
+     , (26407,   8,         10) /* Mass */
+     , (26407,   9,          0) /* ValidLocations - None */
+     , (26407,  11,         20) /* MaxStackSize */
+     , (26407,  12,          1) /* StackSize */
+     , (26407,  13,         10) /* StackUnitEncumbrance */
+     , (26407,  14,         10) /* StackUnitMass */
+     , (26407,  15,        500) /* StackUnitValue */
+     , (26407,  16,          8) /* ItemUseable - Contained */
+     , (26407,  18,          1) /* UiEffects - Magical */
+     , (26407,  19,        500) /* Value */
+     , (26407,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26407,  94,         16) /* TargetType - Creature */
+     , (26407, 106,        210) /* ItemSpellcraft */
+     , (26407, 107,         50) /* ItemCurMana */
+     , (26407, 108,         50) /* ItemMaxMana */
+     , (26407, 109,          0) /* ItemDifficulty */
+     , (26407, 110,          0) /* ItemAllegianceRankLimit */
+     , (26407, 150,        103) /* HookPlacement - Hook */
+     , (26407, 151,          2) /* HookType - Wall */
+     , (26407, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26407,  15, True ) /* LightsStatus */
+     , (26407,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26407, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26407,   1, 'Thasali Cottages Portal Gem') /* Name */
+     , (26407,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26407,   1,   33556769) /* Setup */
+     , (26407,   3,  536870932) /* SoundTable */
+     , (26407,   6,   67111919) /* PaletteBase */
+     , (26407,   7,  268435723) /* ClothingBase */
+     , (26407,   8,  100675760) /* Icon */
+     , (26407,  22,  872415275) /* PhysicsEffectTable */
+     , (26407,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26407,  31,      15196) /* LinkedPortalOne - Thasali Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26408 Thyrinn Cant Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26408 Thyrinn Cant Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26408;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26408, 'gemportalthyrinncantcottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26408,   1,       2048) /* ItemType - Gem */
+     , (26408,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26408,   5,         10) /* EncumbranceVal */
+     , (26408,   8,         10) /* Mass */
+     , (26408,   9,          0) /* ValidLocations - None */
+     , (26408,  11,         20) /* MaxStackSize */
+     , (26408,  12,          1) /* StackSize */
+     , (26408,  13,         10) /* StackUnitEncumbrance */
+     , (26408,  14,         10) /* StackUnitMass */
+     , (26408,  15,        500) /* StackUnitValue */
+     , (26408,  16,          8) /* ItemUseable - Contained */
+     , (26408,  18,          1) /* UiEffects - Magical */
+     , (26408,  19,        500) /* Value */
+     , (26408,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26408,  94,         16) /* TargetType - Creature */
+     , (26408, 106,        210) /* ItemSpellcraft */
+     , (26408, 107,         50) /* ItemCurMana */
+     , (26408, 108,         50) /* ItemMaxMana */
+     , (26408, 109,          0) /* ItemDifficulty */
+     , (26408, 110,          0) /* ItemAllegianceRankLimit */
+     , (26408, 150,        103) /* HookPlacement - Hook */
+     , (26408, 151,          2) /* HookType - Wall */
+     , (26408, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26408,  15, True ) /* LightsStatus */
+     , (26408,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26408, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26408,   1, 'Thyrinn Cant Cottages Portal Gem') /* Name */
+     , (26408,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26408,   1,   33556769) /* Setup */
+     , (26408,   3,  536870932) /* SoundTable */
+     , (26408,   6,   67111919) /* PaletteBase */
+     , (26408,   7,  268435723) /* ClothingBase */
+     , (26408,   8,  100675760) /* Icon */
+     , (26408,  22,  872415275) /* PhysicsEffectTable */
+     , (26408,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26408,  31,      15197) /* LinkedPortalOne - Thyrinn Cant Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26409 Tia-Leh Homestead Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26409 Tia-Leh Homestead Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26409;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26409, 'gemportaltialehhomestead', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26409,   1,       2048) /* ItemType - Gem */
+     , (26409,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26409,   5,         10) /* EncumbranceVal */
+     , (26409,   8,         10) /* Mass */
+     , (26409,   9,          0) /* ValidLocations - None */
+     , (26409,  11,         20) /* MaxStackSize */
+     , (26409,  12,          1) /* StackSize */
+     , (26409,  13,         10) /* StackUnitEncumbrance */
+     , (26409,  14,         10) /* StackUnitMass */
+     , (26409,  15,        500) /* StackUnitValue */
+     , (26409,  16,          8) /* ItemUseable - Contained */
+     , (26409,  18,          1) /* UiEffects - Magical */
+     , (26409,  19,        500) /* Value */
+     , (26409,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26409,  94,         16) /* TargetType - Creature */
+     , (26409, 106,        210) /* ItemSpellcraft */
+     , (26409, 107,         50) /* ItemCurMana */
+     , (26409, 108,         50) /* ItemMaxMana */
+     , (26409, 109,          0) /* ItemDifficulty */
+     , (26409, 110,          0) /* ItemAllegianceRankLimit */
+     , (26409, 150,        103) /* HookPlacement - Hook */
+     , (26409, 151,          2) /* HookType - Wall */
+     , (26409, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26409,  15, True ) /* LightsStatus */
+     , (26409,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26409, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26409,   1, 'Tia-Leh Homestead Portal Gem') /* Name */
+     , (26409,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26409,   1,   33556769) /* Setup */
+     , (26409,   3,  536870932) /* SoundTable */
+     , (26409,   6,   67111919) /* PaletteBase */
+     , (26409,   7,  268435723) /* ClothingBase */
+     , (26409,   8,  100675760) /* Icon */
+     , (26409,  22,  872415275) /* PhysicsEffectTable */
+     , (26409,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26409,  31,      15198) /* LinkedPortalOne - Tia-Leh Homestead Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26410 Tinkelo Hold Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26410 Tinkelo Hold Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26410;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26410, 'gemportaltinkeloholdvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26410,   1,       2048) /* ItemType - Gem */
+     , (26410,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26410,   5,         10) /* EncumbranceVal */
+     , (26410,   8,         10) /* Mass */
+     , (26410,   9,          0) /* ValidLocations - None */
+     , (26410,  11,         20) /* MaxStackSize */
+     , (26410,  12,          1) /* StackSize */
+     , (26410,  13,         10) /* StackUnitEncumbrance */
+     , (26410,  14,         10) /* StackUnitMass */
+     , (26410,  15,        500) /* StackUnitValue */
+     , (26410,  16,          8) /* ItemUseable - Contained */
+     , (26410,  18,          1) /* UiEffects - Magical */
+     , (26410,  19,        500) /* Value */
+     , (26410,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26410,  94,         16) /* TargetType - Creature */
+     , (26410, 106,        210) /* ItemSpellcraft */
+     , (26410, 107,         50) /* ItemCurMana */
+     , (26410, 108,         50) /* ItemMaxMana */
+     , (26410, 109,          0) /* ItemDifficulty */
+     , (26410, 110,          0) /* ItemAllegianceRankLimit */
+     , (26410, 150,        103) /* HookPlacement - Hook */
+     , (26410, 151,          2) /* HookType - Wall */
+     , (26410, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26410,  15, True ) /* LightsStatus */
+     , (26410,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26410, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26410,   1, 'Tinkelo Hold Villas Portal Gem') /* Name */
+     , (26410,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26410,   1,   33556769) /* Setup */
+     , (26410,   3,  536870932) /* SoundTable */
+     , (26410,   6,   67111919) /* PaletteBase */
+     , (26410,   7,  268435723) /* ClothingBase */
+     , (26410,   8,  100675760) /* Icon */
+     , (26410,  22,  872415275) /* PhysicsEffectTable */
+     , (26410,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26410,  31,      15199) /* LinkedPortalOne - Tinkelo Hold Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26411 Tiofor Deeps Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26411 Tiofor Deeps Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26411;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26411, 'gemportaltiofordeeps', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26411,   1,       2048) /* ItemType - Gem */
+     , (26411,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26411,   5,         10) /* EncumbranceVal */
+     , (26411,   8,         10) /* Mass */
+     , (26411,   9,          0) /* ValidLocations - None */
+     , (26411,  11,         20) /* MaxStackSize */
+     , (26411,  12,          1) /* StackSize */
+     , (26411,  13,         10) /* StackUnitEncumbrance */
+     , (26411,  14,         10) /* StackUnitMass */
+     , (26411,  15,        500) /* StackUnitValue */
+     , (26411,  16,          8) /* ItemUseable - Contained */
+     , (26411,  18,          1) /* UiEffects - Magical */
+     , (26411,  19,        500) /* Value */
+     , (26411,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26411,  94,         16) /* TargetType - Creature */
+     , (26411, 106,        210) /* ItemSpellcraft */
+     , (26411, 107,         50) /* ItemCurMana */
+     , (26411, 108,         50) /* ItemMaxMana */
+     , (26411, 109,          0) /* ItemDifficulty */
+     , (26411, 110,          0) /* ItemAllegianceRankLimit */
+     , (26411, 150,        103) /* HookPlacement - Hook */
+     , (26411, 151,          2) /* HookType - Wall */
+     , (26411, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26411,  15, True ) /* LightsStatus */
+     , (26411,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26411, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26411,   1, 'Tiofor Deeps Portal Gem') /* Name */
+     , (26411,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26411,   1,   33556769) /* Setup */
+     , (26411,   3,  536870932) /* SoundTable */
+     , (26411,   6,   67111919) /* PaletteBase */
+     , (26411,   7,  268435723) /* ClothingBase */
+     , (26411,   8,  100675760) /* Icon */
+     , (26411,  22,  872415275) /* PhysicsEffectTable */
+     , (26411,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26411,  31,      12560) /* LinkedPortalOne - Tiofor Deeps Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26412 Tou-Tou Road Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26412 Tou-Tou Road Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26412;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26412, 'gemportaltoutoroadvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26412,   1,       2048) /* ItemType - Gem */
+     , (26412,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26412,   5,         10) /* EncumbranceVal */
+     , (26412,   8,         10) /* Mass */
+     , (26412,   9,          0) /* ValidLocations - None */
+     , (26412,  11,         20) /* MaxStackSize */
+     , (26412,  12,          1) /* StackSize */
+     , (26412,  13,         10) /* StackUnitEncumbrance */
+     , (26412,  14,         10) /* StackUnitMass */
+     , (26412,  15,        500) /* StackUnitValue */
+     , (26412,  16,          8) /* ItemUseable - Contained */
+     , (26412,  18,          1) /* UiEffects - Magical */
+     , (26412,  19,        500) /* Value */
+     , (26412,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26412,  94,         16) /* TargetType - Creature */
+     , (26412, 106,        210) /* ItemSpellcraft */
+     , (26412, 107,         50) /* ItemCurMana */
+     , (26412, 108,         50) /* ItemMaxMana */
+     , (26412, 109,          0) /* ItemDifficulty */
+     , (26412, 110,          0) /* ItemAllegianceRankLimit */
+     , (26412, 150,        103) /* HookPlacement - Hook */
+     , (26412, 151,          2) /* HookType - Wall */
+     , (26412, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26412,  15, True ) /* LightsStatus */
+     , (26412,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26412, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26412,   1, 'Tou-Tou Road Villas Portal Gem') /* Name */
+     , (26412,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26412,   1,   33556769) /* Setup */
+     , (26412,   3,  536870932) /* SoundTable */
+     , (26412,   6,   67111919) /* PaletteBase */
+     , (26412,   7,  268435723) /* ClothingBase */
+     , (26412,   8,  100675760) /* Icon */
+     , (26412,  22,  872415275) /* PhysicsEffectTable */
+     , (26412,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26412,  31,      13137) /* LinkedPortalOne - Tou-Tou Road Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26413 Tou-Tou Penninsula Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26413 Tou-Tou Penninsula Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26413;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26413, 'gemportaltoutoupenninsulacottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26413,   1,       2048) /* ItemType - Gem */
+     , (26413,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26413,   5,         10) /* EncumbranceVal */
+     , (26413,   8,         10) /* Mass */
+     , (26413,   9,          0) /* ValidLocations - None */
+     , (26413,  11,         20) /* MaxStackSize */
+     , (26413,  12,          1) /* StackSize */
+     , (26413,  13,         10) /* StackUnitEncumbrance */
+     , (26413,  14,         10) /* StackUnitMass */
+     , (26413,  15,        500) /* StackUnitValue */
+     , (26413,  16,          8) /* ItemUseable - Contained */
+     , (26413,  18,          1) /* UiEffects - Magical */
+     , (26413,  19,        500) /* Value */
+     , (26413,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26413,  94,         16) /* TargetType - Creature */
+     , (26413, 106,        210) /* ItemSpellcraft */
+     , (26413, 107,         50) /* ItemCurMana */
+     , (26413, 108,         50) /* ItemMaxMana */
+     , (26413, 109,          0) /* ItemDifficulty */
+     , (26413, 110,          0) /* ItemAllegianceRankLimit */
+     , (26413, 150,        103) /* HookPlacement - Hook */
+     , (26413, 151,          2) /* HookType - Wall */
+     , (26413, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26413,  15, True ) /* LightsStatus */
+     , (26413,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26413, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26413,   1, 'Tou-Tou Penninsula Cottages Portal Gem') /* Name */
+     , (26413,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26413,   1,   33556769) /* Setup */
+     , (26413,   3,  536870932) /* SoundTable */
+     , (26413,   6,   67111919) /* PaletteBase */
+     , (26413,   7,  268435723) /* ClothingBase */
+     , (26413,   8,  100675760) /* Icon */
+     , (26413,  22,  872415275) /* PhysicsEffectTable */
+     , (26413,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26413,  31,      12561) /* LinkedPortalOne - Tou-Tou Penninsula Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26414 Tri-Ridge Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26414 Tri-Ridge Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26414;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26414, 'gemportaltriridge', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26414,   1,       2048) /* ItemType - Gem */
+     , (26414,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26414,   5,         10) /* EncumbranceVal */
+     , (26414,   8,         10) /* Mass */
+     , (26414,   9,          0) /* ValidLocations - None */
+     , (26414,  11,         20) /* MaxStackSize */
+     , (26414,  12,          1) /* StackSize */
+     , (26414,  13,         10) /* StackUnitEncumbrance */
+     , (26414,  14,         10) /* StackUnitMass */
+     , (26414,  15,        500) /* StackUnitValue */
+     , (26414,  16,          8) /* ItemUseable - Contained */
+     , (26414,  18,          1) /* UiEffects - Magical */
+     , (26414,  19,        500) /* Value */
+     , (26414,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26414,  94,         16) /* TargetType - Creature */
+     , (26414, 106,        210) /* ItemSpellcraft */
+     , (26414, 107,         50) /* ItemCurMana */
+     , (26414, 108,         50) /* ItemMaxMana */
+     , (26414, 109,          0) /* ItemDifficulty */
+     , (26414, 110,          0) /* ItemAllegianceRankLimit */
+     , (26414, 150,        103) /* HookPlacement - Hook */
+     , (26414, 151,          2) /* HookType - Wall */
+     , (26414, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26414,  15, True ) /* LightsStatus */
+     , (26414,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26414, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26414,   1, 'Tri-Ridge Portal Gem') /* Name */
+     , (26414,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26414,   1,   33556769) /* Setup */
+     , (26414,   3,  536870932) /* SoundTable */
+     , (26414,   6,   67111919) /* PaletteBase */
+     , (26414,   7,  268435723) /* ClothingBase */
+     , (26414,   8,  100675760) /* Icon */
+     , (26414,  22,  872415275) /* PhysicsEffectTable */
+     , (26414,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26414,  31,      14288) /* LinkedPortalOne - Tri-Ridge Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26415 Tusker Notch Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26415 Tusker Notch Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26415;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26415, 'gemportaltuskernotch', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26415,   1,       2048) /* ItemType - Gem */
+     , (26415,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26415,   5,         10) /* EncumbranceVal */
+     , (26415,   8,         10) /* Mass */
+     , (26415,   9,          0) /* ValidLocations - None */
+     , (26415,  11,         20) /* MaxStackSize */
+     , (26415,  12,          1) /* StackSize */
+     , (26415,  13,         10) /* StackUnitEncumbrance */
+     , (26415,  14,         10) /* StackUnitMass */
+     , (26415,  15,        500) /* StackUnitValue */
+     , (26415,  16,          8) /* ItemUseable - Contained */
+     , (26415,  18,          1) /* UiEffects - Magical */
+     , (26415,  19,        500) /* Value */
+     , (26415,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26415,  94,         16) /* TargetType - Creature */
+     , (26415, 106,        210) /* ItemSpellcraft */
+     , (26415, 107,         50) /* ItemCurMana */
+     , (26415, 108,         50) /* ItemMaxMana */
+     , (26415, 109,          0) /* ItemDifficulty */
+     , (26415, 110,          0) /* ItemAllegianceRankLimit */
+     , (26415, 150,        103) /* HookPlacement - Hook */
+     , (26415, 151,          2) /* HookType - Wall */
+     , (26415, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26415,  15, True ) /* LightsStatus */
+     , (26415,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26415, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26415,   1, 'Tusker Notch Portal Gem') /* Name */
+     , (26415,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26415,   1,   33556769) /* Setup */
+     , (26415,   3,  536870932) /* SoundTable */
+     , (26415,   6,   67111919) /* PaletteBase */
+     , (26415,   7,  268435723) /* ClothingBase */
+     , (26415,   8,  100675760) /* Icon */
+     , (26415,  22,  872415275) /* PhysicsEffectTable */
+     , (26415,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26415,  31,      19162) /* LinkedPortalOne - Tusker Notch Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26416 Two Hills Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26416 Two Hills Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26416;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26416, 'gemportaltwohillscottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26416,   1,       2048) /* ItemType - Gem */
+     , (26416,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26416,   5,         10) /* EncumbranceVal */
+     , (26416,   8,         10) /* Mass */
+     , (26416,   9,          0) /* ValidLocations - None */
+     , (26416,  11,         20) /* MaxStackSize */
+     , (26416,  12,          1) /* StackSize */
+     , (26416,  13,         10) /* StackUnitEncumbrance */
+     , (26416,  14,         10) /* StackUnitMass */
+     , (26416,  15,        500) /* StackUnitValue */
+     , (26416,  16,          8) /* ItemUseable - Contained */
+     , (26416,  18,          1) /* UiEffects - Magical */
+     , (26416,  19,        500) /* Value */
+     , (26416,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26416,  94,         16) /* TargetType - Creature */
+     , (26416, 106,        210) /* ItemSpellcraft */
+     , (26416, 107,         50) /* ItemCurMana */
+     , (26416, 108,         50) /* ItemMaxMana */
+     , (26416, 109,          0) /* ItemDifficulty */
+     , (26416, 110,          0) /* ItemAllegianceRankLimit */
+     , (26416, 150,        103) /* HookPlacement - Hook */
+     , (26416, 151,          2) /* HookType - Wall */
+     , (26416, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26416,  15, True ) /* LightsStatus */
+     , (26416,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26416, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26416,   1, 'Two Hills Cottages Portal Gem') /* Name */
+     , (26416,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26416,   1,   33556769) /* Setup */
+     , (26416,   3,  536870932) /* SoundTable */
+     , (26416,   6,   67111919) /* PaletteBase */
+     , (26416,   7,  268435723) /* ClothingBase */
+     , (26416,   8,  100675760) /* Icon */
+     , (26416,  22,  872415275) /* PhysicsEffectTable */
+     , (26416,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26416,  31,      19163) /* LinkedPortalOne - Two Hills Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26417 Tyrrin Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26417 Tyrrin Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26417;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26417, 'gemportaltyrrincottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26417,   1,       2048) /* ItemType - Gem */
+     , (26417,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26417,   5,         10) /* EncumbranceVal */
+     , (26417,   8,         10) /* Mass */
+     , (26417,   9,          0) /* ValidLocations - None */
+     , (26417,  11,         20) /* MaxStackSize */
+     , (26417,  12,          1) /* StackSize */
+     , (26417,  13,         10) /* StackUnitEncumbrance */
+     , (26417,  14,         10) /* StackUnitMass */
+     , (26417,  15,        500) /* StackUnitValue */
+     , (26417,  16,          8) /* ItemUseable - Contained */
+     , (26417,  18,          1) /* UiEffects - Magical */
+     , (26417,  19,        500) /* Value */
+     , (26417,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26417,  94,         16) /* TargetType - Creature */
+     , (26417, 106,        210) /* ItemSpellcraft */
+     , (26417, 107,         50) /* ItemCurMana */
+     , (26417, 108,         50) /* ItemMaxMana */
+     , (26417, 109,          0) /* ItemDifficulty */
+     , (26417, 110,          0) /* ItemAllegianceRankLimit */
+     , (26417, 150,        103) /* HookPlacement - Hook */
+     , (26417, 151,          2) /* HookType - Wall */
+     , (26417, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26417,  15, True ) /* LightsStatus */
+     , (26417,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26417, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26417,   1, 'Tyrrin Cottages Portal Gem') /* Name */
+     , (26417,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26417,   1,   33556769) /* Setup */
+     , (26417,   3,  536870932) /* SoundTable */
+     , (26417,   6,   67111919) /* PaletteBase */
+     , (26417,   7,  268435723) /* ClothingBase */
+     , (26417,   8,  100675760) /* Icon */
+     , (26417,  22,  872415275) /* PhysicsEffectTable */
+     , (26417,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26417,  31,      19164) /* LinkedPortalOne - Tyrrin Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26418 Unified Heart Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26418 Unified Heart Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26418;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26418, 'gemportalunifiedheartvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26418,   1,       2048) /* ItemType - Gem */
+     , (26418,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26418,   5,         10) /* EncumbranceVal */
+     , (26418,   8,         10) /* Mass */
+     , (26418,   9,          0) /* ValidLocations - None */
+     , (26418,  11,         20) /* MaxStackSize */
+     , (26418,  12,          1) /* StackSize */
+     , (26418,  13,         10) /* StackUnitEncumbrance */
+     , (26418,  14,         10) /* StackUnitMass */
+     , (26418,  15,        500) /* StackUnitValue */
+     , (26418,  16,          8) /* ItemUseable - Contained */
+     , (26418,  18,          1) /* UiEffects - Magical */
+     , (26418,  19,        500) /* Value */
+     , (26418,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26418,  94,         16) /* TargetType - Creature */
+     , (26418, 106,        210) /* ItemSpellcraft */
+     , (26418, 107,         50) /* ItemCurMana */
+     , (26418, 108,         50) /* ItemMaxMana */
+     , (26418, 109,          0) /* ItemDifficulty */
+     , (26418, 110,          0) /* ItemAllegianceRankLimit */
+     , (26418, 150,        103) /* HookPlacement - Hook */
+     , (26418, 151,          2) /* HookType - Wall */
+     , (26418, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26418,  15, True ) /* LightsStatus */
+     , (26418,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26418, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26418,   1, 'Unified Heart Villas Portal Gem') /* Name */
+     , (26418,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26418,   1,   33556769) /* Setup */
+     , (26418,   3,  536870932) /* SoundTable */
+     , (26418,   6,   67111919) /* PaletteBase */
+     , (26418,   7,  268435723) /* ClothingBase */
+     , (26418,   8,  100675760) /* Icon */
+     , (26418,  22,  872415275) /* PhysicsEffectTable */
+     , (26418,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26418,  31,      19165) /* LinkedPortalOne - Unified Heart Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26419 Verena Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26419 Verena Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26419;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26419, 'gemportalverena', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26419,   1,       2048) /* ItemType - Gem */
+     , (26419,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26419,   5,         10) /* EncumbranceVal */
+     , (26419,   8,         10) /* Mass */
+     , (26419,   9,          0) /* ValidLocations - None */
+     , (26419,  11,         20) /* MaxStackSize */
+     , (26419,  12,          1) /* StackSize */
+     , (26419,  13,         10) /* StackUnitEncumbrance */
+     , (26419,  14,         10) /* StackUnitMass */
+     , (26419,  15,        500) /* StackUnitValue */
+     , (26419,  16,          8) /* ItemUseable - Contained */
+     , (26419,  18,          1) /* UiEffects - Magical */
+     , (26419,  19,        500) /* Value */
+     , (26419,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26419,  94,         16) /* TargetType - Creature */
+     , (26419, 106,        210) /* ItemSpellcraft */
+     , (26419, 107,         50) /* ItemCurMana */
+     , (26419, 108,         50) /* ItemMaxMana */
+     , (26419, 109,          0) /* ItemDifficulty */
+     , (26419, 110,          0) /* ItemAllegianceRankLimit */
+     , (26419, 150,        103) /* HookPlacement - Hook */
+     , (26419, 151,          2) /* HookType - Wall */
+     , (26419, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26419,  15, True ) /* LightsStatus */
+     , (26419,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26419, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26419,   1, 'Verena Portal Gem') /* Name */
+     , (26419,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26419,   1,   33556769) /* Setup */
+     , (26419,   3,  536870932) /* SoundTable */
+     , (26419,   6,   67111919) /* PaletteBase */
+     , (26419,   7,  268435723) /* ClothingBase */
+     , (26419,   8,  100675760) /* Icon */
+     , (26419,  22,  872415275) /* PhysicsEffectTable */
+     , (26419,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26419,  31,      14674) /* LinkedPortalOne - Verena Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26420 Vesayan Overlook Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26420 Vesayan Overlook Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26420;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26420, 'gemportalvesayanoverlook', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26420,   1,       2048) /* ItemType - Gem */
+     , (26420,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26420,   5,         10) /* EncumbranceVal */
+     , (26420,   8,         10) /* Mass */
+     , (26420,   9,          0) /* ValidLocations - None */
+     , (26420,  11,         20) /* MaxStackSize */
+     , (26420,  12,          1) /* StackSize */
+     , (26420,  13,         10) /* StackUnitEncumbrance */
+     , (26420,  14,         10) /* StackUnitMass */
+     , (26420,  15,        500) /* StackUnitValue */
+     , (26420,  16,          8) /* ItemUseable - Contained */
+     , (26420,  18,          1) /* UiEffects - Magical */
+     , (26420,  19,        500) /* Value */
+     , (26420,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26420,  94,         16) /* TargetType - Creature */
+     , (26420, 106,        210) /* ItemSpellcraft */
+     , (26420, 107,         50) /* ItemCurMana */
+     , (26420, 108,         50) /* ItemMaxMana */
+     , (26420, 109,          0) /* ItemDifficulty */
+     , (26420, 110,          0) /* ItemAllegianceRankLimit */
+     , (26420, 150,        103) /* HookPlacement - Hook */
+     , (26420, 151,          2) /* HookType - Wall */
+     , (26420, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26420,  15, True ) /* LightsStatus */
+     , (26420,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26420, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26420,   1, 'Vesayan Overlook Portal Gem') /* Name */
+     , (26420,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26420,   1,   33556769) /* Setup */
+     , (26420,   3,  536870932) /* SoundTable */
+     , (26420,   6,   67111919) /* PaletteBase */
+     , (26420,   7,  268435723) /* ClothingBase */
+     , (26420,   8,  100675760) /* Icon */
+     , (26420,  22,  872415275) /* PhysicsEffectTable */
+     , (26420,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26420,  31,      12562) /* LinkedPortalOne - Vesayan Overlook Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26421 Village Quan Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26421 Village Quan Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26421;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26421, 'gemportalvillagequan', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26421,   1,       2048) /* ItemType - Gem */
+     , (26421,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26421,   5,         10) /* EncumbranceVal */
+     , (26421,   8,         10) /* Mass */
+     , (26421,   9,          0) /* ValidLocations - None */
+     , (26421,  11,         20) /* MaxStackSize */
+     , (26421,  12,          1) /* StackSize */
+     , (26421,  13,         10) /* StackUnitEncumbrance */
+     , (26421,  14,         10) /* StackUnitMass */
+     , (26421,  15,        500) /* StackUnitValue */
+     , (26421,  16,          8) /* ItemUseable - Contained */
+     , (26421,  18,          1) /* UiEffects - Magical */
+     , (26421,  19,        500) /* Value */
+     , (26421,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26421,  94,         16) /* TargetType - Creature */
+     , (26421, 106,        210) /* ItemSpellcraft */
+     , (26421, 107,         50) /* ItemCurMana */
+     , (26421, 108,         50) /* ItemMaxMana */
+     , (26421, 109,          0) /* ItemDifficulty */
+     , (26421, 110,          0) /* ItemAllegianceRankLimit */
+     , (26421, 150,        103) /* HookPlacement - Hook */
+     , (26421, 151,          2) /* HookType - Wall */
+     , (26421, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26421,  15, True ) /* LightsStatus */
+     , (26421,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26421, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26421,   1, 'Village Quan Portal Gem') /* Name */
+     , (26421,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26421,   1,   33556769) /* Setup */
+     , (26421,   3,  536870932) /* SoundTable */
+     , (26421,   6,   67111919) /* PaletteBase */
+     , (26421,   7,  268435723) /* ClothingBase */
+     , (26421,   8,  100675760) /* Icon */
+     , (26421,  22,  872415275) /* PhysicsEffectTable */
+     , (26421,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26421,  31,      15200) /* LinkedPortalOne - Village Quan Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26422 Villalabar Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26422 Villalabar Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26422;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26422, 'gemportalvillalabar', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26422,   1,       2048) /* ItemType - Gem */
+     , (26422,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26422,   5,         10) /* EncumbranceVal */
+     , (26422,   8,         10) /* Mass */
+     , (26422,   9,          0) /* ValidLocations - None */
+     , (26422,  11,         20) /* MaxStackSize */
+     , (26422,  12,          1) /* StackSize */
+     , (26422,  13,         10) /* StackUnitEncumbrance */
+     , (26422,  14,         10) /* StackUnitMass */
+     , (26422,  15,        500) /* StackUnitValue */
+     , (26422,  16,          8) /* ItemUseable - Contained */
+     , (26422,  18,          1) /* UiEffects - Magical */
+     , (26422,  19,        500) /* Value */
+     , (26422,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26422,  94,         16) /* TargetType - Creature */
+     , (26422, 106,        210) /* ItemSpellcraft */
+     , (26422, 107,         50) /* ItemCurMana */
+     , (26422, 108,         50) /* ItemMaxMana */
+     , (26422, 109,          0) /* ItemDifficulty */
+     , (26422, 110,          0) /* ItemAllegianceRankLimit */
+     , (26422, 150,        103) /* HookPlacement - Hook */
+     , (26422, 151,          2) /* HookType - Wall */
+     , (26422, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26422,  15, True ) /* LightsStatus */
+     , (26422,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26422, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26422,   1, 'Villalabar Portal Gem') /* Name */
+     , (26422,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26422,   1,   33556769) /* Setup */
+     , (26422,   3,  536870932) /* SoundTable */
+     , (26422,   6,   67111919) /* PaletteBase */
+     , (26422,   7,  268435723) /* ClothingBase */
+     , (26422,   8,  100675760) /* Icon */
+     , (26422,  22,  872415275) /* PhysicsEffectTable */
+     , (26422,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26422,  31,      14289) /* LinkedPortalOne - Villalabar Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26423 Vulture's Eye Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26423 Vulture's Eye Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26423;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26423, 'gemportalvultureseyevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26423,   1,       2048) /* ItemType - Gem */
+     , (26423,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26423,   5,         10) /* EncumbranceVal */
+     , (26423,   8,         10) /* Mass */
+     , (26423,   9,          0) /* ValidLocations - None */
+     , (26423,  11,         20) /* MaxStackSize */
+     , (26423,  12,          1) /* StackSize */
+     , (26423,  13,         10) /* StackUnitEncumbrance */
+     , (26423,  14,         10) /* StackUnitMass */
+     , (26423,  15,        500) /* StackUnitValue */
+     , (26423,  16,          8) /* ItemUseable - Contained */
+     , (26423,  18,          1) /* UiEffects - Magical */
+     , (26423,  19,        500) /* Value */
+     , (26423,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26423,  94,         16) /* TargetType - Creature */
+     , (26423, 106,        210) /* ItemSpellcraft */
+     , (26423, 107,         50) /* ItemCurMana */
+     , (26423, 108,         50) /* ItemMaxMana */
+     , (26423, 109,          0) /* ItemDifficulty */
+     , (26423, 110,          0) /* ItemAllegianceRankLimit */
+     , (26423, 150,        103) /* HookPlacement - Hook */
+     , (26423, 151,          2) /* HookType - Wall */
+     , (26423, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26423,  15, True ) /* LightsStatus */
+     , (26423,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26423, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26423,   1, 'Vulture''s Eye Villas Portal Gem') /* Name */
+     , (26423,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26423,   1,   33556769) /* Setup */
+     , (26423,   3,  536870932) /* SoundTable */
+     , (26423,   6,   67111919) /* PaletteBase */
+     , (26423,   7,  268435723) /* ClothingBase */
+     , (26423,   8,  100675760) /* Icon */
+     , (26423,  22,  872415275) /* PhysicsEffectTable */
+     , (26423,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26423,  31,      14675) /* LinkedPortalOne - Vulture's Eye Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26424 West Holtburg Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26424 West Holtburg Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26424;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26424, 'gemportalwestholtburgvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26424,   1,       2048) /* ItemType - Gem */
+     , (26424,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26424,   5,         10) /* EncumbranceVal */
+     , (26424,   8,         10) /* Mass */
+     , (26424,   9,          0) /* ValidLocations - None */
+     , (26424,  11,         20) /* MaxStackSize */
+     , (26424,  12,          1) /* StackSize */
+     , (26424,  13,         10) /* StackUnitEncumbrance */
+     , (26424,  14,         10) /* StackUnitMass */
+     , (26424,  15,        500) /* StackUnitValue */
+     , (26424,  16,          8) /* ItemUseable - Contained */
+     , (26424,  18,          1) /* UiEffects - Magical */
+     , (26424,  19,        500) /* Value */
+     , (26424,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26424,  94,         16) /* TargetType - Creature */
+     , (26424, 106,        210) /* ItemSpellcraft */
+     , (26424, 107,         50) /* ItemCurMana */
+     , (26424, 108,         50) /* ItemMaxMana */
+     , (26424, 109,          0) /* ItemDifficulty */
+     , (26424, 110,          0) /* ItemAllegianceRankLimit */
+     , (26424, 150,        103) /* HookPlacement - Hook */
+     , (26424, 151,          2) /* HookType - Wall */
+     , (26424, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26424,  15, True ) /* LightsStatus */
+     , (26424,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26424, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26424,   1, 'West Holtburg Villas Portal Gem') /* Name */
+     , (26424,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26424,   1,   33556769) /* Setup */
+     , (26424,   3,  536870932) /* SoundTable */
+     , (26424,   6,   67111919) /* PaletteBase */
+     , (26424,   7,  268435723) /* ClothingBase */
+     , (26424,   8,  100675760) /* Icon */
+     , (26424,  22,  872415275) /* PhysicsEffectTable */
+     , (26424,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26424,  31,      13138) /* LinkedPortalOne - West Holtburg Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26425 West Mayoi Mountain Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26425 West Mayoi Mountain Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26425;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26425, 'gemportalwestmayoiimountainvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26425,   1,       2048) /* ItemType - Gem */
+     , (26425,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26425,   5,         10) /* EncumbranceVal */
+     , (26425,   8,         10) /* Mass */
+     , (26425,   9,          0) /* ValidLocations - None */
+     , (26425,  11,         20) /* MaxStackSize */
+     , (26425,  12,          1) /* StackSize */
+     , (26425,  13,         10) /* StackUnitEncumbrance */
+     , (26425,  14,         10) /* StackUnitMass */
+     , (26425,  15,        500) /* StackUnitValue */
+     , (26425,  16,          8) /* ItemUseable - Contained */
+     , (26425,  18,          1) /* UiEffects - Magical */
+     , (26425,  19,        500) /* Value */
+     , (26425,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26425,  94,         16) /* TargetType - Creature */
+     , (26425, 106,        210) /* ItemSpellcraft */
+     , (26425, 107,         50) /* ItemCurMana */
+     , (26425, 108,         50) /* ItemMaxMana */
+     , (26425, 109,          0) /* ItemDifficulty */
+     , (26425, 110,          0) /* ItemAllegianceRankLimit */
+     , (26425, 150,        103) /* HookPlacement - Hook */
+     , (26425, 151,          2) /* HookType - Wall */
+     , (26425, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26425,  15, True ) /* LightsStatus */
+     , (26425,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26425, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26425,   1, 'West Mayoi Mountain Villas Portal Gem') /* Name */
+     , (26425,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26425,   1,   33556769) /* Setup */
+     , (26425,   3,  536870932) /* SoundTable */
+     , (26425,   6,   67111919) /* PaletteBase */
+     , (26425,   7,  268435723) /* ClothingBase */
+     , (26425,   8,  100675760) /* Icon */
+     , (26425,  22,  872415275) /* PhysicsEffectTable */
+     , (26425,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26425,  31,      13139) /* LinkedPortalOne - West Mayoi Mountain Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26426 West Norstead Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26426 West Norstead Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26426;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26426, 'gemportalwestnorstead', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26426,   1,       2048) /* ItemType - Gem */
+     , (26426,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26426,   5,         10) /* EncumbranceVal */
+     , (26426,   8,         10) /* Mass */
+     , (26426,   9,          0) /* ValidLocations - None */
+     , (26426,  11,         20) /* MaxStackSize */
+     , (26426,  12,          1) /* StackSize */
+     , (26426,  13,         10) /* StackUnitEncumbrance */
+     , (26426,  14,         10) /* StackUnitMass */
+     , (26426,  15,        500) /* StackUnitValue */
+     , (26426,  16,          8) /* ItemUseable - Contained */
+     , (26426,  18,          1) /* UiEffects - Magical */
+     , (26426,  19,        500) /* Value */
+     , (26426,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26426,  94,         16) /* TargetType - Creature */
+     , (26426, 106,        210) /* ItemSpellcraft */
+     , (26426, 107,         50) /* ItemCurMana */
+     , (26426, 108,         50) /* ItemMaxMana */
+     , (26426, 109,          0) /* ItemDifficulty */
+     , (26426, 110,          0) /* ItemAllegianceRankLimit */
+     , (26426, 150,        103) /* HookPlacement - Hook */
+     , (26426, 151,          2) /* HookType - Wall */
+     , (26426, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26426,  15, True ) /* LightsStatus */
+     , (26426,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26426, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26426,   1, 'West Norstead Portal Gem') /* Name */
+     , (26426,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26426,   1,   33556769) /* Setup */
+     , (26426,   3,  536870932) /* SoundTable */
+     , (26426,   6,   67111919) /* PaletteBase */
+     , (26426,   7,  268435723) /* ClothingBase */
+     , (26426,   8,  100675760) /* Icon */
+     , (26426,  22,  872415275) /* PhysicsEffectTable */
+     , (26426,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26426,  31,      14290) /* LinkedPortalOne - West Norstead Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26427 West Rithwic Estates Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26427 West Rithwic Estates Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26427;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26427, 'gemportalwestrithwicestates', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26427,   1,       2048) /* ItemType - Gem */
+     , (26427,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26427,   5,         10) /* EncumbranceVal */
+     , (26427,   8,         10) /* Mass */
+     , (26427,   9,          0) /* ValidLocations - None */
+     , (26427,  11,         20) /* MaxStackSize */
+     , (26427,  12,          1) /* StackSize */
+     , (26427,  13,         10) /* StackUnitEncumbrance */
+     , (26427,  14,         10) /* StackUnitMass */
+     , (26427,  15,        500) /* StackUnitValue */
+     , (26427,  16,          8) /* ItemUseable - Contained */
+     , (26427,  18,          1) /* UiEffects - Magical */
+     , (26427,  19,        500) /* Value */
+     , (26427,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26427,  94,         16) /* TargetType - Creature */
+     , (26427, 106,        210) /* ItemSpellcraft */
+     , (26427, 107,         50) /* ItemCurMana */
+     , (26427, 108,         50) /* ItemMaxMana */
+     , (26427, 109,          0) /* ItemDifficulty */
+     , (26427, 110,          0) /* ItemAllegianceRankLimit */
+     , (26427, 150,        103) /* HookPlacement - Hook */
+     , (26427, 151,          2) /* HookType - Wall */
+     , (26427, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26427,  15, True ) /* LightsStatus */
+     , (26427,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26427, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26427,   1, 'West Rithwic Estates Portal Gem') /* Name */
+     , (26427,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26427,   1,   33556769) /* Setup */
+     , (26427,   3,  536870932) /* SoundTable */
+     , (26427,   6,   67111919) /* PaletteBase */
+     , (26427,   7,  268435723) /* ClothingBase */
+     , (26427,   8,  100675760) /* Icon */
+     , (26427,  22,  872415275) /* PhysicsEffectTable */
+     , (26427,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26427,  31,      13140) /* LinkedPortalOne - West Rithwic Estates Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26428 Westshore Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26428 Westshore Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26428;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26428, 'gemportalwestshorecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26428,   1,       2048) /* ItemType - Gem */
+     , (26428,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26428,   5,         10) /* EncumbranceVal */
+     , (26428,   8,         10) /* Mass */
+     , (26428,   9,          0) /* ValidLocations - None */
+     , (26428,  11,         20) /* MaxStackSize */
+     , (26428,  12,          1) /* StackSize */
+     , (26428,  13,         10) /* StackUnitEncumbrance */
+     , (26428,  14,         10) /* StackUnitMass */
+     , (26428,  15,        500) /* StackUnitValue */
+     , (26428,  16,          8) /* ItemUseable - Contained */
+     , (26428,  18,          1) /* UiEffects - Magical */
+     , (26428,  19,        500) /* Value */
+     , (26428,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26428,  94,         16) /* TargetType - Creature */
+     , (26428, 106,        210) /* ItemSpellcraft */
+     , (26428, 107,         50) /* ItemCurMana */
+     , (26428, 108,         50) /* ItemMaxMana */
+     , (26428, 109,          0) /* ItemDifficulty */
+     , (26428, 110,          0) /* ItemAllegianceRankLimit */
+     , (26428, 150,        103) /* HookPlacement - Hook */
+     , (26428, 151,          2) /* HookType - Wall */
+     , (26428, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26428,  15, True ) /* LightsStatus */
+     , (26428,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26428, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26428,   1, 'Westshore Cottages Portal Gem') /* Name */
+     , (26428,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26428,   1,   33556769) /* Setup */
+     , (26428,   3,  536870932) /* SoundTable */
+     , (26428,   6,   67111919) /* PaletteBase */
+     , (26428,   7,  268435723) /* ClothingBase */
+     , (26428,   8,  100675760) /* Icon */
+     , (26428,  22,  872415275) /* PhysicsEffectTable */
+     , (26428,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26428,  31,      14676) /* LinkedPortalOne - Westshore Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26429 West Uziz Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26429 West Uziz Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26429;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26429, 'gemportalwestuzizsettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26429,   1,       2048) /* ItemType - Gem */
+     , (26429,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26429,   5,         10) /* EncumbranceVal */
+     , (26429,   8,         10) /* Mass */
+     , (26429,   9,          0) /* ValidLocations - None */
+     , (26429,  11,         20) /* MaxStackSize */
+     , (26429,  12,          1) /* StackSize */
+     , (26429,  13,         10) /* StackUnitEncumbrance */
+     , (26429,  14,         10) /* StackUnitMass */
+     , (26429,  15,        500) /* StackUnitValue */
+     , (26429,  16,          8) /* ItemUseable - Contained */
+     , (26429,  18,          1) /* UiEffects - Magical */
+     , (26429,  19,        500) /* Value */
+     , (26429,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26429,  94,         16) /* TargetType - Creature */
+     , (26429, 106,        210) /* ItemSpellcraft */
+     , (26429, 107,         50) /* ItemCurMana */
+     , (26429, 108,         50) /* ItemMaxMana */
+     , (26429, 109,          0) /* ItemDifficulty */
+     , (26429, 110,          0) /* ItemAllegianceRankLimit */
+     , (26429, 150,        103) /* HookPlacement - Hook */
+     , (26429, 151,          2) /* HookType - Wall */
+     , (26429, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26429,  15, True ) /* LightsStatus */
+     , (26429,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26429, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26429,   1, 'West Uziz Settlement Portal Gem') /* Name */
+     , (26429,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26429,   1,   33556769) /* Setup */
+     , (26429,   3,  536870932) /* SoundTable */
+     , (26429,   6,   67111919) /* PaletteBase */
+     , (26429,   7,  268435723) /* ClothingBase */
+     , (26429,   8,  100675760) /* Icon */
+     , (26429,  22,  872415275) /* PhysicsEffectTable */
+     , (26429,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26429,  31,      12563) /* LinkedPortalOne - West Uziz Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26430 West Yanshi Namoon Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26430 West Yanshi Namoon Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26430;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26430, 'gemportalwestyanshinamoon', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26430,   1,       2048) /* ItemType - Gem */
+     , (26430,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26430,   5,         10) /* EncumbranceVal */
+     , (26430,   8,         10) /* Mass */
+     , (26430,   9,          0) /* ValidLocations - None */
+     , (26430,  11,         20) /* MaxStackSize */
+     , (26430,  12,          1) /* StackSize */
+     , (26430,  13,         10) /* StackUnitEncumbrance */
+     , (26430,  14,         10) /* StackUnitMass */
+     , (26430,  15,        500) /* StackUnitValue */
+     , (26430,  16,          8) /* ItemUseable - Contained */
+     , (26430,  18,          1) /* UiEffects - Magical */
+     , (26430,  19,        500) /* Value */
+     , (26430,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26430,  94,         16) /* TargetType - Creature */
+     , (26430, 106,        210) /* ItemSpellcraft */
+     , (26430, 107,         50) /* ItemCurMana */
+     , (26430, 108,         50) /* ItemMaxMana */
+     , (26430, 109,          0) /* ItemDifficulty */
+     , (26430, 110,          0) /* ItemAllegianceRankLimit */
+     , (26430, 150,        103) /* HookPlacement - Hook */
+     , (26430, 151,          2) /* HookType - Wall */
+     , (26430, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26430,  15, True ) /* LightsStatus */
+     , (26430,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26430, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26430,   1, 'West Yanshi Namoon Portal Gem') /* Name */
+     , (26430,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26430,   1,   33556769) /* Setup */
+     , (26430,   3,  536870932) /* SoundTable */
+     , (26430,   6,   67111919) /* PaletteBase */
+     , (26430,   7,  268435723) /* ClothingBase */
+     , (26430,   8,  100675760) /* Icon */
+     , (26430,  22,  872415275) /* PhysicsEffectTable */
+     , (26430,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26430,  31,      14291) /* LinkedPortalOne - West Yanshi Namoon Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26431 West Zaikhal Freehold Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26431 West Zaikhal Freehold Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26431;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26431, 'gemportalwestzaikhalfreehold', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26431,   1,       2048) /* ItemType - Gem */
+     , (26431,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26431,   5,         10) /* EncumbranceVal */
+     , (26431,   8,         10) /* Mass */
+     , (26431,   9,          0) /* ValidLocations - None */
+     , (26431,  11,         20) /* MaxStackSize */
+     , (26431,  12,          1) /* StackSize */
+     , (26431,  13,         10) /* StackUnitEncumbrance */
+     , (26431,  14,         10) /* StackUnitMass */
+     , (26431,  15,        500) /* StackUnitValue */
+     , (26431,  16,          8) /* ItemUseable - Contained */
+     , (26431,  18,          1) /* UiEffects - Magical */
+     , (26431,  19,        500) /* Value */
+     , (26431,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26431,  94,         16) /* TargetType - Creature */
+     , (26431, 106,        210) /* ItemSpellcraft */
+     , (26431, 107,         50) /* ItemCurMana */
+     , (26431, 108,         50) /* ItemMaxMana */
+     , (26431, 109,          0) /* ItemDifficulty */
+     , (26431, 110,          0) /* ItemAllegianceRankLimit */
+     , (26431, 150,        103) /* HookPlacement - Hook */
+     , (26431, 151,          2) /* HookType - Wall */
+     , (26431, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26431,  15, True ) /* LightsStatus */
+     , (26431,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26431, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26431,   1, 'West Zaikhal Freehold Portal Gem') /* Name */
+     , (26431,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26431,   1,   33556769) /* Setup */
+     , (26431,   3,  536870932) /* SoundTable */
+     , (26431,   6,   67111919) /* PaletteBase */
+     , (26431,   7,  268435723) /* ClothingBase */
+     , (26431,   8,  100675760) /* Icon */
+     , (26431,  22,  872415275) /* PhysicsEffectTable */
+     , (26431,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26431,  31,      14677) /* LinkedPortalOne - West Zaikhal Freehold Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26432 Whispering Pines Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26432 Whispering Pines Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26432;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26432, 'gemportalwhisperingpinescottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26432,   1,       2048) /* ItemType - Gem */
+     , (26432,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26432,   5,         10) /* EncumbranceVal */
+     , (26432,   8,         10) /* Mass */
+     , (26432,   9,          0) /* ValidLocations - None */
+     , (26432,  11,         20) /* MaxStackSize */
+     , (26432,  12,          1) /* StackSize */
+     , (26432,  13,         10) /* StackUnitEncumbrance */
+     , (26432,  14,         10) /* StackUnitMass */
+     , (26432,  15,        500) /* StackUnitValue */
+     , (26432,  16,          8) /* ItemUseable - Contained */
+     , (26432,  18,          1) /* UiEffects - Magical */
+     , (26432,  19,        500) /* Value */
+     , (26432,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26432,  94,         16) /* TargetType - Creature */
+     , (26432, 106,        210) /* ItemSpellcraft */
+     , (26432, 107,         50) /* ItemCurMana */
+     , (26432, 108,         50) /* ItemMaxMana */
+     , (26432, 109,          0) /* ItemDifficulty */
+     , (26432, 110,          0) /* ItemAllegianceRankLimit */
+     , (26432, 150,        103) /* HookPlacement - Hook */
+     , (26432, 151,          2) /* HookType - Wall */
+     , (26432, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26432,  15, True ) /* LightsStatus */
+     , (26432,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26432, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26432,   1, 'Whispering Pines Cottages Portal Gem') /* Name */
+     , (26432,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26432,   1,   33556769) /* Setup */
+     , (26432,   3,  536870932) /* SoundTable */
+     , (26432,   6,   67111919) /* PaletteBase */
+     , (26432,   7,  268435723) /* ClothingBase */
+     , (26432,   8,  100675760) /* Icon */
+     , (26432,  22,  872415275) /* PhysicsEffectTable */
+     , (26432,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26432,  31,      12564) /* LinkedPortalOne - Whispering Pines Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26433 Wi Badlands Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26433 Wi Badlands Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26433;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26433, 'gemportalwibadlandssettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26433,   1,       2048) /* ItemType - Gem */
+     , (26433,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26433,   5,         10) /* EncumbranceVal */
+     , (26433,   8,         10) /* Mass */
+     , (26433,   9,          0) /* ValidLocations - None */
+     , (26433,  11,         20) /* MaxStackSize */
+     , (26433,  12,          1) /* StackSize */
+     , (26433,  13,         10) /* StackUnitEncumbrance */
+     , (26433,  14,         10) /* StackUnitMass */
+     , (26433,  15,        500) /* StackUnitValue */
+     , (26433,  16,          8) /* ItemUseable - Contained */
+     , (26433,  18,          1) /* UiEffects - Magical */
+     , (26433,  19,        500) /* Value */
+     , (26433,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26433,  94,         16) /* TargetType - Creature */
+     , (26433, 106,        210) /* ItemSpellcraft */
+     , (26433, 107,         50) /* ItemCurMana */
+     , (26433, 108,         50) /* ItemMaxMana */
+     , (26433, 109,          0) /* ItemDifficulty */
+     , (26433, 110,          0) /* ItemAllegianceRankLimit */
+     , (26433, 150,        103) /* HookPlacement - Hook */
+     , (26433, 151,          2) /* HookType - Wall */
+     , (26433, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26433,  15, True ) /* LightsStatus */
+     , (26433,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26433, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26433,   1, 'Wi Badlands Settlement Portal Gem') /* Name */
+     , (26433,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26433,   1,   33556769) /* Setup */
+     , (26433,   3,  536870932) /* SoundTable */
+     , (26433,   6,   67111919) /* PaletteBase */
+     , (26433,   7,  268435723) /* ClothingBase */
+     , (26433,   8,  100675760) /* Icon */
+     , (26433,  22,  872415275) /* PhysicsEffectTable */
+     , (26433,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26433,  31,      12565) /* LinkedPortalOne - Wi Badlands Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26434 Wilomine Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26434 Wilomine Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26434;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26434, 'gemportalwilominevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26434,   1,       2048) /* ItemType - Gem */
+     , (26434,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26434,   5,         10) /* EncumbranceVal */
+     , (26434,   8,         10) /* Mass */
+     , (26434,   9,          0) /* ValidLocations - None */
+     , (26434,  11,         20) /* MaxStackSize */
+     , (26434,  12,          1) /* StackSize */
+     , (26434,  13,         10) /* StackUnitEncumbrance */
+     , (26434,  14,         10) /* StackUnitMass */
+     , (26434,  15,        500) /* StackUnitValue */
+     , (26434,  16,          8) /* ItemUseable - Contained */
+     , (26434,  18,          1) /* UiEffects - Magical */
+     , (26434,  19,        500) /* Value */
+     , (26434,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26434,  94,         16) /* TargetType - Creature */
+     , (26434, 106,        210) /* ItemSpellcraft */
+     , (26434, 107,         50) /* ItemCurMana */
+     , (26434, 108,         50) /* ItemMaxMana */
+     , (26434, 109,          0) /* ItemDifficulty */
+     , (26434, 110,          0) /* ItemAllegianceRankLimit */
+     , (26434, 150,        103) /* HookPlacement - Hook */
+     , (26434, 151,          2) /* HookType - Wall */
+     , (26434, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26434,  15, True ) /* LightsStatus */
+     , (26434,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26434, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26434,   1, 'Wilomine Villas Portal Gem') /* Name */
+     , (26434,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26434,   1,   33556769) /* Setup */
+     , (26434,   3,  536870932) /* SoundTable */
+     , (26434,   6,   67111919) /* PaletteBase */
+     , (26434,   7,  268435723) /* ClothingBase */
+     , (26434,   8,  100675760) /* Icon */
+     , (26434,  22,  872415275) /* PhysicsEffectTable */
+     , (26434,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26434,  31,      15686) /* LinkedPortalOne - Wilomine Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26435 Windrune Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26435 Windrune Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26435;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26435, 'gemportalwindrunecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26435,   1,       2048) /* ItemType - Gem */
+     , (26435,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26435,   5,         10) /* EncumbranceVal */
+     , (26435,   8,         10) /* Mass */
+     , (26435,   9,          0) /* ValidLocations - None */
+     , (26435,  11,         20) /* MaxStackSize */
+     , (26435,  12,          1) /* StackSize */
+     , (26435,  13,         10) /* StackUnitEncumbrance */
+     , (26435,  14,         10) /* StackUnitMass */
+     , (26435,  15,        500) /* StackUnitValue */
+     , (26435,  16,          8) /* ItemUseable - Contained */
+     , (26435,  18,          1) /* UiEffects - Magical */
+     , (26435,  19,        500) /* Value */
+     , (26435,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26435,  94,         16) /* TargetType - Creature */
+     , (26435, 106,        210) /* ItemSpellcraft */
+     , (26435, 107,         50) /* ItemCurMana */
+     , (26435, 108,         50) /* ItemMaxMana */
+     , (26435, 109,          0) /* ItemDifficulty */
+     , (26435, 110,          0) /* ItemAllegianceRankLimit */
+     , (26435, 150,        103) /* HookPlacement - Hook */
+     , (26435, 151,          2) /* HookType - Wall */
+     , (26435, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26435,  15, True ) /* LightsStatus */
+     , (26435,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26435, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26435,   1, 'Windrune Cottages Portal Gem') /* Name */
+     , (26435,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26435,   1,   33556769) /* Setup */
+     , (26435,   3,  536870932) /* SoundTable */
+     , (26435,   6,   67111919) /* PaletteBase */
+     , (26435,   7,  268435723) /* ClothingBase */
+     , (26435,   8,  100675760) /* Icon */
+     , (26435,  22,  872415275) /* PhysicsEffectTable */
+     , (26435,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26435,  31,      15687) /* LinkedPortalOne - Windrune Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26436 Wisp Lake Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26436 Wisp Lake Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26436;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26436, 'gemportalwisplakecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26436,   1,       2048) /* ItemType - Gem */
+     , (26436,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26436,   5,         10) /* EncumbranceVal */
+     , (26436,   8,         10) /* Mass */
+     , (26436,   9,          0) /* ValidLocations - None */
+     , (26436,  11,         20) /* MaxStackSize */
+     , (26436,  12,          1) /* StackSize */
+     , (26436,  13,         10) /* StackUnitEncumbrance */
+     , (26436,  14,         10) /* StackUnitMass */
+     , (26436,  15,        500) /* StackUnitValue */
+     , (26436,  16,          8) /* ItemUseable - Contained */
+     , (26436,  18,          1) /* UiEffects - Magical */
+     , (26436,  19,        500) /* Value */
+     , (26436,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26436,  94,         16) /* TargetType - Creature */
+     , (26436, 106,        210) /* ItemSpellcraft */
+     , (26436, 107,         50) /* ItemCurMana */
+     , (26436, 108,         50) /* ItemMaxMana */
+     , (26436, 109,          0) /* ItemDifficulty */
+     , (26436, 110,          0) /* ItemAllegianceRankLimit */
+     , (26436, 150,        103) /* HookPlacement - Hook */
+     , (26436, 151,          2) /* HookType - Wall */
+     , (26436, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26436,  15, True ) /* LightsStatus */
+     , (26436,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26436, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26436,   1, 'Wisp Lake Cottages Portal Gem') /* Name */
+     , (26436,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26436,   1,   33556769) /* Setup */
+     , (26436,   3,  536870932) /* SoundTable */
+     , (26436,   6,   67111919) /* PaletteBase */
+     , (26436,   7,  268435723) /* ClothingBase */
+     , (26436,   8,  100675760) /* Icon */
+     , (26436,  22,  872415275) /* PhysicsEffectTable */
+     , (26436,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26436,  31,      13141) /* LinkedPortalOne - Wisp Lake Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26437 Wolfenvale Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26437 Wolfenvale Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26437;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26437, 'gemportalwolfenvale', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26437,   1,       2048) /* ItemType - Gem */
+     , (26437,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26437,   5,         10) /* EncumbranceVal */
+     , (26437,   8,         10) /* Mass */
+     , (26437,   9,          0) /* ValidLocations - None */
+     , (26437,  11,         20) /* MaxStackSize */
+     , (26437,  12,          1) /* StackSize */
+     , (26437,  13,         10) /* StackUnitEncumbrance */
+     , (26437,  14,         10) /* StackUnitMass */
+     , (26437,  15,        500) /* StackUnitValue */
+     , (26437,  16,          8) /* ItemUseable - Contained */
+     , (26437,  18,          1) /* UiEffects - Magical */
+     , (26437,  19,        500) /* Value */
+     , (26437,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26437,  94,         16) /* TargetType - Creature */
+     , (26437, 106,        210) /* ItemSpellcraft */
+     , (26437, 107,         50) /* ItemCurMana */
+     , (26437, 108,         50) /* ItemMaxMana */
+     , (26437, 109,          0) /* ItemDifficulty */
+     , (26437, 110,          0) /* ItemAllegianceRankLimit */
+     , (26437, 150,        103) /* HookPlacement - Hook */
+     , (26437, 151,          2) /* HookType - Wall */
+     , (26437, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26437,  15, True ) /* LightsStatus */
+     , (26437,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26437, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26437,   1, 'Wolfenvale Portal Gem') /* Name */
+     , (26437,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26437,   1,   33556769) /* Setup */
+     , (26437,   3,  536870932) /* SoundTable */
+     , (26437,   6,   67111919) /* PaletteBase */
+     , (26437,   7,  268435723) /* ClothingBase */
+     , (26437,   8,  100675760) /* Icon */
+     , (26437,  22,  872415275) /* PhysicsEffectTable */
+     , (26437,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26437,  31,      15201) /* LinkedPortalOne - Wolfenvale Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26438 Woodsbane Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26438 Woodsbane Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26438;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26438, 'gemportalwoodsbanecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26438,   1,       2048) /* ItemType - Gem */
+     , (26438,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26438,   5,         10) /* EncumbranceVal */
+     , (26438,   8,         10) /* Mass */
+     , (26438,   9,          0) /* ValidLocations - None */
+     , (26438,  11,         20) /* MaxStackSize */
+     , (26438,  12,          1) /* StackSize */
+     , (26438,  13,         10) /* StackUnitEncumbrance */
+     , (26438,  14,         10) /* StackUnitMass */
+     , (26438,  15,        500) /* StackUnitValue */
+     , (26438,  16,          8) /* ItemUseable - Contained */
+     , (26438,  18,          1) /* UiEffects - Magical */
+     , (26438,  19,        500) /* Value */
+     , (26438,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26438,  94,         16) /* TargetType - Creature */
+     , (26438, 106,        210) /* ItemSpellcraft */
+     , (26438, 107,         50) /* ItemCurMana */
+     , (26438, 108,         50) /* ItemMaxMana */
+     , (26438, 109,          0) /* ItemDifficulty */
+     , (26438, 110,          0) /* ItemAllegianceRankLimit */
+     , (26438, 150,        103) /* HookPlacement - Hook */
+     , (26438, 151,          2) /* HookType - Wall */
+     , (26438, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26438,  15, True ) /* LightsStatus */
+     , (26438,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26438, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26438,   1, 'Woodsbane Cottages Portal Gem') /* Name */
+     , (26438,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26438,   1,   33556769) /* Setup */
+     , (26438,   3,  536870932) /* SoundTable */
+     , (26438,   6,   67111919) /* PaletteBase */
+     , (26438,   7,  268435723) /* ClothingBase */
+     , (26438,   8,  100675760) /* Icon */
+     , (26438,  22,  872415275) /* PhysicsEffectTable */
+     , (26438,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26438,  31,      12566) /* LinkedPortalOne - Woodsbane Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26439 Woodshore Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26439 Woodshore Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26439;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26439, 'gemportalwoodshorecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26439,   1,       2048) /* ItemType - Gem */
+     , (26439,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26439,   5,         10) /* EncumbranceVal */
+     , (26439,   8,         10) /* Mass */
+     , (26439,   9,          0) /* ValidLocations - None */
+     , (26439,  11,         20) /* MaxStackSize */
+     , (26439,  12,          1) /* StackSize */
+     , (26439,  13,         10) /* StackUnitEncumbrance */
+     , (26439,  14,         10) /* StackUnitMass */
+     , (26439,  15,        500) /* StackUnitValue */
+     , (26439,  16,          8) /* ItemUseable - Contained */
+     , (26439,  18,          1) /* UiEffects - Magical */
+     , (26439,  19,        500) /* Value */
+     , (26439,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26439,  94,         16) /* TargetType - Creature */
+     , (26439, 106,        210) /* ItemSpellcraft */
+     , (26439, 107,         50) /* ItemCurMana */
+     , (26439, 108,         50) /* ItemMaxMana */
+     , (26439, 109,          0) /* ItemDifficulty */
+     , (26439, 110,          0) /* ItemAllegianceRankLimit */
+     , (26439, 150,        103) /* HookPlacement - Hook */
+     , (26439, 151,          2) /* HookType - Wall */
+     , (26439, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26439,  15, True ) /* LightsStatus */
+     , (26439,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26439, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26439,   1, 'Woodshore Cottages Portal Gem') /* Name */
+     , (26439,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26439,   1,   33556769) /* Setup */
+     , (26439,   3,  536870932) /* SoundTable */
+     , (26439,   6,   67111919) /* PaletteBase */
+     , (26439,   7,  268435723) /* ClothingBase */
+     , (26439,   8,  100675760) /* Icon */
+     , (26439,  22,  872415275) /* PhysicsEffectTable */
+     , (26439,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26439,  31,      12567) /* LinkedPortalOne - Woodshore Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26440 Xinh Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26440 Xinh Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26440;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26440, 'gemportalxinh', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26440,   1,       2048) /* ItemType - Gem */
+     , (26440,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26440,   5,         10) /* EncumbranceVal */
+     , (26440,   8,         10) /* Mass */
+     , (26440,   9,          0) /* ValidLocations - None */
+     , (26440,  11,         20) /* MaxStackSize */
+     , (26440,  12,          1) /* StackSize */
+     , (26440,  13,         10) /* StackUnitEncumbrance */
+     , (26440,  14,         10) /* StackUnitMass */
+     , (26440,  15,        500) /* StackUnitValue */
+     , (26440,  16,          8) /* ItemUseable - Contained */
+     , (26440,  18,          1) /* UiEffects - Magical */
+     , (26440,  19,        500) /* Value */
+     , (26440,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26440,  94,         16) /* TargetType - Creature */
+     , (26440, 106,        210) /* ItemSpellcraft */
+     , (26440, 107,         50) /* ItemCurMana */
+     , (26440, 108,         50) /* ItemMaxMana */
+     , (26440, 109,          0) /* ItemDifficulty */
+     , (26440, 110,          0) /* ItemAllegianceRankLimit */
+     , (26440, 150,        103) /* HookPlacement - Hook */
+     , (26440, 151,          2) /* HookType - Wall */
+     , (26440, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26440,  15, True ) /* LightsStatus */
+     , (26440,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26440, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26440,   1, 'Xinh Portal Gem') /* Name */
+     , (26440,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26440,   1,   33556769) /* Setup */
+     , (26440,   3,  536870932) /* SoundTable */
+     , (26440,   6,   67111919) /* PaletteBase */
+     , (26440,   7,  268435723) /* ClothingBase */
+     , (26440,   8,  100675760) /* Icon */
+     , (26440,  22,  872415275) /* PhysicsEffectTable */
+     , (26440,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26440,  31,      14292) /* LinkedPortalOne - Xinh Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26441 Yanshi Namoon North Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26441 Yanshi Namoon North Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26441;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26441, 'gemportalyanshinamoonnorth', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26441,   1,       2048) /* ItemType - Gem */
+     , (26441,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26441,   5,         10) /* EncumbranceVal */
+     , (26441,   8,         10) /* Mass */
+     , (26441,   9,          0) /* ValidLocations - None */
+     , (26441,  11,         20) /* MaxStackSize */
+     , (26441,  12,          1) /* StackSize */
+     , (26441,  13,         10) /* StackUnitEncumbrance */
+     , (26441,  14,         10) /* StackUnitMass */
+     , (26441,  15,        500) /* StackUnitValue */
+     , (26441,  16,          8) /* ItemUseable - Contained */
+     , (26441,  18,          1) /* UiEffects - Magical */
+     , (26441,  19,        500) /* Value */
+     , (26441,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26441,  94,         16) /* TargetType - Creature */
+     , (26441, 106,        210) /* ItemSpellcraft */
+     , (26441, 107,         50) /* ItemCurMana */
+     , (26441, 108,         50) /* ItemMaxMana */
+     , (26441, 109,          0) /* ItemDifficulty */
+     , (26441, 110,          0) /* ItemAllegianceRankLimit */
+     , (26441, 150,        103) /* HookPlacement - Hook */
+     , (26441, 151,          2) /* HookType - Wall */
+     , (26441, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26441,  15, True ) /* LightsStatus */
+     , (26441,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26441, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26441,   1, 'Yanshi Namoon North Portal Gem') /* Name */
+     , (26441,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26441,   1,   33556769) /* Setup */
+     , (26441,   3,  536870932) /* SoundTable */
+     , (26441,   6,   67111919) /* PaletteBase */
+     , (26441,   7,  268435723) /* ClothingBase */
+     , (26441,   8,  100675760) /* Icon */
+     , (26441,  22,  872415275) /* PhysicsEffectTable */
+     , (26441,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26441,  31,      12568) /* LinkedPortalOne - Yanshi Namoon North Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26442 Yee Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26442 Yee Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26442;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26442, 'gemportalyeevillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26442,   1,       2048) /* ItemType - Gem */
+     , (26442,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26442,   5,         10) /* EncumbranceVal */
+     , (26442,   8,         10) /* Mass */
+     , (26442,   9,          0) /* ValidLocations - None */
+     , (26442,  11,         20) /* MaxStackSize */
+     , (26442,  12,          1) /* StackSize */
+     , (26442,  13,         10) /* StackUnitEncumbrance */
+     , (26442,  14,         10) /* StackUnitMass */
+     , (26442,  15,        500) /* StackUnitValue */
+     , (26442,  16,          8) /* ItemUseable - Contained */
+     , (26442,  18,          1) /* UiEffects - Magical */
+     , (26442,  19,        500) /* Value */
+     , (26442,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26442,  94,         16) /* TargetType - Creature */
+     , (26442, 106,        210) /* ItemSpellcraft */
+     , (26442, 107,         50) /* ItemCurMana */
+     , (26442, 108,         50) /* ItemMaxMana */
+     , (26442, 109,          0) /* ItemDifficulty */
+     , (26442, 110,          0) /* ItemAllegianceRankLimit */
+     , (26442, 150,        103) /* HookPlacement - Hook */
+     , (26442, 151,          2) /* HookType - Wall */
+     , (26442, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26442,  15, True ) /* LightsStatus */
+     , (26442,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26442, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26442,   1, 'Yee Villas Portal Gem') /* Name */
+     , (26442,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26442,   1,   33556769) /* Setup */
+     , (26442,   3,  536870932) /* SoundTable */
+     , (26442,   6,   67111919) /* PaletteBase */
+     , (26442,   7,  268435723) /* ClothingBase */
+     , (26442,   8,  100675760) /* Icon */
+     , (26442,  22,  872415275) /* PhysicsEffectTable */
+     , (26442,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26442,  31,      14678) /* LinkedPortalOne - Yee Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26443 Yinar Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26443 Yinar Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26443;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26443, 'gemportalyinar', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26443,   1,       2048) /* ItemType - Gem */
+     , (26443,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26443,   5,         10) /* EncumbranceVal */
+     , (26443,   8,         10) /* Mass */
+     , (26443,   9,          0) /* ValidLocations - None */
+     , (26443,  11,         20) /* MaxStackSize */
+     , (26443,  12,          1) /* StackSize */
+     , (26443,  13,         10) /* StackUnitEncumbrance */
+     , (26443,  14,         10) /* StackUnitMass */
+     , (26443,  15,        500) /* StackUnitValue */
+     , (26443,  16,          8) /* ItemUseable - Contained */
+     , (26443,  18,          1) /* UiEffects - Magical */
+     , (26443,  19,        500) /* Value */
+     , (26443,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26443,  94,         16) /* TargetType - Creature */
+     , (26443, 106,        210) /* ItemSpellcraft */
+     , (26443, 107,         50) /* ItemCurMana */
+     , (26443, 108,         50) /* ItemMaxMana */
+     , (26443, 109,          0) /* ItemDifficulty */
+     , (26443, 110,          0) /* ItemAllegianceRankLimit */
+     , (26443, 150,        103) /* HookPlacement - Hook */
+     , (26443, 151,          2) /* HookType - Wall */
+     , (26443, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26443,  15, True ) /* LightsStatus */
+     , (26443,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26443, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26443,   1, 'Yinar Portal Gem') /* Name */
+     , (26443,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26443,   1,   33556769) /* Setup */
+     , (26443,   3,  536870932) /* SoundTable */
+     , (26443,   6,   67111919) /* PaletteBase */
+     , (26443,   7,  268435723) /* ClothingBase */
+     , (26443,   8,  100675760) /* Icon */
+     , (26443,  22,  872415275) /* PhysicsEffectTable */
+     , (26443,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26443,  31,      14293) /* LinkedPortalOne - Yinar Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26444 Yukikaze  Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26444 Yukikaze  Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26444;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26444, 'gemportalyukikaze', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26444,   1,       2048) /* ItemType - Gem */
+     , (26444,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26444,   5,         10) /* EncumbranceVal */
+     , (26444,   8,         10) /* Mass */
+     , (26444,   9,          0) /* ValidLocations - None */
+     , (26444,  11,         20) /* MaxStackSize */
+     , (26444,  12,          1) /* StackSize */
+     , (26444,  13,         10) /* StackUnitEncumbrance */
+     , (26444,  14,         10) /* StackUnitMass */
+     , (26444,  15,        500) /* StackUnitValue */
+     , (26444,  16,          8) /* ItemUseable - Contained */
+     , (26444,  18,          1) /* UiEffects - Magical */
+     , (26444,  19,        500) /* Value */
+     , (26444,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26444,  94,         16) /* TargetType - Creature */
+     , (26444, 106,        210) /* ItemSpellcraft */
+     , (26444, 107,         50) /* ItemCurMana */
+     , (26444, 108,         50) /* ItemMaxMana */
+     , (26444, 109,          0) /* ItemDifficulty */
+     , (26444, 110,          0) /* ItemAllegianceRankLimit */
+     , (26444, 150,        103) /* HookPlacement - Hook */
+     , (26444, 151,          2) /* HookType - Wall */
+     , (26444, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26444,  15, True ) /* LightsStatus */
+     , (26444,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26444, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26444,   1, 'Yukikaze  Portal Gem') /* Name */
+     , (26444,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26444,   1,   33556769) /* Setup */
+     , (26444,   3,  536870932) /* SoundTable */
+     , (26444,   6,   67111919) /* PaletteBase */
+     , (26444,   7,  268435723) /* ClothingBase */
+     , (26444,   8,  100675760) /* Icon */
+     , (26444,  22,  872415275) /* PhysicsEffectTable */
+     , (26444,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26444,  31,      12569) /* LinkedPortalOne - Yukikaze  Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26445 Yushad Ridge Cottages Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26445 Yushad Ridge Cottages Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26445;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26445, 'gemportalyushadridgecottages', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26445,   1,       2048) /* ItemType - Gem */
+     , (26445,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26445,   5,         10) /* EncumbranceVal */
+     , (26445,   8,         10) /* Mass */
+     , (26445,   9,          0) /* ValidLocations - None */
+     , (26445,  11,         20) /* MaxStackSize */
+     , (26445,  12,          1) /* StackSize */
+     , (26445,  13,         10) /* StackUnitEncumbrance */
+     , (26445,  14,         10) /* StackUnitMass */
+     , (26445,  15,        500) /* StackUnitValue */
+     , (26445,  16,          8) /* ItemUseable - Contained */
+     , (26445,  18,          1) /* UiEffects - Magical */
+     , (26445,  19,        500) /* Value */
+     , (26445,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26445,  94,         16) /* TargetType - Creature */
+     , (26445, 106,        210) /* ItemSpellcraft */
+     , (26445, 107,         50) /* ItemCurMana */
+     , (26445, 108,         50) /* ItemMaxMana */
+     , (26445, 109,          0) /* ItemDifficulty */
+     , (26445, 110,          0) /* ItemAllegianceRankLimit */
+     , (26445, 150,        103) /* HookPlacement - Hook */
+     , (26445, 151,          2) /* HookType - Wall */
+     , (26445, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26445,  15, True ) /* LightsStatus */
+     , (26445,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26445, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26445,   1, 'Yushad Ridge Cottages Portal Gem') /* Name */
+     , (26445,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26445,   1,   33556769) /* Setup */
+     , (26445,   3,  536870932) /* SoundTable */
+     , (26445,   6,   67111919) /* PaletteBase */
+     , (26445,   7,  268435723) /* ClothingBase */
+     , (26445,   8,  100675760) /* Icon */
+     , (26445,  22,  872415275) /* PhysicsEffectTable */
+     , (26445,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26445,  31,      12570) /* LinkedPortalOne - Yushad Ridge Cottages Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26446 Zabool Overlook Settlement Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26446 Zabool Overlook Settlement Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26446;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26446, 'gemportalzabooloverlooksettlement', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26446,   1,       2048) /* ItemType - Gem */
+     , (26446,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26446,   5,         10) /* EncumbranceVal */
+     , (26446,   8,         10) /* Mass */
+     , (26446,   9,          0) /* ValidLocations - None */
+     , (26446,  11,         20) /* MaxStackSize */
+     , (26446,  12,          1) /* StackSize */
+     , (26446,  13,         10) /* StackUnitEncumbrance */
+     , (26446,  14,         10) /* StackUnitMass */
+     , (26446,  15,        500) /* StackUnitValue */
+     , (26446,  16,          8) /* ItemUseable - Contained */
+     , (26446,  18,          1) /* UiEffects - Magical */
+     , (26446,  19,        500) /* Value */
+     , (26446,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26446,  94,         16) /* TargetType - Creature */
+     , (26446, 106,        210) /* ItemSpellcraft */
+     , (26446, 107,         50) /* ItemCurMana */
+     , (26446, 108,         50) /* ItemMaxMana */
+     , (26446, 109,          0) /* ItemDifficulty */
+     , (26446, 110,          0) /* ItemAllegianceRankLimit */
+     , (26446, 150,        103) /* HookPlacement - Hook */
+     , (26446, 151,          2) /* HookType - Wall */
+     , (26446, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26446,  15, True ) /* LightsStatus */
+     , (26446,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26446, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26446,   1, 'Zabool Overlook Settlement Portal Gem') /* Name */
+     , (26446,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26446,   1,   33556769) /* Setup */
+     , (26446,   3,  536870932) /* SoundTable */
+     , (26446,   6,   67111919) /* PaletteBase */
+     , (26446,   7,  268435723) /* ClothingBase */
+     , (26446,   8,  100675760) /* Icon */
+     , (26446,  22,  872415275) /* PhysicsEffectTable */
+     , (26446,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26446,  31,      12571) /* LinkedPortalOne - Zabool Overlook Settlement Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26447 Zaikhal Hills Villas Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26447 Zaikhal Hills Villas Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26447;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26447, 'gemportalzaikhalhillsvillas', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26447,   1,       2048) /* ItemType - Gem */
+     , (26447,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26447,   5,         10) /* EncumbranceVal */
+     , (26447,   8,         10) /* Mass */
+     , (26447,   9,          0) /* ValidLocations - None */
+     , (26447,  11,         20) /* MaxStackSize */
+     , (26447,  12,          1) /* StackSize */
+     , (26447,  13,         10) /* StackUnitEncumbrance */
+     , (26447,  14,         10) /* StackUnitMass */
+     , (26447,  15,        500) /* StackUnitValue */
+     , (26447,  16,          8) /* ItemUseable - Contained */
+     , (26447,  18,          1) /* UiEffects - Magical */
+     , (26447,  19,        500) /* Value */
+     , (26447,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26447,  94,         16) /* TargetType - Creature */
+     , (26447, 106,        210) /* ItemSpellcraft */
+     , (26447, 107,         50) /* ItemCurMana */
+     , (26447, 108,         50) /* ItemMaxMana */
+     , (26447, 109,          0) /* ItemDifficulty */
+     , (26447, 110,          0) /* ItemAllegianceRankLimit */
+     , (26447, 150,        103) /* HookPlacement - Hook */
+     , (26447, 151,          2) /* HookType - Wall */
+     , (26447, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26447,  15, True ) /* LightsStatus */
+     , (26447,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26447, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26447,   1, 'Zaikhal Hills Villas Portal Gem') /* Name */
+     , (26447,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26447,   1,   33556769) /* Setup */
+     , (26447,   3,  536870932) /* SoundTable */
+     , (26447,   6,   67111919) /* PaletteBase */
+     , (26447,   7,  268435723) /* ClothingBase */
+     , (26447,   8,  100675760) /* Icon */
+     , (26447,  22,  872415275) /* PhysicsEffectTable */
+     , (26447,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26447,  31,      13142) /* LinkedPortalOne - Zaikhal Hills Villas Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26448 Zatara Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26448 Zatara Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26448;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26448, 'gemportalzatara', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26448,   1,       2048) /* ItemType - Gem */
+     , (26448,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26448,   5,         10) /* EncumbranceVal */
+     , (26448,   8,         10) /* Mass */
+     , (26448,   9,          0) /* ValidLocations - None */
+     , (26448,  11,         20) /* MaxStackSize */
+     , (26448,  12,          1) /* StackSize */
+     , (26448,  13,         10) /* StackUnitEncumbrance */
+     , (26448,  14,         10) /* StackUnitMass */
+     , (26448,  15,        500) /* StackUnitValue */
+     , (26448,  16,          8) /* ItemUseable - Contained */
+     , (26448,  18,          1) /* UiEffects - Magical */
+     , (26448,  19,        500) /* Value */
+     , (26448,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26448,  94,         16) /* TargetType - Creature */
+     , (26448, 106,        210) /* ItemSpellcraft */
+     , (26448, 107,         50) /* ItemCurMana */
+     , (26448, 108,         50) /* ItemMaxMana */
+     , (26448, 109,          0) /* ItemDifficulty */
+     , (26448, 110,          0) /* ItemAllegianceRankLimit */
+     , (26448, 150,        103) /* HookPlacement - Hook */
+     , (26448, 151,          2) /* HookType - Wall */
+     , (26448, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26448,  15, True ) /* LightsStatus */
+     , (26448,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26448, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26448,   1, 'Zatara Portal Gem') /* Name */
+     , (26448,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26448,   1,   33556769) /* Setup */
+     , (26448,   3,  536870932) /* SoundTable */
+     , (26448,   6,   67111919) /* PaletteBase */
+     , (26448,   7,  268435723) /* ClothingBase */
+     , (26448,   8,  100675760) /* Icon */
+     , (26448,  22,  872415275) /* PhysicsEffectTable */
+     , (26448,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26448,  31,      14294) /* LinkedPortalOne - Zatara Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26449 Zin-Dai Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26449 Zin-Dai Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26449;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26449, 'gemportalzindai', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26449,   1,       2048) /* ItemType - Gem */
+     , (26449,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26449,   5,         10) /* EncumbranceVal */
+     , (26449,   8,         10) /* Mass */
+     , (26449,   9,          0) /* ValidLocations - None */
+     , (26449,  11,         20) /* MaxStackSize */
+     , (26449,  12,          1) /* StackSize */
+     , (26449,  13,         10) /* StackUnitEncumbrance */
+     , (26449,  14,         10) /* StackUnitMass */
+     , (26449,  15,        500) /* StackUnitValue */
+     , (26449,  16,          8) /* ItemUseable - Contained */
+     , (26449,  18,          1) /* UiEffects - Magical */
+     , (26449,  19,        500) /* Value */
+     , (26449,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26449,  94,         16) /* TargetType - Creature */
+     , (26449, 106,        210) /* ItemSpellcraft */
+     , (26449, 107,         50) /* ItemCurMana */
+     , (26449, 108,         50) /* ItemMaxMana */
+     , (26449, 109,          0) /* ItemDifficulty */
+     , (26449, 110,          0) /* ItemAllegianceRankLimit */
+     , (26449, 150,        103) /* HookPlacement - Hook */
+     , (26449, 151,          2) /* HookType - Wall */
+     , (26449, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26449,  15, True ) /* LightsStatus */
+     , (26449,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26449, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26449,   1, 'Zin-Dai Portal Gem') /* Name */
+     , (26449,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26449,   1,   33556769) /* Setup */
+     , (26449,   3,  536870932) /* SoundTable */
+     , (26449,   6,   67111919) /* PaletteBase */
+     , (26449,   7,  268435723) /* ClothingBase */
+     , (26449,   8,  100675760) /* Icon */
+     , (26449,  22,  872415275) /* PhysicsEffectTable */
+     , (26449,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26449,  31,      14679) /* LinkedPortalOne - Zin-Dai Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26450 Zoe's Place Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26450 Zoe's Place Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26450;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26450, 'gemportalzoesplace', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26450,   1,       2048) /* ItemType - Gem */
+     , (26450,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26450,   5,         10) /* EncumbranceVal */
+     , (26450,   8,         10) /* Mass */
+     , (26450,   9,          0) /* ValidLocations - None */
+     , (26450,  11,         20) /* MaxStackSize */
+     , (26450,  12,          1) /* StackSize */
+     , (26450,  13,         10) /* StackUnitEncumbrance */
+     , (26450,  14,         10) /* StackUnitMass */
+     , (26450,  15,        500) /* StackUnitValue */
+     , (26450,  16,          8) /* ItemUseable - Contained */
+     , (26450,  18,          1) /* UiEffects - Magical */
+     , (26450,  19,        500) /* Value */
+     , (26450,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26450,  94,         16) /* TargetType - Creature */
+     , (26450, 106,        210) /* ItemSpellcraft */
+     , (26450, 107,         50) /* ItemCurMana */
+     , (26450, 108,         50) /* ItemMaxMana */
+     , (26450, 109,          0) /* ItemDifficulty */
+     , (26450, 110,          0) /* ItemAllegianceRankLimit */
+     , (26450, 150,        103) /* HookPlacement - Hook */
+     , (26450, 151,          2) /* HookType - Wall */
+     , (26450, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26450,  15, True ) /* LightsStatus */
+     , (26450,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26450, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26450,   1, 'Zoe''s Place Portal Gem') /* Name */
+     , (26450,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26450,   1,   33556769) /* Setup */
+     , (26450,   3,  536870932) /* SoundTable */
+     , (26450,   6,   67111919) /* PaletteBase */
+     , (26450,   7,  268435723) /* ClothingBase */
+     , (26450,   8,  100675760) /* Icon */
+     , (26450,  22,  872415275) /* PhysicsEffectTable */
+     , (26450,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26450,  31,      14295) /* LinkedPortalOne - Zoe's Place Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26451 Zon-Atara Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26451 Zon-Atara Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26451;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26451, 'gemportalzonatara', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26451,   1,       2048) /* ItemType - Gem */
+     , (26451,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (26451,   5,         10) /* EncumbranceVal */
+     , (26451,   8,         10) /* Mass */
+     , (26451,   9,          0) /* ValidLocations - None */
+     , (26451,  11,         20) /* MaxStackSize */
+     , (26451,  12,          1) /* StackSize */
+     , (26451,  13,         10) /* StackUnitEncumbrance */
+     , (26451,  14,         10) /* StackUnitMass */
+     , (26451,  15,        500) /* StackUnitValue */
+     , (26451,  16,          8) /* ItemUseable - Contained */
+     , (26451,  18,          1) /* UiEffects - Magical */
+     , (26451,  19,        500) /* Value */
+     , (26451,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26451,  94,         16) /* TargetType - Creature */
+     , (26451, 106,        210) /* ItemSpellcraft */
+     , (26451, 107,         50) /* ItemCurMana */
+     , (26451, 108,         50) /* ItemMaxMana */
+     , (26451, 109,          0) /* ItemDifficulty */
+     , (26451, 110,          0) /* ItemAllegianceRankLimit */
+     , (26451, 150,        103) /* HookPlacement - Hook */
+     , (26451, 151,          2) /* HookType - Wall */
+     , (26451, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26451,  15, True ) /* LightsStatus */
+     , (26451,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26451, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26451,   1, 'Zon-Atara Portal Gem') /* Name */
+     , (26451,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26451,   1,   33556769) /* Setup */
+     , (26451,   3,  536870932) /* SoundTable */
+     , (26451,   6,   67111919) /* PaletteBase */
+     , (26451,   7,  268435723) /* ClothingBase */
+     , (26451,   8,  100675760) /* Icon */
+     , (26451,  22,  872415275) /* PhysicsEffectTable */
+     , (26451,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26451,  31,      15202) /* LinkedPortalOne - Zon-Atara Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26639 Xarabydun Portal Summoning Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/26639 Xarabydun Portal Summoning Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 26639;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (26639, 'gemportalxarabydun', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (26639,   1,       2048) /* ItemType - Gem */
+     , (26639,   3,         77) /* PaletteTemplate - BlueGreen */
+     , (26639,   5,         10) /* EncumbranceVal */
+     , (26639,   8,         10) /* Mass */
+     , (26639,   9,          0) /* ValidLocations - None */
+     , (26639,  11,         25) /* MaxStackSize */
+     , (26639,  12,          1) /* StackSize */
+     , (26639,  13,         10) /* StackUnitEncumbrance */
+     , (26639,  14,         10) /* StackUnitMass */
+     , (26639,  15,        500) /* StackUnitValue */
+     , (26639,  16,          8) /* ItemUseable - Contained */
+     , (26639,  18,          1) /* UiEffects - Magical */
+     , (26639,  19,        500) /* Value */
+     , (26639,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (26639,  94,         16) /* TargetType - Creature */
+     , (26639, 106,        210) /* ItemSpellcraft */
+     , (26639, 107,         50) /* ItemCurMana */
+     , (26639, 108,         50) /* ItemMaxMana */
+     , (26639, 109,          0) /* ItemDifficulty */
+     , (26639, 110,          0) /* ItemAllegianceRankLimit */
+     , (26639, 150,        103) /* HookPlacement - Hook */
+     , (26639, 151,          2) /* HookType - Wall */
+     , (26639, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (26639,  15, True ) /* LightsStatus */
+     , (26639,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (26639, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (26639,   1, 'Xarabydun Portal Summoning Gem') /* Name */
+     , (26639,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (26639,   1,   33556769) /* Setup */
+     , (26639,   3,  536870932) /* SoundTable */
+     , (26639,   6,   67111919) /* PaletteBase */
+     , (26639,   7,  268435723) /* ClothingBase */
+     , (26639,   8,  100674856) /* Icon */
+     , (26639,  22,  872415275) /* PhysicsEffectTable */
+     , (26639,  28,        157) /* Spell - Summon Primary Portal I */
+     , (26639,  31,      28269) /* LinkedPortalOne - Portal to Xarabydun */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27091 Linvak Tukal Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27091 Linvak Tukal Portal Gem.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27091;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27091, 'gemportallinvaktukal', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27091,   1,       2048) /* ItemType - Gem */
+     , (27091,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (27091,   5,         10) /* EncumbranceVal */
+     , (27091,   8,         10) /* Mass */
+     , (27091,   9,          0) /* ValidLocations - None */
+     , (27091,  11,         25) /* MaxStackSize */
+     , (27091,  12,          1) /* StackSize */
+     , (27091,  13,         10) /* StackUnitEncumbrance */
+     , (27091,  14,         10) /* StackUnitMass */
+     , (27091,  15,        500) /* StackUnitValue */
+     , (27091,  16,          8) /* ItemUseable - Contained */
+     , (27091,  18,          1) /* UiEffects - Magical */
+     , (27091,  19,        500) /* Value */
+     , (27091,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27091,  94,         16) /* TargetType - Creature */
+     , (27091, 106,        210) /* ItemSpellcraft */
+     , (27091, 107,         50) /* ItemCurMana */
+     , (27091, 108,         50) /* ItemMaxMana */
+     , (27091, 109,          0) /* ItemDifficulty */
+     , (27091, 110,          0) /* ItemAllegianceRankLimit */
+     , (27091, 150,        103) /* HookPlacement - Hook */
+     , (27091, 151,          2) /* HookType - Wall */
+     , (27091, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27091,  15, True ) /* LightsStatus */
+     , (27091,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27091, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27091,   1, 'Linvak Tukal Portal Gem') /* Name */
+     , (27091,  15, 'This portal summoning gem works best if used outside in a relatively flat area.') /* ShortDesc */
+     , (27091,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27091,   1,   33556769) /* Setup */
+     , (27091,   3,  536870932) /* SoundTable */
+     , (27091,   6,   67111919) /* PaletteBase */
+     , (27091,   7,  268435723) /* ClothingBase */
+     , (27091,   8,  100674862) /* Icon */
+     , (27091,  22,  872415275) /* PhysicsEffectTable */
+     , (27091,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27091,  31,       8401) /* LinkedPortalOne - Portal to Linvak Tukal */
+     , (27091,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27385 Map of Auberean.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27385 Map of Auberean.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27385;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27385, 'gemquestaubereanmap', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27385,   1,       2048) /* ItemType - Gem */
+     , (27385,   3,         14) /* PaletteTemplate - Red */
+     , (27385,   5,         10) /* EncumbranceVal */
+     , (27385,   8,         10) /* Mass */
+     , (27385,   9,          0) /* ValidLocations - None */
+     , (27385,  11,          1) /* MaxStackSize */
+     , (27385,  12,          1) /* StackSize */
+     , (27385,  13,         10) /* StackUnitEncumbrance */
+     , (27385,  14,         10) /* StackUnitMass */
+     , (27385,  15,        500) /* StackUnitValue */
+     , (27385,  16,          8) /* ItemUseable - Contained */
+     , (27385,  19,        500) /* Value */
+     , (27385,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27385,  94,         16) /* TargetType - Creature */
+     , (27385, 106,        210) /* ItemSpellcraft */
+     , (27385, 107,         50) /* ItemCurMana */
+     , (27385, 108,         50) /* ItemMaxMana */
+     , (27385, 109,          0) /* ItemDifficulty */
+     , (27385, 110,          0) /* ItemAllegianceRankLimit */
+     , (27385, 150,        103) /* HookPlacement - Hook */
+     , (27385, 151,          2) /* HookType - Wall */
+     , (27385, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27385,  15, True ) /* LightsStatus */
+     , (27385,  22, True ) /* Inscribable */
+     , (27385,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27385, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27385,   1, 'Map of Auberean') /* Name */
+     , (27385,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 80+)') /* Use */
+     , (27385,  16, 'Description Here') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27385,   1,   33556769) /* Setup */
+     , (27385,   3,  536870932) /* SoundTable */
+     , (27385,   6,   67111919) /* PaletteBase */
+     , (27385,   7,  268435723) /* ClothingBase */
+     , (27385,   8,  100668364) /* Icon */
+     , (27385,  22,  872415275) /* PhysicsEffectTable */
+     , (27385,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27385,  31,      27396) /* LinkedPortalOne - Map of Auberean */
+     , (27385,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27387 Dark Monolith.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27387 Dark Monolith.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27387;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27387, 'gemquestdarkmonolith', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27387,   1,       2048) /* ItemType - Gem */
+     , (27387,   3,         14) /* PaletteTemplate - Red */
+     , (27387,   5,         10) /* EncumbranceVal */
+     , (27387,   8,         10) /* Mass */
+     , (27387,   9,          0) /* ValidLocations - None */
+     , (27387,  11,          1) /* MaxStackSize */
+     , (27387,  12,          1) /* StackSize */
+     , (27387,  13,         10) /* StackUnitEncumbrance */
+     , (27387,  14,         10) /* StackUnitMass */
+     , (27387,  15,        500) /* StackUnitValue */
+     , (27387,  16,          8) /* ItemUseable - Contained */
+     , (27387,  19,        500) /* Value */
+     , (27387,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27387,  94,         16) /* TargetType - Creature */
+     , (27387, 106,        210) /* ItemSpellcraft */
+     , (27387, 107,         50) /* ItemCurMana */
+     , (27387, 108,         50) /* ItemMaxMana */
+     , (27387, 109,          0) /* ItemDifficulty */
+     , (27387, 110,          0) /* ItemAllegianceRankLimit */
+     , (27387, 150,        103) /* HookPlacement - Hook */
+     , (27387, 151,          2) /* HookType - Wall */
+     , (27387, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27387,  15, True ) /* LightsStatus */
+     , (27387,  22, True ) /* Inscribable */
+     , (27387,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27387, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27387,   1, 'Dark Monolith') /* Name */
+     , (27387,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 80+)') /* Use */
+     , (27387,  16, 'A strange crystal found in the remains of a golem. It is shaped like a mote, but has obvious portal magics surrounding it. While holding it you sense a distant source of power somewhere below.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27387,   1,   33556769) /* Setup */
+     , (27387,   3,  536870932) /* SoundTable */
+     , (27387,   6,   67111919) /* PaletteBase */
+     , (27387,   7,  268435723) /* ClothingBase */
+     , (27387,   8,  100668364) /* Icon */
+     , (27387,  22,  872415275) /* PhysicsEffectTable */
+     , (27387,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27387,  31,      27398) /* LinkedPortalOne - Dark Monolith */
+     , (27387,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27389 Deep Caverns.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27389 Deep Caverns.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27389;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27389, 'gemquestdeepcaverns', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27389,   1,       2048) /* ItemType - Gem */
+     , (27389,   3,         61) /* PaletteTemplate - White */
+     , (27389,   5,         10) /* EncumbranceVal */
+     , (27389,   8,         10) /* Mass */
+     , (27389,   9,          0) /* ValidLocations - None */
+     , (27389,  11,          1) /* MaxStackSize */
+     , (27389,  12,          1) /* StackSize */
+     , (27389,  13,         10) /* StackUnitEncumbrance */
+     , (27389,  14,         10) /* StackUnitMass */
+     , (27389,  15,        500) /* StackUnitValue */
+     , (27389,  16,          8) /* ItemUseable - Contained */
+     , (27389,  19,        500) /* Value */
+     , (27389,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27389,  94,         16) /* TargetType - Creature */
+     , (27389, 106,        210) /* ItemSpellcraft */
+     , (27389, 107,         50) /* ItemCurMana */
+     , (27389, 108,         50) /* ItemMaxMana */
+     , (27389, 109,          0) /* ItemDifficulty */
+     , (27389, 110,          0) /* ItemAllegianceRankLimit */
+     , (27389, 150,        103) /* HookPlacement - Hook */
+     , (27389, 151,          2) /* HookType - Wall */
+     , (27389, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27389,  15, True ) /* LightsStatus */
+     , (27389,  22, True ) /* Inscribable */
+     , (27389,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27389, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27389,   1, 'Deep Caverns') /* Name */
+     , (27389,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 100+)') /* Use */
+     , (27389,  16, 'Strange words float across the surface of the gem. You recognize words you never knew and a dark veil falls before your eyes. "We hold the knowledge of our father. We must prepare for his return."') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27389,   1,   33556769) /* Setup */
+     , (27389,   3,  536870932) /* SoundTable */
+     , (27389,   6,   67111919) /* PaletteBase */
+     , (27389,   7,  268435723) /* ClothingBase */
+     , (27389,   8,  100668365) /* Icon */
+     , (27389,  22,  872415275) /* PhysicsEffectTable */
+     , (27389,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27389,  31,      27400) /* LinkedPortalOne - Deep Caverns */
+     , (27389,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27393 Relic.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27393 Relic.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27393;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27393, 'gemquestrelic', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27393,   1,       2048) /* ItemType - Gem */
+     , (27393,   3,         83) /* PaletteTemplate - Amber */
+     , (27393,   5,         10) /* EncumbranceVal */
+     , (27393,   8,         10) /* Mass */
+     , (27393,   9,          0) /* ValidLocations - None */
+     , (27393,  11,          1) /* MaxStackSize */
+     , (27393,  12,          1) /* StackSize */
+     , (27393,  13,         10) /* StackUnitEncumbrance */
+     , (27393,  14,         10) /* StackUnitMass */
+     , (27393,  15,        500) /* StackUnitValue */
+     , (27393,  16,          8) /* ItemUseable - Contained */
+     , (27393,  19,        500) /* Value */
+     , (27393,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27393,  94,         16) /* TargetType - Creature */
+     , (27393, 106,        210) /* ItemSpellcraft */
+     , (27393, 107,         50) /* ItemCurMana */
+     , (27393, 108,         50) /* ItemMaxMana */
+     , (27393, 109,          0) /* ItemDifficulty */
+     , (27393, 110,          0) /* ItemAllegianceRankLimit */
+     , (27393, 150,        103) /* HookPlacement - Hook */
+     , (27393, 151,          2) /* HookType - Wall */
+     , (27393, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27393,  15, True ) /* LightsStatus */
+     , (27393,  22, True ) /* Inscribable */
+     , (27393,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27393, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27393,   1, 'Relic') /* Name */
+     , (27393,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 40-60)') /* Use */
+     , (27393,  16, 'The Baron has called us to protect The Chalice. We few who remember shall preserve this relic with undying devotion. - Brotherhood of the Chalice') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27393,   1,   33556769) /* Setup */
+     , (27393,   3,  536870932) /* SoundTable */
+     , (27393,   6,   67111919) /* PaletteBase */
+     , (27393,   7,  268435723) /* ClothingBase */
+     , (27393,   8,  100668366) /* Icon */
+     , (27393,  22,  872415275) /* PhysicsEffectTable */
+     , (27393,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27393,  31,      27404) /* LinkedPortalOne - Relic */
+     , (27393,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27395 Wizard's Lab.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27395 Wizard's Lab.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27395;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27395, 'gemquestwizardsblade', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27395,   1,       2048) /* ItemType - Gem */
+     , (27395,   3,         83) /* PaletteTemplate - Amber */
+     , (27395,   5,         10) /* EncumbranceVal */
+     , (27395,   8,         10) /* Mass */
+     , (27395,   9,          0) /* ValidLocations - None */
+     , (27395,  11,          1) /* MaxStackSize */
+     , (27395,  12,          1) /* StackSize */
+     , (27395,  13,         10) /* StackUnitEncumbrance */
+     , (27395,  14,         10) /* StackUnitMass */
+     , (27395,  15,        500) /* StackUnitValue */
+     , (27395,  16,          8) /* ItemUseable - Contained */
+     , (27395,  19,        500) /* Value */
+     , (27395,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27395,  94,         16) /* TargetType - Creature */
+     , (27395, 106,        210) /* ItemSpellcraft */
+     , (27395, 107,         50) /* ItemCurMana */
+     , (27395, 108,         50) /* ItemMaxMana */
+     , (27395, 109,          0) /* ItemDifficulty */
+     , (27395, 110,          0) /* ItemAllegianceRankLimit */
+     , (27395, 150,        103) /* HookPlacement - Hook */
+     , (27395, 151,          2) /* HookType - Wall */
+     , (27395, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27395,  15, True ) /* LightsStatus */
+     , (27395,  22, True ) /* Inscribable */
+     , (27395,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27395, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27395,   1, 'Wizard''s Lab') /* Name */
+     , (27395,  14, 'This portal summoning gem works best if used outside in a relatively flat area. (Quest Difficulty: 60-80)') /* Use */
+     , (27395,  16, 'The human who has altered our servants has been found. He fumbles about with our creations attempting an understanding beyond his physical limitations. The odds of his continued existence are low. We currently deem the loss of servants less troublesome than attempting to eliminate this nuisance, but continued observance of his activities is instructed.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27395,   1,   33556769) /* Setup */
+     , (27395,   3,  536870932) /* SoundTable */
+     , (27395,   6,   67111919) /* PaletteBase */
+     , (27395,   7,  268435723) /* ClothingBase */
+     , (27395,   8,  100676445) /* Icon */
+     , (27395,  22,  872415275) /* PhysicsEffectTable */
+     , (27395,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27395,  31,      27406) /* LinkedPortalOne - Wizard's Lab */
+     , (27395,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27768 Eye of the Depths.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27768 Eye of the Depths.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27768;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27768, 'gemportalsunkenmereextreme', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27768,   1,       2048) /* ItemType - Gem */
+     , (27768,   5,         25) /* EncumbranceVal */
+     , (27768,   8,          5) /* Mass */
+     , (27768,   9,          0) /* ValidLocations - None */
+     , (27768,  11,          1) /* MaxStackSize */
+     , (27768,  12,          1) /* StackSize */
+     , (27768,  13,         25) /* StackUnitEncumbrance */
+     , (27768,  14,          5) /* StackUnitMass */
+     , (27768,  15,      30000) /* StackUnitValue */
+     , (27768,  16,          8) /* ItemUseable - Contained */
+     , (27768,  18,          1) /* UiEffects - Magical */
+     , (27768,  19,      30000) /* Value */
+     , (27768,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27768,  94,         16) /* TargetType - Creature */
+     , (27768, 106,        210) /* ItemSpellcraft */
+     , (27768, 107,         50) /* ItemCurMana */
+     , (27768, 108,         50) /* ItemMaxMana */
+     , (27768, 109,          0) /* ItemDifficulty */
+     , (27768, 110,          0) /* ItemAllegianceRankLimit */
+     , (27768, 150,        103) /* HookPlacement - Hook */
+     , (27768, 151,          1) /* HookType - Floor */
+     , (27768, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27768,  15, True ) /* LightsStatus */
+     , (27768,  22, True ) /* Inscribable */
+     , (27768,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27768, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27768,   1, 'Eye of the Depths') /* Name */
+     , (27768,  14, 'Double-click on this portal gem to summon a portal. You must be level 80 or greater to enter the summoned portal.') /* Use */
+     , (27768,  15, 'A green portal gem surrounded by a clasp, held by an amethyst cradle, adorned with a sparkling cluster of aquamarine and placed atop a jade dais.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27768,   1,   33558806) /* Setup */
+     , (27768,   3,  536870932) /* SoundTable */
+     , (27768,   8,  100676636) /* Icon */
+     , (27768,  22,  872415275) /* PhysicsEffectTable */
+     , (27768,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27768,  31,      27777) /* LinkedPortalOne - Sunken Mere */
+     , (27768,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27769 Beholding Adjanite Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27769 Beholding Adjanite Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27769;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27769, 'gemportalsunkenmerehigh', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27769,   1,       2048) /* ItemType - Gem */
+     , (27769,   5,         25) /* EncumbranceVal */
+     , (27769,   8,          5) /* Mass */
+     , (27769,   9,          0) /* ValidLocations - None */
+     , (27769,  11,          1) /* MaxStackSize */
+     , (27769,  12,          1) /* StackSize */
+     , (27769,  13,         25) /* StackUnitEncumbrance */
+     , (27769,  14,          5) /* StackUnitMass */
+     , (27769,  15,      20000) /* StackUnitValue */
+     , (27769,  16,          8) /* ItemUseable - Contained */
+     , (27769,  18,          1) /* UiEffects - Magical */
+     , (27769,  19,      20000) /* Value */
+     , (27769,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27769,  94,         16) /* TargetType - Creature */
+     , (27769, 106,        210) /* ItemSpellcraft */
+     , (27769, 107,         50) /* ItemCurMana */
+     , (27769, 108,         50) /* ItemMaxMana */
+     , (27769, 109,          0) /* ItemDifficulty */
+     , (27769, 110,          0) /* ItemAllegianceRankLimit */
+     , (27769, 150,        103) /* HookPlacement - Hook */
+     , (27769, 151,          1) /* HookType - Floor */
+     , (27769, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27769,  15, True ) /* LightsStatus */
+     , (27769,  22, True ) /* Inscribable */
+     , (27769,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27769, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27769,   1, 'Beholding Adjanite Gem') /* Name */
+     , (27769,  14, 'Double-click on this portal gem to summon a portal. You must be level 60 or greater to enter the summoned portal.') /* Use */
+     , (27769,  15, 'A green portal gem surrounded by a clasp, held by an amethyst cradle and adorned with a sparkling cluster of aquamarine.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27769,   1,   33558811) /* Setup */
+     , (27769,   3,  536870932) /* SoundTable */
+     , (27769,   8,  100676635) /* Icon */
+     , (27769,  22,  872415275) /* PhysicsEffectTable */
+     , (27769,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27769,  31,      27778) /* LinkedPortalOne - Sunken Mere */
+     , (27769,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27770 Decorated Adjanite Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27770 Decorated Adjanite Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27770;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27770, 'gemportalsunkenmerelow', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27770,   1,       2048) /* ItemType - Gem */
+     , (27770,   5,         25) /* EncumbranceVal */
+     , (27770,   8,          5) /* Mass */
+     , (27770,   9,          0) /* ValidLocations - None */
+     , (27770,  11,          1) /* MaxStackSize */
+     , (27770,  12,          1) /* StackSize */
+     , (27770,  13,         25) /* StackUnitEncumbrance */
+     , (27770,  14,          5) /* StackUnitMass */
+     , (27770,  15,      10000) /* StackUnitValue */
+     , (27770,  16,          8) /* ItemUseable - Contained */
+     , (27770,  18,          1) /* UiEffects - Magical */
+     , (27770,  19,      10000) /* Value */
+     , (27770,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27770,  94,         16) /* TargetType - Creature */
+     , (27770, 106,        210) /* ItemSpellcraft */
+     , (27770, 107,         50) /* ItemCurMana */
+     , (27770, 108,         50) /* ItemMaxMana */
+     , (27770, 109,          0) /* ItemDifficulty */
+     , (27770, 110,          0) /* ItemAllegianceRankLimit */
+     , (27770, 150,        103) /* HookPlacement - Hook */
+     , (27770, 151,          2) /* HookType - Wall */
+     , (27770, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27770,  15, True ) /* LightsStatus */
+     , (27770,  22, True ) /* Inscribable */
+     , (27770,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27770, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27770,   1, 'Decorated Adjanite Gem') /* Name */
+     , (27770,  14, 'Double-click on this portal gem to summon a portal. You must be level 20 or greater to enter the summoned portal.') /* Use */
+     , (27770,  15, 'A green portal gem surrounded by a clasp.  ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27770,   1,   33558807) /* Setup */
+     , (27770,   3,  536870932) /* SoundTable */
+     , (27770,   8,  100676633) /* Icon */
+     , (27770,  22,  872415275) /* PhysicsEffectTable */
+     , (27770,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27770,  31,      27779) /* LinkedPortalOne - Sunken Mere */
+     , (27770,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27771 Entrancing Adjanite Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27771 Entrancing Adjanite Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27771;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27771, 'gemportalsunkenmeremid', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27771,   1,       2048) /* ItemType - Gem */
+     , (27771,   5,         25) /* EncumbranceVal */
+     , (27771,   8,          5) /* Mass */
+     , (27771,   9,          0) /* ValidLocations - None */
+     , (27771,  11,          1) /* MaxStackSize */
+     , (27771,  12,          1) /* StackSize */
+     , (27771,  13,         25) /* StackUnitEncumbrance */
+     , (27771,  14,          5) /* StackUnitMass */
+     , (27771,  15,      15000) /* StackUnitValue */
+     , (27771,  16,          8) /* ItemUseable - Contained */
+     , (27771,  18,          1) /* UiEffects - Magical */
+     , (27771,  19,      15000) /* Value */
+     , (27771,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27771,  94,         16) /* TargetType - Creature */
+     , (27771, 106,        210) /* ItemSpellcraft */
+     , (27771, 107,         50) /* ItemCurMana */
+     , (27771, 108,         50) /* ItemMaxMana */
+     , (27771, 109,          0) /* ItemDifficulty */
+     , (27771, 110,          0) /* ItemAllegianceRankLimit */
+     , (27771, 150,        103) /* HookPlacement - Hook */
+     , (27771, 151,          1) /* HookType - Floor */
+     , (27771, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27771,  15, True ) /* LightsStatus */
+     , (27771,  22, True ) /* Inscribable */
+     , (27771,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27771, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27771,   1, 'Entrancing Adjanite Gem') /* Name */
+     , (27771,  14, 'Double-click on this portal gem to summon a portal. You must be level 40 or greater to enter the summoned portal.') /* Use */
+     , (27771,  15, 'A green portal gem surrounded by a clasp and held by an amethyst cradle.  ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27771,   1,   33558803) /* Setup */
+     , (27771,   3,  536870932) /* SoundTable */
+     , (27771,   8,  100676634) /* Icon */
+     , (27771,  22,  872415275) /* PhysicsEffectTable */
+     , (27771,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27771,  31,      27780) /* LinkedPortalOne - Sunken Mere */
+     , (27771,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27772 Adjanite Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/27772 Adjanite Gem.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 27772;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (27772, 'gemportalsunkenmerenewbie', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (27772,   1,       2048) /* ItemType - Gem */
+     , (27772,   5,         25) /* EncumbranceVal */
+     , (27772,   8,          5) /* Mass */
+     , (27772,   9,          0) /* ValidLocations - None */
+     , (27772,  11,          1) /* MaxStackSize */
+     , (27772,  12,          1) /* StackSize */
+     , (27772,  13,         25) /* StackUnitEncumbrance */
+     , (27772,  14,          5) /* StackUnitMass */
+     , (27772,  15,       5000) /* StackUnitValue */
+     , (27772,  16,          8) /* ItemUseable - Contained */
+     , (27772,  18,          1) /* UiEffects - Magical */
+     , (27772,  19,       5000) /* Value */
+     , (27772,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (27772,  94,         16) /* TargetType - Creature */
+     , (27772, 106,        210) /* ItemSpellcraft */
+     , (27772, 107,         50) /* ItemCurMana */
+     , (27772, 108,         50) /* ItemMaxMana */
+     , (27772, 109,          0) /* ItemDifficulty */
+     , (27772, 110,          0) /* ItemAllegianceRankLimit */
+     , (27772, 150,        103) /* HookPlacement - Hook */
+     , (27772, 151,          2) /* HookType - Wall */
+     , (27772, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (27772,  15, True ) /* LightsStatus */
+     , (27772,  22, True ) /* Inscribable */
+     , (27772,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (27772, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (27772,   1, 'Adjanite Gem') /* Name */
+     , (27772,  14, 'Double-click on this portal gem to summon a portal.') /* Use */
+     , (27772,  15, 'A green portal gem.  ') /* ShortDesc */
+     , (27772,  33, 'PickedUpGemPortalSunkenMereNewbie') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (27772,   1,   33558808) /* Setup */
+     , (27772,   3,  536870932) /* SoundTable */
+     , (27772,   8,  100676632) /* Icon */
+     , (27772,  22,  872415275) /* PhysicsEffectTable */
+     , (27772,  28,        157) /* Spell - Summon Primary Portal I */
+     , (27772,  31,      27781) /* LinkedPortalOne - Sunken Mere */
+     , (27772,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30799 Corrupted Skull.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30799 Corrupted Skull.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30799;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30799, 'gemportalfloatingtower', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30799,   1,       2048) /* ItemType - Gem */
+     , (30799,   5,         50) /* EncumbranceVal */
+     , (30799,   8,          5) /* Mass */
+     , (30799,   9,          0) /* ValidLocations - None */
+     , (30799,  11,          1) /* MaxStackSize */
+     , (30799,  12,          1) /* StackSize */
+     , (30799,  13,         50) /* StackUnitEncumbrance */
+     , (30799,  14,          5) /* StackUnitMass */
+     , (30799,  15,       5000) /* StackUnitValue */
+     , (30799,  16,          8) /* ItemUseable - Contained */
+     , (30799,  18,          1) /* UiEffects - Magical */
+     , (30799,  19,       5000) /* Value */
+     , (30799,  33,          0) /* Bonded - Normal */
+     , (30799,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30799,  94,         16) /* TargetType - Creature */
+     , (30799, 106,        210) /* ItemSpellcraft */
+     , (30799, 107,         50) /* ItemCurMana */
+     , (30799, 108,         50) /* ItemMaxMana */
+     , (30799, 109,          0) /* ItemDifficulty */
+     , (30799, 110,          0) /* ItemAllegianceRankLimit */
+     , (30799, 114,          0) /* Attuned - Normal */
+     , (30799, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30799,  15, True ) /* LightsStatus */
+     , (30799,  22, True ) /* Inscribable */
+     , (30799,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30799, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30799,   1, 'Corrupted Skull') /* Name */
+     , (30799,  14, 'Double Click on this item to summon a portal to the floating towers of the Singularity Caul.') /* Use */
+     , (30799,  15, 'A soot covered skull. The eyes emit an eerie bright green glow. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30799,   1,   33555205) /* Setup */
+     , (30799,   3,  536870932) /* SoundTable */
+     , (30799,   8,  100677491) /* Icon */
+     , (30799,  22,  872415275) /* PhysicsEffectTable */
+     , (30799,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30799,  31,      30819) /* LinkedPortalOne - Floating Tower */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30800 Black Glass Array.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30800 Black Glass Array.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30800;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30800, 'gemportalobsidianplains', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30800,   1,       2048) /* ItemType - Gem */
+     , (30800,   5,         50) /* EncumbranceVal */
+     , (30800,   8,          5) /* Mass */
+     , (30800,   9,          0) /* ValidLocations - None */
+     , (30800,  11,          1) /* MaxStackSize */
+     , (30800,  12,          1) /* StackSize */
+     , (30800,  13,         50) /* StackUnitEncumbrance */
+     , (30800,  14,          5) /* StackUnitMass */
+     , (30800,  15,       5000) /* StackUnitValue */
+     , (30800,  16,          8) /* ItemUseable - Contained */
+     , (30800,  19,       5000) /* Value */
+     , (30800,  33,          0) /* Bonded - Normal */
+     , (30800,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30800,  94,         16) /* TargetType - Creature */
+     , (30800, 106,        210) /* ItemSpellcraft */
+     , (30800, 107,         50) /* ItemCurMana */
+     , (30800, 108,         50) /* ItemMaxMana */
+     , (30800, 109,          0) /* ItemDifficulty */
+     , (30800, 110,          0) /* ItemAllegianceRankLimit */
+     , (30800, 114,          0) /* Attuned - Normal */
+     , (30800, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30800,  15, True ) /* LightsStatus */
+     , (30800,  22, True ) /* Inscribable */
+     , (30800,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30800, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30800,   1, 'Black Glass Array') /* Name */
+     , (30800,  14, 'Double Click on this item to summon a portal to the Obsidian Plains.') /* Use */
+     , (30800,  15, 'A collection of obsidian spheres magically suspended in the air by some unknown force.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30800,   1,   33559264) /* Setup */
+     , (30800,   3,  536870932) /* SoundTable */
+     , (30800,   8,  100677495) /* Icon */
+     , (30800,  22,  872415275) /* PhysicsEffectTable */
+     , (30800,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30800,  31,       4046) /* LinkedPortalOne - Obsidian Plains */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30801 Blood Fang Jewel.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30801 Blood Fang Jewel.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30801;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30801, 'gemportalobsidianrim', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30801,   1,       2048) /* ItemType - Gem */
+     , (30801,   5,         50) /* EncumbranceVal */
+     , (30801,   8,          5) /* Mass */
+     , (30801,   9,          0) /* ValidLocations - None */
+     , (30801,  11,          1) /* MaxStackSize */
+     , (30801,  12,          1) /* StackSize */
+     , (30801,  13,         50) /* StackUnitEncumbrance */
+     , (30801,  14,          5) /* StackUnitMass */
+     , (30801,  15,       5000) /* StackUnitValue */
+     , (30801,  16,          8) /* ItemUseable - Contained */
+     , (30801,  19,       5000) /* Value */
+     , (30801,  33,          0) /* Bonded - Normal */
+     , (30801,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30801,  94,         16) /* TargetType - Creature */
+     , (30801, 106,        210) /* ItemSpellcraft */
+     , (30801, 107,         50) /* ItemCurMana */
+     , (30801, 108,         50) /* ItemMaxMana */
+     , (30801, 109,          0) /* ItemDifficulty */
+     , (30801, 110,          0) /* ItemAllegianceRankLimit */
+     , (30801, 114,          0) /* Attuned - Normal */
+     , (30801, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30801,  15, True ) /* LightsStatus */
+     , (30801,  22, True ) /* Inscribable */
+     , (30801,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30801, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30801,   1, 'Blood Fang Jewel') /* Name */
+     , (30801,  14, 'Double Click on this item to summon a portal to the Obsidian Rim.') /* Use */
+     , (30801,  15, 'A blood red jewel in the shape of a fang. Odd etchings running the length of the jewel suggest that it has a Dericostian origin.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30801,   1,   33559266) /* Setup */
+     , (30801,   3,  536870932) /* SoundTable */
+     , (30801,   8,  100677494) /* Icon */
+     , (30801,  22,  872415275) /* PhysicsEffectTable */
+     , (30801,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30801,  31,       7210) /* LinkedPortalOne - Obsidian Rim Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30802 Soul Chalice.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30802 Soul Chalice.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30802;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30802, 'gemportalpanopticon', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30802,   1,       2048) /* ItemType - Gem */
+     , (30802,   5,         50) /* EncumbranceVal */
+     , (30802,   8,          5) /* Mass */
+     , (30802,   9,          0) /* ValidLocations - None */
+     , (30802,  11,          1) /* MaxStackSize */
+     , (30802,  12,          1) /* StackSize */
+     , (30802,  13,         50) /* StackUnitEncumbrance */
+     , (30802,  14,          5) /* StackUnitMass */
+     , (30802,  15,       5000) /* StackUnitValue */
+     , (30802,  16,          8) /* ItemUseable - Contained */
+     , (30802,  19,       5000) /* Value */
+     , (30802,  33,          0) /* Bonded - Normal */
+     , (30802,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30802,  94,         16) /* TargetType - Creature */
+     , (30802, 106,        210) /* ItemSpellcraft */
+     , (30802, 107,         50) /* ItemCurMana */
+     , (30802, 108,         50) /* ItemMaxMana */
+     , (30802, 109,          0) /* ItemDifficulty */
+     , (30802, 110,          0) /* ItemAllegianceRankLimit */
+     , (30802, 114,          0) /* Attuned - Normal */
+     , (30802, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30802,  15, True ) /* LightsStatus */
+     , (30802,  22, True ) /* Inscribable */
+     , (30802,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30802, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30802,   1, 'Soul Chalice') /* Name */
+     , (30802,  14, 'Double Click on this item to summon a portal to the Panopticon.') /* Use */
+     , (30802,  15, 'A shimmering emerald chalice believed to hold the souls of the dead.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30802,   1,   33554661) /* Setup */
+     , (30802,   3,  536870932) /* SoundTable */
+     , (30802,   8,  100677498) /* Icon */
+     , (30802,  22,  872415275) /* PhysicsEffectTable */
+     , (30802,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30802,  31,       9296) /* LinkedPortalOne - Panopticon Portal */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30803 Desolate Seed.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30803 Desolate Seed.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30803;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30803, 'gemportalsingularitycaul', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30803,   1,       2048) /* ItemType - Gem */
+     , (30803,   5,         50) /* EncumbranceVal */
+     , (30803,   8,          5) /* Mass */
+     , (30803,   9,          0) /* ValidLocations - None */
+     , (30803,  11,          1) /* MaxStackSize */
+     , (30803,  12,          1) /* StackSize */
+     , (30803,  13,         50) /* StackUnitEncumbrance */
+     , (30803,  14,          5) /* StackUnitMass */
+     , (30803,  15,       5000) /* StackUnitValue */
+     , (30803,  16,          8) /* ItemUseable - Contained */
+     , (30803,  19,       5000) /* Value */
+     , (30803,  33,          0) /* Bonded - Normal */
+     , (30803,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30803,  94,         16) /* TargetType - Creature */
+     , (30803, 106,        210) /* ItemSpellcraft */
+     , (30803, 107,         50) /* ItemCurMana */
+     , (30803, 108,         50) /* ItemMaxMana */
+     , (30803, 109,          0) /* ItemDifficulty */
+     , (30803, 110,          0) /* ItemAllegianceRankLimit */
+     , (30803, 114,          0) /* Attuned - Normal */
+     , (30803, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30803,  15, True ) /* LightsStatus */
+     , (30803,  22, True ) /* Inscribable */
+     , (30803,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30803, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30803,   1, 'Desolate Seed') /* Name */
+     , (30803,  14, 'Double Click on this item to summon a portal to the Singularity Caul.') /* Use */
+     , (30803,  15, 'A small, blackened seed with golden runes etched into its side.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30803,   1,   33557130) /* Setup */
+     , (30803,   3,  536870932) /* SoundTable */
+     , (30803,   8,  100677489) /* Icon */
+     , (30803,  22,  872415275) /* PhysicsEffectTable */
+     , (30803,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30803,  31,      10794) /* LinkedPortalOne - Singularity Caul */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30804 Singularity Caul Asylum.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30804 Singularity Caul Asylum.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30804;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30804, 'gemquestasylum', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30804,   1,       2048) /* ItemType - Gem */
+     , (30804,   3,         14) /* PaletteTemplate - Red */
+     , (30804,   5,         50) /* EncumbranceVal */
+     , (30804,   8,         10) /* Mass */
+     , (30804,   9,          0) /* ValidLocations - None */
+     , (30804,  11,          1) /* MaxStackSize */
+     , (30804,  12,          1) /* StackSize */
+     , (30804,  13,         50) /* StackUnitEncumbrance */
+     , (30804,  14,         10) /* StackUnitMass */
+     , (30804,  15,       5000) /* StackUnitValue */
+     , (30804,  16,          8) /* ItemUseable - Contained */
+     , (30804,  19,       5000) /* Value */
+     , (30804,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30804,  94,         16) /* TargetType - Creature */
+     , (30804, 106,        210) /* ItemSpellcraft */
+     , (30804, 107,         50) /* ItemCurMana */
+     , (30804, 108,         50) /* ItemMaxMana */
+     , (30804, 109,          0) /* ItemDifficulty */
+     , (30804, 110,          0) /* ItemAllegianceRankLimit */
+     , (30804, 150,        103) /* HookPlacement - Hook */
+     , (30804, 151,          2) /* HookType - Wall */
+     , (30804, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30804,  15, True ) /* LightsStatus */
+     , (30804,  22, True ) /* Inscribable */
+     , (30804,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30804, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30804,   1, 'Singularity Caul Asylum') /* Name */
+     , (30804,  14, 'Double click this gem to summon a portal to the Caul Asylum.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30804,   1,   33556769) /* Setup */
+     , (30804,   3,  536870932) /* SoundTable */
+     , (30804,   6,   67111919) /* PaletteBase */
+     , (30804,   7,  268435723) /* ClothingBase */
+     , (30804,   8,  100668364) /* Icon */
+     , (30804,  22,  872415275) /* PhysicsEffectTable */
+     , (30804,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30804,  31,      30815) /* LinkedPortalOne - Singularity Caul Asylum */
+     , (30804,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30805 Ancient Temple.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30805 Ancient Temple.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30805;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30805, 'gemquestlivingtome', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30805,   1,       2048) /* ItemType - Gem */
+     , (30805,   3,         14) /* PaletteTemplate - Red */
+     , (30805,   5,         50) /* EncumbranceVal */
+     , (30805,   8,         10) /* Mass */
+     , (30805,   9,          0) /* ValidLocations - None */
+     , (30805,  11,          1) /* MaxStackSize */
+     , (30805,  12,          1) /* StackSize */
+     , (30805,  13,         50) /* StackUnitEncumbrance */
+     , (30805,  14,         10) /* StackUnitMass */
+     , (30805,  15,       5000) /* StackUnitValue */
+     , (30805,  16,          8) /* ItemUseable - Contained */
+     , (30805,  19,       5000) /* Value */
+     , (30805,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30805,  94,         16) /* TargetType - Creature */
+     , (30805, 106,        210) /* ItemSpellcraft */
+     , (30805, 107,         50) /* ItemCurMana */
+     , (30805, 108,         50) /* ItemMaxMana */
+     , (30805, 109,          0) /* ItemDifficulty */
+     , (30805, 110,          0) /* ItemAllegianceRankLimit */
+     , (30805, 150,        103) /* HookPlacement - Hook */
+     , (30805, 151,          2) /* HookType - Wall */
+     , (30805, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30805,  15, True ) /* LightsStatus */
+     , (30805,  22, True ) /* Inscribable */
+     , (30805,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30805, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30805,   1, 'Ancient Temple') /* Name */
+     , (30805,  14, 'Double click this gem to summon a portal to the Falatacot Temple and seek out the Living Tome.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30805,   1,   33556769) /* Setup */
+     , (30805,   3,  536870932) /* SoundTable */
+     , (30805,   6,   67111919) /* PaletteBase */
+     , (30805,   7,  268435723) /* ClothingBase */
+     , (30805,   8,  100668364) /* Icon */
+     , (30805,  22,  872415275) /* PhysicsEffectTable */
+     , (30805,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30805,  31,      25396) /* LinkedPortalOne - Ancient Temple */
+     , (30805,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30806 Cavernous Olthoi Chasm.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30806 Cavernous Olthoi Chasm.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30806;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30806, 'gemquestolthoichasm', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30806,   1,       2048) /* ItemType - Gem */
+     , (30806,   3,         14) /* PaletteTemplate - Red */
+     , (30806,   5,         50) /* EncumbranceVal */
+     , (30806,   8,         10) /* Mass */
+     , (30806,   9,          0) /* ValidLocations - None */
+     , (30806,  11,          1) /* MaxStackSize */
+     , (30806,  12,          1) /* StackSize */
+     , (30806,  13,         50) /* StackUnitEncumbrance */
+     , (30806,  14,         10) /* StackUnitMass */
+     , (30806,  15,       5000) /* StackUnitValue */
+     , (30806,  16,          8) /* ItemUseable - Contained */
+     , (30806,  19,       5000) /* Value */
+     , (30806,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30806,  94,         16) /* TargetType - Creature */
+     , (30806, 106,        210) /* ItemSpellcraft */
+     , (30806, 107,         50) /* ItemCurMana */
+     , (30806, 108,         50) /* ItemMaxMana */
+     , (30806, 109,          0) /* ItemDifficulty */
+     , (30806, 110,          0) /* ItemAllegianceRankLimit */
+     , (30806, 150,        103) /* HookPlacement - Hook */
+     , (30806, 151,          2) /* HookType - Wall */
+     , (30806, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30806,  15, True ) /* LightsStatus */
+     , (30806,  22, True ) /* Inscribable */
+     , (30806,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30806, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30806,   1, 'Cavernous Olthoi Chasm') /* Name */
+     , (30806,  14, 'Double click this gem to summon a portal to the Cavernous Olthoi Chasm.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30806,   1,   33556769) /* Setup */
+     , (30806,   3,  536870932) /* SoundTable */
+     , (30806,   6,   67111919) /* PaletteBase */
+     , (30806,   7,  268435723) /* ClothingBase */
+     , (30806,   8,  100668364) /* Icon */
+     , (30806,  22,  872415275) /* PhysicsEffectTable */
+     , (30806,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30806,  31,      25687) /* LinkedPortalOne - Cavernous Olthoi Chasm */
+     , (30806,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30807 The Orphanage.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30807 The Orphanage.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30807;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30807, 'gemquestorphanage', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30807,   1,       2048) /* ItemType - Gem */
+     , (30807,   3,         14) /* PaletteTemplate - Red */
+     , (30807,   5,         50) /* EncumbranceVal */
+     , (30807,   8,         10) /* Mass */
+     , (30807,   9,          0) /* ValidLocations - None */
+     , (30807,  11,          1) /* MaxStackSize */
+     , (30807,  12,          1) /* StackSize */
+     , (30807,  13,         50) /* StackUnitEncumbrance */
+     , (30807,  14,         10) /* StackUnitMass */
+     , (30807,  15,       5000) /* StackUnitValue */
+     , (30807,  16,          8) /* ItemUseable - Contained */
+     , (30807,  19,       5000) /* Value */
+     , (30807,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30807,  94,         16) /* TargetType - Creature */
+     , (30807, 106,        210) /* ItemSpellcraft */
+     , (30807, 107,         50) /* ItemCurMana */
+     , (30807, 108,         50) /* ItemMaxMana */
+     , (30807, 109,          0) /* ItemDifficulty */
+     , (30807, 110,          0) /* ItemAllegianceRankLimit */
+     , (30807, 150,        103) /* HookPlacement - Hook */
+     , (30807, 151,          2) /* HookType - Wall */
+     , (30807, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30807,  15, True ) /* LightsStatus */
+     , (30807,  22, True ) /* Inscribable */
+     , (30807,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30807, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30807,   1, 'The Orphanage') /* Name */
+     , (30807,  14, 'Double click this gem to summon a portal to the Orphanage.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30807,   1,   33556769) /* Setup */
+     , (30807,   3,  536870932) /* SoundTable */
+     , (30807,   6,   67111919) /* PaletteBase */
+     , (30807,   7,  268435723) /* ClothingBase */
+     , (30807,   8,  100668364) /* Icon */
+     , (30807,  22,  872415275) /* PhysicsEffectTable */
+     , (30807,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30807,  31,      30816) /* LinkedPortalOne - The Orphanage */
+     , (30807,  50,  100676404) /* IconOverlay */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30808 Seething Skull.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30808 Seething Skull.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30808;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30808, 'gemportafloatingbridge', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30808,   1,       2048) /* ItemType - Gem */
+     , (30808,   5,         50) /* EncumbranceVal */
+     , (30808,   8,          5) /* Mass */
+     , (30808,   9,          0) /* ValidLocations - None */
+     , (30808,  11,          1) /* MaxStackSize */
+     , (30808,  12,          1) /* StackSize */
+     , (30808,  13,         50) /* StackUnitEncumbrance */
+     , (30808,  14,          5) /* StackUnitMass */
+     , (30808,  15,       5000) /* StackUnitValue */
+     , (30808,  16,          8) /* ItemUseable - Contained */
+     , (30808,  18,          1) /* UiEffects - Magical */
+     , (30808,  19,       5000) /* Value */
+     , (30808,  33,          0) /* Bonded - Normal */
+     , (30808,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30808,  94,         16) /* TargetType - Creature */
+     , (30808, 106,        210) /* ItemSpellcraft */
+     , (30808, 107,         50) /* ItemCurMana */
+     , (30808, 108,         50) /* ItemMaxMana */
+     , (30808, 109,          0) /* ItemDifficulty */
+     , (30808, 110,          0) /* ItemAllegianceRankLimit */
+     , (30808, 114,          0) /* Attuned - Normal */
+     , (30808, 150,        103) /* HookPlacement - Hook */
+     , (30808, 151,          2) /* HookType - Wall */
+     , (30808, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30808,  15, True ) /* LightsStatus */
+     , (30808,  22, True ) /* Inscribable */
+     , (30808,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30808, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30808,   1, 'Seething Skull') /* Name */
+     , (30808,  14, 'Double Click on this item to summon a portal to the floating bridge of the Singularity Caul.') /* Use */
+     , (30808,  15, 'A soot covered skull. The eyes emit an eerie bright green glow. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30808,   1,   33555205) /* Setup */
+     , (30808,   3,  536870932) /* SoundTable */
+     , (30808,   8,  100677491) /* Icon */
+     , (30808,  22,  872415275) /* PhysicsEffectTable */
+     , (30808,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30808,  31,      30818) /* LinkedPortalOne - Floating Bridge */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30809 Warrior's Emblem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30809 Warrior's Emblem.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30809;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30809, 'gemportalayntayn', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30809,   1,       2048) /* ItemType - Gem */
+     , (30809,   5,         50) /* EncumbranceVal */
+     , (30809,   8,          5) /* Mass */
+     , (30809,   9,          0) /* ValidLocations - None */
+     , (30809,  11,          1) /* MaxStackSize */
+     , (30809,  12,          1) /* StackSize */
+     , (30809,  13,         50) /* StackUnitEncumbrance */
+     , (30809,  14,          5) /* StackUnitMass */
+     , (30809,  15,       5000) /* StackUnitValue */
+     , (30809,  16,          8) /* ItemUseable - Contained */
+     , (30809,  19,       5000) /* Value */
+     , (30809,  33,          0) /* Bonded - Normal */
+     , (30809,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30809,  94,         16) /* TargetType - Creature */
+     , (30809, 106,        210) /* ItemSpellcraft */
+     , (30809, 107,         50) /* ItemCurMana */
+     , (30809, 108,         50) /* ItemMaxMana */
+     , (30809, 109,          0) /* ItemDifficulty */
+     , (30809, 110,          0) /* ItemAllegianceRankLimit */
+     , (30809, 114,          0) /* Attuned - Normal */
+     , (30809, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30809,  15, True ) /* LightsStatus */
+     , (30809,  22, True ) /* Inscribable */
+     , (30809,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30809, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30809,   1, 'Warrior''s Emblem') /* Name */
+     , (30809,  14, 'Double Click on this item to summon a portal to the battlefield of Ayn Tayn.') /* Use */
+     , (30809,  15, 'A brightly colored military medal. This honor was once pinned to the chest of one of the Undead warriors who fell at the battle of Ayn Tayn.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30809,   1,   33559265) /* Setup */
+     , (30809,   3,  536870932) /* SoundTable */
+     , (30809,   8,  100677497) /* Icon */
+     , (30809,  22,  872415275) /* PhysicsEffectTable */
+     , (30809,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30809,  31,      30822) /* LinkedPortalOne - Battlefield of Ayn Tayn */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30810 Shadow Cursed Totem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30810 Shadow Cursed Totem.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30810;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30810, 'gemportalburningtower', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30810,   1,       2048) /* ItemType - Gem */
+     , (30810,   5,         50) /* EncumbranceVal */
+     , (30810,   8,          5) /* Mass */
+     , (30810,   9,          0) /* ValidLocations - None */
+     , (30810,  11,          1) /* MaxStackSize */
+     , (30810,  12,          1) /* StackSize */
+     , (30810,  13,         50) /* StackUnitEncumbrance */
+     , (30810,  14,          5) /* StackUnitMass */
+     , (30810,  15,       5000) /* StackUnitValue */
+     , (30810,  16,          8) /* ItemUseable - Contained */
+     , (30810,  19,       5000) /* Value */
+     , (30810,  33,          0) /* Bonded - Normal */
+     , (30810,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30810,  94,         16) /* TargetType - Creature */
+     , (30810, 106,        210) /* ItemSpellcraft */
+     , (30810, 107,         50) /* ItemCurMana */
+     , (30810, 108,         50) /* ItemMaxMana */
+     , (30810, 109,          0) /* ItemDifficulty */
+     , (30810, 110,          0) /* ItemAllegianceRankLimit */
+     , (30810, 114,          0) /* Attuned - Normal */
+     , (30810, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30810,  15, True ) /* LightsStatus */
+     , (30810,  22, True ) /* Inscribable */
+     , (30810,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30810, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30810,   1, 'Shadow Cursed Totem') /* Name */
+     , (30810,  14, 'Double Click on this item to summon a portal to the burning tower of the Singularity Caul.') /* Use */
+     , (30810,  15, 'A small Dericost totem, touched by the black madness. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30810,   1,   33559267) /* Setup */
+     , (30810,   3,  536870932) /* SoundTable */
+     , (30810,   8,  100677490) /* Icon */
+     , (30810,  22,  872415275) /* PhysicsEffectTable */
+     , (30810,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30810,  31,      30820) /* LinkedPortalOne - Burning Tower */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30811 Burning Veil.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30811 Burning Veil.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30811;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30811, 'gemportalcaulcano', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30811,   1,       2048) /* ItemType - Gem */
+     , (30811,   3,         39) /* PaletteTemplate - Black */
+     , (30811,   5,         50) /* EncumbranceVal */
+     , (30811,   8,          5) /* Mass */
+     , (30811,   9,          0) /* ValidLocations - None */
+     , (30811,  11,          1) /* MaxStackSize */
+     , (30811,  12,          1) /* StackSize */
+     , (30811,  13,         50) /* StackUnitEncumbrance */
+     , (30811,  14,          5) /* StackUnitMass */
+     , (30811,  15,       5000) /* StackUnitValue */
+     , (30811,  16,          8) /* ItemUseable - Contained */
+     , (30811,  19,       5000) /* Value */
+     , (30811,  33,          0) /* Bonded - Normal */
+     , (30811,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30811,  94,         16) /* TargetType - Creature */
+     , (30811, 106,        210) /* ItemSpellcraft */
+     , (30811, 107,         50) /* ItemCurMana */
+     , (30811, 108,         50) /* ItemMaxMana */
+     , (30811, 109,          0) /* ItemDifficulty */
+     , (30811, 110,          0) /* ItemAllegianceRankLimit */
+     , (30811, 114,          0) /* Attuned - Normal */
+     , (30811, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30811,  15, True ) /* LightsStatus */
+     , (30811,  22, True ) /* Inscribable */
+     , (30811,  23, True ) /* DestroyOnSell */
+     , (30811,  84, True ) /* IgnoreCloIcons */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30811, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30811,   1, 'Burning Veil') /* Name */
+     , (30811,  14, 'Double Click on this item to summon a portal to the center of the Singularity Caul.') /* Use */
+     , (30811,  15, 'A horribly damaged crown decorated with a handful of sparkling gems.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30811,   1,   33554685) /* Setup */
+     , (30811,   3,  536870932) /* SoundTable */
+     , (30811,   6,   67108990) /* PaletteBase */
+     , (30811,   7,  268435509) /* ClothingBase */
+     , (30811,   8,  100677493) /* Icon */
+     , (30811,  22,  872415275) /* PhysicsEffectTable */
+     , (30811,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30811,  31,      30821) /* LinkedPortalOne - Center of the Singularity Caul */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30812 Antiquated Compass.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30812 Antiquated Compass.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30812;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30812, 'gemportalcauloasis', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30812,   1,       2048) /* ItemType - Gem */
+     , (30812,   5,         50) /* EncumbranceVal */
+     , (30812,   8,          5) /* Mass */
+     , (30812,   9,          0) /* ValidLocations - None */
+     , (30812,  11,          1) /* MaxStackSize */
+     , (30812,  12,          1) /* StackSize */
+     , (30812,  13,         50) /* StackUnitEncumbrance */
+     , (30812,  14,          5) /* StackUnitMass */
+     , (30812,  15,       5000) /* StackUnitValue */
+     , (30812,  16,          8) /* ItemUseable - Contained */
+     , (30812,  19,       5000) /* Value */
+     , (30812,  33,          0) /* Bonded - Normal */
+     , (30812,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30812,  94,         16) /* TargetType - Creature */
+     , (30812, 106,        210) /* ItemSpellcraft */
+     , (30812, 107,         50) /* ItemCurMana */
+     , (30812, 108,         50) /* ItemMaxMana */
+     , (30812, 109,          0) /* ItemDifficulty */
+     , (30812, 110,          0) /* ItemAllegianceRankLimit */
+     , (30812, 114,          0) /* Attuned - Normal */
+     , (30812, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30812,  15, True ) /* LightsStatus */
+     , (30812,  22, True ) /* Inscribable */
+     , (30812,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30812, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30812,   1, 'Antiquated Compass') /* Name */
+     , (30812,  14, 'Double Click on this item to summon a portal to the oasis of the Singularity Caul.') /* Use */
+     , (30812,  15, 'A masterfully crafted gold compass. The needles of the compass shiver with an unknown power.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30812,   1,   33559265) /* Setup */
+     , (30812,   3,  536870932) /* SoundTable */
+     , (30812,   8,  100677496) /* Icon */
+     , (30812,  22,  872415275) /* PhysicsEffectTable */
+     , (30812,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30812,  31,      30817) /* LinkedPortalOne - Caul Oasis */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30831 Shadow Lugian Stronghold Portal Gem.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30831 Shadow Lugian Stronghold Portal Gem.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30831;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30831, 'gemportalshadowlugianstronghold', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30831,   1,       2048) /* ItemType - Gem */
+     , (30831,   3,         83) /* PaletteTemplate - Amber */
+     , (30831,   5,         10) /* EncumbranceVal */
+     , (30831,   8,         10) /* Mass */
+     , (30831,   9,          0) /* ValidLocations - None */
+     , (30831,  11,          1) /* MaxStackSize */
+     , (30831,  12,          1) /* StackSize */
+     , (30831,  13,         10) /* StackUnitEncumbrance */
+     , (30831,  14,         10) /* StackUnitMass */
+     , (30831,  15,        500) /* StackUnitValue */
+     , (30831,  16,          8) /* ItemUseable - Contained */
+     , (30831,  19,        500) /* Value */
+     , (30831,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30831,  94,         16) /* TargetType - Creature */
+     , (30831, 106,        210) /* ItemSpellcraft */
+     , (30831, 107,         50) /* ItemCurMana */
+     , (30831, 108,         50) /* ItemMaxMana */
+     , (30831, 109,          0) /* ItemDifficulty */
+     , (30831, 110,          0) /* ItemAllegianceRankLimit */
+     , (30831, 150,        103) /* HookPlacement - Hook */
+     , (30831, 151,          2) /* HookType - Wall */
+     , (30831, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30831,  15, True ) /* LightsStatus */
+     , (30831,  22, True ) /* Inscribable */
+     , (30831,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30831, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30831,   1, 'Shadow Lugian Stronghold Portal Gem') /* Name */
+     , (30831,  16, 'This portal summoning gem works best if used outside in a relatively flat area.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30831,   1,   33556769) /* Setup */
+     , (30831,   3,  536870932) /* SoundTable */
+     , (30831,   6,   67111919) /* PaletteBase */
+     , (30831,   7,  268435723) /* ClothingBase */
+     , (30831,   8,  100672368) /* Icon */
+     , (30831,  22,  872415275) /* PhysicsEffectTable */
+     , (30831,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30831,  31,      30845) /* LinkedPortalOne - Shadow Lugian Stronghold */;

--- a/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30857 Sezzherei's Lair.sql
+++ b/Database/Patches/2011-10-CloakOfDarkness/9 WeenieDefaults/Gem/Gem/30857 Sezzherei's Lair.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 30857;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (30857, 'gemportalboss0205', 38, '2020-05-13 10:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (30857,   1,       2048) /* ItemType - Gem */
+     , (30857,   3,         83) /* PaletteTemplate - Amber */
+     , (30857,   5,         10) /* EncumbranceVal */
+     , (30857,   8,         10) /* Mass */
+     , (30857,   9,          0) /* ValidLocations - None */
+     , (30857,  11,          1) /* MaxStackSize */
+     , (30857,  12,          1) /* StackSize */
+     , (30857,  13,         10) /* StackUnitEncumbrance */
+     , (30857,  14,         10) /* StackUnitMass */
+     , (30857,  15,        500) /* StackUnitValue */
+     , (30857,  16,          8) /* ItemUseable - Contained */
+     , (30857,  19,        500) /* Value */
+     , (30857,  33,          1) /* Bonded - Bonded */
+     , (30857,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (30857,  94,         16) /* TargetType - Creature */
+     , (30857, 106,        210) /* ItemSpellcraft */
+     , (30857, 107,         50) /* ItemCurMana */
+     , (30857, 108,         50) /* ItemMaxMana */
+     , (30857, 109,          0) /* ItemDifficulty */
+     , (30857, 110,          0) /* ItemAllegianceRankLimit */
+     , (30857, 114,          1) /* Attuned - Attuned */
+     , (30857, 280,       1000) /* SharedCooldown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (30857,  15, True ) /* LightsStatus */
+     , (30857,  22, True ) /* Inscribable */
+     , (30857,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (30857, 167,      15) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (30857,   1, 'Sezzherei''s Lair') /* Name */
+     , (30857,  14, 'This portal summoning gem works best if used outside in a relatively flat area.') /* Use */
+     , (30857,  16, 'This gem casts a portal to lair of Sezzherei, demon-child of the darkness beneath the world') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (30857,   1,   33556769) /* Setup */
+     , (30857,   3,  536870932) /* SoundTable */
+     , (30857,   6,   67111919) /* PaletteBase */
+     , (30857,   7,  268435723) /* ClothingBase */
+     , (30857,   8,  100672368) /* Icon */
+     , (30857,  22,  872415275) /* PhysicsEffectTable */
+     , (30857,  28,        157) /* Spell - Summon Primary Portal I */
+     , (30857,  31,      30905) /* LinkedPortalOne - Sezzherei's Lair */;


### PR DESCRIPTION
ready for review

This PR adds, 
280,       1000) /* SharedCooldown */
167,      15) /* CooldownDuration */

To all portal gems located in, 
ACE-World-16PY/Database/3-Core/9 WeenieDefaults/SQL/Gem/Gem/

Excluding ones that have already been updated in PR#432 and here,
ACE-World-16PY-Patches/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Gem/Gem/

Range 26059 - 26639 in base I don't believe were ever available in game, but I updated all of them in one bulk go, so included them for anyone who may want them. Can remove them from PR if need be. 

The last change to portal gems was making them 15 seconds in the Cloak of Darkness Patch. So I placed the weenies there. 

https://asheron.fandom.com/wiki/Cloak_of_Darkness
