### PR TITLE
updating dot statmodvals to match retail (per tick, instead of total)

### DIFF
--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05205 Surge of Affliction.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05205 Surge of Affliction.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5205;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `last_Modified`)
-VALUES (5205, 'Surge of Affliction', 36868 /* Int, SingleStat, Additive */, 318 /* DamageOverTime */, 150, 19, '2019-07-16 09:00:00');
+VALUES (5205, 'Surge of Affliction', 36868 /* Int, SingleStat, Additive */, 318 /* DamageOverTime */, 30, 19, '2019-07-16 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05208 Surge of Regeneration.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05208 Surge of Regeneration.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5208;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `last_Modified`)
-VALUES (5208, 'Surge of Regeneration', 33591300 /* Int, SingleStat, Additive, Beneficial */, 312 /* HealingOverTime */, 150, 19, '2019-07-16 09:00:00');
+VALUES (5208, 'Surge of Regeneration', 33591300 /* Int, SingleStat, Additive, Beneficial */, 312 /* HealingOverTime */, 30, 19, '2019-07-16 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05337 Destructive Curse VII.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05337 Destructive Curse VII.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5337;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5337, 'Destructive Curse VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 294, 30, 1024 /* Nether */, 294, '2019-03-18 09:00:00');
+VALUES (5337, 'Destructive Curse VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 42, 30, 1024 /* Nether */, 294, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05338 Incantation of Destructive Curse.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05338 Incantation of Destructive Curse.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5338;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5338, 'Incantation of Destructive Curse', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 357, 30, 1024 /* Nether */, 357, '2019-03-18 09:00:00');
+VALUES (5338, 'Incantation of Destructive Curse', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 51, 30, 1024 /* Nether */, 357, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05339 Destructive Curse I.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05339 Destructive Curse I.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5339;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5339, 'Destructive Curse I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 56, 30, 1024 /* Nether */, 56, '2019-03-18 09:00:00');
+VALUES (5339, 'Destructive Curse I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 8, 30, 1024 /* Nether */, 56, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05340 Destructive Curse II.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05340 Destructive Curse II.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5340;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5340, 'Destructive Curse II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 91, 30, 1024 /* Nether */, 91, '2019-03-18 09:00:00');
+VALUES (5340, 'Destructive Curse II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 13, 30, 1024 /* Nether */, 91, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05341 Destructive Curse III.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05341 Destructive Curse III.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5341;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5341, 'Destructive Curse III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 126, 30, 1024 /* Nether */, 126, '2019-03-18 09:00:00');
+VALUES (5341, 'Destructive Curse III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 18, 30, 1024 /* Nether */, 126, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05342 Destructive Curse IV.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05342 Destructive Curse IV.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5342;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5342, 'Destructive Curse IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 154, 30, 1024 /* Nether */, 154, '2019-03-18 09:00:00');
+VALUES (5342, 'Destructive Curse IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 22, 30, 1024 /* Nether */, 154, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05343 Destructive Curse V.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05343 Destructive Curse V.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5343;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5343, 'Destructive Curse V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 189, 30, 1024 /* Nether */, 189, '2019-03-18 09:00:00');
+VALUES (5343, 'Destructive Curse V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 27, 30, 1024 /* Nether */, 189, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05344 Destructive Curse VI.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05344 Destructive Curse VI.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5344;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `e_Type`, `base_Intensity`, `last_Modified`)
-VALUES (5344, 'Destructive Curse VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 231, 30, 1024 /* Nether */, 231, '2019-03-18 09:00:00');
+VALUES (5344, 'Destructive Curse VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 33, 30, 1024 /* Nether */, 231, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05387 Corrosion I.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05387 Corrosion I.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5387;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5387, 'Corrosion I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 76, 1024 /* Nether */, 76, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5387, 'Corrosion I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 19, 1024 /* Nether */, 76, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05388 Corrosion II.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05388 Corrosion II.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5388;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5388, 'Corrosion II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 116, 1024 /* Nether */, 116, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5388, 'Corrosion II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 29, 1024 /* Nether */, 116, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05389 Corrosion III.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05389 Corrosion III.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5389;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5389, 'Corrosion III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 152, 1024 /* Nether */, 152, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5389, 'Corrosion III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 38, 1024 /* Nether */, 152, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05390 Corrosion IV.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05390 Corrosion IV.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5390;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5390, 'Corrosion IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 192, 1024 /* Nether */, 192, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5390, 'Corrosion IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 48, 1024 /* Nether */, 192, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05391 Corrosion V.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05391 Corrosion V.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5391;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5391, 'Corrosion V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 204, 1024 /* Nether */, 204, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5391, 'Corrosion V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 51, 1024 /* Nether */, 204, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05392 Corrosion VI.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05392 Corrosion VI.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5392;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5392, 'Corrosion VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 288, 1024 /* Nether */, 288, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5392, 'Corrosion VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 72, 1024 /* Nether */, 288, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05393 Corrosion VII.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05393 Corrosion VII.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5393;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5393, 'Corrosion VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 360, 1024 /* Nether */, 360, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5393, 'Corrosion VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 90, 1024 /* Nether */, 360, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05394 Incantation of Corrosion.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05394 Incantation of Corrosion.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5394;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `dot_Duration`, `last_Modified`)
-VALUES (5394, 'Incantation of Corrosion', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 448, 1024 /* Nether */, 448, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');
+VALUES (5394, 'Incantation of Corrosion', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 112, 1024 /* Nether */, 448, 0, 43344 /* Nether Bolt */, 1, 15, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05395 Corruption I.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05395 Corruption I.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5395;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5395, 'Corruption I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 56, 1024 /* Nether */, 56, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');
+VALUES (5395, 'Corruption I', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 8, 1024 /* Nether */, 56, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05396 Corruption II.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05396 Corruption II.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5396;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5396, 'Corruption II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 91, 1024 /* Nether */, 91, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');
+VALUES (5396, 'Corruption II', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 13, 1024 /* Nether */, 91, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05397 Corruption III.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05397 Corruption III.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5397;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5397, 'Corruption III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 126, 1024 /* Nether */, 126, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');
+VALUES (5397, 'Corruption III', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 18, 1024 /* Nether */, 126, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05398 Corruption IV.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05398 Corruption IV.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5398;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5398, 'Corruption IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 154, 1024 /* Nether */, 154, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');
+VALUES (5398, 'Corruption IV', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 22, 1024 /* Nether */, 154, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05399 Corruption V.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05399 Corruption V.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5399;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5399, 'Corruption V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 189, 1024 /* Nether */, 189, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');
+VALUES (5399, 'Corruption V', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 27, 1024 /* Nether */, 189, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05400 Corruption VI.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05400 Corruption VI.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5400;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5400, 'Corruption VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 231, 1024 /* Nether */, 231, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');
+VALUES (5400, 'Corruption VI', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 33, 1024 /* Nether */, 231, 0, 43344 /* Nether Bolt */, 3, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05401 Corruption VII.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05401 Corruption VII.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5401;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5401, 'Corruption VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 294, 1024 /* Nether */, 294, 0, 43344 /* Nether Bolt */, 5, 90, 30, '2019-03-18 09:00:00');
+VALUES (5401, 'Corruption VII', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 42, 1024 /* Nether */, 294, 0, 43344 /* Nether Bolt */, 5, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05402 Incantation of Corruption.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05402 Incantation of Corruption.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5402;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `spread_Angle`, `dot_Duration`, `last_Modified`)
-VALUES (5402, 'Incantation of Corruption', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 357, 1024 /* Nether */, 357, 0, 43344 /* Nether Bolt */, 5, 90, 30, '2019-03-18 09:00:00');
+VALUES (5402, 'Incantation of Corruption', 36868 /* Int, SingleStat, Additive */, 330 /* NetherOverTime */, 51, 1024 /* Nether */, 357, 0, 43344 /* Nether Bolt */, 5, 90, 30, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05939 Bleeding Assault.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05939 Bleeding Assault.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5939;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `last_Modified`)
-VALUES (5939, 'Bleeding Assault', 36868 /* Int, SingleStat, Additive */, 318 /* DamageOverTime */, 120, 20, '2019-03-18 09:00:00');
+VALUES (5939, 'Bleeding Assault', 36868 /* Int, SingleStat, Additive */, 318 /* DamageOverTime */, 24, 20, '2019-03-18 09:00:00');

--- a/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05943 Bleeding Blow.sql
+++ b/Database/Patches/2017-01-EndOfRetail/2 SpellTableExtendedData/SQL/05943 Bleeding Blow.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 5943;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `dot_Duration`, `last_Modified`)
-VALUES (5943, 'Bleeding Blow', 36868 /* Int, SingleStat, Additive */, 318 /* DamageOverTime */, 60, 20, '2019-03-18 09:00:00');
+VALUES (5943, 'Bleeding Blow', 36868 /* Int, SingleStat, Additive */, 318 /* DamageOverTime */, 12, 20, '2019-03-18 09:00:00');


### PR DESCRIPTION
** This PR must be installed in tandem with https://github.com/ACEmulator/ACE/pull/3166 **

For the DoT enchantment.StatModValues sent over the wire in retail, these were based on the amount per tick, and not total amount over the course of the duration of the spell.

DoTs were a bit weird in this regard, void DoTs especially, as the StatModValue in the enchantment that was sent across the wire would not always equal the StatModValue in the base spell. For void DoTs especially, a 'pre-calculation' would be done, that would factor in things that would buff the outgoing damage, and then it would write this buffed value to the enchantment. ie. for void dots, enchantment.StatModValue = spell.StatModValue * buffs

This can get tricky with the frequency of the ticks. Currently in ACE, the DoT ticks are based on the heartbeat ticks. If a creature has something other than the default 5s heartbeat, then it needs to be ensured this 'damage per tick' this dot StatModValue represents has the correct heartbeat factored in.

In retail, it could have been possible that DoTs had their own ticking mechanism, with a static 5s rate, regardless of the heartbeat rate. For example, if i cast a DoT on a monster w/ a 1s heartbeat, would the DoTs tick at 1s in retail, or would they tick at 5s? In ACE currently, they would tick at 1s. ACE already calculates the correct damage per tick for the target's heartbeat, but this is just another concern to be aware of.

Since the dot enchantment.StatModValues that were sent across the wire in retail were munged, we don't know "for sure" whether the actual base spell.StatModValues had these "damage per tick, assuming 5s heartbeat" values, or if those were only calculated for the enchantments. Still, normalizing this spell data with the "base values" for what retail sent over the wire for dot enchantments, seems like it would match up closer

* IMPORTANT NOTE * the version of the database this pr goes into *must* be updated in tandem with the code update. If you update the database without updating the code, then your DoT damage will be way too low. If you update the code without updating the database, then your DoT damage will be way too high.

ACE could continue to handle the spell.StatModValues for the dots as it does today, as all of the calculations are still technically possible with either method. However, with some of the upcoming changes to Void Magic to more closely match retail, I would rather just pull this bandaid off and update it at this point

These values were updated programmatically, to reduce the chance of error. The code update describes the formula for 'number of ticks' that ACE has been using.