### PR TITLE
From Gaining Ground patch, increase the number of generated Aqua Vitae by 3x

### DIFF
--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04499 Aqua Vitae.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04499 Aqua Vitae.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4499;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4499, 0, 38 /* Alchemy */, 80, 0, 24683 /* Aqua Vitae */, 165, 'The pyreal dissolves in the aqua incanta enhancing the magic.', 0, 0, 'Your attempt results in useless sludge.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4499;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4499, 9342 /* Concentrated Aqua Incanta */,  6329 /* Pyreal Bar */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04500 Aqua Vitae.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04500 Aqua Vitae.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4500;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4500, 0, 38 /* Alchemy */, 100, 0, 24683 /* Aqua Vitae */, 375, 'The pyreal dissolves in the aqua incanta enhancing the magic.', 0, 0, 'Your attempt results in useless sludge.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4500;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4500, 9342 /* Concentrated Aqua Incanta */,  6330 /* Pyreal Ingot */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04501 Aqua Vitae.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04501 Aqua Vitae.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4501;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4501, 0, 38 /* Alchemy */, 90, 0, 24683 /* Aqua Vitae */, 375, 'The pyreal dissolves in the aqua incanta enhancing the magic.', 0, 0, 'Your attempt results in useless sludge.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4501;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4501, 9342 /* Concentrated Aqua Incanta */,  6331 /* Quality Pyreal Ingot */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04502 Aqua Vitae.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04502 Aqua Vitae.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4502;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4502, 0, 38 /* Alchemy */, 50, 0, 24683 /* Aqua Vitae */, 15, 'The pyreal dissolves in the aqua incanta enhancing the magic.', 0, 0, 'Your attempt results in useless sludge.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4502;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4502, 9342 /* Concentrated Aqua Incanta */,  6353 /* Pyreal Mote */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04503 Aqua Vitae.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04503 Aqua Vitae.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4503;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4503, 0, 38 /* Alchemy */, 70, 0, 24683 /* Aqua Vitae */, 75, 'The pyreal dissolves in the aqua incanta enhancing the magic.', 0, 0, 'Your attempt results in useless sludge.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4503;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4503, 9342 /* Concentrated Aqua Incanta */,  6354 /* Pyreal Nugget */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04504 Aqua Vitae.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04504 Aqua Vitae.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4504;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4504, 0, 38 /* Alchemy */, 60, 0, 24683 /* Aqua Vitae */, 30, 'The pyreal dissolves in the aqua incanta enhancing the magic.', 0, 0, 'Your attempt results in useless sludge.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4504;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4504, 9342 /* Concentrated Aqua Incanta */,  6355 /* Pyreal Sliver */, '2005-02-09 10:00:00');


### PR DESCRIPTION
This is my first PR so let me know if there is anything I could be doing differently.

My eventual goal is to make all the alchemy-related changes from the Gaining Ground (2009/12) patch but this one starts by just updating the amounts of Aqua Vitae generated by combining Concentrated Aqua Incanta with pyreal motes (and slivers, etc).  According to the [acpedia wiki](http://acpedia.org/wiki/Gaining_Ground#Alchemy_and_Gearcrafting_Updates), the amount simply tripled, though I'm a little confused by the specified ranges.  After talking with folks in the discord content_recreation channel we decided to just ignore the ranges and go with a static output.

I basically just copy/pasted the sql files from the ACE-World repo and put them in the appropriate patch folder with updated success_amounts.  Let me know if there's anything else you'd like to see here.  I figured I would break this up into smaller PRs rather than try to make all the alchemy-related changes in my first PR.