### PR TITLE
Casting Stone and Crimson Scarab Update

### DIFF
--- a/Database/Patches/2013-09-TheQuestForFreedom/9 WeenieDefaults/SQL/Caster/Caster/51899 Casting Stone.sql
+++ b/Database/Patches/2013-09-TheQuestForFreedom/9 WeenieDefaults/SQL/Caster/Caster/51899 Casting Stone.sql
@@ -36,7 +36,7 @@ VALUES (51899,   5,  -0.025) /* ManaRate */
      , (51899,  29,    1.22) /* WeaponDefense */
      , (51899,  39,     0.5) /* DefaultScale */
      , (51899, 144,     0.1) /* ManaConversionMod */
-     , (51899, 147,       1) /* CriticalFrequency */
+     , (51899, 147,     0.3) /* CriticalFrequency */
      , (51899, 149,    1.04) /* WeaponMissileDefense */
      , (51899, 150,    1.04) /* WeaponMagicDefense */
      , (51899, 152,     1.2) /* ElementalDamageMod */

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Clothing/Jewelry/52036 Purified Crimson Scarab.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Clothing/Jewelry/52036 Purified Crimson Scarab.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 52036;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (52036, 'ace52036-purifiedcrimsonscarab', 1, '2019-02-10 00:00:00') /* Generic */;
+VALUES (52036, 'ace52036-purifiedcrimsonscarab', 1, '2021-03-14 09:22:34') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (52036,   1,          8) /* ItemType - Jewelry */
@@ -42,8 +42,17 @@ VALUES (52036,   1,   33555211) /* Setup */
      , (52036,  22,  872415275) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (52036,  4548,      2)  /* FealtySelf8 */
-     , (52036,  5146,      2)  /* TrinketHealth3 */
-     , (52036,  5149,      2)  /* TrinketMana3 */
-     , (52036,  5150,      2)  /* TrinketStamina1 */
-     , (52036,  6105,      2)  /* CantripFocus4 */;
+VALUES (52036,  4548,      2) /* FealtySelf8 */
+     , (52036,  5146,      2) /* TrinketHealth3 */
+     , (52036,  5149,      2) /* TrinketMana3 */
+     , (52036,  5150,      2) /* TrinketStamina1 */
+     , (52036,  6105,      2) /* CantripFocus4 */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (52036, 25 /* Wield */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You slowly close your eyes and feel the wind pass through your body.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+


### PR DESCRIPTION
Corrected critical frequency on Casting Stone from 1 to 0.3.

Added missing wield emote for Purified Crimson Scarab (source, retail video, about 3 min in, https://www.youtube.com/watch?v=9Jiqt0sIozg).