### PR TITLE
Reset Nether and Life magic resistance for Mukkir

### DIFF
--- a/Database/Patches/2006-01-Reprisals/9 WeenieDefaults/Creature/Mukkir/31897 Barbaric Mukkir.sql
+++ b/Database/Patches/2006-01-Reprisals/9 WeenieDefaults/Creature/Mukkir/31897 Barbaric Mukkir.sql
@@ -48,14 +48,14 @@ VALUES (31897,   1,       5) /* HeartbeatInterval */
      , (31897,  69,    0.42) /* ResistAcid */
      , (31897,  70,    0.25) /* ResistElectric */
      , (31897,  71,    0.25) /* ResistHealthBoost */
-     , (31897,  72,    0.25) /* ResistStaminaDrain */
+     , (31897,  72,       1) /* ResistStaminaDrain */
      , (31897,  73,       1) /* ResistStaminaBoost */
-     , (31897,  74,     0.5) /* ResistManaDrain */
+     , (31897,  74,       1) /* ResistManaDrain */
      , (31897,  75,       1) /* ResistManaBoost */
      , (31897,  77,       1) /* PhysicsScriptIntensity */
      , (31897, 104,      10) /* ObviousRadarRange */
      , (31897, 117,     0.6) /* FocusedProbability */
-     , (31897, 125,    0.25) /* ResistHealthDrain */;
+     , (31897, 125,		  1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (31897,   1, 'Barbaric Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/31901 Fanatical Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/31901 Fanatical Mukkir.sql
@@ -45,14 +45,14 @@ VALUES (31901,   1,       5) /* HeartbeatInterval */
      , (31901,  69,    0.42) /* ResistAcid */
      , (31901,  70,    0.25) /* ResistElectric */
      , (31901,  71,    0.25) /* ResistHealthBoost */
-     , (31901,  72,    0.25) /* ResistStaminaDrain */
+     , (31901,  72,       1) /* ResistStaminaDrain */
      , (31901,  73,       1) /* ResistStaminaBoost */
-     , (31901,  74,     0.5) /* ResistManaDrain */
+     , (31901,  74,       1) /* ResistManaDrain */
      , (31901,  75,       1) /* ResistManaBoost */
      , (31901,  77,       1) /* PhysicsScriptIntensity */
      , (31901, 104,      10) /* ObviousRadarRange */
      , (31901, 117,     0.6) /* FocusedProbability */
-     , (31901, 125,    0.25) /* ResistHealthDrain */;
+     , (31901, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (31901,   1, 'Fanatical Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33037 Vile Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33037 Vile Mukkir.sql
@@ -44,15 +44,15 @@ VALUES (33037,   1,       5) /* HeartbeatInterval */
      , (33037,  68,    0.75) /* ResistCold */
      , (33037,  69,    0.42) /* ResistAcid */
      , (33037,  70,    0.25) /* ResistElectric */
-     , (33037,  71,    0.25) /* ResistHealthBoost */
-     , (33037,  72,    0.25) /* ResistStaminaDrain */
+     , (33037,  71,       1) /* ResistHealthBoost */
+     , (33037,  72,       1) /* ResistStaminaDrain */
      , (33037,  73,       1) /* ResistStaminaBoost */
-     , (33037,  74,     0.5) /* ResistManaDrain */
+     , (33037,  74,       1) /* ResistManaDrain */
      , (33037,  75,       1) /* ResistManaBoost */
      , (33037,  77,       1) /* PhysicsScriptIntensity */
      , (33037, 104,      10) /* ObviousRadarRange */
      , (33037, 117,     0.6) /* FocusedProbability */
-     , (33037, 125,    0.25) /* ResistHealthDrain */;
+     , (33037, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33037,   1, 'Vile Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33038 Coruscating Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33038 Coruscating Mukkir.sql
@@ -47,14 +47,14 @@ VALUES (33038,   1,       5) /* HeartbeatInterval */
      , (33038,  69,    0.42) /* ResistAcid */
      , (33038,  70,    0.25) /* ResistElectric */
      , (33038,  71,    0.25) /* ResistHealthBoost */
-     , (33038,  72,    0.25) /* ResistStaminaDrain */
+     , (33038,  72,       1) /* ResistStaminaDrain */
      , (33038,  73,       1) /* ResistStaminaBoost */
-     , (33038,  74,     0.5) /* ResistManaDrain */
+     , (33038,  74,       1) /* ResistManaDrain */
      , (33038,  75,       1) /* ResistManaBoost */
      , (33038,  77,       1) /* PhysicsScriptIntensity */
      , (33038, 104,      10) /* ObviousRadarRange */
      , (33038, 117,     0.6) /* FocusedProbability */
-     , (33038, 125,    0.25) /* ResistHealthDrain */;
+     , (33038, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33038,   1, 'Coruscating Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33130 Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33130 Mukkir.sql
@@ -45,14 +45,14 @@ VALUES (33130,   1,       5) /* HeartbeatInterval */
      , (33130,  69,    0.42) /* ResistAcid */
      , (33130,  70,    0.25) /* ResistElectric */
      , (33130,  71,    0.25) /* ResistHealthBoost */
-     , (33130,  72,    0.25) /* ResistStaminaDrain */
+     , (33130,  72,       1) /* ResistStaminaDrain */
      , (33130,  73,       1) /* ResistStaminaBoost */
-     , (33130,  74,     0.5) /* ResistManaDrain */
+     , (33130,  74,       1) /* ResistManaDrain */
      , (33130,  75,       1) /* ResistManaBoost */
      , (33130,  77,       1) /* PhysicsScriptIntensity */
      , (33130, 104,      10) /* ObviousRadarRange */
      , (33130, 117,     0.6) /* FocusedProbability */
-     , (33130, 125,    0.25) /* ResistHealthDrain */;
+     , (33130, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33130,   1, 'Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33538 Fanatical Mukkir Ward Guardian.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33538 Fanatical Mukkir Ward Guardian.sql
@@ -45,16 +45,16 @@ VALUES (33538,   1,       5) /* HeartbeatInterval */
      , (33538,  68,     0.2) /* ResistCold */
      , (33538,  69,     0.2) /* ResistAcid */
      , (33538,  70,     0.1) /* ResistElectric */
-     , (33538, 166,     0.2) /* ResistNether */
+     , (33538, 166,       1) /* ResistNether */
      , (33538,  71,    0.25) /* ResistHealthBoost */
-     , (33538,  72,    0.25) /* ResistStaminaDrain */
+     , (33538,  72,       1) /* ResistStaminaDrain */
      , (33538,  73,       1) /* ResistStaminaBoost */
-     , (33538,  74,     0.5) /* ResistManaDrain */
+     , (33538,  74,       1) /* ResistManaDrain */
      , (33538,  75,       1) /* ResistManaBoost */
      , (33538,  77,       1) /* PhysicsScriptIntensity */
      , (33538, 104,      10) /* ObviousRadarRange */
      , (33538, 117,     0.6) /* FocusedProbability */
-     , (33538, 125,    0.25) /* ResistHealthDrain */;
+     , (33538, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33538,   1, 'Fanatical Mukkir Ward Guardian') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33623 Biaka Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33623 Biaka Mukkir.sql
@@ -50,14 +50,14 @@ VALUES (33623,   1,       5) /* HeartbeatInterval */
      , (33623,  69,    0.42) /* ResistAcid */
      , (33623,  70,    0.25) /* ResistElectric */
      , (33623,  71,    0.25) /* ResistHealthBoost */
-     , (33623,  72,    0.25) /* ResistStaminaDrain */
+     , (33623,  72,       1) /* ResistStaminaDrain */
      , (33623,  73,       1) /* ResistStaminaBoost */
-     , (33623,  74,     0.5) /* ResistManaDrain */
+     , (33623,  74,       1) /* ResistManaDrain */
      , (33623,  75,       1) /* ResistManaBoost */
      , (33623,  77,       1) /* PhysicsScriptIntensity */
      , (33623, 104,      10) /* ObviousRadarRange */
      , (33623, 117,     0.6) /* FocusedProbability */
-     , (33623, 125,    0.25) /* ResistHealthDrain */;
+     , (33623, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33623,   1, 'Biaka Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33624 Degenerate Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33624 Degenerate Mukkir.sql
@@ -47,15 +47,15 @@ VALUES (33624,   1,       5) /* HeartbeatInterval */
      , (33624,  69,     0.2) /* ResistAcid */
      , (33624,  70,     0.1) /* ResistElectric */
      , (33624,  71,    0.25) /* ResistHealthBoost */
-     , (33624,  72,    0.25) /* ResistStaminaDrain */
+     , (33624,  72,       1) /* ResistStaminaDrain */
      , (33624,  73,       1) /* ResistStaminaBoost */
-     , (33624,  74,     0.5) /* ResistManaDrain */
+     , (33624,  74,       1) /* ResistManaDrain */
      , (33624,  75,       1) /* ResistManaBoost */
      , (33624,  77,       1) /* PhysicsScriptIntensity */
      , (33624, 104,      10) /* ObviousRadarRange */
      , (33624, 117,     0.6) /* FocusedProbability */
-     , (33624, 125,    0.25) /* ResistHealthDrain */
-     , (33624, 166,     0.2) /* ResistNether */;
+     , (33624, 125,       1) /* ResistHealthDrain */
+     , (33624, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33624,   1, 'Degenerate Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33625 Depraved Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33625 Depraved Mukkir.sql
@@ -47,15 +47,15 @@ VALUES (33625,   1,       5) /* HeartbeatInterval */
      , (33625,  69,     0.2) /* ResistAcid */
      , (33625,  70,     0.1) /* ResistElectric */
      , (33625,  71,    0.25) /* ResistHealthBoost */
-     , (33625,  72,    0.25) /* ResistStaminaDrain */
+     , (33625,  72,       1) /* ResistStaminaDrain */
      , (33625,  73,       1) /* ResistStaminaBoost */
-     , (33625,  74,     0.5) /* ResistManaDrain */
+     , (33625,  74,       1) /* ResistManaDrain */
      , (33625,  75,       1) /* ResistManaBoost */
      , (33625,  77,       1) /* PhysicsScriptIntensity */
      , (33625, 104,      10) /* ObviousRadarRange */
      , (33625, 117,     0.6) /* FocusedProbability */
-     , (33625, 125,    0.25) /* ResistHealthDrain */
-     , (33625, 166,     0.2) /* ResistNether */;
+     , (33625, 125,       1) /* ResistHealthDrain */
+     , (33625, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33625,   1, 'Depraved Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33626 Hellion Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33626 Hellion Mukkir.sql
@@ -49,14 +49,14 @@ VALUES (33626,   1,       5) /* HeartbeatInterval */
      , (33626,  69,    0.42) /* ResistAcid */
      , (33626,  70,    0.25) /* ResistElectric */
      , (33626,  71,    0.25) /* ResistHealthBoost */
-     , (33626,  72,    0.25) /* ResistStaminaDrain */
+     , (33626,  72,       1) /* ResistStaminaDrain */
      , (33626,  73,       1) /* ResistStaminaBoost */
-     , (33626,  74,     0.5) /* ResistManaDrain */
+     , (33626,  74,       1) /* ResistManaDrain */
      , (33626,  75,       1) /* ResistManaBoost */
      , (33626,  77,       1) /* PhysicsScriptIntensity */
      , (33626, 104,      10) /* ObviousRadarRange */
      , (33626, 117,     0.6) /* FocusedProbability */
-     , (33626, 125,    0.25) /* ResistHealthDrain */;
+     , (33626, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33626,   1, 'Hellion Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33732 Degenerate Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33732 Degenerate Mukkir.sql
@@ -47,16 +47,16 @@ VALUES (33732,   1,       5) /* HeartbeatInterval */
      , (33732,  68,     0.2) /* ResistCold */
      , (33732,  69,     0.2) /* ResistAcid */
      , (33732,  70,     0.1) /* ResistElectric */
-     , (33732, 166,     0.2) /* ResistNether */
+     , (33732, 166,       1) /* ResistNether */
      , (33732,  71,    0.25) /* ResistHealthBoost */
-     , (33732,  72,    0.25) /* ResistStaminaDrain */
+     , (33732,  72,       1) /* ResistStaminaDrain */
      , (33732,  73,       1) /* ResistStaminaBoost */
-     , (33732,  74,     0.5) /* ResistManaDrain */
+     , (33732,  74,       1) /* ResistManaDrain */
      , (33732,  75,       1) /* ResistManaBoost */
      , (33732,  77,       1) /* PhysicsScriptIntensity */
      , (33732, 104,      10) /* ObviousRadarRange */
      , (33732, 117,     0.6) /* FocusedProbability */
-     , (33732, 125,    0.25) /* ResistHealthDrain */;
+     , (33732, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33732,   1, 'Degenerate Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33733 Depraved Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/33733 Depraved Mukkir.sql
@@ -47,16 +47,16 @@ VALUES (33733,   1,       5) /* HeartbeatInterval */
      , (33733,  68,     0.2) /* ResistCold */
      , (33733,  69,     0.2) /* ResistAcid */
      , (33733,  70,     0.1) /* ResistElectric */
-     , (33733, 166,     0.2) /* ResistNether */
+     , (33733, 166,       1) /* ResistNether */
      , (33733,  71,    0.25) /* ResistHealthBoost */
-     , (33733,  72,    0.25) /* ResistStaminaDrain */
+     , (33733,  72,       1) /* ResistStaminaDrain */
      , (33733,  73,       1) /* ResistStaminaBoost */
-     , (33733,  74,     0.5) /* ResistManaDrain */
+     , (33733,  74,       1) /* ResistManaDrain */
      , (33733,  75,       1) /* ResistManaBoost */
      , (33733,  77,       1) /* PhysicsScriptIntensity */
      , (33733, 104,      10) /* ObviousRadarRange */
      , (33733, 117,     0.6) /* FocusedProbability */
-     , (33733, 125,    0.25) /* ResistHealthDrain */;
+     , (33733, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33733,   1, 'Depraved Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/40281 Degenerate Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/40281 Degenerate Mukkir.sql
@@ -44,16 +44,16 @@ VALUES (40281,   1,       5) /* HeartbeatInterval */
      , (40281,  68,     0.2) /* ResistCold */
      , (40281,  69,     0.2) /* ResistAcid */
      , (40281,  70,     0.1) /* ResistElectric */
-     , (40281, 166,     0.2) /* ResistNether */
+     , (40281, 166,       1) /* ResistNether */
      , (40281,  71,    0.25) /* ResistHealthBoost */
-     , (40281,  72,    0.25) /* ResistStaminaDrain */
+     , (40281,  72,       1) /* ResistStaminaDrain */
      , (40281,  73,       1) /* ResistStaminaBoost */
-     , (40281,  74,     0.5) /* ResistManaDrain */
+     , (40281,  74,       1) /* ResistManaDrain */
      , (40281,  75,       1) /* ResistManaBoost */
      , (40281,  77,       1) /* PhysicsScriptIntensity */
      , (40281, 104,      10) /* ObviousRadarRange */
      , (40281, 117,     0.6) /* FocusedProbability */
-     , (40281, 125,    0.25) /* ResistHealthDrain */;
+     , (40281, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40281,   1, 'Degenerate Mukkir') /* Name */;

--- a/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/40282 Depraved Mukkir.sql
+++ b/Database/Patches/2006-07-TowardAncientShores/9 WeenieDefaults/Creature/Mukkir/40282 Depraved Mukkir.sql
@@ -44,16 +44,16 @@ VALUES (40282,   1,       5) /* HeartbeatInterval */
      , (40282,  68,     0.2) /* ResistCold */
      , (40282,  69,     0.2) /* ResistAcid */
      , (40282,  70,     0.1) /* ResistElectric */
-     , (40282, 166,     0.2) /* ResistNether */
+     , (40282, 166,       1) /* ResistNether */
      , (40282,  71,    0.25) /* ResistHealthBoost */
-     , (40282,  72,    0.25) /* ResistStaminaDrain */
+     , (40282,  72,       1) /* ResistStaminaDrain */
      , (40282,  73,       1) /* ResistStaminaBoost */
-     , (40282,  74,     0.5) /* ResistManaDrain */
+     , (40282,  74,       1) /* ResistManaDrain */
      , (40282,  75,       1) /* ResistManaBoost */
      , (40282,  77,       1) /* PhysicsScriptIntensity */
      , (40282, 104,      10) /* ObviousRadarRange */
      , (40282, 117,     0.6) /* FocusedProbability */
-     , (40282, 125,    0.25) /* ResistHealthDrain */;
+     , (40282, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40282,   1, 'Depraved Mukkir') /* Name */;

--- a/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33131 Mukkir Laktar.sql
+++ b/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33131 Mukkir Laktar.sql
@@ -48,15 +48,15 @@ VALUES (33131,   1,       5) /* HeartbeatInterval */
      , (33131,  69,     0.2) /* ResistAcid */
      , (33131,  70,     0.1) /* ResistElectric */
      , (33131,  71,    0.25) /* ResistHealthBoost */
-     , (33131,  72,    0.25) /* ResistStaminaDrain */
+     , (33131,  72,       1) /* ResistStaminaDrain */
      , (33131,  73,       1) /* ResistStaminaBoost */
-     , (33131,  74,     0.5) /* ResistManaDrain */
+     , (33131,  74,       1) /* ResistManaDrain */
      , (33131,  75,       1) /* ResistManaBoost */
      , (33131,  77,       1) /* PhysicsScriptIntensity */
      , (33131, 104,      10) /* ObviousRadarRange */
      , (33131, 117,     0.6) /* FocusedProbability */
-     , (33131, 125,    0.25) /* ResistHealthDrain */
-     , (33131, 166,     0.2) /* ResistNether */;
+     , (33131, 125,       1) /* ResistHealthDrain */
+     , (33131, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33131,   1, 'Mukkir Laktar') /* Name */;

--- a/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33132 Mukkir Kartak.sql
+++ b/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33132 Mukkir Kartak.sql
@@ -48,15 +48,15 @@ VALUES (33132,   1,       5) /* HeartbeatInterval */
      , (33132,  69,     0.2) /* ResistAcid */
      , (33132,  70,     0.1) /* ResistElectric */
      , (33132,  71,    0.25) /* ResistHealthBoost */
-     , (33132,  72,    0.25) /* ResistStaminaDrain */
+     , (33132,  72,       1) /* ResistStaminaDrain */
      , (33132,  73,       1) /* ResistStaminaBoost */
-     , (33132,  74,     0.5) /* ResistManaDrain */
+     , (33132,  74,       1) /* ResistManaDrain */
      , (33132,  75,       1) /* ResistManaBoost */
      , (33132,  77,       1) /* PhysicsScriptIntensity */
      , (33132, 104,      10) /* ObviousRadarRange */
      , (33132, 117,     0.6) /* FocusedProbability */
-     , (33132, 125,    0.25) /* ResistHealthDrain */
-     , (33132, 166,     0.2) /* ResistNether */;
+     , (33132, 125,       1) /* ResistHealthDrain */
+     , (33132, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33132,   1, 'Mukkir Kartak') /* Name */;

--- a/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33133 Mukkir Draktehn.sql
+++ b/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33133 Mukkir Draktehn.sql
@@ -48,15 +48,15 @@ VALUES (33133,   1,       5) /* HeartbeatInterval */
      , (33133,  69,     0.2) /* ResistAcid */
      , (33133,  70,     0.1) /* ResistElectric */
      , (33133,  71,    0.25) /* ResistHealthBoost */
-     , (33133,  72,    0.25) /* ResistStaminaDrain */
+     , (33133,  72,       1) /* ResistStaminaDrain */
      , (33133,  73,       1) /* ResistStaminaBoost */
-     , (33133,  74,     0.5) /* ResistManaDrain */
+     , (33133,  74,       1) /* ResistManaDrain */
      , (33133,  75,       1) /* ResistManaBoost */
      , (33133,  77,       1) /* PhysicsScriptIntensity */
      , (33133, 104,      10) /* ObviousRadarRange */
      , (33133, 117,     0.6) /* FocusedProbability */
-     , (33133, 125,    0.25) /* ResistHealthDrain */
-     , (33133, 166,     0.2) /* ResistNether */;
+     , (33133, 125,       1) /* ResistHealthDrain */
+     , (33133, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33133,   1, 'Mukkir Draktehn') /* Name */;

--- a/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33458 Mukkir Aspect of Grael.sql
+++ b/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33458 Mukkir Aspect of Grael.sql
@@ -46,15 +46,15 @@ VALUES (33458,   1,       5) /* HeartbeatInterval */
      , (33458,  69,     0.2) /* ResistAcid */
      , (33458,  70,     0.1) /* ResistElectric */
      , (33458,  71,    0.25) /* ResistHealthBoost */
-     , (33458,  72,    0.25) /* ResistStaminaDrain */
+     , (33458,  72,       1) /* ResistStaminaDrain */
      , (33458,  73,       1) /* ResistStaminaBoost */
      , (33458,  74,     0.5) /* ResistManaDrain */
      , (33458,  75,       1) /* ResistManaBoost */
      , (33458,  77,       1) /* PhysicsScriptIntensity */
      , (33458, 104,      10) /* ObviousRadarRange */
      , (33458, 117,     0.6) /* FocusedProbability */
-     , (33458, 125,    0.25) /* ResistHealthDrain */
-     , (33458, 166,     0.2) /* ResistNether */;
+     , (33458, 125,       1) /* ResistHealthDrain */
+     , (33458, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33458,   1, 'Mukkir Aspect of Grael') /* Name */;

--- a/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33898 Mukkir Progenitor.sql
+++ b/Database/Patches/2006-08-ShatteringTheDark/9 WeenieDefaults/Creature/Mukkir/33898 Mukkir Progenitor.sql
@@ -48,15 +48,15 @@ VALUES (33898,   1,       5) /* HeartbeatInterval */
      , (33898,  69,     0.2) /* ResistAcid */
      , (33898,  70,     0.1) /* ResistElectric */
      , (33898,  71,    0.25) /* ResistHealthBoost */
-     , (33898,  72,    0.25) /* ResistStaminaDrain */
+     , (33898,  72,       1) /* ResistStaminaDrain */
      , (33898,  73,       1) /* ResistStaminaBoost */
-     , (33898,  74,     0.5) /* ResistManaDrain */
+     , (33898,  74,       1) /* ResistManaDrain */
      , (33898,  75,       1) /* ResistManaBoost */
      , (33898,  77,       1) /* PhysicsScriptIntensity */
      , (33898, 104,      10) /* ObviousRadarRange */
      , (33898, 117,     0.6) /* FocusedProbability */
-     , (33898, 125,    0.25) /* ResistHealthDrain */
-     , (33898, 166,     0.2) /* ResistNether */;
+     , (33898, 125,       1) /* ResistHealthDrain */
+     , (33898, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33898,   1, 'Mukkir Progenitor') /* Name */;

--- a/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/Creature/Mukkir/31898 Umbral Mukkir.sql
+++ b/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/Creature/Mukkir/31898 Umbral Mukkir.sql
@@ -48,15 +48,15 @@ VALUES (31898,   1,       5) /* HeartbeatInterval */
      , (31898,  69,     0.2) /* ResistAcid */
      , (31898,  70,     0.1) /* ResistElectric */
      , (31898,  71,    0.25) /* ResistHealthBoost */
-     , (31898,  72,    0.25) /* ResistStaminaDrain */
+     , (31898,  72,       1) /* ResistStaminaDrain */
      , (31898,  73,       1) /* ResistStaminaBoost */
-     , (31898,  74,     0.5) /* ResistManaDrain */
+     , (31898,  74,       1) /* ResistManaDrain */
      , (31898,  75,       1) /* ResistManaBoost */
      , (31898,  77,       1) /* PhysicsScriptIntensity */
      , (31898, 104,      10) /* ObviousRadarRange */
      , (31898, 117,     0.6) /* FocusedProbability */
-     , (31898, 125,    0.25) /* ResistHealthDrain */
-     , (31898, 166,     0.2) /* ResistNether */;
+     , (31898, 125,       1) /* ResistHealthDrain */
+     , (31898, 166,       1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (31898,   1, 'Umbral Mukkir') /* Name */;

--- a/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35142 Mukkir Draktehn.sql
+++ b/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35142 Mukkir Draktehn.sql
@@ -43,14 +43,14 @@ VALUES (35142,   1,       5) /* HeartbeatInterval */
      , (35142,  69,    0.42) /* ResistAcid */
      , (35142,  70,    0.25) /* ResistElectric */
      , (35142,  71,    0.25) /* ResistHealthBoost */
-     , (35142,  72,    0.25) /* ResistStaminaDrain */
+     , (35142,  72,       1) /* ResistStaminaDrain */
      , (35142,  73,       1) /* ResistStaminaBoost */
-     , (35142,  74,     0.5) /* ResistManaDrain */
+     , (35142,  74,       1) /* ResistManaDrain */
      , (35142,  75,       1) /* ResistManaBoost */
      , (35142,  77,       1) /* PhysicsScriptIntensity */
      , (35142, 104,      10) /* ObviousRadarRange */
      , (35142, 117,     0.6) /* FocusedProbability */
-     , (35142, 125,    0.25) /* ResistHealthDrain */;
+     , (35142, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35142,   1, 'Mukkir Draktehn') /* Name */;

--- a/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35143 Mukkir Kartak.sql
+++ b/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35143 Mukkir Kartak.sql
@@ -43,14 +43,14 @@ VALUES (35143,   1,       5) /* HeartbeatInterval */
      , (35143,  69,    0.42) /* ResistAcid */
      , (35143,  70,    0.25) /* ResistElectric */
      , (35143,  71,    0.25) /* ResistHealthBoost */
-     , (35143,  72,    0.25) /* ResistStaminaDrain */
+     , (35143,  72,       1) /* ResistStaminaDrain */
      , (35143,  73,       1) /* ResistStaminaBoost */
-     , (35143,  74,     0.5) /* ResistManaDrain */
+     , (35143,  74,       1) /* ResistManaDrain */
      , (35143,  75,       1) /* ResistManaBoost */
      , (35143,  77,       1) /* PhysicsScriptIntensity */
      , (35143, 104,      10) /* ObviousRadarRange */
      , (35143, 117,     0.6) /* FocusedProbability */
-     , (35143, 125,    0.25) /* ResistHealthDrain */;
+     , (35143, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35143,   1, 'Mukkir Kartak') /* Name */;

--- a/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35144 Mukkir Laktar.sql
+++ b/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35144 Mukkir Laktar.sql
@@ -43,14 +43,14 @@ VALUES (35144,   1,       5) /* HeartbeatInterval */
      , (35144,  69,    0.42) /* ResistAcid */
      , (35144,  70,    0.25) /* ResistElectric */
      , (35144,  71,    0.25) /* ResistHealthBoost */
-     , (35144,  72,    0.25) /* ResistStaminaDrain */
+     , (35144,  72,       1) /* ResistStaminaDrain */
      , (35144,  73,       1) /* ResistStaminaBoost */
-     , (35144,  74,     0.5) /* ResistManaDrain */
+     , (35144,  74,       1) /* ResistManaDrain */
      , (35144,  75,       1) /* ResistManaBoost */
      , (35144,  77,       1) /* PhysicsScriptIntensity */
      , (35144, 104,      10) /* ObviousRadarRange */
      , (35144, 117,     0.6) /* FocusedProbability */
-     , (35144, 125,    0.25) /* ResistHealthDrain */;
+     , (35144, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35144,   1, 'Mukkir Laktar') /* Name */;

--- a/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35145 Umbral Mukkir.sql
+++ b/Database/Patches/2007-02-RekindlingTheLight/9 WeenieDefaults/SQL/Creature/Mukkir/35145 Umbral Mukkir.sql
@@ -43,14 +43,14 @@ VALUES (35145,   1,       5) /* HeartbeatInterval */
      , (35145,  69,    0.42) /* ResistAcid */
      , (35145,  70,    0.25) /* ResistElectric */
      , (35145,  71,    0.25) /* ResistHealthBoost */
-     , (35145,  72,    0.25) /* ResistStaminaDrain */
+     , (35145,  72,       1) /* ResistStaminaDrain */
      , (35145,  73,       1) /* ResistStaminaBoost */
-     , (35145,  74,     0.5) /* ResistManaDrain */
+     , (35145,  74,       1) /* ResistManaDrain */
      , (35145,  75,       1) /* ResistManaBoost */
      , (35145,  77,       1) /* PhysicsScriptIntensity */
      , (35145, 104,      10) /* ObviousRadarRange */
      , (35145, 117,     0.6) /* FocusedProbability */
-     , (35145, 125,    0.25) /* ResistHealthDrain */;
+     , (35145, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35145,   1, 'Umbral Mukkir') /* Name */;


### PR DESCRIPTION
Retail pcaps indicate that Mukkir in general are not resistant to
Nether and life magic spells. There are no counter indications known, and it
appears that the resistances may have originally been copied from other mobs.