### PR TITLE
T8 Death Treasure Profiles

### DIFF
--- a/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02000 Tier 8 Loot.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02000 Tier 8 Loot.sql
@@ -1,0 +1,41 @@
+
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 2000;
+
+INSERT INTO `treasure_death` 
+    (`treasure_Type`, 
+     `tier`, 
+     `loot_Quality_Mod`, 
+     `unknown_Chances`, 
+     `item_Chance`, 
+     `item_Min_Amount`, 
+     `item_Max_Amount`, 
+     `item_Treasure_Type_Selection_Chances`, 
+     `magic_Item_Chance`, 
+     `magic_Item_Min_Amount`, 
+     `magic_Item_Max_Amount`, 
+     `magic_Item_Treasure_Type_Selection_Chances`, 
+     `mundane_Item_Chance`, 
+     `mundane_Item_Min_Amount`, 
+     `mundane_Item_Max_Amount`, 
+     `mundane_Item_Type_Selection_Chances`, 
+     `last_Modified`)
+
+VALUES 
+    (2000,      /* treasure_Type */
+        8,      /* tier */ 
+        0,      /* loot_Quality_Mod  */
+       19,      /* unknown_Chances */
+      100,      /* item_Chance */ 
+        1,      /* item_Min_Amount */ 
+        2,      /* item_Max_Amount */ 
+        8,      /* item_Treasure_Type_Selection_Chances */
+      100,      /* magic_Item_Chance */
+        2,      /* magic_Item_Min_Amount */
+        3,      /* magic_Item_Max_Amount */
+        8,      /* magic_Item_Treasure_Type_Selection_Chances */
+      100,      /* mundane_Item_Chance */
+        0,      /* mundane_Item_Min_Amount */
+        1,      /* mundane_Item_Max_Amount */
+        7,      /* mundane_Item_Type_Selection_Chances */
+        '2019-08-16 00:00:00'); /* last_Modified */
+        

--- a/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02000.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02000.sql
@@ -1,4 +1,0 @@
-DELETE FROM `treasure_death` WHERE `treasure_Type` = 2000;
-
-INSERT INTO `treasure_death` (`treasure_Type`, `tier`, `loot_Quality_Mod`, `unknown_Chances`, `item_Chance`, `item_Min_Amount`, `item_Max_Amount`, `item_Treasure_Type_Selection_Chances`, `magic_Item_Chance`, `magic_Item_Min_Amount`, `magic_Item_Max_Amount`, `magic_Item_Treasure_Type_Selection_Chances`, `mundane_Item_Chance`, `mundane_Item_Min_Amount`, `mundane_Item_Max_Amount`, `mundane_Item_Type_Selection_Chances`, `last_Modified`)
-VALUES (2000, 7, 0, 19, 100, 1, 2, 8, 100, 2, 3, 8, 100, 1, 2, 7, '2019-08-16 00:00:00');

--- a/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02001 Legendary Mixed Equipment Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02001 Legendary Mixed Equipment Chest.sql
@@ -1,0 +1,41 @@
+
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 2001;
+
+INSERT INTO `treasure_death` 
+    (`treasure_Type`, 
+     `tier`, 
+     `loot_Quality_Mod`, 
+     `unknown_Chances`, 
+     `item_Chance`, 
+     `item_Min_Amount`, 
+     `item_Max_Amount`, 
+     `item_Treasure_Type_Selection_Chances`, 
+     `magic_Item_Chance`, 
+     `magic_Item_Min_Amount`, 
+     `magic_Item_Max_Amount`, 
+     `magic_Item_Treasure_Type_Selection_Chances`, 
+     `mundane_Item_Chance`, 
+     `mundane_Item_Min_Amount`, 
+     `mundane_Item_Max_Amount`, 
+     `mundane_Item_Type_Selection_Chances`, 
+     `last_Modified`)
+	 
+VALUES 
+    (2001,      /* treasure_Type */
+        8,      /* tier */
+      0.3,      /* loot_Quality_Mod  */ 
+        0,      /* unknown_Chances */
+      100,      /* item_Chance */
+        0,      /* item_Min_Amount */
+        0,      /* item_Max_Amount */
+       10,      /* item_Treasure_Type_Selection_Chances */
+      100,      /* magic_Item_Chance */
+        4,      /* magic_Item_Min_Amount */
+        5,      /* magic_Item_Max_Amount */
+       10,      /* magic_Item_Treasure_Type_Selection_Chances */
+      100,      /* mundane_Item_Chance */
+        0,      /* mundane_Item_Min_Amount */
+        0,      /* mundane_Item_Max_Amount */
+       10,      /* mundane_Item_Type_Selection_Chances */
+        '2019-11-12 14:00:00'); /* last_Modified */
+        

--- a/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02002 Legendary Armor Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02002 Legendary Armor Chest.sql
@@ -1,0 +1,41 @@
+
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 2002;
+
+INSERT INTO `treasure_death` 
+    (`treasure_Type`, 
+     `tier`, 
+     `loot_Quality_Mod`, 
+     `unknown_Chances`, 
+     `item_Chance`, 
+     `item_Min_Amount`, 
+     `item_Max_Amount`, 
+     `item_Treasure_Type_Selection_Chances`, 
+     `magic_Item_Chance`, 
+     `magic_Item_Min_Amount`, 
+     `magic_Item_Max_Amount`, 
+     `magic_Item_Treasure_Type_Selection_Chances`, 
+     `mundane_Item_Chance`, 
+     `mundane_Item_Min_Amount`, 
+     `mundane_Item_Max_Amount`, 
+     `mundane_Item_Type_Selection_Chances`, 
+     `last_Modified`)
+     
+VALUES 
+    (2002,      /* treasure_Type */
+        8,      /* tier */
+      0.3,  /* loot_Quality_Mod  */ 
+        0,      /* unknown_Chances */
+        0,      /* item_Chance */
+        0,      /* item_Min_Amount */
+        0,      /* item_Max_Amount */
+       10,      /* item_Treasure_Type_Selection_Chances */
+      100,      /* magic_Item_Chance */
+        4,      /* magic_Item_Min_Amount */
+        5,      /* magic_Item_Max_Amount */
+       10,      /* magic_Item_Treasure_Type_Selection_Chances */
+        0,      /* mundane_Item_Chance */
+        0,      /* mundane_Item_Min_Amount */
+        0,      /* mundane_Item_Max_Amount */
+       10,      /* mundane_Item_Type_Selection_Chances */
+        '2019-11-12 14:00:00'); /* last_Modified */
+        

--- a/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02003 Legendary Magic Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02003 Legendary Magic Chest.sql
@@ -1,0 +1,41 @@
+
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 2003;
+
+INSERT INTO `treasure_death` 
+    (`treasure_Type`, 
+     `tier`, 
+     `loot_Quality_Mod`, 
+     `unknown_Chances`, 
+     `item_Chance`, 
+     `item_Min_Amount`, 
+     `item_Max_Amount`, 
+     `item_Treasure_Type_Selection_Chances`, 
+     `magic_Item_Chance`, 
+     `magic_Item_Min_Amount`, 
+     `magic_Item_Max_Amount`, 
+     `magic_Item_Treasure_Type_Selection_Chances`, 
+     `mundane_Item_Chance`, 
+     `mundane_Item_Min_Amount`, 
+     `mundane_Item_Max_Amount`, 
+     `mundane_Item_Type_Selection_Chances`, 
+     `last_Modified`)
+
+VALUES 
+    (2003,      /* treasure_Type */
+        8,      /* tier */
+      0.3,      /* loot_Quality_Mod  */ 
+        0,      /* unknown_Chances */
+      100,      /* item_Chance */
+        0,      /* item_Min_Amount */
+        0,      /* item_Max_Amount */
+       10,      /* item_Treasure_Type_Selection_Chances */
+      100,      /* magic_Item_Chance */
+        4,      /* magic_Item_Min_Amount */
+        5,      /* magic_Item_Max_Amount */
+       10,      /* magic_Item_Treasure_Type_Selection_Chances */
+      100,      /* mundane_Item_Chance */
+        0,      /* mundane_Item_Min_Amount */
+        0,      /* mundane_Item_Max_Amount */
+       10,      /* mundane_Item_Type_Selection_Chances */
+        '2019-11-12 14:00:00'); /* last_Modified */
+        

--- a/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02004 Legendary Weapon Chest.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/3 TreasureTable/Death/02004 Legendary Weapon Chest.sql
@@ -1,0 +1,41 @@
+
+DELETE FROM `treasure_death` WHERE `treasure_Type` = 2004;
+
+INSERT INTO `treasure_death` 
+    (`treasure_Type`, 
+     `tier`, 
+     `loot_Quality_Mod`, 
+     `unknown_Chances`, 
+     `item_Chance`, 
+     `item_Min_Amount`, 
+     `item_Max_Amount`, 
+     `item_Treasure_Type_Selection_Chances`, 
+     `magic_Item_Chance`, 
+     `magic_Item_Min_Amount`, 
+     `magic_Item_Max_Amount`, 
+     `magic_Item_Treasure_Type_Selection_Chances`, 
+     `mundane_Item_Chance`, 
+     `mundane_Item_Min_Amount`, 
+     `mundane_Item_Max_Amount`, 
+     `mundane_Item_Type_Selection_Chances`, 
+     `last_Modified`)
+     
+VALUES 
+    (2004,      /* treasure_Type */
+        8,      /* tier */
+      0.3,      /* loot_Quality_Mod  */ 
+        0,      /* unknown_Chances */
+        0,      /* item_Chance */
+        0,      /* item_Min_Amount */
+        0,      /* item_Max_Amount */
+       10,      /* item_Treasure_Type_Selection_Chances */
+      100,      /* magic_Item_Chance */
+        4,      /* magic_Item_Min_Amount */
+        5,      /* magic_Item_Max_Amount */
+       10,      /* magic_Item_Treasure_Type_Selection_Chances */
+        0,      /* mundane_Item_Chance */
+        0,      /* mundane_Item_Min_Amount */
+        0,      /* mundane_Item_Max_Amount */
+       10,      /* mundane_Item_Type_Selection_Chances */
+        '2019-11-12 14:00:00'); /* last_Modified */
+        


### PR DESCRIPTION
The following is to add T8 Death Treasure Profiles.  This update will have all creatures that currently use DT 2000 drop T8 Loot.  The old DT 2000 was set for T7.  Server Ops need to be aware of this change.