### PR TITLE
From the Gaining Ground 2009-12 patch, doubled the success output of alchemy gems

### DIFF
--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04604 Gem of Greater Cold Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04604 Gem of Greater Cold Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4604;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4604, 0, 38 /* Alchemy */, 275, 0, 24821 /* Gem of Greater Cold Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4604;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4604, 24766 /* Treated Colcothar and Frankincense Crucible */,   791 /* Powdered Quartz */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04605 Gem of Lightning Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04605 Gem of Lightning Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4605;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4605, 0, 38 /* Alchemy */, 175, 0, 24801 /* Gem of Lightning Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4605;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4605, 24779 /* Treated Cobalt and Henbane Crucible */,   782 /* Powdered Agate */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04606 Gem of Improved Lightning Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04606 Gem of Improved Lightning Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4606;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4606, 0, 38 /* Alchemy */, 225, 0, 24812 /* Gem of Improved Lightning Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4606;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4606, 24746 /* Treated Cobalt and Amaranth Crucible */,   782 /* Powdered Agate */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04607 Gem of Greater Lightning Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04607 Gem of Greater Lightning Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4607;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4607, 0, 38 /* Alchemy */, 275, 0, 24823 /* Gem of Greater Lightning Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4607;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4607, 24768 /* Treated Cobalt and Frankincense Crucible */,   782 /* Powdered Agate */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04608 Gem of Lesser Rejuvenation.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04608 Gem of Lesser Rejuvenation.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4608;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4608, 0, 38 /* Alchemy */, 125, 0, 24794 /* Gem of Lesser Rejuvenation */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4608;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4608, 24761 /* Treated Cinnabar and Eyebright Crucible */,   783 /* Powdered Amber */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04609 Gem of Rejuvenation.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04609 Gem of Rejuvenation.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4609;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4609, 0, 38 /* Alchemy */, 175, 0, 24805 /* Gem of Rejuvenation */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4609;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4609, 24783 /* Treated Cinnabar and Henbane Crucible */,   783 /* Powdered Amber */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04610 Gem of Improved Rejuvenation.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04610 Gem of Improved Rejuvenation.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4610;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4610, 0, 38 /* Alchemy */, 225, 0, 24816 /* Gem of Improved Rejuvenation */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4610;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4610, 24750 /* Treated Cinnabar and Amaranth Crucible */,   783 /* Powdered Amber */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04611 Gem of Greater Rejuvenation.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04611 Gem of Greater Rejuvenation.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4611;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4611, 0, 38 /* Alchemy */, 275, 0, 24827 /* Gem of Greater Rejuvenation */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4611;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4611, 24772 /* Treated Cinnabar and Frankincense Crucible */,   783 /* Powdered Amber */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04612 Gem of Lesser Regeneration.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04612 Gem of Lesser Regeneration.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4612;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4612, 0, 38 /* Alchemy */, 125, 0, 24793 /* Gem of Lesser Regeneration */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4612;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4612, 24756 /* Treated Vitriol and Eyebright Crucible */,   785 /* Powdered Bloodstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04613 Gem of Regeneration.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04613 Gem of Regeneration.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4613;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4613, 0, 38 /* Alchemy */, 175, 0, 24804 /* Gem of Regeneration */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4613;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4613, 24778 /* Treated Vitriol and Henbane Crucible */,   785 /* Powdered Bloodstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04614 Gem of Improved Regeneration.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04614 Gem of Improved Regeneration.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4614;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4614, 0, 38 /* Alchemy */, 225, 0, 24815 /* Gem of Improved Regeneration */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4614;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4614, 24745 /* Treated Vitriol and Amaranth Crucible */,   785 /* Powdered Bloodstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04615 Gem of Greater Regeneration.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04615 Gem of Greater Regeneration.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4615;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4615, 0, 38 /* Alchemy */, 275, 0, 24826 /* Gem of Greater Regeneration */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4615;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4615, 24767 /* Treated Vitriol and Frankincense Crucible */,   785 /* Powdered Bloodstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04616 Gem of Lesser Fire Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04616 Gem of Lesser Fire Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4616;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4616, 0, 38 /* Alchemy */, 125, 0, 24789 /* Gem of Lesser Fire Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4616;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4616, 24754 /* Treated Turpeth and Eyebright Crucible */,   786 /* Powdered Carnelian */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04617 Gem of Fire Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04617 Gem of Fire Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4617;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4617, 0, 38 /* Alchemy */, 175, 0, 24800 /* Gem of Fire Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4617;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4617, 24776 /* Treated Turpeth and Henbane Crucible */,   786 /* Powdered Carnelian */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04618 Gem of Improved Fire Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04618 Gem of Improved Fire Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4618;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4618, 0, 38 /* Alchemy */, 225, 0, 24811 /* Gem of Improved Fire Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4618;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4618, 24743 /* Treated Turpeth and Amaranth Crucible */,   786 /* Powdered Carnelian */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04619 Gem of Greater Fire Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04619 Gem of Greater Fire Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4619;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4619, 0, 38 /* Alchemy */, 275, 0, 24822 /* Gem of Greater Fire Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4619;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4619, 24765 /* Treated Turpeth and Frankincense Crucible */,   786 /* Powdered Carnelian */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04620 Gem of Lesser Piercing Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04620 Gem of Lesser Piercing Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4620;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4620, 0, 38 /* Alchemy */, 125, 0, 24792 /* Gem of Lesser Piercing Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4620;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4620, 24759 /* Treated Quicksilver and Eyebright Crucible */,   626 /* Powdered Hematite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04621 Gem of Piercing Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04621 Gem of Piercing Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4621;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4621, 0, 38 /* Alchemy */, 175, 0, 24803 /* Gem of Piercing Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4621;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4621, 24781 /* Treated Quicksilver and Henbane Crucible */,   626 /* Powdered Hematite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04622 Gem of Improved Piercing Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04622 Gem of Improved Piercing Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4622;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4622, 0, 38 /* Alchemy */, 225, 0, 24814 /* Gem of Improved Piercing Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4622;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4622, 24748 /* Treated Quicksilver and Amaranth Crucible */,   626 /* Powdered Hematite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04623 Gem of Greater Piercing Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04623 Gem of Greater Piercing Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4623;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4623, 0, 38 /* Alchemy */, 275, 0, 24825 /* Gem of Greater Piercing Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4623;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4623, 24770 /* Treated Quicksilver and Frankincense Crucible */,   626 /* Powdered Hematite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04624 Gem of Lesser Mana Renewal.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04624 Gem of Lesser Mana Renewal.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4624;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4624, 0, 38 /* Alchemy */, 125, 0, 24791 /* Gem of Lesser Mana Renewal */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4624;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4624, 24758 /* Gypsum and Eyebright Crucible */,   787 /* Powdered Lapis Lazuli */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04625 Gem of Mana Renewal.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04625 Gem of Mana Renewal.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4625;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4625, 0, 38 /* Alchemy */, 175, 0, 24802 /* Gem of Mana Renewal */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4625;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4625, 24780 /* Treated Gypsum and Henbane Crucible */,   787 /* Powdered Lapis Lazuli */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04626 Gem of Improved Mana Renewal.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04626 Gem of Improved Mana Renewal.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4626;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4626, 0, 38 /* Alchemy */, 225, 0, 24813 /* Gem of Improved Mana Renewal */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4626;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4626, 24747 /* Treated Gypsum and Amaranth Crucible */,   787 /* Powdered Lapis Lazuli */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04627 Gem of Greater Mana Renewal.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04627 Gem of Greater Mana Renewal.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4627;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4627, 0, 38 /* Alchemy */, 275, 0, 24824 /* Gem of Greater Mana Renewal */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4627;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4627, 24769 /* Treated Gypsum and Frankincense Crucible */,   787 /* Powdered Lapis Lazuli */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04628 Gem of Lesser Acid Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04628 Gem of Lesser Acid Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4628;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4628, 0, 38 /* Alchemy */, 125, 0, 24784 /* Gem of Lesser Acid Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4628;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4628, 24751 /* Treated Brimstone and Eyebright Crucible */,   788 /* Powdered Malachite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04629 Gem of Acid Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04629 Gem of Acid Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4629;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4629, 0, 38 /* Alchemy */, 175, 0, 24795 /* Gem of Acid Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4629;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4629, 24773 /* Treated Brimstone and Henbane Crucible */,   788 /* Powdered Malachite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04630 Gem of Improved Acid Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04630 Gem of Improved Acid Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4630;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4630, 0, 38 /* Alchemy */, 225, 0, 24806 /* Gem of Improved Acid Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4630;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4630, 24740 /* Treated Brimstone and Amaranth Crucible */,   788 /* Powdered Malachite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04631 Gem of Greater Acid Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04631 Gem of Greater Acid Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4631;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4631, 0, 38 /* Alchemy */, 275, 0, 24817 /* Gem of Greater Acid Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4631;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4631, 24762 /* Treated Brimstone and Frankincense Crucible */,   788 /* Powdered Malachite */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04632 Gem of Lesser Blade Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04632 Gem of Lesser Blade Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4632;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4632, 0, 38 /* Alchemy */, 125, 0, 24786 /* Gem of Lesser Blade Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4632;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4632, 24760 /* Treated Cadmia and Eyebright Crucible */,   789 /* Powdered Moonstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04633 Gem of Blade Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04633 Gem of Blade Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4633;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4633, 0, 38 /* Alchemy */, 175, 0, 24797 /* Gem of Blade Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4633;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4633, 24782 /* Treated Cadmia and Henbane Crucible */,   789 /* Powdered Moonstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04634 Gem of Improved Blade Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04634 Gem of Improved Blade Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4634;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4634, 0, 38 /* Alchemy */, 225, 0, 24808 /* Gem of Improved Blade Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4634;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4634, 24749 /* Treated Cadmia and Amaranth Crucible */,   789 /* Powdered Moonstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04635 Gem of Greater Blade Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04635 Gem of Greater Blade Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4635;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4635, 0, 38 /* Alchemy */, 275, 0, 24819 /* Gem of Greater Blade Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4635;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4635, 24771 /* Treated Cadmia and Frankincense Crucible */,   789 /* Powdered Moonstone */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04636 Gem of Lesser Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04636 Gem of Lesser Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4636;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4636, 0, 38 /* Alchemy */, 125, 0, 24785 /* Gem of Lesser Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4636;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4636, 24752 /* Treated Stibnite and Eyebright Crucible */,   790 /* Powdered Onyx */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04637 Gem of Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04637 Gem of Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4637;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4637, 0, 38 /* Alchemy */, 175, 0, 24796 /* Gem of Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4637;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4637, 24774 /* Treated Stibnite and Henbane Crucible */,   790 /* Powdered Onyx */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04638 Gem of Improved Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04638 Gem of Improved Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4638;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4638, 0, 38 /* Alchemy */, 225, 0, 24807 /* Gem of Improved Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4638;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4638, 24741 /* Treated Stibnite and Amaranth Crucible */,   790 /* Powdered Onyx */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04639 Gem of Greater Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04639 Gem of Greater Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4639;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4639, 0, 38 /* Alchemy */, 275, 0, 24818 /* Gem of Greater Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4639;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4639, 24763 /* Treated Stibnite and Frankincense Crucible */,   790 /* Powdered Onyx */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04640 Gem of Lesser Cold Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04640 Gem of Lesser Cold Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4640;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4640, 0, 38 /* Alchemy */, 125, 0, 24788 /* Gem of Lesser Cold Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4640;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4640, 24755 /* Treated Colcothar and Eyebright Crucible */,   791 /* Powdered Quartz */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04641 Gem of Cold Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04641 Gem of Cold Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4641;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4641, 0, 38 /* Alchemy */, 175, 0, 24799 /* Gem of Cold Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4641;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4641, 24777 /* Treated Colcothar and Henbane Crucible */,   791 /* Powdered Quartz */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04642 Gem of Improved Cold Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04642 Gem of Improved Cold Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4642;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4642, 0, 38 /* Alchemy */, 225, 0, 24810 /* Gem of Improved Cold Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4642;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4642, 24744 /* Treated Colcothar and Amaranth Crucible */,   791 /* Powdered Quartz */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04643 Gem of Lesser Lightning Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04643 Gem of Lesser Lightning Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4643;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4643, 0, 38 /* Alchemy */, 125, 0, 24790 /* Gem of Lesser Lightning Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4643;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4643, 24757 /* Treated Cobalt and Eyebright Crucible */,   782 /* Powdered Agate */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04644 Gem of Lesser Bludgeon Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04644 Gem of Lesser Bludgeon Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4644;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4644, 0, 38 /* Alchemy */, 125, 0, 24787 /* Gem of Lesser Bludgeon Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4644;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4644, 24753 /* Treated Verdigris and Eyebright Crucible */,   792 /* Powdered Turquoise */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04645 Gem of Greater Bludgeon Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04645 Gem of Greater Bludgeon Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4645;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4645, 0, 38 /* Alchemy */, 275, 0, 24820 /* Gem of Greater Bludgeon Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4645;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4645, 24764 /* Treated Verdigris and Frankincense Crucible */,   792 /* Powdered Turquoise */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04646 Gem of Bludgeon Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04646 Gem of Bludgeon Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4646;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4646, 0, 38 /* Alchemy */, 175, 0, 24798 /* Gem of Bludgeon Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4646;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4646, 24775 /* Treated Verdigris and Henbane Crucible */,   792 /* Powdered Turquoise */, '2005-02-09 10:00:00');

--- a/Database/Patches/2009-12-GainingGround/4 CraftTable/04647 Gem of Imrpoved Bludgeon Protection.sql
+++ b/Database/Patches/2009-12-GainingGround/4 CraftTable/04647 Gem of Imrpoved Bludgeon Protection.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4647;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4647, 0, 38 /* Alchemy */, 225, 0, 24809 /* Gem of Imrpoved Bludgeon Protection */, 2, 'The powder congeals into a gem-like substance. The process is a success!', 0, 0, 'The process was an utter failure, leaving you with a messy mass of mush to show for your efforts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-01-14 19:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4647;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4647, 24742 /* Treated Verdigris and Amaranth Crucible */,   792 /* Powdered Turquoise */, '2005-02-09 10:00:00');


### PR DESCRIPTION
In the 2009-12 Gaining Ground patch, the success output when creating alchemy gems was doubled from 1 to 2.  For this patch I've copied over the alchemy gem recipe files and changed the success_Amount field to 2 and updated the last_Modified field.

This should contain all existing gems from levels III to VI.

Link to wiki page: http://acpedia.org/wiki/Alchemy_Gems
Link to one of the original recipe files for comparison: https://github.com/ACEmulator/ACE-World-16PY/blob/master/Database/3-Core/4%20CraftTable/SQL/04637%20Gem%20of%20Protection.sql