### PR TITLE
Update Count Phainors Amulet Quest Timer

### DIFF
--- a/Database/Patches/2013-02-BalanceOfPower/8 QuestDefDB/countphainorsamuletwait.sql
+++ b/Database/Patches/2013-02-BalanceOfPower/8 QuestDefDB/countphainorsamuletwait.sql
@@ -1,4 +1,4 @@
 DELETE FROM `quest` WHERE `name` = 'countphainorsamuletwait';
 
 INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('countphainorsamuletwait', 518400, -1, 'Received reward from Grularr', '2020-02-04 06:51:50');
+VALUES ('countphainorsamuletwait', 72000, -1, 'Received reward from Grularr', '2020-02-04 06:51:50');


### PR DESCRIPTION
Updated Quest timer to 20 Hours.

> 

Count Phainor's Amulet | Solo/Group | 10,000 | 10,000 | 20 hours
-- | -- | -- | -- | --





