### PR TITLE
update to PreTOD Guises

### DIFF
--- a/Database/Patches/2017-01-EndOfRetail/22024 Full Mu-miyah Guise.sql
+++ b/Database/Patches/2017-01-EndOfRetail/22024 Full Mu-miyah Guise.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 22024;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (22024, 'costumemummyhead', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (22024,   1,          2) /* ItemType - Armor */
+     , (22024,   3,         46) /* PaletteTemplate - Tan */
+     , (22024,   4,      130816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Head, Hands, Feet */
+     , (22024,   5,       1750) /* EncumbranceVal */
+     , (22024,   8,         75) /* Mass */
+     , (22024,   9,      32545) /* ValidLocations - HeadWear, HandWear, Armor */
+     , (22024,  16,          1) /* ItemUseable - No */
+     , (22024,  19,         75) /* Value */
+     , (22024,  27,          2) /* ArmorType - Leather */
+     , (22024,  28,         10) /* ArmorLevel */
+     , (22024,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (22024, 150,        103) /* HookPlacement - Hook */
+     , (22024, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (22024,  22, True ) /* Inscribable */
+     , (22024,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (22024,  12,    0.66) /* Shade */
+     , (22024,  13,     0.5) /* ArmorModVsSlash */
+     , (22024,  14,     0.5) /* ArmorModVsPierce */
+     , (22024,  15,    0.75) /* ArmorModVsBludgeon */
+     , (22024,  16,    0.65) /* ArmorModVsCold */
+     , (22024,  17,    0.55) /* ArmorModVsFire */
+     , (22024,  18,    0.55) /* ArmorModVsAcid */
+     , (22024,  19,    0.65) /* ArmorModVsElectric */
+     , (22024,  39,     0.8) /* DefaultScale */
+     , (22024, 110,       1) /* BulkMod */
+     , (22024, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (22024,   1, 'Full Mu-miyah Guise') /* Name */
+     , (22024,  16, 'A finely crafted mu-miyah costume complete with head. The smell of mold and old dirt lingers despite the glues used to hold the costume together. There is a thin line of padding that has been added to the interior to protect the wearer from touching the aged bandages.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (22024,   1,   33558022) /* Setup */
+     , (22024,   3,  536870932) /* SoundTable */
+     , (22024,   6,   67108990) /* PaletteBase */
+     , (22024,   7,  268436476) /* ClothingBase */
+     , (22024,   8,  100673715) /* Icon */
+     , (22024,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2017-01-EndOfRetail/28858 Armored Skeleton Guise.sql
+++ b/Database/Patches/2017-01-EndOfRetail/28858 Armored Skeleton Guise.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28858;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28858, 'costumearmoredskeleton', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28858,   1,          4) /* ItemType - Clothing */
+     , (28858,   3,          4) /* PaletteTemplate - Brown */
+     , (28858,   4,      130816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Head, Hands, Feet */
+     , (28858,   5,       1400) /* EncumbranceVal */
+     , (28858,   8,        150) /* Mass */
+     , (28858,   9,      32545) /* ValidLocations - HeadWear, HandWear, Armor */
+     , (28858,  16,          1) /* ItemUseable - No */
+     , (28858,  19,       1000) /* Value */
+     , (28858,  27,          1) /* ArmorType - Cloth */
+     , (28858,  28,         10) /* ArmorLevel */
+     , (28858,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (28858, 150,        103) /* HookPlacement - Hook */
+     , (28858, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28858,  22, True ) /* Inscribable */
+     , (28858,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28858,  12,       0) /* Shade */
+     , (28858,  13,     0.5) /* ArmorModVsSlash */
+     , (28858,  14,     0.5) /* ArmorModVsPierce */
+     , (28858,  15,    0.75) /* ArmorModVsBludgeon */
+     , (28858,  16,    0.65) /* ArmorModVsCold */
+     , (28858,  17,    0.55) /* ArmorModVsFire */
+     , (28858,  18,    0.55) /* ArmorModVsAcid */
+     , (28858,  19,    0.65) /* ArmorModVsElectric */
+     , (28858,  39,       1) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28858,   1, 'Armored Skeleton Guise') /* Name */
+     , (28858,  16, 'A finely-built armored skeleton costume.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28858,   1,   33559012) /* Setup */
+     , (28858,   3,  536870932) /* SoundTable */
+     , (28858,   6,   67108990) /* PaletteBase */
+     , (28858,   7,  268436865) /* ClothingBase */
+     , (28858,   8,  100677086) /* Icon */
+     , (28858,  22,  872415275) /* PhysicsEffectTable */
+     , (28858,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2017-01-EndOfRetail/28859 Armored Undead Guise.sql
+++ b/Database/Patches/2017-01-EndOfRetail/28859 Armored Undead Guise.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28859;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28859, 'costumearmoredundead', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28859,   1,          4) /* ItemType - Clothing */
+     , (28859,   3,          4) /* PaletteTemplate - Brown */
+     , (28859,   4,      130816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Head, Hands, Feet */
+     , (28859,   5,       1400) /* EncumbranceVal */
+     , (28859,   8,        150) /* Mass */
+     , (28859,   9,      32545) /* ValidLocations - HeadWear, HandWear, Armor */
+     , (28859,  16,          1) /* ItemUseable - No */
+     , (28859,  19,       1000) /* Value */
+     , (28859,  27,          1) /* ArmorType - Cloth */
+     , (28859,  28,         10) /* ArmorLevel */
+     , (28859,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (28859, 150,        103) /* HookPlacement - Hook */
+     , (28859, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28859,  22, True ) /* Inscribable */
+     , (28859,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28859,  12,       0) /* Shade */
+     , (28859,  13,     0.5) /* ArmorModVsSlash */
+     , (28859,  14,     0.5) /* ArmorModVsPierce */
+     , (28859,  15,    0.75) /* ArmorModVsBludgeon */
+     , (28859,  16,    0.65) /* ArmorModVsCold */
+     , (28859,  17,    0.55) /* ArmorModVsFire */
+     , (28859,  18,    0.55) /* ArmorModVsAcid */
+     , (28859,  19,    0.65) /* ArmorModVsElectric */
+     , (28859,  39,       1) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28859,   1, 'Armored Undead Guise') /* Name */
+     , (28859,  16, 'A finely-built armored undead costume.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28859,   1,   33559006) /* Setup */
+     , (28859,   3,  536870932) /* SoundTable */
+     , (28859,   6,   67108990) /* PaletteBase */
+     , (28859,   7,  268436864) /* ClothingBase */
+     , (28859,   8,  100677085) /* Icon */
+     , (28859,  22,  872415275) /* PhysicsEffectTable */
+     , (28859,  36,  234881046) /* MutateFilter */;

--- a/Database/Patches/2017-01-EndOfRetail/28860 Scarecrow Guise.sql
+++ b/Database/Patches/2017-01-EndOfRetail/28860 Scarecrow Guise.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28860;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28860, 'costumescarecrow', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28860,   1,          4) /* ItemType - Clothing */
+     , (28860,   3,          4) /* PaletteTemplate - Brown */
+     , (28860,   4,      130816) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Head, Hands, Feet */
+     , (28860,   5,       1400) /* EncumbranceVal */
+     , (28860,   8,        150) /* Mass */
+     , (28860,   9,      32545) /* ValidLocations - HeadWear, HandWear, Armor */
+     , (28860,  16,          1) /* ItemUseable - No */
+     , (28860,  19,       1000) /* Value */
+     , (28860,  27,          1) /* ArmorType - Cloth */
+     , (28860,  28,         10) /* ArmorLevel */
+     , (28860,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (28860, 150,        103) /* HookPlacement - Hook */
+     , (28860, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28860,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28860,  12,       0) /* Shade */
+     , (28860,  13,    0.75) /* ArmorModVsSlash */
+     , (28860,  14,    0.75) /* ArmorModVsPierce */
+     , (28860,  15,     0.5) /* ArmorModVsBludgeon */
+     , (28860,  16,     0.5) /* ArmorModVsCold */
+     , (28860,  17,     0.3) /* ArmorModVsFire */
+     , (28860,  18,     0.3) /* ArmorModVsAcid */
+     , (28860,  19,     0.5) /* ArmorModVsElectric */
+     , (28860,  39,       1) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28860,   1, 'Scarecrow Guise') /* Name */
+     , (28860,  16, 'A finely-built scarecrow costume. The pumpkin head feels a bit breezy, as thought it might not offer any real protection.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28860,   1,   33559001) /* Setup */
+     , (28860,   3,  536870932) /* SoundTable */
+     , (28860,   6,   67108990) /* PaletteBase */
+     , (28860,   7,  268436866) /* ClothingBase */
+     , (28860,   8,  100677084) /* Icon */
+     , (28860,  22,  872415275) /* PhysicsEffectTable */
+     , (28860,  36,  234881046) /* MutateFilter */;


### PR DESCRIPTION
Ive updated the clothing priority and valid locations. to reflect end of retail. Wiki shows screen shots of Full Coverage in these guises. where as ACE core weenies did not cover hands. I believe these were updated sometime in 2006 but I could not find any mention of it on the Wiki, or Fandom.
http://acpedia.org/wiki/Full_Mu-miyah_Guise
http://acpedia.org/wiki/Scarecrow_Guise
http://acpedia.org/wiki/Armored_Undead_Guise
http://acpedia.org/wiki/Armored_Skeleton_Guise

Gmriggs suggested it go in the EOR folder.