### PR TITLE
updating destructive curse dot duration

### DIFF
--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05337 Destructive Curse VII.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05337 Destructive Curse VII.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5337;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5337, 'Destructive Curse VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 294, 1024 /* Nether */, 294, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5337, 'Destructive Curse VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 294, 30, 1024 /* Nether */, 294, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05338 Incantation of Destructive Curse.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05338 Incantation of Destructive Curse.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5338;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5338, 'Incantation of Destructive Curse', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 357, 1024 /* Nether */, 357, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5338, 'Incantation of Destructive Curse', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 357, 30, 1024 /* Nether */, 357, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05339 Destructive Curse I.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05339 Destructive Curse I.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5339;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5339, 'Destructive Curse I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 56, 1024 /* Nether */, 56, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5339, 'Destructive Curse I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 56, 30, 1024 /* Nether */, 56, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05340 Destructive Curse II.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05340 Destructive Curse II.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5340;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5340, 'Destructive Curse II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 91, 1024 /* Nether */, 91, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5340, 'Destructive Curse II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 91, 30, 1024 /* Nether */, 91, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05341 Destructive Curse III.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05341 Destructive Curse III.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5341;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5341, 'Destructive Curse III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 126, 1024 /* Nether */, 126, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5341, 'Destructive Curse III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 126, 30, 1024 /* Nether */, 126, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05342 Destructive Curse IV.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05342 Destructive Curse IV.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5342;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5342, 'Destructive Curse IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 154, 1024 /* Nether */, 154, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5342, 'Destructive Curse IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 154, 30, 1024 /* Nether */, 154, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05343 Destructive Curse V.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05343 Destructive Curse V.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5343;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5343, 'Destructive Curse V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 189, 1024 /* Nether */, 189, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5343, 'Destructive Curse V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 189, 30, 1024 /* Nether */, 189, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05344 Destructive Curse VI.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05344 Destructive Curse VI.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5344;
 
-INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5344, 'Destructive Curse VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 231, 1024 /* Nether */, 231, '2019-03-18 09:00:00');
+INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
+VALUES (5344, 'Destructive Curse VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 231, 30, 1024 /* Nether */, 231, '2019-03-18 09:00:00');


### PR DESCRIPTION
Destructive Curse was missing the special DoT duration signifier, causing it to behave slighltly differently than it should (not getting the tick spread out over an extra +5s, and incorrectly being given boosts by spell duration aug)