### PR TITLE
Remove (200) from essence names

### DIFF
--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48956 Fire Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48956 Fire Skeleton Samurai Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 48956;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (48956, 'ace48956-fireskeletonsamuraiessence200', 70, '2020-08-04 10:12:33') /* PetDevice */;
+VALUES (48956, 'ace48956-fireskeletonsamuraiessence200', 70, '2020-10-11 10:12:33') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (48956,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (48956,   1,        128) /* ItemType - Misc */
      , (48956,  18,         32) /* UiEffects - Fire */
      , (48956,  19,       4000) /* Value */
      , (48956,  33,          0) /* Bonded - Normal */
-     , (48956,  65,        101) /* Placement - Resting */
      , (48956,  91,         50) /* MaxStructure */
      , (48956,  92,         50) /* Structure */
      , (48956,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (48956,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (48956,   1, False) /* Stuck */
-     , (48956,  11, True ) /* IgnoreCollisions */
-     , (48956,  13, True ) /* Ethereal */
-     , (48956,  14, True ) /* GravityStatus */
-     , (48956,  19, True ) /* Attackable */
      , (48956,  22, True ) /* Inscribable */
      , (48956,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (48956,  39,     0.4) /* DefaultScale */
      , (48956, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (48956,   1, 'Fire Skeleton Samurai Essence (200)') /* Name */
+VALUES (48956,   1, 'Fire Skeleton Samurai Essence') /* Name */
      , (48956,  14, 'Use this essence to summon or dismiss your Fire Skeleton Samurai.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48956 Fire Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48956 Fire Skeleton Samurai Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (48956,   1,        128) /* ItemType - Misc */
      , (48956,   5,         50) /* EncumbranceVal */
      , (48956,  16,          8) /* ItemUseable - Contained */
      , (48956,  18,         32) /* UiEffects - Fire */
-     , (48956,  19,       4000) /* Value */
+     , (48956,  19,      10000) /* Value */
      , (48956,  33,          0) /* Bonded - Normal */
      , (48956,  91,         50) /* MaxStructure */
      , (48956,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48956 Fire Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48956 Fire Skeleton Samurai Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (48956,   1,        128) /* ItemType - Misc */
      , (48956, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (48956,   1, False) /* Stuck */
-     , (48956,  22, True ) /* Inscribable */
+VALUES (48956,  22, True ) /* Inscribable */
      , (48956,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48957 Incendiary Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48957 Incendiary Knight Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (48957,   1,        128) /* ItemType - Misc */
      , (48957,   5,         50) /* EncumbranceVal */
      , (48957,  16,          8) /* ItemUseable - Contained */
      , (48957,  18,         32) /* UiEffects - Fire */
-     , (48957,  19,       4000) /* Value */
+     , (48957,  19,      10000) /* Value */
      , (48957,  33,          0) /* Bonded - Normal */
      , (48957,  91,         50) /* MaxStructure */
      , (48957,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48957 Incendiary Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48957 Incendiary Knight Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 48957;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (48957, 'ace48957-incendiaryknightessence200', 70, '2020-08-04 10:12:42') /* PetDevice */;
+VALUES (48957, 'ace48957-incendiaryknightessence200', 70, '2020-10-11 10:12:42') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (48957,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (48957,   1,        128) /* ItemType - Misc */
      , (48957,  18,         32) /* UiEffects - Fire */
      , (48957,  19,       4000) /* Value */
      , (48957,  33,          0) /* Bonded - Normal */
-     , (48957,  65,        101) /* Placement - Resting */
      , (48957,  91,         50) /* MaxStructure */
      , (48957,  92,         50) /* Structure */
      , (48957,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (48957,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (48957,   1, False) /* Stuck */
-     , (48957,  11, True ) /* IgnoreCollisions */
-     , (48957,  13, True ) /* Ethereal */
-     , (48957,  14, True ) /* GravityStatus */
-     , (48957,  19, True ) /* Attackable */
      , (48957,  22, True ) /* Inscribable */
      , (48957,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (48957,  39,     0.4) /* DefaultScale */
      , (48957, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (48957,   1, 'Incendiary Knight Essence (200)') /* Name */
+VALUES (48957,   1, 'Incendiary Knight Essence') /* Name */
      , (48957,  14, 'Use this essence to summon or dismiss your Incendiary Knight.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48957 Incendiary Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/48957 Incendiary Knight Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (48957,   1,        128) /* ItemType - Misc */
      , (48957, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (48957,   1, False) /* Stuck */
-     , (48957,  22, True ) /* Inscribable */
+VALUES (48957,  22, True ) /* Inscribable */
      , (48957,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49212 Frost Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49212 Frost Skeleton Samurai Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49212,   1,        128) /* ItemType - Misc */
      , (49212, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49212,   1, False) /* Stuck */
-     , (49212,  22, True ) /* Inscribable */
+VALUES (49212,  22, True ) /* Inscribable */
      , (49212,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49212 Frost Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49212 Frost Skeleton Samurai Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49212;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49212, 'ace49212-frostskeletonsamuraiessence200', 70, '2020-08-04 10:12:51') /* PetDevice */;
+VALUES (49212, 'ace49212-frostskeletonsamuraiessence200', 70, '2020-10-11 10:12:51') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49212,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49212,   1,        128) /* ItemType - Misc */
      , (49212,  18,        128) /* UiEffects - Frost */
      , (49212,  19,       4000) /* Value */
      , (49212,  33,          0) /* Bonded - Normal */
-     , (49212,  65,        101) /* Placement - Resting */
      , (49212,  91,         50) /* MaxStructure */
      , (49212,  92,         50) /* Structure */
      , (49212,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49212,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49212,   1, False) /* Stuck */
-     , (49212,  11, True ) /* IgnoreCollisions */
-     , (49212,  13, True ) /* Ethereal */
-     , (49212,  14, True ) /* GravityStatus */
-     , (49212,  19, True ) /* Attackable */
      , (49212,  22, True ) /* Inscribable */
      , (49212,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49212,  39,     0.4) /* DefaultScale */
      , (49212, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49212,   1, 'Frost Skeleton Samurai Essence (200)') /* Name */
+VALUES (49212,   1, 'Frost Skeleton Samurai Essence') /* Name */
      , (49212,  14, 'Use this essence to summon or dismiss your Frost Skeleton Samurai.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49212 Frost Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49212 Frost Skeleton Samurai Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49212,   1,        128) /* ItemType - Misc */
      , (49212,   5,         50) /* EncumbranceVal */
      , (49212,  16,          8) /* ItemUseable - Contained */
      , (49212,  18,        128) /* UiEffects - Frost */
-     , (49212,  19,       4000) /* Value */
+     , (49212,  19,      10000) /* Value */
      , (49212,  33,          0) /* Bonded - Normal */
      , (49212,  91,         50) /* MaxStructure */
      , (49212,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49219 Acid Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49219 Acid Skeleton Samurai Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49219,   1,        128) /* ItemType - Misc */
      , (49219, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49219,   1, False) /* Stuck */
-     , (49219,  22, True ) /* Inscribable */
+VALUES (49219,  22, True ) /* Inscribable */
      , (49219,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49219 Acid Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49219 Acid Skeleton Samurai Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49219;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49219, 'ace49219-acidskeletonsamuraiessence200', 70, '2020-08-04 10:13:10') /* PetDevice */;
+VALUES (49219, 'ace49219-acidskeletonsamuraiessence200', 70, '2020-10-11 10:13:10') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49219,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49219,   1,        128) /* ItemType - Misc */
      , (49219,  18,        256) /* UiEffects - Acid */
      , (49219,  19,       4000) /* Value */
      , (49219,  33,          0) /* Bonded - Normal */
-     , (49219,  65,        101) /* Placement - Resting */
      , (49219,  91,         50) /* MaxStructure */
      , (49219,  92,         50) /* Structure */
      , (49219,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49219,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49219,   1, False) /* Stuck */
-     , (49219,  11, True ) /* IgnoreCollisions */
-     , (49219,  13, True ) /* Ethereal */
-     , (49219,  14, True ) /* GravityStatus */
-     , (49219,  19, True ) /* Attackable */
      , (49219,  22, True ) /* Inscribable */
      , (49219,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49219,  39,     0.4) /* DefaultScale */
      , (49219, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49219,   1, 'Acid Skeleton Samurai Essence (200)') /* Name */
+VALUES (49219,   1, 'Acid Skeleton Samurai Essence') /* Name */
      , (49219,  14, 'Use this essence to summon or dismiss your Acid Skeleton Samurai.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49219 Acid Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49219 Acid Skeleton Samurai Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49219,   1,        128) /* ItemType - Misc */
      , (49219,   5,         50) /* EncumbranceVal */
      , (49219,  16,          8) /* ItemUseable - Contained */
      , (49219,  18,        256) /* UiEffects - Acid */
-     , (49219,  19,       4000) /* Value */
+     , (49219,  19,      10000) /* Value */
      , (49219,  33,          0) /* Bonded - Normal */
      , (49219,  91,         50) /* MaxStructure */
      , (49219,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49226 Lightning Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49226 Lightning Skeleton Samurai Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49226,   1,        128) /* ItemType - Misc */
      , (49226,   5,         50) /* EncumbranceVal */
      , (49226,  16,          8) /* ItemUseable - Contained */
      , (49226,  18,         64) /* UiEffects - Lightning */
-     , (49226,  19,       4000) /* Value */
+     , (49226,  19,      10000) /* Value */
      , (49226,  33,          0) /* Bonded - Normal */
      , (49226,  91,         50) /* MaxStructure */
      , (49226,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49226 Lightning Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49226 Lightning Skeleton Samurai Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49226;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49226, 'ace49226-lightningskeletonsamuraiessence200', 70, '2020-08-04 10:13:17') /* PetDevice */;
+VALUES (49226, 'ace49226-lightningskeletonsamuraiessence200', 70, '2020-10-11 10:13:17') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49226,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49226,   1,        128) /* ItemType - Misc */
      , (49226,  18,         64) /* UiEffects - Lightning */
      , (49226,  19,       4000) /* Value */
      , (49226,  33,          0) /* Bonded - Normal */
-     , (49226,  65,        101) /* Placement - Resting */
      , (49226,  91,         50) /* MaxStructure */
      , (49226,  92,         50) /* Structure */
      , (49226,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49226,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49226,   1, False) /* Stuck */
-     , (49226,  11, True ) /* IgnoreCollisions */
-     , (49226,  13, True ) /* Ethereal */
-     , (49226,  14, True ) /* GravityStatus */
-     , (49226,  19, True ) /* Attackable */
      , (49226,  22, True ) /* Inscribable */
      , (49226,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49226,  39,     0.4) /* DefaultScale */
      , (49226, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49226,   1, 'Lightning Skeleton Samurai Essence (200)') /* Name */
+VALUES (49226,   1, 'Lightning Skeleton Samurai Essence') /* Name */
      , (49226,  14, 'Use this essence to summon or dismiss your Lightning Skeleton Samurai.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49226 Lightning Skeleton Samurai Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49226 Lightning Skeleton Samurai Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49226,   1,        128) /* ItemType - Misc */
      , (49226, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49226,   1, False) /* Stuck */
-     , (49226,  22, True ) /* Inscribable */
+VALUES (49226,  22, True ) /* Inscribable */
      , (49226,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49233 Frigid Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49233 Frigid Zombie Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49233;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49233, 'ace49233-frigidzombieessence200', 70, '2020-08-04 10:13:26') /* PetDevice */;
+VALUES (49233, 'ace49233-frigidzombieessence200', 70, '2020-10-11 10:13:26') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49233,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49233,   1,        128) /* ItemType - Misc */
      , (49233,  18,        128) /* UiEffects - Frost */
      , (49233,  19,       4000) /* Value */
      , (49233,  33,          0) /* Bonded - Normal */
-     , (49233,  65,        101) /* Placement - Resting */
      , (49233,  91,         50) /* MaxStructure */
      , (49233,  92,         50) /* Structure */
      , (49233,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49233,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49233,   1, False) /* Stuck */
-     , (49233,  11, True ) /* IgnoreCollisions */
-     , (49233,  13, True ) /* Ethereal */
-     , (49233,  14, True ) /* GravityStatus */
-     , (49233,  19, True ) /* Attackable */
      , (49233,  22, True ) /* Inscribable */
      , (49233,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49233,  39,     0.4) /* DefaultScale */
      , (49233, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49233,   1, 'Frigid Zombie Essence (200)') /* Name */
+VALUES (49233,   1, 'Frigid Zombie Essence') /* Name */
      , (49233,  14, 'Use this essence to summon or dismiss your Frigid Zombie.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49233 Frigid Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49233 Frigid Zombie Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49233,   1,        128) /* ItemType - Misc */
      , (49233, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49233,   1, False) /* Stuck */
-     , (49233,  22, True ) /* Inscribable */
+VALUES (49233,  22, True ) /* Inscribable */
      , (49233,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49233 Frigid Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49233 Frigid Zombie Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49233,   1,        128) /* ItemType - Misc */
      , (49233,   5,         50) /* EncumbranceVal */
      , (49233,  16,          8) /* ItemUseable - Contained */
      , (49233,  18,        128) /* UiEffects - Frost */
-     , (49233,  19,       4000) /* Value */
+     , (49233,  19,      10000) /* Value */
      , (49233,  33,          0) /* Bonded - Normal */
      , (49233,  91,         50) /* MaxStructure */
      , (49233,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49239 Blistered Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49239 Blistered Zombie Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49239,   1,        128) /* ItemType - Misc */
      , (49239, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49239,   1, False) /* Stuck */
-     , (49239,  22, True ) /* Inscribable */
+VALUES (49239,  22, True ) /* Inscribable */
      , (49239,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49239 Blistered Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49239 Blistered Zombie Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49239;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49239, 'ace49239-blisteredzombieessence200', 70, '2020-08-04 10:13:33') /* PetDevice */;
+VALUES (49239, 'ace49239-blisteredzombieessence200', 70, '2020-10-11 10:13:33') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49239,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49239,   1,        128) /* ItemType - Misc */
      , (49239,  18,        256) /* UiEffects - Acid */
      , (49239,  19,       4000) /* Value */
      , (49239,  33,          0) /* Bonded - Normal */
-     , (49239,  65,        101) /* Placement - Resting */
      , (49239,  91,         50) /* MaxStructure */
      , (49239,  92,         50) /* Structure */
      , (49239,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49239,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49239,   1, False) /* Stuck */
-     , (49239,  11, True ) /* IgnoreCollisions */
-     , (49239,  13, True ) /* Ethereal */
-     , (49239,  14, True ) /* GravityStatus */
-     , (49239,  19, True ) /* Attackable */
      , (49239,  22, True ) /* Inscribable */
      , (49239,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49239,  39,     0.4) /* DefaultScale */
      , (49239, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49239,   1, 'Blistered Zombie Essence (200)') /* Name */
+VALUES (49239,   1, 'Blistered Zombie Essence') /* Name */
      , (49239,  14, 'Use this essence to summon or dismiss your Blistered Zombie.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49239 Blistered Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49239 Blistered Zombie Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49239,   1,        128) /* ItemType - Misc */
      , (49239,   5,         50) /* EncumbranceVal */
      , (49239,  16,          8) /* ItemUseable - Contained */
      , (49239,  18,        256) /* UiEffects - Acid */
-     , (49239,  19,       4000) /* Value */
+     , (49239,  19,      10000) /* Value */
      , (49239,  33,          0) /* Bonded - Normal */
      , (49239,  91,         50) /* MaxStructure */
      , (49239,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49246 Shocked Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49246 Shocked Zombie Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49246,   1,        128) /* ItemType - Misc */
      , (49246,   5,         50) /* EncumbranceVal */
      , (49246,  16,          8) /* ItemUseable - Contained */
      , (49246,  18,         64) /* UiEffects - Lightning */
-     , (49246,  19,       4000) /* Value */
+     , (49246,  19,      10000) /* Value */
      , (49246,  33,          0) /* Bonded - Normal */
      , (49246,  91,         50) /* MaxStructure */
      , (49246,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49246 Shocked Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49246 Shocked Zombie Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49246,   1,        128) /* ItemType - Misc */
      , (49246, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49246,   1, False) /* Stuck */
-     , (49246,  22, True ) /* Inscribable */
+VALUES (49246,  22, True ) /* Inscribable */
      , (49246,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49246 Shocked Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49246 Shocked Zombie Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49246;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49246, 'ace49246-shockedzombieessence200', 70, '2020-08-04 10:13:41') /* PetDevice */;
+VALUES (49246, 'ace49246-shockedzombieessence200', 70, '2020-10-11 10:13:41') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49246,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49246,   1,        128) /* ItemType - Misc */
      , (49246,  18,         64) /* UiEffects - Lightning */
      , (49246,  19,       4000) /* Value */
      , (49246,  33,          0) /* Bonded - Normal */
-     , (49246,  65,        101) /* Placement - Resting */
      , (49246,  91,         50) /* MaxStructure */
      , (49246,  92,         50) /* Structure */
      , (49246,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49246,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49246,   1, False) /* Stuck */
-     , (49246,  11, True ) /* IgnoreCollisions */
-     , (49246,  13, True ) /* Ethereal */
-     , (49246,  14, True ) /* GravityStatus */
-     , (49246,  19, True ) /* Attackable */
      , (49246,  22, True ) /* Inscribable */
      , (49246,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49246,  39,     0.4) /* DefaultScale */
      , (49246, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49246,   1, 'Shocked Zombie Essence (200)') /* Name */
+VALUES (49246,   1, 'Shocked Zombie Essence') /* Name */
      , (49246,  14, 'Use this essence to summon or dismiss your Shocked Zombie.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49253 Charred Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49253 Charred Zombie Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49253,   1,        128) /* ItemType - Misc */
      , (49253, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49253,   1, False) /* Stuck */
-     , (49253,  22, True ) /* Inscribable */
+VALUES (49253,  22, True ) /* Inscribable */
      , (49253,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49253 Charred Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49253 Charred Zombie Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49253,   1,        128) /* ItemType - Misc */
      , (49253,   5,         50) /* EncumbranceVal */
      , (49253,  16,          8) /* ItemUseable - Contained */
      , (49253,  18,         32) /* UiEffects - Fire */
-     , (49253,  19,       4000) /* Value */
+     , (49253,  19,      10000) /* Value */
      , (49253,  33,          0) /* Bonded - Normal */
      , (49253,  91,         50) /* MaxStructure */
      , (49253,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49253 Charred Zombie Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49253 Charred Zombie Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49253;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49253, 'ace49253-charredzombieessence200', 70, '2020-08-04 10:13:48') /* PetDevice */;
+VALUES (49253, 'ace49253-charredzombieessence200', 70, '2020-10-11 10:13:48') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49253,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49253,   1,        128) /* ItemType - Misc */
      , (49253,  18,         32) /* UiEffects - Fire */
      , (49253,  19,       4000) /* Value */
      , (49253,  33,          0) /* Bonded - Normal */
-     , (49253,  65,        101) /* Placement - Resting */
      , (49253,  91,         50) /* MaxStructure */
      , (49253,  92,         50) /* Structure */
      , (49253,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49253,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49253,   1, False) /* Stuck */
-     , (49253,  11, True ) /* IgnoreCollisions */
-     , (49253,  13, True ) /* Ethereal */
-     , (49253,  14, True ) /* GravityStatus */
-     , (49253,  19, True ) /* Attackable */
      , (49253,  22, True ) /* Inscribable */
      , (49253,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49253,  39,     0.4) /* DefaultScale */
      , (49253, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49253,   1, 'Charred Zombie Essence (200)') /* Name */
+VALUES (49253,   1, 'Charred Zombie Essence') /* Name */
      , (49253,  14, 'Use this essence to summon or dismiss your Charred Zombie.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49260 Glacial Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49260 Glacial Knight Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49260;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49260, 'ace49260-glacialknightessence200', 70, '2020-08-04 10:13:55') /* PetDevice */;
+VALUES (49260, 'ace49260-glacialknightessence200', 70, '2020-10-11 10:13:55') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49260,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49260,   1,        128) /* ItemType - Misc */
      , (49260,  18,        128) /* UiEffects - Frost */
      , (49260,  19,       4000) /* Value */
      , (49260,  33,          0) /* Bonded - Normal */
-     , (49260,  65,        101) /* Placement - Resting */
      , (49260,  91,         50) /* MaxStructure */
      , (49260,  92,         50) /* Structure */
      , (49260,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49260,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49260,   1, False) /* Stuck */
-     , (49260,  11, True ) /* IgnoreCollisions */
-     , (49260,  13, True ) /* Ethereal */
-     , (49260,  14, True ) /* GravityStatus */
-     , (49260,  19, True ) /* Attackable */
      , (49260,  22, True ) /* Inscribable */
      , (49260,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49260,  39,     0.4) /* DefaultScale */
      , (49260, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49260,   1, 'Glacial Knight Essence (200)') /* Name */
+VALUES (49260,   1, 'Glacial Knight Essence') /* Name */
      , (49260,  14, 'Use this essence to summon or dismiss your Glacial Knight.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49260 Glacial Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49260 Glacial Knight Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49260,   1,        128) /* ItemType - Misc */
      , (49260,   5,         50) /* EncumbranceVal */
      , (49260,  16,          8) /* ItemUseable - Contained */
      , (49260,  18,        128) /* UiEffects - Frost */
-     , (49260,  19,       4000) /* Value */
+     , (49260,  19,      10000) /* Value */
      , (49260,  33,          0) /* Bonded - Normal */
      , (49260,  91,         50) /* MaxStructure */
      , (49260,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49260 Glacial Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49260 Glacial Knight Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49260,   1,        128) /* ItemType - Misc */
      , (49260, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49260,   1, False) /* Stuck */
-     , (49260,  22, True ) /* Inscribable */
+VALUES (49260,  22, True ) /* Inscribable */
      , (49260,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49267 Caustic Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49267 Caustic Knight Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49267,   1,        128) /* ItemType - Misc */
      , (49267,   5,         50) /* EncumbranceVal */
      , (49267,  16,          8) /* ItemUseable - Contained */
      , (49267,  18,        256) /* UiEffects - Acid */
-     , (49267,  19,       4000) /* Value */
+     , (49267,  19,      10000) /* Value */
      , (49267,  33,          0) /* Bonded - Normal */
      , (49267,  91,         50) /* MaxStructure */
      , (49267,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49267 Caustic Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49267 Caustic Knight Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49267,   1,        128) /* ItemType - Misc */
      , (49267, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49267,   1, False) /* Stuck */
-     , (49267,  22, True ) /* Inscribable */
+VALUES (49267,  22, True ) /* Inscribable */
      , (49267,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49267 Caustic Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49267 Caustic Knight Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49267;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49267, 'ace49267-causticknightessence200', 70, '2020-08-04 10:14:03') /* PetDevice */;
+VALUES (49267, 'ace49267-causticknightessence200', 70, '2020-10-11 10:14:03') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49267,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49267,   1,        128) /* ItemType - Misc */
      , (49267,  18,        256) /* UiEffects - Acid */
      , (49267,  19,       4000) /* Value */
      , (49267,  33,          0) /* Bonded - Normal */
-     , (49267,  65,        101) /* Placement - Resting */
      , (49267,  91,         50) /* MaxStructure */
      , (49267,  92,         50) /* Structure */
      , (49267,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49267,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49267,   1, False) /* Stuck */
-     , (49267,  11, True ) /* IgnoreCollisions */
-     , (49267,  13, True ) /* Ethereal */
-     , (49267,  14, True ) /* GravityStatus */
-     , (49267,  19, True ) /* Attackable */
      , (49267,  22, True ) /* Inscribable */
      , (49267,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49267,  39,     0.4) /* DefaultScale */
      , (49267, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49267,   1, 'Caustic Knight Essence (200)') /* Name */
+VALUES (49267,   1, 'Caustic Knight Essence') /* Name */
      , (49267,  14, 'Use this essence to summon or dismiss your Caustic Knight.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49274 Galvanic Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49274 Galvanic Knight Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49274;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49274, 'ace49274-galvanicknightessence200', 70, '2020-08-04 10:14:10') /* PetDevice */;
+VALUES (49274, 'ace49274-galvanicknightessence200', 70, '2020-10-11 10:14:10') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49274,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49274,   1,        128) /* ItemType - Misc */
      , (49274,  18,         64) /* UiEffects - Lightning */
      , (49274,  19,       4000) /* Value */
      , (49274,  33,          0) /* Bonded - Normal */
-     , (49274,  65,        101) /* Placement - Resting */
      , (49274,  91,         50) /* MaxStructure */
      , (49274,  92,         50) /* Structure */
      , (49274,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49274,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49274,   1, False) /* Stuck */
-     , (49274,  11, True ) /* IgnoreCollisions */
-     , (49274,  13, True ) /* Ethereal */
-     , (49274,  14, True ) /* GravityStatus */
-     , (49274,  19, True ) /* Attackable */
      , (49274,  22, True ) /* Inscribable */
      , (49274,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49274,  39,     0.4) /* DefaultScale */
      , (49274, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49274,   1, 'Galvanic Knight Essence (200)') /* Name */
+VALUES (49274,   1, 'Galvanic Knight Essence') /* Name */
      , (49274,  14, 'Use this essence to summon or dismiss your Galvanic Knight.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49274 Galvanic Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49274 Galvanic Knight Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49274,   1,        128) /* ItemType - Misc */
      , (49274,   5,         50) /* EncumbranceVal */
      , (49274,  16,          8) /* ItemUseable - Contained */
      , (49274,  18,         64) /* UiEffects - Lightning */
-     , (49274,  19,       4000) /* Value */
+     , (49274,  19,      10000) /* Value */
      , (49274,  33,          0) /* Bonded - Normal */
      , (49274,  91,         50) /* MaxStructure */
      , (49274,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49274 Galvanic Knight Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49274 Galvanic Knight Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49274,   1,        128) /* ItemType - Misc */
      , (49274, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49274,   1, False) /* Stuck */
-     , (49274,  22, True ) /* Inscribable */
+VALUES (49274,  22, True ) /* Inscribable */
      , (49274,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49281 K'nath R'ajed Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49281 K'nath R'ajed Essence (200).sql
@@ -10,7 +10,6 @@ VALUES (49281,   1,        128) /* ItemType - Misc */
      , (49281,  18,        128) /* UiEffects - Frost */
      , (49281,  19,       4000) /* Value */
      , (49281,  33,          0) /* Bonded - Normal */
-     , (49281,  65,        101) /* Placement - Resting */
      , (49281,  91,         50) /* MaxStructure */
      , (49281,  92,         50) /* Structure */
      , (49281,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49281,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49281,   1, False) /* Stuck */
-     , (49281,  11, True ) /* IgnoreCollisions */
-     , (49281,  13, True ) /* Ethereal */
-     , (49281,  14, True ) /* GravityStatus */
-     , (49281,  19, True ) /* Attackable */
      , (49281,  22, True ) /* Inscribable */
      , (49281,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49281,  39,     0.4) /* DefaultScale */
      , (49281, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49281,   1, 'K''nath R''ajed Essence (200)') /* Name */
+VALUES (49281,   1, 'K''nath R''ajed Essence') /* Name */
      , (49281,  14, 'Use this essence to summon or dismiss your K''nath R''ajed.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49281 K'nath R'ajed Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49281 K'nath R'ajed Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49281,   1,        128) /* ItemType - Misc */
      , (49281,   5,         50) /* EncumbranceVal */
      , (49281,  16,          8) /* ItemUseable - Contained */
      , (49281,  18,        128) /* UiEffects - Frost */
-     , (49281,  19,       4000) /* Value */
+     , (49281,  19,      10000) /* Value */
      , (49281,  33,          0) /* Bonded - Normal */
      , (49281,  91,         50) /* MaxStructure */
      , (49281,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49281 K'nath R'ajed Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49281 K'nath R'ajed Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49281,   1,        128) /* ItemType - Misc */
      , (49281, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49281,   1, False) /* Stuck */
-     , (49281,  22, True ) /* Inscribable */
+VALUES (49281,  22, True ) /* Inscribable */
      , (49281,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49288 K'nath Y'nda Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49288 K'nath Y'nda Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49288,   1,        128) /* ItemType - Misc */
      , (49288,   5,         50) /* EncumbranceVal */
      , (49288,  16,          8) /* ItemUseable - Contained */
      , (49288,  18,        256) /* UiEffects - Acid */
-     , (49288,  19,       4000) /* Value */
+     , (49288,  19,      10000) /* Value */
      , (49288,  33,          0) /* Bonded - Normal */
      , (49288,  91,         50) /* MaxStructure */
      , (49288,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49288 K'nath Y'nda Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49288 K'nath Y'nda Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49288,   1,        128) /* ItemType - Misc */
      , (49288, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49288,   1, False) /* Stuck */
-     , (49288,  22, True ) /* Inscribable */
+VALUES (49288,  22, True ) /* Inscribable */
      , (49288,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49288 K'nath Y'nda Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49288 K'nath Y'nda Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49288;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49288, 'ace49288-knathyndaessence200', 70, '2020-08-04 10:14:57') /* PetDevice */;
+VALUES (49288, 'ace49288-knathyndaessence200', 70, '2020-10-11 10:14:57') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49288,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49288,   1,        128) /* ItemType - Misc */
      , (49288,  18,        256) /* UiEffects - Acid */
      , (49288,  19,       4000) /* Value */
      , (49288,  33,          0) /* Bonded - Normal */
-     , (49288,  65,        101) /* Placement - Resting */
      , (49288,  91,         50) /* MaxStructure */
      , (49288,  92,         50) /* Structure */
      , (49288,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49288,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49288,   1, False) /* Stuck */
-     , (49288,  11, True ) /* IgnoreCollisions */
-     , (49288,  13, True ) /* Ethereal */
-     , (49288,  14, True ) /* GravityStatus */
-     , (49288,  19, True ) /* Attackable */
      , (49288,  22, True ) /* Inscribable */
      , (49288,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49288,  39,     0.4) /* DefaultScale */
      , (49288, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49288,   1, 'K''nath Y''nda Essence (200)') /* Name */
+VALUES (49288,   1, 'K''nath Y''nda Essence') /* Name */
      , (49288,  14, 'Use this essence to summon or dismiss your K''nath Y''nda.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49295 K'nath T'soct Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49295 K'nath T'soct Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49295,   1,        128) /* ItemType - Misc */
      , (49295,   5,         50) /* EncumbranceVal */
      , (49295,  16,          8) /* ItemUseable - Contained */
      , (49295,  18,         64) /* UiEffects - Lightning */
-     , (49295,  19,       4000) /* Value */
+     , (49295,  19,      10000) /* Value */
      , (49295,  33,          0) /* Bonded - Normal */
      , (49295,  91,         50) /* MaxStructure */
      , (49295,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49295 K'nath T'soct Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49295 K'nath T'soct Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49295;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49295, 'ace49295-knathtsoctessence200', 70, '2020-08-04 10:15:16') /* PetDevice */;
+VALUES (49295, 'ace49295-knathtsoctessence200', 70, '2020-10-11 10:15:16') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49295,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49295,   1,        128) /* ItemType - Misc */
      , (49295,  18,         64) /* UiEffects - Lightning */
      , (49295,  19,       4000) /* Value */
      , (49295,  33,          0) /* Bonded - Normal */
-     , (49295,  65,        101) /* Placement - Resting */
      , (49295,  91,         50) /* MaxStructure */
      , (49295,  92,         50) /* Structure */
      , (49295,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49295,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49295,   1, False) /* Stuck */
-     , (49295,  11, True ) /* IgnoreCollisions */
-     , (49295,  13, True ) /* Ethereal */
-     , (49295,  14, True ) /* GravityStatus */
-     , (49295,  19, True ) /* Attackable */
      , (49295,  22, True ) /* Inscribable */
      , (49295,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49295,  39,     0.4) /* DefaultScale */
      , (49295, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49295,   1, 'K''nath T''soct Essence (200)') /* Name */
+VALUES (49295,   1, 'K''nath T''soct Essence') /* Name */
      , (49295,  14, 'Use this essence to summon or dismiss your K''nath T''soct.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49295 K'nath T'soct Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49295 K'nath T'soct Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49295,   1,        128) /* ItemType - Misc */
      , (49295, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49295,   1, False) /* Stuck */
-     , (49295,  22, True ) /* Inscribable */
+VALUES (49295,  22, True ) /* Inscribable */
      , (49295,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49302 K'nath B'orret Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49302 K'nath B'orret Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49302,   1,        128) /* ItemType - Misc */
      , (49302, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49302,   1, False) /* Stuck */
-     , (49302,  22, True ) /* Inscribable */
+VALUES (49302,  22, True ) /* Inscribable */
      , (49302,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49302 K'nath B'orret Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49302 K'nath B'orret Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49302,   1,        128) /* ItemType - Misc */
      , (49302,   5,         50) /* EncumbranceVal */
      , (49302,  16,          8) /* ItemUseable - Contained */
      , (49302,  18,         32) /* UiEffects - Fire */
-     , (49302,  19,       4000) /* Value */
+     , (49302,  19,      10000) /* Value */
      , (49302,  33,          0) /* Bonded - Normal */
      , (49302,  91,         50) /* MaxStructure */
      , (49302,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49302 K'nath B'orret Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49302 K'nath B'orret Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49302;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49302, 'ace49302-knathborretessence200', 70, '2020-08-04 10:15:36') /* PetDevice */;
+VALUES (49302, 'ace49302-knathborretessence200', 70, '2020-10-11 10:15:36') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49302,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49302,   1,        128) /* ItemType - Misc */
      , (49302,  18,         32) /* UiEffects - Fire */
      , (49302,  19,       4000) /* Value */
      , (49302,  33,          0) /* Bonded - Normal */
-     , (49302,  65,        101) /* Placement - Resting */
      , (49302,  91,         50) /* MaxStructure */
      , (49302,  92,         50) /* Structure */
      , (49302,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49302,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49302,   1, False) /* Stuck */
-     , (49302,  11, True ) /* IgnoreCollisions */
-     , (49302,  13, True ) /* Ethereal */
-     , (49302,  14, True ) /* GravityStatus */
-     , (49302,  19, True ) /* Attackable */
      , (49302,  22, True ) /* Inscribable */
      , (49302,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49302,  39,     0.4) /* DefaultScale */
      , (49302, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49302,   1, 'K''nath B''orret Essence (200)') /* Name */
+VALUES (49302,   1, 'K''nath B''orret Essence') /* Name */
      , (49302,  14, 'Use this essence to summon or dismiss your K''nath B''orret.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49309 Blizzard Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49309 Blizzard Wisp Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49309,   1,        128) /* ItemType - Misc */
      , (49309,   5,         50) /* EncumbranceVal */
      , (49309,  16,          8) /* ItemUseable - Contained */
      , (49309,  18,        128) /* UiEffects - Frost */
-     , (49309,  19,       4000) /* Value */
+     , (49309,  19,      10000) /* Value */
      , (49309,  33,          0) /* Bonded - Normal */
      , (49309,  91,         50) /* MaxStructure */
      , (49309,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49309 Blizzard Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49309 Blizzard Wisp Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49309,   1,        128) /* ItemType - Misc */
      , (49309, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49309,   1, False) /* Stuck */
-     , (49309,  22, True ) /* Inscribable */
+VALUES (49309,  22, True ) /* Inscribable */
      , (49309,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49309 Blizzard Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49309 Blizzard Wisp Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49309;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49309, 'ace49309-blizzardwispessence200', 70, '2020-08-04 10:15:47') /* PetDevice */;
+VALUES (49309, 'ace49309-blizzardwispessence200', 70, '2020-10-11 10:15:47') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49309,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49309,   1,        128) /* ItemType - Misc */
      , (49309,  18,        128) /* UiEffects - Frost */
      , (49309,  19,       4000) /* Value */
      , (49309,  33,          0) /* Bonded - Normal */
-     , (49309,  65,        101) /* Placement - Resting */
      , (49309,  91,         50) /* MaxStructure */
      , (49309,  92,         50) /* Structure */
      , (49309,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49309,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49309,   1, False) /* Stuck */
-     , (49309,  11, True ) /* IgnoreCollisions */
-     , (49309,  13, True ) /* Ethereal */
-     , (49309,  14, True ) /* GravityStatus */
-     , (49309,  19, True ) /* Attackable */
      , (49309,  22, True ) /* Inscribable */
      , (49309,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49309,  39,     0.4) /* DefaultScale */
      , (49309, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49309,   1, 'Blizzard Wisp Essence (200)') /* Name */
+VALUES (49309,   1, 'Blizzard Wisp Essence') /* Name */
      , (49309,  14, 'Use this essence to summon or dismiss your Blizzard Wisp.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49316 Corrosion Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49316 Corrosion Wisp Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49316,   1,        128) /* ItemType - Misc */
      , (49316,   5,         50) /* EncumbranceVal */
      , (49316,  16,          8) /* ItemUseable - Contained */
      , (49316,  18,        256) /* UiEffects - Acid */
-     , (49316,  19,       4000) /* Value */
+     , (49316,  19,      10000) /* Value */
      , (49316,  33,          0) /* Bonded - Normal */
      , (49316,  91,         50) /* MaxStructure */
      , (49316,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49316 Corrosion Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49316 Corrosion Wisp Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49316;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49316, 'ace49316-corrosionwispessence200', 70, '2020-08-04 10:15:55') /* PetDevice */;
+VALUES (49316, 'ace49316-corrosionwispessence200', 70, '2020-10-11 10:15:55') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49316,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49316,   1,        128) /* ItemType - Misc */
      , (49316,  18,        256) /* UiEffects - Acid */
      , (49316,  19,       4000) /* Value */
      , (49316,  33,          0) /* Bonded - Normal */
-     , (49316,  65,        101) /* Placement - Resting */
      , (49316,  91,         50) /* MaxStructure */
      , (49316,  92,         50) /* Structure */
      , (49316,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49316,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49316,   1, False) /* Stuck */
-     , (49316,  11, True ) /* IgnoreCollisions */
-     , (49316,  13, True ) /* Ethereal */
-     , (49316,  14, True ) /* GravityStatus */
-     , (49316,  19, True ) /* Attackable */
      , (49316,  22, True ) /* Inscribable */
      , (49316,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49316,  39,     0.4) /* DefaultScale */
      , (49316, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49316,   1, 'Corrosion Wisp Essence (200)') /* Name */
+VALUES (49316,   1, 'Corrosion Wisp Essence') /* Name */
      , (49316,  14, 'Use this essence to summon or dismiss your Corrosion Wisp.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49316 Corrosion Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49316 Corrosion Wisp Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49316,   1,        128) /* ItemType - Misc */
      , (49316, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49316,   1, False) /* Stuck */
-     , (49316,  22, True ) /* Inscribable */
+VALUES (49316,  22, True ) /* Inscribable */
      , (49316,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49323 Voltiac Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49323 Voltiac Wisp Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49323,   1,        128) /* ItemType - Misc */
      , (49323,   5,         50) /* EncumbranceVal */
      , (49323,  16,          8) /* ItemUseable - Contained */
      , (49323,  18,         64) /* UiEffects - Lightning */
-     , (49323,  19,       4000) /* Value */
+     , (49323,  19,      10000) /* Value */
      , (49323,  33,          0) /* Bonded - Normal */
      , (49323,  91,         50) /* MaxStructure */
      , (49323,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49323 Voltiac Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49323 Voltiac Wisp Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49323;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49323, 'ace49323-voltiacwispessence200', 70, '2020-08-04 10:16:04') /* PetDevice */;
+VALUES (49323, 'ace49323-voltiacwispessence200', 70, '2020-10-11 10:16:04') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49323,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49323,   1,        128) /* ItemType - Misc */
      , (49323,  18,         64) /* UiEffects - Lightning */
      , (49323,  19,       4000) /* Value */
      , (49323,  33,          0) /* Bonded - Normal */
-     , (49323,  65,        101) /* Placement - Resting */
      , (49323,  91,         50) /* MaxStructure */
      , (49323,  92,         50) /* Structure */
      , (49323,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49323,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49323,   1, False) /* Stuck */
-     , (49323,  11, True ) /* IgnoreCollisions */
-     , (49323,  13, True ) /* Ethereal */
-     , (49323,  14, True ) /* GravityStatus */
-     , (49323,  19, True ) /* Attackable */
      , (49323,  22, True ) /* Inscribable */
      , (49323,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49323,  39,     0.4) /* DefaultScale */
      , (49323, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49323,   1, 'Voltiac Wisp Essence (200)') /* Name */
+VALUES (49323,   1, 'Voltiac Wisp Essence') /* Name */
      , (49323,  14, 'Use this essence to summon or dismiss your Voltiac Wisp.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49323 Voltiac Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49323 Voltiac Wisp Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49323,   1,        128) /* ItemType - Misc */
      , (49323, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49323,   1, False) /* Stuck */
-     , (49323,  22, True ) /* Inscribable */
+VALUES (49323,  22, True ) /* Inscribable */
      , (49323,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49330 Incendiary Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49330 Incendiary Wisp Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49330;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49330, 'ace49330-incendiarywispessence200', 70, '2020-08-04 10:16:13') /* PetDevice */;
+VALUES (49330, 'ace49330-incendiarywispessence200', 70, '2020-10-11 10:16:13') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49330,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49330,   1,        128) /* ItemType - Misc */
      , (49330,  18,         32) /* UiEffects - Fire */
      , (49330,  19,       4000) /* Value */
      , (49330,  33,          0) /* Bonded - Normal */
-     , (49330,  65,        101) /* Placement - Resting */
      , (49330,  91,         50) /* MaxStructure */
      , (49330,  92,         50) /* Structure */
      , (49330,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49330,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49330,   1, False) /* Stuck */
-     , (49330,  11, True ) /* IgnoreCollisions */
-     , (49330,  13, True ) /* Ethereal */
-     , (49330,  14, True ) /* GravityStatus */
-     , (49330,  19, True ) /* Attackable */
      , (49330,  22, True ) /* Inscribable */
      , (49330,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49330,  39,     0.4) /* DefaultScale */
      , (49330, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49330,   1, 'Incendiary Wisp Essence (200)') /* Name */
+VALUES (49330,   1, 'Incendiary Wisp Essence') /* Name */
      , (49330,  14, 'Use this essence to summon or dismiss your Incendiary Wisp.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49330 Incendiary Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49330 Incendiary Wisp Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49330,   1,        128) /* ItemType - Misc */
      , (49330, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49330,   1, False) /* Stuck */
-     , (49330,  22, True ) /* Inscribable */
+VALUES (49330,  22, True ) /* Inscribable */
      , (49330,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49330 Incendiary Wisp Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49330 Incendiary Wisp Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49330,   1,        128) /* ItemType - Misc */
      , (49330,   5,         50) /* EncumbranceVal */
      , (49330,  16,          8) /* ItemUseable - Contained */
      , (49330,  18,         32) /* UiEffects - Fire */
-     , (49330,  19,       4000) /* Value */
+     , (49330,  19,      10000) /* Value */
      , (49330,  33,          0) /* Bonded - Normal */
      , (49330,  91,         50) /* MaxStructure */
      , (49330,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49337 Freezing Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49337 Freezing Moar Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49337;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49337, 'ace49337-freezingmoaressence200', 70, '2020-08-04 10:16:22') /* PetDevice */;
+VALUES (49337, 'ace49337-freezingmoaressence200', 70, '2020-10-11 10:16:22') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49337,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49337,   1,        128) /* ItemType - Misc */
      , (49337,  18,        128) /* UiEffects - Frost */
      , (49337,  19,       4000) /* Value */
      , (49337,  33,          0) /* Bonded - Normal */
-     , (49337,  65,        101) /* Placement - Resting */
      , (49337,  91,         50) /* MaxStructure */
      , (49337,  92,         50) /* Structure */
      , (49337,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49337,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49337,   1, False) /* Stuck */
-     , (49337,  11, True ) /* IgnoreCollisions */
-     , (49337,  13, True ) /* Ethereal */
-     , (49337,  14, True ) /* GravityStatus */
-     , (49337,  19, True ) /* Attackable */
      , (49337,  22, True ) /* Inscribable */
      , (49337,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49337,  39,     0.4) /* DefaultScale */
      , (49337, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49337,   1, 'Freezing Moar Essence (200)') /* Name */
+VALUES (49337,   1, 'Freezing Moar Essence') /* Name */
      , (49337,  14, 'Use this essence to summon or dismiss your Freezing Moar.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49337 Freezing Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49337 Freezing Moar Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49337,   1,        128) /* ItemType - Misc */
      , (49337, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49337,   1, False) /* Stuck */
-     , (49337,  22, True ) /* Inscribable */
+VALUES (49337,  22, True ) /* Inscribable */
      , (49337,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49337 Freezing Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49337 Freezing Moar Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49337,   1,        128) /* ItemType - Misc */
      , (49337,   5,         50) /* EncumbranceVal */
      , (49337,  16,          8) /* ItemUseable - Contained */
      , (49337,  18,        128) /* UiEffects - Frost */
-     , (49337,  19,       4000) /* Value */
+     , (49337,  19,      10000) /* Value */
      , (49337,  33,          0) /* Bonded - Normal */
      , (49337,  91,         50) /* MaxStructure */
      , (49337,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49344 Blistering Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49344 Blistering Moar Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49344;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49344, 'ace49344-blisteringmoaressence200', 70, '2020-08-04 10:16:31') /* PetDevice */;
+VALUES (49344, 'ace49344-blisteringmoaressence200', 70, '2020-10-11 10:16:31') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49344,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49344,   1,        128) /* ItemType - Misc */
      , (49344,  18,        256) /* UiEffects - Acid */
      , (49344,  19,       4000) /* Value */
      , (49344,  33,          0) /* Bonded - Normal */
-     , (49344,  65,        101) /* Placement - Resting */
      , (49344,  91,         50) /* MaxStructure */
      , (49344,  92,         50) /* Structure */
      , (49344,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49344,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49344,   1, False) /* Stuck */
-     , (49344,  11, True ) /* IgnoreCollisions */
-     , (49344,  13, True ) /* Ethereal */
-     , (49344,  14, True ) /* GravityStatus */
-     , (49344,  19, True ) /* Attackable */
      , (49344,  22, True ) /* Inscribable */
      , (49344,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49344,  39,     0.4) /* DefaultScale */
      , (49344, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49344,   1, 'Blistering Moar Essence (200)') /* Name */
+VALUES (49344,   1, 'Blistering Moar Essence') /* Name */
      , (49344,  14, 'Use this essence to summon or dismiss your Blistering Moar.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49344 Blistering Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49344 Blistering Moar Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49344,   1,        128) /* ItemType - Misc */
      , (49344,   5,         50) /* EncumbranceVal */
      , (49344,  16,          8) /* ItemUseable - Contained */
      , (49344,  18,        256) /* UiEffects - Acid */
-     , (49344,  19,       4000) /* Value */
+     , (49344,  19,      10000) /* Value */
      , (49344,  33,          0) /* Bonded - Normal */
      , (49344,  91,         50) /* MaxStructure */
      , (49344,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49344 Blistering Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49344 Blistering Moar Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49344,   1,        128) /* ItemType - Misc */
      , (49344, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49344,   1, False) /* Stuck */
-     , (49344,  22, True ) /* Inscribable */
+VALUES (49344,  22, True ) /* Inscribable */
      , (49344,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49351 Electrified Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49351 Electrified Moar Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49351,   1,        128) /* ItemType - Misc */
      , (49351, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49351,   1, False) /* Stuck */
-     , (49351,  22, True ) /* Inscribable */
+VALUES (49351,  22, True ) /* Inscribable */
      , (49351,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49351 Electrified Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49351 Electrified Moar Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49351;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49351, 'ace49351-electrifiedmoaressence200', 70, '2020-08-04 10:16:39') /* PetDevice */;
+VALUES (49351, 'ace49351-electrifiedmoaressence200', 70, '2020-10-11 10:16:39') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49351,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49351,   1,        128) /* ItemType - Misc */
      , (49351,  18,         64) /* UiEffects - Lightning */
      , (49351,  19,       4000) /* Value */
      , (49351,  33,          0) /* Bonded - Normal */
-     , (49351,  65,        101) /* Placement - Resting */
      , (49351,  91,         50) /* MaxStructure */
      , (49351,  92,         50) /* Structure */
      , (49351,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49351,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49351,   1, False) /* Stuck */
-     , (49351,  11, True ) /* IgnoreCollisions */
-     , (49351,  13, True ) /* Ethereal */
-     , (49351,  14, True ) /* GravityStatus */
-     , (49351,  19, True ) /* Attackable */
      , (49351,  22, True ) /* Inscribable */
      , (49351,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49351,  39,     0.4) /* DefaultScale */
      , (49351, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49351,   1, 'Electrified Moar Essence (200)') /* Name */
+VALUES (49351,   1, 'Electrified Moar Essence') /* Name */
      , (49351,  14, 'Use this essence to summon or dismiss your Electrified Moar.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49351 Electrified Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49351 Electrified Moar Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49351,   1,        128) /* ItemType - Misc */
      , (49351,   5,         50) /* EncumbranceVal */
      , (49351,  16,          8) /* ItemUseable - Contained */
      , (49351,  18,         64) /* UiEffects - Lightning */
-     , (49351,  19,       4000) /* Value */
+     , (49351,  19,      10000) /* Value */
      , (49351,  33,          0) /* Bonded - Normal */
      , (49351,  91,         50) /* MaxStructure */
      , (49351,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49358 Volcanic Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49358 Volcanic Moar Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49358;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49358, 'ace49358-volcanicmoaressence200', 70, '2020-08-04 10:16:47') /* PetDevice */;
+VALUES (49358, 'ace49358-volcanicmoaressence200', 70, '2020-10-11 10:16:47') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49358,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49358,   1,        128) /* ItemType - Misc */
      , (49358,  18,         32) /* UiEffects - Fire */
      , (49358,  19,       4000) /* Value */
      , (49358,  33,          0) /* Bonded - Normal */
-     , (49358,  65,        101) /* Placement - Resting */
      , (49358,  91,         50) /* MaxStructure */
      , (49358,  92,         50) /* Structure */
      , (49358,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49358,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49358,   1, False) /* Stuck */
-     , (49358,  11, True ) /* IgnoreCollisions */
-     , (49358,  13, True ) /* Ethereal */
-     , (49358,  14, True ) /* GravityStatus */
-     , (49358,  19, True ) /* Attackable */
      , (49358,  22, True ) /* Inscribable */
      , (49358,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49358,  39,     0.4) /* DefaultScale */
      , (49358, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49358,   1, 'Volcanic Moar Essence (200)') /* Name */
+VALUES (49358,   1, 'Volcanic Moar Essence') /* Name */
      , (49358,  14, 'Use this essence to summon or dismiss your Volcanic Moar.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49358 Volcanic Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49358 Volcanic Moar Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49358,   1,        128) /* ItemType - Misc */
      , (49358,   5,         50) /* EncumbranceVal */
      , (49358,  16,          8) /* ItemUseable - Contained */
      , (49358,  18,         32) /* UiEffects - Fire */
-     , (49358,  19,       4000) /* Value */
+     , (49358,  19,      10000) /* Value */
      , (49358,  33,          0) /* Bonded - Normal */
      , (49358,  91,         50) /* MaxStructure */
      , (49358,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49358 Volcanic Moar Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49358 Volcanic Moar Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49358,   1,        128) /* ItemType - Misc */
      , (49358, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49358,   1, False) /* Stuck */
-     , (49358,  22, True ) /* Inscribable */
+VALUES (49358,  22, True ) /* Inscribable */
      , (49358,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49365 Arctic Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49365 Arctic Grievver Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49365,   1,        128) /* ItemType - Misc */
      , (49365,   5,         50) /* EncumbranceVal */
      , (49365,  16,          8) /* ItemUseable - Contained */
      , (49365,  18,        128) /* UiEffects - Frost */
-     , (49365,  19,       4000) /* Value */
+     , (49365,  19,      10000) /* Value */
      , (49365,  33,          0) /* Bonded - Normal */
      , (49365,  91,         50) /* MaxStructure */
      , (49365,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49365 Arctic Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49365 Arctic Grievver Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49365;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49365, 'ace49365-arcticgrievveressence200', 70, '2020-08-04 10:17:20') /* PetDevice */;
+VALUES (49365, 'ace49365-arcticgrievveressence200', 70, '2020-10-11 10:17:20') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49365,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49365,   1,        128) /* ItemType - Misc */
      , (49365,  18,        128) /* UiEffects - Frost */
      , (49365,  19,       4000) /* Value */
      , (49365,  33,          0) /* Bonded - Normal */
-     , (49365,  65,        101) /* Placement - Resting */
      , (49365,  91,         50) /* MaxStructure */
      , (49365,  92,         50) /* Structure */
      , (49365,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49365,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49365,   1, False) /* Stuck */
-     , (49365,  11, True ) /* IgnoreCollisions */
-     , (49365,  13, True ) /* Ethereal */
-     , (49365,  14, True ) /* GravityStatus */
-     , (49365,  19, True ) /* Attackable */
      , (49365,  22, True ) /* Inscribable */
      , (49365,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49365,  39,     0.4) /* DefaultScale */
      , (49365, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49365,   1, 'Arctic Grievver Essence (200)') /* Name */
+VALUES (49365,   1, 'Arctic Grievver Essence') /* Name */
      , (49365,  14, 'Use this essence to summon or dismiss your Arctic Grievver.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49365 Arctic Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49365 Arctic Grievver Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49365,   1,        128) /* ItemType - Misc */
      , (49365, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49365,   1, False) /* Stuck */
-     , (49365,  22, True ) /* Inscribable */
+VALUES (49365,  22, True ) /* Inscribable */
      , (49365,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49372 Caustic Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49372 Caustic Grievver Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49372;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49372, 'ace49372-causticgrievveressence200', 70, '2020-08-04 10:16:54') /* PetDevice */;
+VALUES (49372, 'ace49372-causticgrievveressence200', 70, '2020-10-11 10:16:54') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49372,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49372,   1,        128) /* ItemType - Misc */
      , (49372,  18,        256) /* UiEffects - Acid */
      , (49372,  19,       4000) /* Value */
      , (49372,  33,          0) /* Bonded - Normal */
-     , (49372,  65,        101) /* Placement - Resting */
      , (49372,  91,         50) /* MaxStructure */
      , (49372,  92,         50) /* Structure */
      , (49372,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49372,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49372,   1, False) /* Stuck */
-     , (49372,  11, True ) /* IgnoreCollisions */
-     , (49372,  13, True ) /* Ethereal */
-     , (49372,  14, True ) /* GravityStatus */
-     , (49372,  19, True ) /* Attackable */
      , (49372,  22, True ) /* Inscribable */
      , (49372,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49372,  39,     0.4) /* DefaultScale */
      , (49372, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49372,   1, 'Caustic Grievver Essence (200)') /* Name */
+VALUES (49372,   1, 'Caustic Grievver Essence') /* Name */
      , (49372,  14, 'Use this essence to summon or dismiss your Caustic Grievver.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49372 Caustic Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49372 Caustic Grievver Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49372,   1,        128) /* ItemType - Misc */
      , (49372, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49372,   1, False) /* Stuck */
-     , (49372,  22, True ) /* Inscribable */
+VALUES (49372,  22, True ) /* Inscribable */
      , (49372,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49372 Caustic Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49372 Caustic Grievver Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49372,   1,        128) /* ItemType - Misc */
      , (49372,   5,         50) /* EncumbranceVal */
      , (49372,  16,          8) /* ItemUseable - Contained */
      , (49372,  18,        256) /* UiEffects - Acid */
-     , (49372,  19,       4000) /* Value */
+     , (49372,  19,      10000) /* Value */
      , (49372,  33,          0) /* Bonded - Normal */
      , (49372,  91,         50) /* MaxStructure */
      , (49372,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49379 Excited Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49379 Excited Grievver Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49379,   1,        128) /* ItemType - Misc */
      , (49379, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49379,   1, False) /* Stuck */
-     , (49379,  22, True ) /* Inscribable */
+VALUES (49379,  22, True ) /* Inscribable */
      , (49379,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49379 Excited Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49379 Excited Grievver Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49379;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49379, 'ace49379-excitedgrievveressence200', 70, '2020-08-04 10:17:02') /* PetDevice */;
+VALUES (49379, 'ace49379-excitedgrievveressence200', 70, '2020-10-11 10:17:02') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49379,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49379,   1,        128) /* ItemType - Misc */
      , (49379,  18,         64) /* UiEffects - Lightning */
      , (49379,  19,       4000) /* Value */
      , (49379,  33,          0) /* Bonded - Normal */
-     , (49379,  65,        101) /* Placement - Resting */
      , (49379,  91,         50) /* MaxStructure */
      , (49379,  92,         50) /* Structure */
      , (49379,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49379,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49379,   1, False) /* Stuck */
-     , (49379,  11, True ) /* IgnoreCollisions */
-     , (49379,  13, True ) /* Ethereal */
-     , (49379,  14, True ) /* GravityStatus */
-     , (49379,  19, True ) /* Attackable */
      , (49379,  22, True ) /* Inscribable */
      , (49379,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49379,  39,     0.4) /* DefaultScale */
      , (49379, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49379,   1, 'Excited Grievver Essence (200)') /* Name */
+VALUES (49379,   1, 'Excited Grievver Essence') /* Name */
      , (49379,  14, 'Use this essence to summon or dismiss your Excited Grievver.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49379 Excited Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49379 Excited Grievver Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49379,   1,        128) /* ItemType - Misc */
      , (49379,   5,         50) /* EncumbranceVal */
      , (49379,  16,          8) /* ItemUseable - Contained */
      , (49379,  18,         64) /* UiEffects - Lightning */
-     , (49379,  19,       4000) /* Value */
+     , (49379,  19,      10000) /* Value */
      , (49379,  33,          0) /* Bonded - Normal */
      , (49379,  91,         50) /* MaxStructure */
      , (49379,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49386 Scorched Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49386 Scorched Grievver Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49386,   1,        128) /* ItemType - Misc */
      , (49386, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49386,   1, False) /* Stuck */
-     , (49386,  22, True ) /* Inscribable */
+VALUES (49386,  22, True ) /* Inscribable */
      , (49386,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49386 Scorched Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49386 Scorched Grievver Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49386;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49386, 'ace49386-scorchedgrievveressence200', 70, '2020-08-04 10:17:09') /* PetDevice */;
+VALUES (49386, 'ace49386-scorchedgrievveressence200', 70, '2020-10-11 10:17:09') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49386,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49386,   1,        128) /* ItemType - Misc */
      , (49386,  18,         32) /* UiEffects - Fire */
      , (49386,  19,       4000) /* Value */
      , (49386,  33,          0) /* Bonded - Normal */
-     , (49386,  65,        101) /* Placement - Resting */
      , (49386,  91,         50) /* MaxStructure */
      , (49386,  92,         50) /* Structure */
      , (49386,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49386,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49386,   1, False) /* Stuck */
-     , (49386,  11, True ) /* IgnoreCollisions */
-     , (49386,  13, True ) /* Ethereal */
-     , (49386,  14, True ) /* GravityStatus */
-     , (49386,  19, True ) /* Attackable */
      , (49386,  22, True ) /* Inscribable */
      , (49386,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49386,  39,     0.4) /* DefaultScale */
      , (49386, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49386,   1, 'Scorched Grievver Essence (200)') /* Name */
+VALUES (49386,   1, 'Scorched Grievver Essence') /* Name */
      , (49386,  14, 'Use this essence to summon or dismiss your Scorched Grievver.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49386 Scorched Grievver Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49386 Scorched Grievver Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49386,   1,        128) /* ItemType - Misc */
      , (49386,   5,         50) /* EncumbranceVal */
      , (49386,  16,          8) /* ItemUseable - Contained */
      , (49386,  18,         32) /* UiEffects - Fire */
-     , (49386,  19,       4000) /* Value */
+     , (49386,  19,      10000) /* Value */
      , (49386,  33,          0) /* Bonded - Normal */
      , (49386,  91,         50) /* MaxStructure */
      , (49386,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49427 Acid Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49427 Acid Maiden Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49427,   1,        128) /* ItemType - Misc */
      , (49427, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49427,   1, False) /* Stuck */
-     , (49427,  22, True ) /* Inscribable */
+VALUES (49427,  22, True ) /* Inscribable */
      , (49427,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49427 Acid Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49427 Acid Maiden Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49427,   1,        128) /* ItemType - Misc */
      , (49427,   5,         50) /* EncumbranceVal */
      , (49427,  16,          8) /* ItemUseable - Contained */
      , (49427,  18,        256) /* UiEffects - Acid */
-     , (49427,  19,       4000) /* Value */
+     , (49427,  19,      10000) /* Value */
      , (49427,  33,          0) /* Bonded - Normal */
      , (49427,  91,         50) /* MaxStructure */
      , (49427,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49427 Acid Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49427 Acid Maiden Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49427;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49427, 'ace49427-acidmaidenessence200', 70, '2020-08-04 10:17:30') /* PetDevice */;
+VALUES (49427, 'ace49427-acidmaidenessence200', 70, '2020-10-11 10:17:30') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49427,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49427,   1,        128) /* ItemType - Misc */
      , (49427,  18,        256) /* UiEffects - Acid */
      , (49427,  19,       4000) /* Value */
      , (49427,  33,          0) /* Bonded - Normal */
-     , (49427,  65,        101) /* Placement - Resting */
      , (49427,  91,         50) /* MaxStructure */
      , (49427,  92,         50) /* Structure */
      , (49427,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49427,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49427,   1, False) /* Stuck */
-     , (49427,  11, True ) /* IgnoreCollisions */
-     , (49427,  13, True ) /* Ethereal */
-     , (49427,  14, True ) /* GravityStatus */
-     , (49427,  19, True ) /* Attackable */
      , (49427,  22, True ) /* Inscribable */
      , (49427,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49427,  39,     0.4) /* DefaultScale */
      , (49427, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49427,   1, 'Acid Maiden Essence (200)') /* Name */
+VALUES (49427,   1, 'Acid Maiden Essence') /* Name */
      , (49427,  14, 'Use this essence to summon or dismiss your Acid Maiden.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49434 Lightning Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49434 Lightning Maiden Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49434,   1,        128) /* ItemType - Misc */
      , (49434,   5,         50) /* EncumbranceVal */
      , (49434,  16,          8) /* ItemUseable - Contained */
      , (49434,  18,         64) /* UiEffects - Lightning */
-     , (49434,  19,       4000) /* Value */
+     , (49434,  19,      10000) /* Value */
      , (49434,  33,          0) /* Bonded - Normal */
      , (49434,  91,         50) /* MaxStructure */
      , (49434,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49434 Lightning Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49434 Lightning Maiden Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49434,   1,        128) /* ItemType - Misc */
      , (49434, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49434,   1, False) /* Stuck */
-     , (49434,  22, True ) /* Inscribable */
+VALUES (49434,  22, True ) /* Inscribable */
      , (49434,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49434 Lightning Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49434 Lightning Maiden Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49434;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49434, 'ace49434-lightningmaidenessence200', 70, '2020-08-04 10:17:40') /* PetDevice */;
+VALUES (49434, 'ace49434-lightningmaidenessence200', 70, '2020-10-11 10:17:40') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49434,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49434,   1,        128) /* ItemType - Misc */
      , (49434,  18,         64) /* UiEffects - Lightning */
      , (49434,  19,       4000) /* Value */
      , (49434,  33,          0) /* Bonded - Normal */
-     , (49434,  65,        101) /* Placement - Resting */
      , (49434,  91,         50) /* MaxStructure */
      , (49434,  92,         50) /* Structure */
      , (49434,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49434,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49434,   1, False) /* Stuck */
-     , (49434,  11, True ) /* IgnoreCollisions */
-     , (49434,  13, True ) /* Ethereal */
-     , (49434,  14, True ) /* GravityStatus */
-     , (49434,  19, True ) /* Attackable */
      , (49434,  22, True ) /* Inscribable */
      , (49434,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49434,  39,     0.4) /* DefaultScale */
      , (49434, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49434,   1, 'Lightning Maiden Essence (200)') /* Name */
+VALUES (49434,   1, 'Lightning Maiden Essence') /* Name */
      , (49434,  14, 'Use this essence to summon or dismiss your Lightning Maiden.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49441 Fire Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49441 Fire Maiden Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49441;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49441, 'ace49441-firemaidenessence200', 70, '2020-08-04 10:17:49') /* PetDevice */;
+VALUES (49441, 'ace49441-firemaidenessence200', 70, '2020-10-11 10:17:49') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49441,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49441,   1,        128) /* ItemType - Misc */
      , (49441,  18,         32) /* UiEffects - Fire */
      , (49441,  19,       4000) /* Value */
      , (49441,  33,          0) /* Bonded - Normal */
-     , (49441,  65,        101) /* Placement - Resting */
      , (49441,  91,         50) /* MaxStructure */
      , (49441,  92,         50) /* Structure */
      , (49441,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49441,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49441,   1, False) /* Stuck */
-     , (49441,  11, True ) /* IgnoreCollisions */
-     , (49441,  13, True ) /* Ethereal */
-     , (49441,  14, True ) /* GravityStatus */
-     , (49441,  19, True ) /* Attackable */
      , (49441,  22, True ) /* Inscribable */
      , (49441,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49441,  39,     0.4) /* DefaultScale */
      , (49441, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49441,   1, 'Fire Maiden Essence (200)') /* Name */
+VALUES (49441,   1, 'Fire Maiden Essence') /* Name */
      , (49441,  14, 'Use this essence to summon or dismiss your Fire Maiden.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49441 Fire Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49441 Fire Maiden Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49441,   1,        128) /* ItemType - Misc */
      , (49441, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49441,   1, False) /* Stuck */
-     , (49441,  22, True ) /* Inscribable */
+VALUES (49441,  22, True ) /* Inscribable */
      , (49441,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49441 Fire Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49441 Fire Maiden Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49441,   1,        128) /* ItemType - Misc */
      , (49441,   5,         50) /* EncumbranceVal */
      , (49441,  16,          8) /* ItemUseable - Contained */
      , (49441,  18,         32) /* UiEffects - Fire */
-     , (49441,  19,       4000) /* Value */
+     , (49441,  19,      10000) /* Value */
      , (49441,  33,          0) /* Bonded - Normal */
      , (49441,  91,         50) /* MaxStructure */
      , (49441,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49448 Frost Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49448 Frost Maiden Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49448,   1,        128) /* ItemType - Misc */
      , (49448,   5,         50) /* EncumbranceVal */
      , (49448,  16,          8) /* ItemUseable - Contained */
      , (49448,  18,        128) /* UiEffects - Frost */
-     , (49448,  19,       4000) /* Value */
+     , (49448,  19,      10000) /* Value */
      , (49448,  33,          0) /* Bonded - Normal */
      , (49448,  91,         50) /* MaxStructure */
      , (49448,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49448 Frost Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49448 Frost Maiden Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49448,   1,        128) /* ItemType - Misc */
      , (49448, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49448,   1, False) /* Stuck */
-     , (49448,  22, True ) /* Inscribable */
+VALUES (49448,  22, True ) /* Inscribable */
      , (49448,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49448 Frost Maiden Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49448 Frost Maiden Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49448;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49448, 'ace49448-frostmaidenessence200', 70, '2020-08-04 10:18:02') /* PetDevice */;
+VALUES (49448, 'ace49448-frostmaidenessence200', 70, '2020-10-11 10:18:02') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49448,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49448,   1,        128) /* ItemType - Misc */
      , (49448,  18,        128) /* UiEffects - Frost */
      , (49448,  19,       4000) /* Value */
      , (49448,  33,          0) /* Bonded - Normal */
-     , (49448,  65,        101) /* Placement - Resting */
      , (49448,  91,         50) /* MaxStructure */
      , (49448,  92,         50) /* Structure */
      , (49448,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49448,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49448,   1, False) /* Stuck */
-     , (49448,  11, True ) /* IgnoreCollisions */
-     , (49448,  13, True ) /* Ethereal */
-     , (49448,  14, True ) /* GravityStatus */
-     , (49448,  19, True ) /* Attackable */
      , (49448,  22, True ) /* Inscribable */
      , (49448,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49448,  39,     0.4) /* DefaultScale */
      , (49448, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49448,   1, 'Frost Maiden Essence (200)') /* Name */
+VALUES (49448,   1, 'Frost Maiden Essence') /* Name */
      , (49448,  14, 'Use this essence to summon or dismiss your Frost Maiden.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49530 Acid Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49530 Acid Phyntos Swarm Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49530,   1,        128) /* ItemType - Misc */
      , (49530,   5,         50) /* EncumbranceVal */
      , (49530,  16,          8) /* ItemUseable - Contained */
      , (49530,  18,        256) /* UiEffects - Acid */
-     , (49530,  19,       4000) /* Value */
+     , (49530,  19,      10000) /* Value */
      , (49530,  33,          0) /* Bonded - Normal */
      , (49530,  91,         50) /* MaxStructure */
      , (49530,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49530 Acid Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49530 Acid Phyntos Swarm Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49530,   1,        128) /* ItemType - Misc */
      , (49530, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49530,   1, False) /* Stuck */
-     , (49530,  22, True ) /* Inscribable */
+VALUES (49530,  22, True ) /* Inscribable */
      , (49530,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49530 Acid Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49530 Acid Phyntos Swarm Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49530;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49530, 'ace49530-acidphyntosswarmessence200', 70, '2020-08-04 10:18:12') /* PetDevice */;
+VALUES (49530, 'ace49530-acidphyntosswarmessence200', 70, '2020-10-11 10:18:12') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49530,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49530,   1,        128) /* ItemType - Misc */
      , (49530,  18,        256) /* UiEffects - Acid */
      , (49530,  19,       4000) /* Value */
      , (49530,  33,          0) /* Bonded - Normal */
-     , (49530,  65,        101) /* Placement - Resting */
      , (49530,  91,         50) /* MaxStructure */
      , (49530,  92,         50) /* Structure */
      , (49530,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49530,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49530,   1, False) /* Stuck */
-     , (49530,  11, True ) /* IgnoreCollisions */
-     , (49530,  13, True ) /* Ethereal */
-     , (49530,  14, True ) /* GravityStatus */
-     , (49530,  19, True ) /* Attackable */
      , (49530,  22, True ) /* Inscribable */
      , (49530,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49530,  39,     0.4) /* DefaultScale */
      , (49530, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49530,   1, 'Acid Phyntos Swarm Essence (200)') /* Name */
+VALUES (49530,   1, 'Acid Phyntos Swarm Essence') /* Name */
      , (49530,  14, 'Use this essence to summon or dismiss your Acid Phyntos Swarm.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49537,   1,        128) /* ItemType - Misc */
      , (49537, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49537,   1, False) /* Stuck */
-     , (49537,  22, True ) /* Inscribable */
+VALUES (49537,  22, True ) /* Inscribable */
      , (49537,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49537;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49537, 'ace49537-firephyntosswarmessence200', 70, '2020-08-04 10:18:20') /* PetDevice */;
+VALUES (49537, 'ace49537-firephyntosswarmessence200', 70, '2020-10-11 10:18:20') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49537,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49537,   1,        128) /* ItemType - Misc */
      , (49537,  18,         32) /* UiEffects - Fire */
      , (49537,  19,       4000) /* Value */
      , (49537,  33,          0) /* Bonded - Normal */
-     , (49537,  65,        101) /* Placement - Resting */
      , (49537,  91,         50) /* MaxStructure */
      , (49537,  92,         50) /* Structure */
      , (49537,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49537,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49537,   1, False) /* Stuck */
-     , (49537,  11, True ) /* IgnoreCollisions */
-     , (49537,  13, True ) /* Ethereal */
-     , (49537,  14, True ) /* GravityStatus */
-     , (49537,  19, True ) /* Attackable */
      , (49537,  22, True ) /* Inscribable */
      , (49537,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49537,  39,     0.4) /* DefaultScale */
      , (49537, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49537,   1, 'Fire Phyntos Swarm Essence (200)') /* Name */
+VALUES (49537,   1, 'Fire Phyntos Swarm Essence)') /* Name */
      , (49537,  14, 'Use this essence to summon or dismiss your Fire Phyntos Swarm.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
@@ -34,7 +34,7 @@ VALUES (49537,  39,     0.4) /* DefaultScale */
      , (49537, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49537,   1, 'Fire Phyntos Swarm Essence)') /* Name */
+VALUES (49537,   1, 'Fire Phyntos Swarm Essence') /* Name */
      , (49537,  14, 'Use this essence to summon or dismiss your Fire Phyntos Swarm.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49537 Fire Phyntos Swarm Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49537,   1,        128) /* ItemType - Misc */
      , (49537,   5,         50) /* EncumbranceVal */
      , (49537,  16,          8) /* ItemUseable - Contained */
      , (49537,  18,         32) /* UiEffects - Fire */
-     , (49537,  19,       4000) /* Value */
+     , (49537,  19,      10000) /* Value */
      , (49537,  33,          0) /* Bonded - Normal */
      , (49537,  91,         50) /* MaxStructure */
      , (49537,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49544 Frost Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49544 Frost Phyntos Swarm Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49544;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49544, 'ace49544-frostphyntosswarmessence200', 70, '2020-08-04 10:18:32') /* PetDevice */;
+VALUES (49544, 'ace49544-frostphyntosswarmessence200', 70, '2020-10-11 10:18:32') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49544,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49544,   1,        128) /* ItemType - Misc */
      , (49544,  18,        128) /* UiEffects - Frost */
      , (49544,  19,       4000) /* Value */
      , (49544,  33,          0) /* Bonded - Normal */
-     , (49544,  65,        101) /* Placement - Resting */
      , (49544,  91,         50) /* MaxStructure */
      , (49544,  92,         50) /* Structure */
      , (49544,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49544,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49544,   1, False) /* Stuck */
-     , (49544,  11, True ) /* IgnoreCollisions */
-     , (49544,  13, True ) /* Ethereal */
-     , (49544,  14, True ) /* GravityStatus */
-     , (49544,  19, True ) /* Attackable */
      , (49544,  22, True ) /* Inscribable */
      , (49544,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49544,  39,     0.4) /* DefaultScale */
      , (49544, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49544,   1, 'Frost Phyntos Swarm Essence (200)') /* Name */
+VALUES (49544,   1, 'Frost Phyntos Swarm Essence') /* Name */
      , (49544,  14, 'Use this essence to summon or dismiss your Frost Phyntos Swarm.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49544 Frost Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49544 Frost Phyntos Swarm Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49544,   1,        128) /* ItemType - Misc */
      , (49544,   5,         50) /* EncumbranceVal */
      , (49544,  16,          8) /* ItemUseable - Contained */
      , (49544,  18,        128) /* UiEffects - Frost */
-     , (49544,  19,       4000) /* Value */
+     , (49544,  19,      10000) /* Value */
      , (49544,  33,          0) /* Bonded - Normal */
      , (49544,  91,         50) /* MaxStructure */
      , (49544,  92,         50) /* Structure */

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49544 Frost Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49544 Frost Phyntos Swarm Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49544,   1,        128) /* ItemType - Misc */
      , (49544, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49544,   1, False) /* Stuck */
-     , (49544,  22, True ) /* Inscribable */
+VALUES (49544,  22, True ) /* Inscribable */
      , (49544,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49551 Lightning Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49551 Lightning Phyntos Swarm Essence (200).sql
@@ -25,8 +25,7 @@ VALUES (49551,   1,        128) /* ItemType - Misc */
      , (49551, 369,        185) /* UseRequiresLevel */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49551,   1, False) /* Stuck */
-     , (49551,  22, True ) /* Inscribable */
+VALUES (49551,  22, True ) /* Inscribable */
      , (49551,  69, True ) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49551 Lightning Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49551 Lightning Phyntos Swarm Essence (200).sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49551;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49551, 'ace49551-lightningphyntosswarmessence200', 70, '2020-08-04 10:18:41') /* PetDevice */;
+VALUES (49551, 'ace49551-lightningphyntosswarmessence200', 70, '2020-10-11 10:18:41') /* PetDevice */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49551,   1,        128) /* ItemType - Misc */
@@ -10,7 +10,6 @@ VALUES (49551,   1,        128) /* ItemType - Misc */
      , (49551,  18,         64) /* UiEffects - Lightning */
      , (49551,  19,       4000) /* Value */
      , (49551,  33,          0) /* Bonded - Normal */
-     , (49551,  65,        101) /* Placement - Resting */
      , (49551,  91,         50) /* MaxStructure */
      , (49551,  92,         50) /* Structure */
      , (49551,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -27,10 +26,6 @@ VALUES (49551,   1,        128) /* ItemType - Misc */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (49551,   1, False) /* Stuck */
-     , (49551,  11, True ) /* IgnoreCollisions */
-     , (49551,  13, True ) /* Ethereal */
-     , (49551,  14, True ) /* GravityStatus */
-     , (49551,  19, True ) /* Attackable */
      , (49551,  22, True ) /* Inscribable */
      , (49551,  69, True ) /* IsSellable */;
 
@@ -39,7 +34,7 @@ VALUES (49551,  39,     0.4) /* DefaultScale */
      , (49551, 167,      45) /* CooldownDuration */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (49551,   1, 'Lightning Phyntos Swarm Essence (200)') /* Name */
+VALUES (49551,   1, 'Lightning Phyntos Swarm Essence') /* Name */
      , (49551,  14, 'Use this essence to summon or dismiss your Lightning Phyntos Swarm.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49551 Lightning Phyntos Swarm Essence (200).sql
+++ b/Database/Patches/2013-02-BalanceOfPower/9 WeenieDefaults/PetDevice/49551 Lightning Phyntos Swarm Essence (200).sql
@@ -8,7 +8,7 @@ VALUES (49551,   1,        128) /* ItemType - Misc */
      , (49551,   5,         50) /* EncumbranceVal */
      , (49551,  16,          8) /* ItemUseable - Contained */
      , (49551,  18,         64) /* UiEffects - Lightning */
-     , (49551,  19,       4000) /* Value */
+     , (49551,  19,      10000) /* Value */
      , (49551,  33,          0) /* Bonded - Normal */
      , (49551,  91,         50) /* MaxStructure */
      , (49551,  92,         50) /* Structure */


### PR DESCRIPTION
ready for review

This PR cleans up the 36 lvl 200 summoning essences. 

Remove (200) from essence name
Changed value from 4k to 10k
Remove unneeded properties