### PR TITLE
Move Apprentice Cook from Tou-Tou to Mayoi

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/6 LandBlockExtendedData/E532.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/6 LandBlockExtendedData/E532.sql
@@ -1,3 +1,7 @@
 REPLACE INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (2119376916, 28682, 3845259520, 181.889, 39.9224, 32.405, -0.993403, 0, 0, 0.114678, False, '2019-02-04 06:52:23'); /* Nawamara Ujio */
 /* @teleloc 0xE5320100 [181.889000 39.922400 32.405000] -0.993403 0.000000 0.000000 0.114678 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7E53202E, 28187, 0xE532010F, 125.909, 35.253, 32.405003, -0.98601, 0, 0, 0.166686, False, '2020-07-14 11:20:23'); /* Apprentice Cook */
+/* @teleloc 0xE532010F [125.908997 35.252998 32.405003] -0.986010 0.000000 0.000000 0.166686 */


### PR DESCRIPTION
ready for review

https://asheron.fandom.com/wiki/A_Rising_Darkness
Apprentice Cook (Tou-Tou) - relocated to Mayoi (61.8S, 81.8E) 