### PR TITLE
Add Amelia's Lost Toys quest

### DIFF
--- a/Database/Patches/2007-03-AncientEnemies/6 LandBlockExtendedData/482E.sql
+++ b/Database/Patches/2007-03-AncientEnemies/6 LandBlockExtendedData/482E.sql
@@ -1,1 +1,0 @@
-DELETE FROM `landblock_instance` WHERE `landblock` = 0x482E;

--- a/Database/Patches/2007-03-AncientEnemies/6 LandBlockExtendedData/482E.sql
+++ b/Database/Patches/2007-03-AncientEnemies/6 LandBlockExtendedData/482E.sql
@@ -1,0 +1,1 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x482E;

--- a/Database/Patches/2007-08-CorruptedSovereigns/6 LandBlockExtendedData/482E.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/6 LandBlockExtendedData/482E.sql
@@ -1,0 +1,35 @@
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E000, 80070, 0x482e0027, 107.135, 162.376, 7.072, 0, 0, 0, 0, False, '2020-09-20 00:00:00'); /* Amelia Dirt Pile 1 Generator */
+/* @teleloc 0x482e0027 107.135 162.376 7.072 0 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E001, 80071, 0x482e0017, 49.627, 164.081, 9.311, 0, 0, 0, 0, False, '2020-09-20 00:00:00'); /* Amelia Dirt Pile 2 Generator */
+/* @teleloc 0x482E0017 49.627 164.081 9.311 0 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E002, 80072, 0x482E000C, 46.328, 76.863, 10, 0, 0, 0, 0, False, '2020-09-21 00:00:00'); /* Amelia Dirt Pile 3 Generator */
+/* @teleloc 0x482e000c 46.328 76.863 10 0 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E003, 80073, 0x482E000B, 24.353, 63.315, 10, 0, 0, 0, 0, False, '2020-09-21 00:00:00'); /* Amelia Dirt Pile 4 Generator */
+/* @teleloc 0x482e000b 24.353 63.314 10 0 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E004, 80074, 0x482e0007, 22.885, 151.848, 9.4, 0, 0, 0, 0, False, '2020-09-21 00:00:00'); /* Amelia Dirt Pile 5 Generator */
+/* @teleloc 0x482e0007 22.885 151.848 9.4 0 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E005, 80075, 0x482e0009, 42.066, 22.359, 9.868, 0, 0, 0, 0, False, '2020-09-21 00:00:00'); /* Amelia Dirt Pile 6 Generator */
+/* @teleloc 0x482E0009 42.066 22.359 9.868 0 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E006, 80076, 0x482E0023, 110.113, 59.89, 9.031, -0.897, 0, 0, 0.442, False, '2020-09-21 00:00:00'); /* Amelia Wanderer Generator */
+/* @teleloc 0x482e0023 110.113 59.89 9.031 0.897 0 0 0.442 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E007, 80077, 0x482E0023, 110.113, 59.89, 9.031, -0.897, 0, 0, 0.442, False, '2020-09-21 00:00:00'); /* Amelia Generator */
+/* @teleloc 0x482e0023 110.113 59.89 9.031 0.897 0 0 0.442 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7482E008, 35932, 0x482E0023, 110.113, 59.89, 9.031, -0.897, 0, 0, 0.442, False, '2020-09-21 00:00:00'); /* Amelia */
+/* @teleloc 0x482e0023 110.113 59.89 9.031 0.897 0 0 0.442 */

--- a/Database/Patches/2007-08-CorruptedSovereigns/8 QuestDefDB/AmeliaToysInProgress.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/8 QuestDefDB/AmeliaToysInProgress.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'AmeliaToysInProgress';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AmeliaToysInProgress', 0, 1, 'Flags a player while they are active in the Amelia Toys quest', '2020-09-20 00:00:00');

--- a/Database/Patches/2007-08-CorruptedSovereigns/8 QuestDefDB/AmeliaToysTurnedInCount.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/8 QuestDefDB/AmeliaToysTurnedInCount.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'AmeliaToysTurnedInCount';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AmeliaToysTurnedInCount', 0, 6, 'Keeps track of how many toys a player has turned in to Amelia', '2020-09-22 00:00:00');

--- a/Database/Patches/2007-08-CorruptedSovereigns/8 QuestDefDB/AmeliaToysWait.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/8 QuestDefDB/AmeliaToysWait.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'AmeliaToysWait';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AmeliaToysWait', 72000, -1, 'Timer for repeating the Amelia Lost Toys quest', '2020-09-22 00:00:00');

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35923 Dirt Pile.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35923 Dirt Pile.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35923;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35923, 'ace35923-dirtpile', 10, '2020-09-20 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35923,   1,         16) /* ItemType - Creature */
+     , (35923,   6,         -1) /* ItemsCapacity */
+     , (35923,   7,         -1) /* ContainersCapacity */
+     , (35923,  16,         32) /* ItemUseable - Remote */
+     , (35923,  93,    4195348) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, EdgeSlide */
+     , (35923,  95,          8) /* RadarBlipColor - Yellow */
+     , (35923, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35923, 267,         30) /* Lifespan */
+     , (35923, 268,         30) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35923,   1, True ) /* Stuck */
+     , (35923,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35923,  39,     0.7) /* DefaultScale */
+     , (35923,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35923,   1, 'Dirt Pile') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35923,   1,   33557839) /* Setup */
+     , (35923,   2,  150995355) /* MotionTable */
+     , (35923,   3,  536870913) /* SoundTable */
+     , (35923,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35923, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35923, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You dig through the turned dirt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You find a strange ghostly toy!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35917 /* Amelia's Red Ball */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35924 Dirt Pile.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35924 Dirt Pile.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35924;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35924, 'ace35924-dirtpile', 10, '2020-09-20 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35924,   1,         16) /* ItemType - Creature */
+     , (35924,   6,         -1) /* ItemsCapacity */
+     , (35924,   7,         -1) /* ContainersCapacity */
+     , (35924,  16,         32) /* ItemUseable - Remote */
+     , (35924,  93,    4195348) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, EdgeSlide */
+     , (35924,  95,          8) /* RadarBlipColor - Yellow */
+     , (35924, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35924, 267,         30) /* Lifespan */
+     , (35924, 268,         30) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35924,   1, True ) /* Stuck */
+     , (35924,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35924,  39,     0.7) /* DefaultScale */
+     , (35924,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35924,   1, 'Dirt Pile') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35924,   1,   33557839) /* Setup */
+     , (35924,   2,  150995355) /* MotionTable */
+     , (35924,   3,  536870913) /* SoundTable */
+     , (35924,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35924, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35924, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You dig through the turned dirt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You find a strange ghostly toy!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35918 /* Amelia's Green Ball */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35925 Dirt Pile.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35925 Dirt Pile.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35925;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35925, 'ace35925-dirtpile', 10, '2020-09-20 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35925,   1,         16) /* ItemType - Creature */
+     , (35925,   6,         -1) /* ItemsCapacity */
+     , (35925,   7,         -1) /* ContainersCapacity */
+     , (35925,  16,         32) /* ItemUseable - Remote */
+     , (35925,  93,    4195348) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, EdgeSlide */
+     , (35925,  95,          8) /* RadarBlipColor - Yellow */
+     , (35925, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35925, 267,         30) /* Lifespan */
+     , (35925, 268,         30) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35925,   1, True ) /* Stuck */
+     , (35925,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35925,  39,     0.7) /* DefaultScale */
+     , (35925,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35925,   1, 'Dirt Pile') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35925,   1,   33557839) /* Setup */
+     , (35925,   2,  150995355) /* MotionTable */
+     , (35925,   3,  536870913) /* SoundTable */
+     , (35925,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35925, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35925, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You dig through the turned dirt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You find a strange ghostly toy!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35919 /* Amelia's Doll House */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35926 Dirt Pile.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35926 Dirt Pile.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35926;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35926, 'ace35926-dirtpile', 10, '2020-09-20 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35926,   1,         16) /* ItemType - Creature */
+     , (35926,   6,         -1) /* ItemsCapacity */
+     , (35926,   7,         -1) /* ContainersCapacity */
+     , (35926,  16,         32) /* ItemUseable - Remote */
+     , (35926,  93,    4195348) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, EdgeSlide */
+     , (35926,  95,          8) /* RadarBlipColor - Yellow */
+     , (35926, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35926, 267,         30) /* Lifespan */
+     , (35926, 268,         30) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35926,   1, True ) /* Stuck */
+     , (35926,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35926,  39,     0.7) /* DefaultScale */
+     , (35926,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35926,   1, 'Dirt Pile') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35926,   1,   33557839) /* Setup */
+     , (35926,   2,  150995355) /* MotionTable */
+     , (35926,   3,  536870913) /* SoundTable */
+     , (35926,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35926, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35926, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You dig through the turned dirt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You find a strange ghostly toy!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35920 /* Amelia's Snowman Doll */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35927 Dirt Pile.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35927 Dirt Pile.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35927;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35927, 'ace35927-dirtpile', 10, '2020-09-20 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35927,   1,         16) /* ItemType - Creature */
+     , (35927,   6,         -1) /* ItemsCapacity */
+     , (35927,   7,         -1) /* ContainersCapacity */
+     , (35927,  16,         32) /* ItemUseable - Remote */
+     , (35927,  93,    4195348) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, EdgeSlide */
+     , (35927,  95,          8) /* RadarBlipColor - Yellow */
+     , (35927, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35927, 267,         30) /* Lifespan */
+     , (35927, 268,         30) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35927,   1, True ) /* Stuck */
+     , (35927,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35927,  39,     0.7) /* DefaultScale */
+     , (35927,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35927,   1, 'Dirt Pile') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35927,   1,   33557839) /* Setup */
+     , (35927,   2,  150995355) /* MotionTable */
+     , (35927,   3,  536870913) /* SoundTable */
+     , (35927,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35927, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35927, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You dig through the turned dirt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You find a strange ghostly toy!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35921 /* Amelia's Golem Doll */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35928 Dirt Pile.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Creature/35928 Dirt Pile.sql
@@ -1,0 +1,52 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35928;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35928, 'ace35928-dirtpile', 10, '2020-09-20 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35928,   1,         16) /* ItemType - Creature */
+     , (35928,   6,         -1) /* ItemsCapacity */
+     , (35928,   7,         -1) /* ContainersCapacity */
+     , (35928,  16,         32) /* ItemUseable - Remote */
+     , (35928,  93,    4195348) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, EdgeSlide */
+     , (35928,  95,          8) /* RadarBlipColor - Yellow */
+     , (35928, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35928, 267,         30) /* Lifespan */
+     , (35928, 268,         29) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35928,   1, True ) /* Stuck */
+     , (35928,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35928,  39,     0.7) /* DefaultScale */
+     , (35928,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35928,   1, 'Dirt Pile') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35928,   1,   33557839) /* Setup */
+     , (35928,   2,  150995355) /* MotionTable */
+     , (35928,   3,  536870913) /* SoundTable */
+     , (35928,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35928, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35928, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You dig through the turned dirt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You find a strange ghostly toy!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35922 /* Amelia's Toy Sword */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35932 Amelia.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35932 Amelia.sql
@@ -1,0 +1,226 @@
+/* This version of Amelia is normally spawned in the world. She accepts quest items and also starts the Amelia's Lost Toys quest, where she despawns, and then spawns the wandering verison of herself. */
+
+DELETE FROM `weenie` WHERE `class_Id` = 35932;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35932, 'ace35932-amelia', 10, '2020-09-22 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35932,   1,         16) /* ItemType - Creature */
+     , (35932,   2,         77) /* CreatureType - Ghost */
+	 , (35932,   3,         61) /* PaletteTemplate - White */
+     , (35932,   6,         -1) /* ItemsCapacity */
+     , (35932,   7,         -1) /* ContainersCapacity */
+     , (35932,  16,         32) /* ItemUseable - Remote */
+     , (35932,  25,          1) /* Level */
+     , (35932,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (35932,  95,          8) /* RadarBlipColor - Yellow */
+     , (35932, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35932, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35932,   1, True ) /* Stuck */
+     , (35932,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35932,  12,       1) /* Shade */
+     , (35932,  39,    0.75) /* DefaultScale */
+     , (35932,  54,       3) /* UseRadius */
+     , (35932,  76,     0.4) /* Translucency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35932,   1, 'Amelia') /* Name */
+     , (35932,   5, 'Ghostly Orphan') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35932,   1,   33554510) /* Setup */
+     , (35932,   2,  150994945) /* MotionTable */
+     , (35932,   3,  536871094) /* SoundTable */
+     , (35932,   6,   67108990) /* PaletteBase */
+	 , (35932,   7,  268437213) /* ClothingBase */
+     , (35932,   8,  100676679) /* Icon */
+     , (35932,  22,  872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (35932,   1,     0, 0, 0, 200250) /* MaxHealth */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysWait', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AmeliaToysWait', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'Thank you so much for helping me find my toys! I bet I won''t lose them for a whole week!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You must wait %tqt before attempting this quest again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysWait', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 51 /* InqEvent */, 0, 1, NULL, 'AmeliaLostToys', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 28 /* EventFailure */, 1, NULL, NULL, NULL, 'AmeliaLostToys', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 23 /* StartEvent */, 0, 1, NULL, 'AmeliaLostToys', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0, 1, NULL, 'My mother told me she would be right back, but she has been gone a long time. When she finds out I lost my toys she will be angry. Would you come with me and help me retrieve my six toys if I can find where they were buried?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 75 /* InqYesNo */, 0, 1, NULL, 'InqYesNo', 'Amelia wants you to follow her and help her gather her toys. Are you ready to begin?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'InqYesNo', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 70 /* SetQuestCompletions */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 70 /* SetQuestCompletions */, 0, 1, NULL, 'AmeliaToysTurnedInCount', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35917 /* Amelia's Red Ball */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35918 /* Amelia's Green Ball */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35919 /* Amelia's Doll House */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35920 /* Amelia's Snowman Doll */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35921 /* Amelia's Golem Doll */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35922 /* Amelia's Toy Sword */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 88 /* LocalSignal */, 0, 1, NULL, 'AmeliaWanderer', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'InqYesNo', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 24 /* StopEvent */, 0, 1, NULL, 'AmeliaLostToys', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 6 /* Give */, 1, 35917 /* Amelia's Red Ball */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Oooh. I love my red ball. Thank you so much!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckQuestComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 6 /* Give */, 1, 35918 /* Amelia's Green Ball */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Oooh. This is one of my favorites. Thank you!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckQuestComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 6 /* Give */, 1, 35919 /* Amelia's Doll House */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'I was so sad when I could not find this!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckQuestComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 6 /* Give */, 1, 35920 /* Amelia's Snowman Doll */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'My snowman! Thanks!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckQuestComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 6 /* Give */, 1, 35921 /* Amelia's Golem Doll */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Yay! My toy golem!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckQuestComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 6 /* Give */, 1, 35922 /* Amelia's Toy Sword */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Someday I''ll become a knight!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckQuestComplete', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'CheckQuestComplete', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'AmeliaToysTurnedInCount', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 22 /* StampQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysWait@CheckTimer', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AmeliaToysWait@CheckTimer', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'TakeAllItems', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AmeliaToysWait@CheckTimer', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AmeliaToysTurnedInCount', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AmeliaToysTurnedInCount', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'You found them all! Yay! Now my mother won''t be mad... when she gets back.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 22 /* StampQuest */, 0, 1, NULL, 'AmeliaToysWait', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 31 /* EraseQuest */, 0, 1, NULL, 'AmeliaToysInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 31 /* EraseQuest */, 0, 1, NULL, 'AmeliaToysTurnedInCount', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 62 /* AwardNoShareXP */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 7500, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 1, 1, NULL, 'I also found this coin, but it''s no fun.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35383 /* Ancient Mhoire Coin */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 34 /* AddCharacterTitle */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 518 /* AmeliasCaretaker */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 18 /* DirectBroadcast */, 1, 1, NULL, 'You have gained the title Amelia''s Caretaker!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35931 /* Amelia's Gargoyle Amulet */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 10 /* Tell */, 1, 1, NULL, 'I think you''re the best! My pet needs a new home and I think he would like you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35932, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'TakeAllItems', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35917 /* Amelia's Red Ball */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35918 /* Amelia's Green Ball */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35919 /* Amelia's Doll House */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35920 /* Amelia's Snowman Doll */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35921 /* Amelia's Golem Doll */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 35922 /* Amelia's Toy Sword */, 999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35932_Amelia_Talker.es
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35932_Amelia_Talker.es
@@ -1,0 +1,86 @@
+Use:
+	- InqQuest: AmeliaToysWait
+		QuestSuccess:
+			- Tell: Thank you so much for helping me find my toys! I bet I won't lose them for a whole week!
+			- DirectBroadcast: You must wait %tqt before attempting this quest again.			
+		QuestFailure:
+			- InqEvent: AmeliaLostToys
+				EventFailure:
+					- StartEvent: AmeliaLostToys					
+					- TurnToTarget
+					- Tell: My mother told me she would be right back, but she has been gone a long time. When she finds out I lost my toys she will be angry. Would you come with me and help me retrieve my six toys if I can find where they were buried?
+					- InqYesNo: Amelia wants you to follow her and help her gather her toys. Are you ready to begin?
+						TestSuccess:					
+							- SetQuestCompletions: AmeliaToysInProgress, 0
+							- SetQuestCompletions: AmeliaToysTurnedInCount, 0
+							- TakeItems: 35917, 999
+							- TakeItems: 35918, 999
+							- TakeItems: 35919, 999
+							- TakeItems: 35920, 999
+							- TakeItems: 35921, 999
+							- TakeItems: 35922, 999
+							- LocalSignal: AmeliaWanderer							
+							- DeleteSelf												
+						TestFailure:
+							- StopEvent: AmeliaLostToys				
+
+Give: 35917
+	- TurnToTarget
+	- Tell: Oooh. I love my red ball. Thank you so much!	
+	- Goto: CheckQuestComplete
+
+Give: 35918
+	- TurnToTarget
+	- Tell: Oooh. This is one of my favorites. Thank you!
+	- Goto: CheckQuestComplete
+
+Give: 35919
+	- TurnToTarget
+	- Tell: I was so sad when I could not find this!
+	- Goto: CheckQuestComplete
+	
+Give: 35920
+	- TurnToTarget
+	- Tell: My snowman! Thanks!
+	- Goto: CheckQuestComplete
+	
+Give: 35921
+	- TurnToTarget
+	- Tell: Yay! My toy golem!
+	- Goto: CheckQuestComplete
+	
+Give: 35922
+	- TurnToTarget
+	- Tell: Someday I'll become a knight!
+	- Goto: CheckQuestComplete	
+	
+GotoSet: CheckQuestComplete
+	- StampQuest: AmeliaToysTurnedInCount
+	- StampQuest: AmeliaToysInProgress
+	- InqQuest AmeliaToysWait@CheckTimer
+		QuestSuccess:
+			- Goto: TakeAllItems
+		QuestFailure:
+			- InqQuest AmeliaToysTurnedInCount
+				QuestSuccess:
+					- Tell: You found them all! Yay! Now my mother won't be mad... when she gets back.
+					- StampQuest: AmeliaToysWait
+					- EraseQuest: AmeliaToysInProgress
+					- EraseQuest: AmeliaToysTurnedInCount
+					- Delay: 1, AwardNoShareXP: 30,000,000
+					- AwardLuminance: 7,500
+					- Delay: 1, Tell: I also found this coin, but it's no fun.
+					- Delay: 1, Give: Ancient Mhoire Coin (35383)
+					- AddCharacterTitle: AmeliasCaretaker
+					- Delay: 1, DirectBroadcast: You have gained the title Amelia's Caretaker!
+					- Delay: 1, Give: Amelia's Gargoyle Amulet (35931)
+					- Delay: 1, Tell: I think you're the best! My pet needs a new home and I think he would like you.
+			
+GotoSet TakeAllItems
+	- TakeItems: 35917, 999
+	- TakeItems: 35918, 999
+	- TakeItems: 35919, 999
+	- TakeItems: 35920, 999
+	- TakeItems: 35921, 999
+	- TakeItems: 35922, 999
+			

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35933 Amelia.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35933 Amelia.sql
@@ -1,0 +1,110 @@
+/* This version of Amelia is spawned for the Amelia's Lots Toy quest and is only meant to run to the quest points and then despawn (while spawning the original version of Amelia) */
+
+DELETE FROM `weenie` WHERE `class_Id` = 35933;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35933, 'ace35933-amelia', 10, '2020-09-22 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35933,   1,         16) /* ItemType - Creature */
+     , (35933,   2,         77) /* CreatureType - Ghost */
+	 , (35933,   3,         61) /* PaletteTemplate - White */
+     , (35933,   6,         -1) /* ItemsCapacity */
+     , (35933,   7,         -1) /* ContainersCapacity */
+     , (35933,  16,         32) /* ItemUseable - Remote */
+     , (35933,  25,          1) /* Level */
+     , (35933,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (35933,  95,          8) /* RadarBlipColor - Yellow */
+     , (35933, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35933, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35933,   1, True ) /* Stuck */
+     , (35933,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35933,  12,       1) /* Shade */
+     , (35933,  39,    0.75) /* DefaultScale */
+     , (35933,  54,       3) /* UseRadius */
+     , (35933,  76,     0.4) /* Translucency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35933,   1, 'Amelia') /* Name */
+     , (35933,   5, 'Ghostly Orphan') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35933,   1,   33554510) /* Setup */
+     , (35933,   2,  150994945) /* MotionTable */
+     , (35933,   3,  536871094) /* SoundTable */
+     , (35933,   6,   67108990) /* PaletteBase */
+	 , (35933,   7,  268437213) /* ClothingBase */
+     , (35933,   8,  100676679) /* Icon */
+     , (35933,  22,  872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (35933,   1,     0, 0, 0, 200250) /* MaxHealth */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35933, 5 /* HeartBeat */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 51 /* InqEvent */, 0, 1, NULL, 'AmeliaLostToys', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35933, 28 /* EventFailure */, 1, NULL, NULL, NULL, 'AmeliaLostToys', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 4 /* MoveHome */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 88 /* LocalSignal */, 30, 1, NULL, 'AmeliaRegular', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35933, 27 /* EventSuccess */, 1, NULL, NULL, NULL, 'AmeliaLostToys', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E001D /* 0x482E001D [93.011 109.193 7.001] 0 0 0 0 */, 93.011, 109.193, 7.001, 0, 0, 0, 0)
+     , (@parent_id, 1, 87 /* MoveToPos */, 15, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E0027 /* 0x482E0027 [107.159 161.267 7.0751] -1 0 0 0.042 */, 107.159, 161.267, 7.0751, -1, 0, 0, 0.042)
+     , (@parent_id, 2, 8 /* Say */, 20, 1, NULL, 'I am pretty sure I was playing here with my toys...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 5 /* Motion */, 2, 1, 0x40000018 /* Pickup */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 88 /* LocalSignal */, 2, 1, NULL, 'DirtPile1', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 5 /* Motion */, 2, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E001F /* 0x482E001F [80.365 159.847 10.723] 0 0 0 0 */, 80.365, 159.847, 10.723, 0, 0, 0, 0)
+     , (@parent_id, 7, 87 /* MoveToPos */, 8, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E0017 /* 0x482E0017 [50.923 163.813 9.401] -0.788 0 0 -0.615 */, 50.923, 163.813, 9.401, -0.788, 0, 0, -0.615)
+     , (@parent_id, 8, 8 /* Say */, 12, 1, NULL, 'It''s around here somewhere...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 5 /* Motion */, 2, 1, 0x40000018 /* Pickup */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 88 /* LocalSignal */, 2, 1, NULL, 'DirtPile2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 5 /* Motion */, 2, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E000C /* 0x482E000C [46.394 78.074 10.005] -0.034 0 0 -0.999 */, 46.394, 78.074, 10.005, -0.034, 0, 0, -0.999)
+     , (@parent_id, 13, 8 /* Say */, 30, 1, NULL, 'Do you see anything around here?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 14, 5 /* Motion */, 2, 1, 0x40000018 /* Pickup */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 15, 88 /* LocalSignal */, 2, 1, NULL, 'DirtPile3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 16, 5 /* Motion */, 2, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 17, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E000B /* 0x482E000B [25.808 63.462 10.005] -0.669 0 0 -0.743 */, 25.808, 63.462, 10.005, -0.669, 0, 0, -0.743)
+     , (@parent_id, 18, 8 /* Say */, 10, 1, NULL, 'Hmmm. I think I left a toy near here...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 19, 5 /* Motion */, 2, 1, 0x40000018 /* Pickup */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 20, 88 /* LocalSignal */, 2, 1, NULL, 'DirtPile4', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 21, 5 /* Motion */, 2, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 22, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E0007 /* 0x482E0007 [22.856 150.254 9.92] -1 0 0 0.006 */, 22.856, 150.254, 9.92, -1, 0, 0, 0.006)
+     , (@parent_id, 23, 8 /* Say */, 30, 1, NULL, 'I wonder if this is the place where my toys got lost?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 24, 5 /* Motion */, 2, 1, 0x40000018 /* Pickup */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 25, 88 /* LocalSignal */, 2, 1, NULL, 'DirtPile5', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 26, 5 /* Motion */, 2, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 27, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E0014 /* 0x482E0014 [49.585 94.781 10.066] 0 0 0 0 */, 49.585, 94.781, 10.066, 0, 0, 0, 0)
+     , (@parent_id, 28, 87 /* MoveToPos */, 20, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E0009 /* 0x482E0009 [42.047 23.774 9.986] 0.002 0 0 1 */, 42.047, 23.774, 9.986, 0.002, 0, 0, 1)
+     , (@parent_id, 29, 8 /* Say */, 30, 1, NULL, 'My last toy was lying around here somewhere...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 30, 5 /* Motion */, 2, 1, 0x40000018 /* Pickup */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 31, 88 /* LocalSignal */, 2, 1, NULL, 'DirtPile6', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 32, 5 /* Motion */, 2, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 33, 8 /* Say */, 2, 1, NULL, 'I have to go home now, but I''ll meet you back where we first met. That''s my favorite spot!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 34, 87 /* MoveToPos */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0x482E0012 /* 0x482E0012 [70.571 27.972 10.005] 0 0 0 0 */, 70.571, 27.972, 10.005, 0, 0, 0, 0)
+     , (@parent_id, 35, 4 /* MoveHome */, 10, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 36, 24 /* StopEvent */, 15, 1, NULL, 'AmeliaLostToys', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 37, 88 /* LocalSignal */, 0, 1, NULL, 'AmeliaRegular', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 38, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35933_Amelia_Wanderer.es
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Ghost/35933_Amelia_Wanderer.es
@@ -1,0 +1,47 @@
+Heartbeat:
+	- InqEvent: AmeliaLostToys
+		EventFailure:
+			- MoveHome
+			- Delay: 30, LocalSignal: AmeliaRegular
+			- DeleteSelf			
+		EventSuccess:
+			- MoveToPos: 0x482E001D [93.011 109.193 7.001] 0 0 0 0
+			- Delay: 15, MoveToPos: 0x482E0027 [107.159 161.267 7.0751] -1 0 0 0.042
+			- Delay: 20, Say: I am pretty sure I was playing here with my toys...
+			- Delay: 2, Motion: 1073741848
+			- Delay: 2, LocalSignal: DirtPile1
+			- Delay: 2, Motion: 1090519043
+			- MoveToPos: 0x482E001F [80.365 159.847 10.723] 0 0 0 0
+			- Delay: 8, MoveToPos: 0x482E0017 [50.923 163.813 9.401] -0.788 0 0 -0.615		 
+			- Delay: 12, Say: It's around here somewhere...
+			- Delay: 2, Motion: 1073741848
+			- Delay: 2, LocalSignal: DirtPile2
+			- Delay: 2, Motion: 1090519043
+			- MoveToPos:  0x482E000C [46.394 78.074 10.005] -0.034 0 0 -0.999
+			- Delay: 30, Say: Do you see anything around here?
+			- Delay: 2, Motion: 1073741848
+			- Delay: 2, LocalSignal: DirtPile3
+			- Delay: 2, Motion: 1090519043
+			- MoveToPos: 0x482E000B [25.808 63.462 10.005] -0.669 0 0 -0.743
+			- Delay: 10, Say: Hmmm. I think I left a toy near here...
+			- Delay: 2, Motion: 1073741848
+			- Delay: 2, LocalSignal: DirtPile4
+			- Delay: 2, Motion: 1090519043
+			- MoveToPos: 0x482E0007 [22.856 150.254 9.920] -1 0 0 0.006
+			- Delay: 30, Say: I wonder if this is the place where my toys got lost?
+			- Delay: 2, Motion: 1073741848
+			- Delay: 2, LocalSignal: DirtPile5
+			- Delay: 2, Motion: 1090519043
+			- MoveToPos: 0x482E0014 [49.585 94.781 10.066] 0 0 0 0
+			- Delay 20, MoveToPos: 0x482E0009 [42.047 23.774 9.986] 0.002 0 0 1
+			- Delay: 30, Say: My last toy was lying around here somewhere...
+			- Delay: 2, Motion: 1073741848
+			- Delay: 2, LocalSignal: DirtPile6
+			- Delay: 2, Motion: 1090519043		
+			- Delay: 2, Say: I have to go home now, but I'll meet you back where we first met. That's my favorite spot!
+			- MoveToPos: 0x482E0012 [70.571 27.972 10.005] 0 0 0 0
+			- Delay: 10, MoveHome
+			- Delay: 15, StopEvent: AmeliaLostToys
+			- LocalSignal: AmeliaRegular
+			- DeleteSelf			
+	

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80070 Amelia Dirt Pile 1 Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80070 Amelia Dirt Pile 1 Generator.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80070;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80070, 'ace80070-ameliadirtpile1gen', 1, '2020-09-20 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80070,  81,          1) /* MaxGeneratedObjects */
+     , (80070,  82,          0) /* InitGeneratedObjects */
+     , (80070,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80070, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80070, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80070, 290,          1) /* HearLocalSignals */
+     , (80070, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80070,   1, True ) /* Stuck */
+     , (80070,  11, True ) /* IgnoreCollisions */
+     , (80070,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80070,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80070,   1, 'Amelia Dirt Pile 1 Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80070,   1,   33555051) /* Setup */
+     , (80070,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80070, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DirtPile1', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80070, -1, 35925, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dirt Pile (35925) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80071 Amelia Dirt Pile 2 Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80071 Amelia Dirt Pile 2 Generator.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80071;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80071, 'ace80071-ameliadirtpile2gen', 1, '2020-09-20 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80071,  81,          1) /* MaxGeneratedObjects */
+     , (80071,  82,          0) /* InitGeneratedObjects */
+     , (80071,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80071, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80071, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80071, 290,          1) /* HearLocalSignals */
+     , (80071, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80071,   1, True ) /* Stuck */
+     , (80071,  11, True ) /* IgnoreCollisions */
+     , (80071,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80071,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80071,   1, 'Amelia Dirt Pile 2 Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80071,   1,   33555051) /* Setup */
+     , (80071,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80071, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DirtPile2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80071, -1, 35923, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dirt Pile (35923) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80072 Amelia Dirt Pile 3 Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80072 Amelia Dirt Pile 3 Generator.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80072;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80072, 'ace80072-ameliadirtpile3gen', 1, '2020-09-20 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80072,  81,          1) /* MaxGeneratedObjects */
+     , (80072,  82,          0) /* InitGeneratedObjects */
+     , (80072,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80072, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80072, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80072, 290,          1) /* HearLocalSignals */
+     , (80072, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80072,   1, True ) /* Stuck */
+     , (80072,  11, True ) /* IgnoreCollisions */
+     , (80072,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80072,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80072,   1, 'Amelia Dirt Pile 3 Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80072,   1,   33555051) /* Setup */
+     , (80072,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80072, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DirtPile3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80072, -1, 35926, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dirt Pile (35926) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80073 Amelia Dirt Pile 4 Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80073 Amelia Dirt Pile 4 Generator.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80073;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80073, 'ace80073-ameliadirtpile4gen', 1, '2020-09-20 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80073,  81,          1) /* MaxGeneratedObjects */
+     , (80073,  82,          0) /* InitGeneratedObjects */
+     , (80073,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80073, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80073, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80073, 290,          1) /* HearLocalSignals */
+     , (80073, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80073,   1, True ) /* Stuck */
+     , (80073,  11, True ) /* IgnoreCollisions */
+     , (80073,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80073,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80073,   1, 'Amelia Dirt Pile 4 Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80073,   1,   33555051) /* Setup */
+     , (80073,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80073, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DirtPile4', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80073, -1, 35927, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dirt Pile (35927) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80074 Amelia Dirt Pile 5 Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80074 Amelia Dirt Pile 5 Generator.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80074;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80074, 'ace80074-ameliadirtpile5gen', 1, '2020-09-20 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80074,  81,          1) /* MaxGeneratedObjects */
+     , (80074,  82,          0) /* InitGeneratedObjects */
+     , (80074,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80074, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80074, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80074, 290,          1) /* HearLocalSignals */
+     , (80074, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80074,   1, True ) /* Stuck */
+     , (80074,  11, True ) /* IgnoreCollisions */
+     , (80074,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80074,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80074,   1, 'Amelia Dirt Pile 5 Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80074,   1,   33555051) /* Setup */
+     , (80074,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80074, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DirtPile5', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80074, -1, 35924, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dirt Pile (35924) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80075 Amelia Dirt Pile 6 Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80075 Amelia Dirt Pile 6 Generator.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 80075;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80075, 'ace80075-ameliadirtpile6gen', 1, '2020-09-20 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80075,  81,          1) /* MaxGeneratedObjects */
+     , (80075,  82,          0) /* InitGeneratedObjects */
+     , (80075,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80075, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80075, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80075, 290,          1) /* HearLocalSignals */
+     , (80075, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80075,   1, True ) /* Stuck */
+     , (80075,  11, True ) /* IgnoreCollisions */
+     , (80075,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80075,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80075,   1, 'Amelia Dirt Pile 6 Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80075,   1,   33555051) /* Setup */
+     , (80075,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80075, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DirtPile6', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80075, -1, 35928, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dirt Pile (35928) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80076 Amelia Wanderer Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80076 Amelia Wanderer Generator.sql
@@ -1,0 +1,40 @@
+/* This generator is for Amelia's Lost Toys Quest. It will spawn the wanderer version of Amelia when it receives a signal */
+DELETE FROM `weenie` WHERE `class_Id` = 80076;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80076, 'ace80076-ameliawanderergen', 1, '2020-09-22 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80076,  81,          1) /* MaxGeneratedObjects */
+     , (80076,  82,          0) /* InitGeneratedObjects */
+     , (80076,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80076, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80076, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80076, 290,          1) /* HearLocalSignals */
+     , (80076, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80076,   1, True ) /* Stuck */
+     , (80076,  11, True ) /* IgnoreCollisions */
+     , (80076,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80076,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80076,   1, 'Amelia Wanderer Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80076,   1,   33555051) /* Setup */
+     , (80076,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80076, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'AmeliaWanderer', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80076, -1, 35933, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Amelia (35933) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80077 Amelia Generator.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Generic/Unsorted/80077 Amelia Generator.sql
@@ -1,0 +1,40 @@
+/* This generator is for Amelia's Lost Toys Quest. It will spawn the regular version of Amelia when it receives a signal (when the quest is over) */
+DELETE FROM `weenie` WHERE `class_Id` = 80077;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (80077, 'ace80077-ameliagen', 1, '2020-09-22 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (80077,  81,          1) /* MaxGeneratedObjects */
+     , (80077,  82,          0) /* InitGeneratedObjects */
+     , (80077,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (80077, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (80077, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (80077, 290,          1) /* HearLocalSignals */
+     , (80077, 291,         20) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (80077,   1, True ) /* Stuck */
+     , (80077,  11, True ) /* IgnoreCollisions */
+     , (80077,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (80077,  41,          0) /* RegenerationInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (80077,   1, 'Amelia Generator') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (80077,   1,   33555051) /* Setup */
+     , (80077,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (80077, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'AmeliaRegular', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (80077, -1, 35932, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Amelia (35932) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Pet/Creature/35930 Pet Gargoyle.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Pet/Creature/35930 Pet Gargoyle.sql
@@ -1,0 +1,50 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35930;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35930, 'ace35930-ameliaspetgargoyle', 69, '2020-09-22 00:00:00') /* Pet */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35930,   1,         16) /* ItemType - Creature */
+     , (35930,   2,         77) /* CreatureType - Ghost */
+	 , (35930,   3,          5) /* PaletteTemplate - DarkBlue */
+     , (35930,   6,         -1) /* ItemsCapacity */
+     , (35930,   7,         -1) /* ContainersCapacity */
+     , (35930,  16,          1) /* ItemUseable - No */
+     , (35930,  25,          5) /* Level */
+     , (35930,  93,    2098196) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (35930,  95,          8) /* RadarBlipColor - Yellow */
+     , (35930, 133,          1) /* ShowableOnRadar - ShowNever */
+     , (35930, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35930,   1, True ) /* Stuck */
+     , (35930,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35930,  39,     0.5) /* DefaultScale */
+     , (35930,  76,     0.6) /* Translucency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35930,   1, 'Amelia''s Pet Gargoyle') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35930,   1,   33558554) /* Setup */
+     , (35930,   2,  150995263) /* MotionTable */
+     , (35930,   3,  536871080) /* SoundTable */
+     , (35930,   6,   67114728) /* PaletteBase */
+	 , (35930,   7,  268436733) /* ClothingBase */
+     , (35930,   8,  100675661) /* Icon */
+     , (35930,  22,  872415411) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (35930,   1,  45, 0, 0) /* Strength */
+     , (35930,   2,  25, 0, 0) /* Endurance */
+     , (35930,   3,  20, 0, 0) /* Quickness */
+     , (35930,   4,  45, 0, 0) /* Coordination */
+     , (35930,   5,  30, 0, 0) /* Focus */
+     , (35930,   6,  30, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (35930,   1,    16, 0, 0, 28) /* MaxHealth */
+     , (35930,   3,    95, 0, 0, 120) /* MaxStamina */
+     , (35930,   5,     0, 0, 0, 30) /* MaxMana */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/PetDevice/Misc/35931 Amelia's Gargoyle Amulet.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/PetDevice/Misc/35931 Amelia's Gargoyle Amulet.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35931;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35931, 'ace35931-ameliasgargoyleamulet', 70, '2020-09-22 00:00:00') /* PetDevice */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35931,   1,        128) /* ItemType - Misc */
+     , (35931,   5,         50) /* EncumbranceVal */
+     , (35931,  16,          8) /* ItemUseable - Contained */
+     , (35931,  19,          0) /* Value */
+     , (35931,  33,          1) /* Bonded - Bonded */
+     , (35931,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35931,  94,         16) /* TargetType - Creature */
+     , (35931, 114,          1) /* Attuned - Attuned */
+	 , (35931, 266,      35930) /* PetClass - Amelia's Pet Gargoyle */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35931,  22, True ) /* Inscribable */
+     , (35931,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35931,   1, 'Amelia''s Gargoyle Amulet') /* Name */
+     , (35931,  14, 'Grasp this amulet to summon or dismiss Amelia''s ghostly gargoyle.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35931,   1,   33554680) /* Setup */
+     , (35931,   3,  536870932) /* SoundTable */
+     , (35931,   6,   67111919) /* PaletteBase */
+     , (35931,   8,  100668602) /* Icon */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35917 Amelia's Red Ball.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35917 Amelia's Red Ball.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35917;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35917, 'ace35917-ameliasredball', 51, '2020-09-21 00:00:00') /* Stackable */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35917,   1,        128) /* ItemType - Misc */
+     , (35917,   5,         10) /* EncumbranceVal */
+     , (35917,  11,          1) /* MaxStackSize */
+     , (35917,  12,          1) /* StackSize */
+     , (35917,  13,         10) /* StackUnitEncumbrance */
+     , (35917,  15,          0) /* StackUnitValue */
+     , (35917,  16,          1) /* ItemUseable - No */
+     , (35917,  19,          0) /* Value */
+     , (35917,  33,          1) /* Bonded - Bonded */
+     , (35917,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35917, 114,          1) /* Attuned - Attuned */
+     , (35917, 267,       3600) /* Lifespan */
+     , (35917, 268,       3600) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35917,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35917,   1, 'Amelia''s Red Ball') /* Name */
+     , (35917,  15, 'A red ball. This child''s toy is somewhat transparent, and has a strange ethereal quality. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35917,   1,   33554669) /* Setup */
+     , (35917,   3,  536870932) /* SoundTable */
+     , (35917,   6,   67111928) /* PaletteBase */
+     , (35917,   8,  100668724) /* Icon */
+     , (35917,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35918 Amelia's Green Ball.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35918 Amelia's Green Ball.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35918;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35918, 'ace35918-ameliasgreenball', 51, '2020-09-21 00:00:00') /* Stackable */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35918,   1,        128) /* ItemType - Misc */
+     , (35918,   5,         10) /* EncumbranceVal */
+     , (35918,  11,          1) /* MaxStackSize */
+     , (35918,  12,          1) /* StackSize */
+     , (35918,  13,         10) /* StackUnitEncumbrance */
+     , (35918,  15,          0) /* StackUnitValue */
+     , (35918,  16,          1) /* ItemUseable - No */
+     , (35918,  19,          0) /* Value */
+     , (35918,  33,          1) /* Bonded - Bonded */
+     , (35918,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35918, 114,          1) /* Attuned - Attuned */
+     , (35918, 267,       3600) /* Lifespan */
+     , (35918, 268,       3600) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35918,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35918,   1, 'Amelia''s Green Ball') /* Name */
+     , (35918,  15, 'A green ball. This child''s toy is somewhat transparent, and has a strange ethereal quality. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35918,   1,   33554669) /* Setup */
+     , (35918,   3,  536870932) /* SoundTable */
+     , (35918,   6,   67111928) /* PaletteBase */
+     , (35918,   8,  100668725) /* Icon */
+     , (35918,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35919 Amelia's Doll House.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35919 Amelia's Doll House.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35919;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35919, 'ace35919-ameliasdollhouse', 51, '2020-09-21 00:00:00') /* Stackable */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35919,   1,        128) /* ItemType - Misc */
+     , (35919,   5,         10) /* EncumbranceVal */
+     , (35919,  11,          1) /* MaxStackSize */
+     , (35919,  12,          1) /* StackSize */
+     , (35919,  13,         10) /* StackUnitEncumbrance */
+     , (35919,  15,          0) /* StackUnitValue */
+     , (35919,  16,          1) /* ItemUseable - No */
+     , (35919,  19,          0) /* Value */
+     , (35919,  33,          1) /* Bonded - Bonded */
+     , (35919,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35919, 114,          1) /* Attuned - Attuned */
+     , (35919, 267,       3600) /* Lifespan */
+     , (35919, 268,       3600) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35919,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35919,  39,     0.9) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35919,   1, 'Amelia''s Doll House') /* Name */
+     , (35919,  15, 'A doll house. This child''s toy is somewhat transparent, and has a strange ethereal quality. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35919,   1,   33560158) /* Setup */
+     , (35919,   3,  536870932) /* SoundTable */
+     , (35919,   8,  100689310) /* Icon */
+     , (35919,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35920 Amelia's Snowman Doll.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35920 Amelia's Snowman Doll.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35920;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35920, 'ace35920-ameliassnowmandoll', 51, '2020-09-20 00:00:00') /* Stackable */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35920,   1,        128) /* ItemType - Misc */
+     , (35920,   5,         10) /* EncumbranceVal */
+     , (35920,  11,          1) /* MaxStackSize */
+     , (35920,  12,          1) /* StackSize */
+     , (35920,  13,         10) /* StackUnitEncumbrance */
+     , (35920,  15,          0) /* StackUnitValue */
+     , (35920,  16,          1) /* ItemUseable - No */
+     , (35920,  19,          0) /* Value */
+     , (35920,  33,          1) /* Bonded - Bonded */
+     , (35920,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35920, 114,          1) /* Attuned - Attuned */
+     , (35920, 267,       3600) /* Lifespan */
+     , (35920, 268,       3600) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35920,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35920,  39,     0.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35920,   1, 'Amelia''s Snowman Doll') /* Name */
+     , (35920,  15, 'A snowman doll. This child''s toy is somewhat transparent, and has a strange ethereal quality. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35920,   1,   33557444) /* Setup */
+     , (35920,   3,  536870932) /* SoundTable */
+     , (35920,   8,  100672418) /* Icon */
+     , (35920,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35921 Amelia's Golem Doll.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35921 Amelia's Golem Doll.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35921;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35921, 'ace35921-ameliasgolemdoll', 51, '2020-09-21 00:00:00') /* Stackable */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35921,   1,        128) /* ItemType - Misc */
+     , (35921,   5,         10) /* EncumbranceVal */
+     , (35921,  11,          1) /* MaxStackSize */
+     , (35921,  12,          1) /* StackSize */
+     , (35921,  13,         10) /* StackUnitEncumbrance */
+     , (35921,  15,          0) /* StackUnitValue */
+     , (35921,  16,          1) /* ItemUseable - No */
+     , (35921,  19,          0) /* Value */
+     , (35921,  33,          1) /* Bonded - Bonded */
+     , (35921,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35921, 114,          1) /* Attuned - Attuned */
+     , (35921, 267,       3600) /* Lifespan */
+     , (35921, 268,       3600) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35921,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35921,  39,     0.4) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35921,   1, 'Amelia''s Golem Doll') /* Name */
+     , (35921,  15, 'A golem doll. This child''s toy is somewhat transparent, and has a strange ethereal quality. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35921,   1,   33560282) /* Setup */
+     , (35921,   2,  150995206) /* MotionTable */
+     , (35921,   3,  536870933) /* SoundTable */
+     , (35921,   8,  100674350) /* Icon */
+     , (35921,  22,  872415269) /* PhysicsEffectTable */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35922 Amelia's Toy Sword.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Stackable/Misc/35922 Amelia's Toy Sword.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 35922;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (35922, 'ace35922-ameliastoysword', 51, '2020-09-21 00:00:00') /* Stackable */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (35922,   1,        128) /* ItemType - Misc */
+     , (35922,   5,         10) /* EncumbranceVal */
+     , (35922,  11,          1) /* MaxStackSize */
+     , (35922,  12,          1) /* StackSize */
+     , (35922,  13,         10) /* StackUnitEncumbrance */
+     , (35922,  15,          0) /* StackUnitValue */
+     , (35922,  16,          1) /* ItemUseable - No */
+     , (35922,  19,          0) /* Value */
+     , (35922,  33,          1) /* Bonded - Bonded */
+     , (35922,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (35922, 114,          1) /* Attuned - Attuned */
+     , (35922, 267,       3600) /* Lifespan */
+     , (35922, 268,       3600) /* RemainingLifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (35922,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (35922,  39,     0.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (35922,   1, 'Amelia''s Toy Sword') /* Name */
+     , (35922,  15, 'A toy sword. This child''s toy is somewhat transparent, and has a strange ethereal quality. ') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (35922,   1,   33554758) /* Setup */
+     , (35922,   3,  536870932) /* SoundTable */
+     , (35922,   6,   67111919) /* PaletteBase */
+     , (35922,   8,  100669024) /* Icon */
+     , (35922,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/B GameEventDefDB/AmeliaLostToys.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/B GameEventDefDB/AmeliaLostToys.sql
@@ -1,0 +1,4 @@
+DELETE FROM `event` WHERE `name` = 'AmeliaLostToys';
+
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('AmeliaLostToys', -1, -1, 3, '2020-09-22 00:00:00');


### PR DESCRIPTION
The basic flow of the quest is that the player talks to Amelia (35932) which
pops up a yes/no box. If the player accepts then a signal is sent to spawn
Amelia (35933), then Amelia (35932) despawns. Amelia will then run to
certain points and emit a signal.

There are generators setup at each location which listen for
the signal and then spawn a specific dirt pile. The dirt pile last for 30
seconds and then disappear. When the player interacts with the dirt pile
it will give them a specific toy.

After going to the last dirt pile Amelia (35933) will run home, emit a
signal to spawn the original version (35932), then despawn.

Amelia (35932) will accept the toys and give a reward once all 6 toys have
been handed over.

Information on dirt pile locations was taken from PCAP but also from this
video: https://www.youtube.com/watch?v=9SyAqFNuwzo. Not all locations were
shown in the video so some guesswork was done.