### PR TITLE
WeaponType and SlayerDamageBonus Fixes

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/24207 Weeping Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/24207 Weeping Wand.sql
@@ -14,8 +14,6 @@ VALUES (24207,   1,      32768) /* ItemType - Caster */
      , (24207,  33,          1) /* Bonded - Bonded */
      , (24207,  36,       9999) /* ResistMagic */
      , (24207,  46,        512) /* DefaultCombatStyle - Magic */
-     , (24207,  52,          1) /* ParentLocation */
-     , (24207,  53,        101) /* PlacementPosition */
      , (24207,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24207,  94,         16) /* TargetType - Creature */
      , (24207, 106,        325) /* ItemSpellcraft */
@@ -29,25 +27,19 @@ VALUES (24207,   1,      32768) /* ItemType - Caster */
      , (24207, 158,          2) /* WieldRequirements - RawSkill */
      , (24207, 159,         33) /* WieldSkillType - LifeMagic */
      , (24207, 160,        300) /* WieldDifficulty */
-     , (24207, 166,         31) /* SlayerCreatureType - Human */
-     , (24207, 353,          0) /* WeaponType - Undef */;
+     , (24207, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24207,  11, True ) /* IgnoreCollisions */
-     , (24207,  13, True ) /* Ethereal */
-     , (24207,  14, True ) /* GravityStatus */
-     , (24207,  19, True ) /* Attackable */
-     , (24207,  22, True ) /* Inscribable */
-     , (24207,  23, True ) /* DestroyOnSell */
+VALUES (24207,  22, True ) /* Inscribable */
      , (24207,  69, False) /* IsSellable */
      , (24207,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24207,   5, -0.025000000372529) /* ManaRate */
+VALUES (24207,   5,  -0.025) /* ManaRate */
      , (24207,  29,       1) /* WeaponDefense */
      , (24207,  39,       1) /* DefaultScale */
-     , (24207, 138, 1.39999997615814) /* SlayerDamageBonus */
-     , (24207, 144, 0.0199999995529652) /* ManaConversionMod */;
+     , (24207, 138,     1.4) /* SlayerDamageBonus */
+     , (24207, 144,    0.02) /* ManaConversionMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (24207,   1, 'Weeping Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46215 Enhanced Shimmering Isparian Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46215 Enhanced Shimmering Isparian Wand.sql
@@ -28,20 +28,17 @@ VALUES (46215,   1,      32768) /* ItemType - Caster */
      , (46215, 166,         62) /* SlayerCreatureType - Elemental */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46215,  11, True ) /* IgnoreCollisions */
-     , (46215,  13, True ) /* Ethereal */
-     , (46215,  14, True ) /* GravityStatus */
-     , (46215,  19, True ) /* Attackable */
-     , (46215,  22, True ) /* Inscribable */
+VALUES (46215,  22, True ) /* Inscribable */
      , (46215,  69, False) /* IsSellable */
      , (46215,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46215,   5, -0.025000000372529) /* ManaRate */
-     , (46215,  29, 1.13999998569489) /* WeaponDefense */
-     , (46215, 144, 0.0799999982118607) /* ManaConversionMod */
-     , (46215, 147, 0.219999998807907) /* CriticalFrequency */
-     , (46215, 152, 1.19000005722046) /* ElementalDamageMod */;
+VALUES (46215,   5, -0.025) /* ManaRate */
+     , (46215,  29,   1.14) /* WeaponDefense */
+     , (46215, 144,   0.08) /* ManaConversionMod */
+     , (46215, 147,   0.22) /* CriticalFrequency */
+     , (46215, 138,      4) /* SlayerDamageBonus */
+     , (46215, 152,   1.19) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46215,   1, 'Enhanced Shimmering Isparian Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46220 Blackfire Dissolving Isparian Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46220 Blackfire Dissolving Isparian Wand.sql
@@ -16,8 +16,6 @@ VALUES (46220,   1,      32768) /* ItemType - Caster */
      , (46220,  45,         32) /* DamageType - Acid */
      , (46220,  46,        512) /* DefaultCombatStyle - Magic */
      , (46220,  48,         34) /* WeaponSkill - WarMagic */
-     , (46220,  52,          1) /* ParentLocation - RightHand */
-     , (46220,  53,          3) /* PlacementPosition - LeftHand */
      , (46220,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (46220, 106,        325) /* ItemSpellcraft */
      , (46220, 107,        500) /* ItemCurMana */
@@ -31,20 +29,17 @@ VALUES (46220,   1,      32768) /* ItemType - Caster */
      , (46220, 166,         42) /* SlayerCreatureType - LightningElemental */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46220,  11, True ) /* IgnoreCollisions */
-     , (46220,  13, True ) /* Ethereal */
-     , (46220,  14, True ) /* GravityStatus */
-     , (46220,  19, True ) /* Attackable */
-     , (46220,  22, True ) /* Inscribable */
+VALUES (46220,  22, True ) /* Inscribable */
      , (46220,  69, False) /* IsSellable */
      , (46220,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46220,   5, -0.025000000372529) /* ManaRate */
-     , (46220,  29, 1.12000000476837) /* WeaponDefense */
-     , (46220, 144, 0.0599999986588955) /* ManaConversionMod */
-     , (46220, 147, 0.170000001788139) /* CriticalFrequency */
-     , (46220, 152, 1.16999995708466) /* ElementalDamageMod */;
+VALUES (46220,   5, -0.025) /* ManaRate */
+     , (46220,  29,   1.12) /* WeaponDefense */
+     , (46220, 138,      3) /* SlayerDamageBonus */
+     , (46220, 144,   0.06) /* ManaConversionMod */
+     , (46220, 147,   0.17) /* CriticalFrequency */
+     , (46220, 152,   1.17) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46220,   1, 'Blackfire Dissolving Isparian Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46258 Enhanced Chilling Isparian Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46258 Enhanced Chilling Isparian Wand.sql
@@ -28,20 +28,17 @@ VALUES (46258,   1,      32768) /* ItemType - Caster */
      , (46258, 166,         38) /* SlayerCreatureType - FireElemental */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46258,  11, True ) /* IgnoreCollisions */
-     , (46258,  13, True ) /* Ethereal */
-     , (46258,  14, True ) /* GravityStatus */
-     , (46258,  19, True ) /* Attackable */
-     , (46258,  22, True ) /* Inscribable */
+VALUES (46258,  22, True ) /* Inscribable */
      , (46258,  69, False) /* IsSellable */
      , (46258,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46258,   5, -0.025000000372529) /* ManaRate */
-     , (46258,  29, 1.13999998569489) /* WeaponDefense */
-     , (46258, 144, 0.0799999982118607) /* ManaConversionMod */
-     , (46258, 147, 0.219999998807907) /* CriticalFrequency */
-     , (46258, 152, 1.19000005722046) /* ElementalDamageMod */;
+VALUES (46258,   5, -0.025) /* ManaRate */
+     , (46258,  29,   1.14) /* WeaponDefense */
+     , (46258, 138,      4) /* SlayerDamageBonus */
+     , (46258, 144,   0.08) /* ManaConversionMod */
+     , (46258, 147,   0.22) /* CriticalFrequency */
+     , (46258, 152,   1.19) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46258,   1, 'Enhanced Chilling Isparian Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46260 Enhanced Flaming Isparian Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46260 Enhanced Flaming Isparian Wand.sql
@@ -28,20 +28,17 @@ VALUES (46260,   1,      32768) /* ItemType - Caster */
      , (46260, 166,         61) /* SlayerCreatureType - FrostElemental */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46260,  11, True ) /* IgnoreCollisions */
-     , (46260,  13, True ) /* Ethereal */
-     , (46260,  14, True ) /* GravityStatus */
-     , (46260,  19, True ) /* Attackable */
-     , (46260,  22, True ) /* Inscribable */
+VALUES (46260,  22, True ) /* Inscribable */
      , (46260,  69, False) /* IsSellable */
      , (46260,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46260,   5, -0.025000000372529) /* ManaRate */
-     , (46260,  29, 1.13999998569489) /* WeaponDefense */
-     , (46260, 144, 0.0799999982118607) /* ManaConversionMod */
-     , (46260, 147, 0.219999998807907) /* CriticalFrequency */
-     , (46260, 152, 1.19000005722046) /* ElementalDamageMod */;
+VALUES (46260,   5, -0.025) /* ManaRate */
+     , (46260,  29,   1.14) /* WeaponDefense */
+     , (46260, 138,      4) /* SlayerDamageBonus */
+     , (46260, 144,   0.08) /* ManaConversionMod */
+     , (46260, 147,   0.22) /* CriticalFrequency */
+     , (46260, 152,   1.19) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46260,   1, 'Enhanced Flaming Isparian Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46262 Enhanced Coruscating Isparian Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46262 Enhanced Coruscating Isparian Wand.sql
@@ -28,20 +28,17 @@ VALUES (46262,   1,      32768) /* ItemType - Caster */
      , (46262, 166,         60) /* SlayerCreatureType - AcidElemental */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46262,  11, True ) /* IgnoreCollisions */
-     , (46262,  13, True ) /* Ethereal */
-     , (46262,  14, True ) /* GravityStatus */
-     , (46262,  19, True ) /* Attackable */
-     , (46262,  22, True ) /* Inscribable */
+VALUES (46262,  22, True ) /* Inscribable */
      , (46262,  69, False) /* IsSellable */
      , (46262,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46262,   5, -0.025000000372529) /* ManaRate */
-     , (46262,  29, 1.13999998569489) /* WeaponDefense */
-     , (46262, 144, 0.0799999982118607) /* ManaConversionMod */
-     , (46262, 147, 0.219999998807907) /* CriticalFrequency */
-     , (46262, 152, 1.19000005722046) /* ElementalDamageMod */;
+VALUES (46262,   5, -0.025) /* ManaRate */
+     , (46262,  29,   1.14) /* WeaponDefense */
+     , (46262, 138,      4) /* SlayerDamageBonus */
+     , (46262, 144,   0.08) /* ManaConversionMod */
+     , (46262, 147,   0.22) /* CriticalFrequency */
+     , (46262, 152,   1.19) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46262,   1, 'Enhanced Coruscating Isparian Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46264 Enhanced Dissolving Isparian Wand.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Caster/46264 Enhanced Dissolving Isparian Wand.sql
@@ -28,20 +28,17 @@ VALUES (46264,   1,      32768) /* ItemType - Caster */
      , (46264, 166,         42) /* SlayerCreatureType - LightningElemental */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46264,  11, True ) /* IgnoreCollisions */
-     , (46264,  13, True ) /* Ethereal */
-     , (46264,  14, True ) /* GravityStatus */
-     , (46264,  19, True ) /* Attackable */
-     , (46264,  22, True ) /* Inscribable */
+VALUES (46264,  22, True ) /* Inscribable */
      , (46264,  69, False) /* IsSellable */
      , (46264,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46264,   5, -0.025000000372529) /* ManaRate */
-     , (46264,  29, 1.13999998569489) /* WeaponDefense */
-     , (46264, 144, 0.0799999982118607) /* ManaConversionMod */
-     , (46264, 147, 0.219999998807907) /* CriticalFrequency */
-     , (46264, 152, 1.19000005722046) /* ElementalDamageMod */;
+VALUES (46264,   5, -0.025) /* ManaRate */
+     , (46264,  29,   1.14) /* WeaponDefense */
+     , (46264, 138,      4) /* SlayerDamageBonus */
+     , (46264, 144,   0.08) /* ManaConversionMod */
+     , (46264, 147,   0.22) /* CriticalFrequency */
+     , (46264, 152,   1.19) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46264,   1, 'Enhanced Dissolving Isparian Wand') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Jewelry/30364 Weeping Ring.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Clothing/Jewelry/30364 Weeping Ring.sql
@@ -13,8 +13,6 @@ VALUES (30364,   1,          8) /* ItemType - Jewelry */
      , (30364,  17,        273) /* RareId */
      , (30364,  19,      50000) /* Value */
      , (30364,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
-     , (30364,  52,          2) /* ParentLocation */
-     , (30364,  53,        101) /* PlacementPosition */
      , (30364,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30364, 106,        350) /* ItemSpellcraft */
      , (30364, 107,       3000) /* ItemCurMana */
@@ -29,16 +27,12 @@ VALUES (30364,   4,          0) /* ItemTotalXp */
      , (30364,   5, 2000000000) /* ItemBaseXp */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (30364,  11, True ) /* IgnoreCollisions */
-     , (30364,  13, True ) /* Ethereal */
-     , (30364,  14, True ) /* GravityStatus */
-     , (30364,  19, True ) /* Attackable */
-     , (30364,  22, True ) /* Inscribable */
+VALUES (30364,  22, True ) /* Inscribable */
      , (30364, 100, False) /* Dyable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (30364,   5, -0.0333333015441895) /* ManaRate */
-     , (30364,  12, 0.660000026226044) /* Shade */
+VALUES (30364,   5,  -0.033) /* ManaRate */
+     , (30364,  12,    0.66) /* Shade */
      , (30364,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24198 Weeping Axe.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24198 Weeping Axe.sql
@@ -20,7 +20,6 @@ VALUES (24198,   1,          1) /* ItemType - MeleeWeapon */
      , (24198,  48,         45) /* WeaponSkill - LightWeapons */
      , (24198,  49,         25) /* WeaponTime */
      , (24198,  51,          1) /* CombatUse - Melee */
-     , (24198,  53,        101) /* PlacementPosition */
      , (24198,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24198, 106,        300) /* ItemSpellcraft */
      , (24198, 107,        800) /* ItemCurMana */
@@ -35,23 +34,18 @@ VALUES (24198,   1,          1) /* ItemType - MeleeWeapon */
      , (24198, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24198,  11, True ) /* IgnoreCollisions */
-     , (24198,  13, True ) /* Ethereal */
-     , (24198,  14, True ) /* GravityStatus */
-     , (24198,  19, True ) /* Attackable */
-     , (24198,  22, True ) /* Inscribable */
-     , (24198,  23, True ) /* DestroyOnSell */
+VALUES (24198,  22, True ) /* Inscribable */
      , (24198,  69, False) /* IsSellable */
      , (24198,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24198,   5, -0.025000000372529) /* ManaRate */
+VALUES (24198,   5,  -0.025) /* ManaRate */
      , (24198,  21,    0.75) /* WeaponLength */
-     , (24198,  22, 0.400000005960464) /* DamageVariance */
-     , (24198,  29, 1.17999994754791) /* WeaponDefense */
+     , (24198,  22,     0.4) /* DamageVariance */
+     , (24198,  29,    1.18) /* WeaponDefense */
      , (24198,  39,       1) /* DefaultScale */
-     , (24198,  62, 1.23000001907349) /* WeaponOffense */
-     , (24198, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24198,  62,    1.23) /* WeaponOffense */
+     , (24198, 138,     3.4) /* SlayerDamageBonus */
      , (24198, 151,       1) /* IgnoreShield */
      , (24198, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24200 Weeping Claw.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24200 Weeping Claw.sql
@@ -20,8 +20,6 @@ VALUES (24200,   1,          1) /* ItemType - MeleeWeapon */
      , (24200,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (24200,  49,          1) /* WeaponTime */
      , (24200,  51,          1) /* CombatUse - Melee */
-     , (24200,  52,          1) /* ParentLocation */
-     , (24200,  53,        101) /* PlacementPosition */
      , (24200,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24200, 106,        300) /* ItemSpellcraft */
      , (24200, 107,        800) /* ItemCurMana */
@@ -36,25 +34,20 @@ VALUES (24200,   1,          1) /* ItemType - MeleeWeapon */
      , (24200, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24200,  11, True ) /* IgnoreCollisions */
-     , (24200,  13, True ) /* Ethereal */
-     , (24200,  14, True ) /* GravityStatus */
-     , (24200,  19, True ) /* Attackable */
-     , (24200,  22, True ) /* Inscribable */
-     , (24200,  23, True ) /* DestroyOnSell */
+VALUES (24200,  22, True ) /* Inscribable */
      , (24200,  69, False) /* IsSellable */
      , (24200,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24200,   5, -0.025000000372529) /* ManaRate */
-     , (24200,  21, 0.550000011920929) /* WeaponLength */
+VALUES (24200,   5,  -0.025) /* ManaRate */
+     , (24200,  21,    0.55) /* WeaponLength */
      , (24200,  22,     0.5) /* DamageVariance */
      , (24200,  26,       0) /* MaximumVelocity */
-     , (24200,  29, 1.17999994754791) /* WeaponDefense */
+     , (24200,  29,    1.18) /* WeaponDefense */
      , (24200,  39,       1) /* DefaultScale */
-     , (24200,  62, 1.23000001907349) /* WeaponOffense */
+     , (24200,  62,    1.23) /* WeaponOffense */
      , (24200,  63,       1) /* DamageMod */
-     , (24200, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24200, 138,     3.4) /* SlayerDamageBonus */
      , (24200, 151,       1) /* IgnoreShield */
      , (24200, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24202 Weeping Dagger.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24202 Weeping Dagger.sql
@@ -20,8 +20,6 @@ VALUES (24202,   1,          1) /* ItemType - MeleeWeapon */
      , (24202,  48,         45) /* WeaponSkill - LightWeapons */
      , (24202,  49,          1) /* WeaponTime */
      , (24202,  51,          1) /* CombatUse - Melee */
-     , (24202,  52,          1) /* ParentLocation */
-     , (24202,  53,          1) /* PlacementPosition */
      , (24202,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24202, 106,        300) /* ItemSpellcraft */
      , (24202, 107,        800) /* ItemCurMana */
@@ -36,25 +34,20 @@ VALUES (24202,   1,          1) /* ItemType - MeleeWeapon */
      , (24202, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24202,  11, True ) /* IgnoreCollisions */
-     , (24202,  13, True ) /* Ethereal */
-     , (24202,  14, True ) /* GravityStatus */
-     , (24202,  19, True ) /* Attackable */
-     , (24202,  22, True ) /* Inscribable */
-     , (24202,  23, True ) /* DestroyOnSell */
+VALUES (24202,  22, True ) /* Inscribable */
      , (24202,  69, False) /* IsSellable */
      , (24202,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24202,   5, -0.025000000372529) /* ManaRate */
-     , (24202,  21, 0.400000005960464) /* WeaponLength */
-     , (24202,  22, 0.300000011920929) /* DamageVariance */
+VALUES (24202,   5,  -0.025) /* ManaRate */
+     , (24202,  21,     0.4) /* WeaponLength */
+     , (24202,  22,     0.3) /* DamageVariance */
      , (24202,  26,       0) /* MaximumVelocity */
-     , (24202,  29, 1.21000003814697) /* WeaponDefense */
+     , (24202,  29,    1.21) /* WeaponDefense */
      , (24202,  39,       1) /* DefaultScale */
-     , (24202,  62, 1.20000004768372) /* WeaponOffense */
+     , (24202,  62,     1.2) /* WeaponOffense */
      , (24202,  63,       1) /* DamageMod */
-     , (24202, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24202, 138,     3.4) /* SlayerDamageBonus */
      , (24202, 151,       1) /* IgnoreShield */
      , (24202, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24203 Weeping Mace.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24203 Weeping Mace.sql
@@ -20,7 +20,6 @@ VALUES (24203,   1,          1) /* ItemType - MeleeWeapon */
      , (24203,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (24203,  49,          5) /* WeaponTime */
      , (24203,  51,          1) /* CombatUse - Melee */
-     , (24203,  53,        101) /* PlacementPosition */
      , (24203,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24203, 106,        300) /* ItemSpellcraft */
      , (24203, 107,        800) /* ItemCurMana */
@@ -35,25 +34,20 @@ VALUES (24203,   1,          1) /* ItemType - MeleeWeapon */
      , (24203, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24203,  11, True ) /* IgnoreCollisions */
-     , (24203,  13, True ) /* Ethereal */
-     , (24203,  14, True ) /* GravityStatus */
-     , (24203,  19, True ) /* Attackable */
-     , (24203,  22, True ) /* Inscribable */
-     , (24203,  23, True ) /* DestroyOnSell */
+VALUES (24203,  22, True ) /* Inscribable */
      , (24203,  69, False) /* IsSellable */
      , (24203,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24203,   5, -0.025000000372529) /* ManaRate */
-     , (24203,  21, 0.600000023841858) /* WeaponLength */
-     , (24203,  22, 0.300000011920929) /* DamageVariance */
+VALUES (24203,   5,  -0.025) /* ManaRate */
+     , (24203,  21,     0.6) /* WeaponLength */
+     , (24203,  22,     0.3) /* DamageVariance */
      , (24203,  26,       0) /* MaximumVelocity */
-     , (24203,  29, 1.21000003814697) /* WeaponDefense */
+     , (24203,  29,    1.21) /* WeaponDefense */
      , (24203,  39,       1) /* DefaultScale */
-     , (24203,  62, 1.20000004768372) /* WeaponOffense */
+     , (24203,  62,     1.2) /* WeaponOffense */
      , (24203,  63,       1) /* DamageMod */
-     , (24203, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24203, 138,     3.4) /* SlayerDamageBonus */
      , (24203, 151,       1) /* IgnoreShield */
      , (24203, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24204 Weeping Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24204 Weeping Spear.sql
@@ -20,7 +20,6 @@ VALUES (24204,   1,          1) /* ItemType - MeleeWeapon */
      , (24204,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (24204,  49,          1) /* WeaponTime */
      , (24204,  51,          1) /* CombatUse - Melee */
-     , (24204,  53,        101) /* PlacementPosition */
      , (24204,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24204, 106,        300) /* ItemSpellcraft */
      , (24204, 107,        800) /* ItemCurMana */
@@ -35,25 +34,20 @@ VALUES (24204,   1,          1) /* ItemType - MeleeWeapon */
      , (24204, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24204,  11, True ) /* IgnoreCollisions */
-     , (24204,  13, True ) /* Ethereal */
-     , (24204,  14, True ) /* GravityStatus */
-     , (24204,  19, True ) /* Attackable */
-     , (24204,  22, True ) /* Inscribable */
-     , (24204,  23, True ) /* DestroyOnSell */
+VALUES (24204,  22, True ) /* Inscribable */
      , (24204,  69, False) /* IsSellable */
      , (24204,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24204,   5, -0.025000000372529) /* ManaRate */
+VALUES (24204,   5,  -0.025) /* ManaRate */
      , (24204,  21,     1.5) /* WeaponLength */
-     , (24204,  22, 0.449999988079071) /* DamageVariance */
+     , (24204,  22,    0.45) /* DamageVariance */
      , (24204,  26,       0) /* MaximumVelocity */
-     , (24204,  29, 1.17999994754791) /* WeaponDefense */
+     , (24204,  29,    1.18) /* WeaponDefense */
      , (24204,  39,       1) /* DefaultScale */
-     , (24204,  62, 1.23000001907349) /* WeaponOffense */
+     , (24204,  62,    1.23) /* WeaponOffense */
      , (24204,  63,       1) /* DamageMod */
-     , (24204, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24204, 138,     3.4) /* SlayerDamageBonus */
      , (24204, 151,       1) /* IgnoreShield */
      , (24204, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24205 Weeping Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24205 Weeping Staff.sql
@@ -20,8 +20,6 @@ VALUES (24205,   1,          1) /* ItemType - MeleeWeapon */
      , (24205,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (24205,  49,          1) /* WeaponTime */
      , (24205,  51,          1) /* CombatUse - Melee */
-     , (24205,  52,          1) /* ParentLocation */
-     , (24205,  53,        101) /* PlacementPosition */
      , (24205,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24205, 106,        300) /* ItemSpellcraft */
      , (24205, 107,        800) /* ItemCurMana */
@@ -36,23 +34,18 @@ VALUES (24205,   1,          1) /* ItemType - MeleeWeapon */
      , (24205, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24205,  11, True ) /* IgnoreCollisions */
-     , (24205,  13, True ) /* Ethereal */
-     , (24205,  14, True ) /* GravityStatus */
-     , (24205,  19, True ) /* Attackable */
-     , (24205,  22, True ) /* Inscribable */
-     , (24205,  23, True ) /* DestroyOnSell */
+VALUES (24205,  22, True ) /* Inscribable */
      , (24205,  69, False) /* IsSellable */
      , (24205,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24205,   5, -0.025000000372529) /* ManaRate */
-     , (24205,  21, 1.33000004291534) /* WeaponLength */
-     , (24205,  22, 0.300000011920929) /* DamageVariance */
-     , (24205,  29, 1.17999994754791) /* WeaponDefense */
+VALUES (24205,   5,  -0.025) /* ManaRate */
+     , (24205,  21,    1.33) /* WeaponLength */
+     , (24205,  22,     0.3) /* DamageVariance */
+     , (24205,  29,    1.18) /* WeaponDefense */
      , (24205,  39,       1) /* DefaultScale */
-     , (24205,  62, 1.23000001907349) /* WeaponOffense */
-     , (24205, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24205,  62,    1.23) /* WeaponOffense */
+     , (24205, 138,     3.4) /* SlayerDamageBonus */
      , (24205, 151,       1) /* IgnoreShield */
      , (24205, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24206 Weeping Sword.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/24206 Weeping Sword.sql
@@ -20,7 +20,6 @@ VALUES (24206,   1,          1) /* ItemType - MeleeWeapon */
      , (24206,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (24206,  49,          5) /* WeaponTime */
      , (24206,  51,          1) /* CombatUse - Melee */
-     , (24206,  53,        101) /* PlacementPosition */
      , (24206,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24206, 106,        300) /* ItemSpellcraft */
      , (24206, 107,        800) /* ItemCurMana */
@@ -35,25 +34,20 @@ VALUES (24206,   1,          1) /* ItemType - MeleeWeapon */
      , (24206, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24206,  11, True ) /* IgnoreCollisions */
-     , (24206,  13, True ) /* Ethereal */
-     , (24206,  14, True ) /* GravityStatus */
-     , (24206,  19, True ) /* Attackable */
-     , (24206,  22, True ) /* Inscribable */
-     , (24206,  23, True ) /* DestroyOnSell */
+VALUES (24206,  22, True ) /* Inscribable */
      , (24206,  69, False) /* IsSellable */
      , (24206,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24206,   5, -0.025000000372529) /* ManaRate */
+VALUES (24206,   5,  -0.025) /* ManaRate */
      , (24206,  21,       1) /* WeaponLength */
-     , (24206,  22, 0.400000005960464) /* DamageVariance */
+     , (24206,  22,     0.4) /* DamageVariance */
      , (24206,  26,       0) /* MaximumVelocity */
-     , (24206,  29, 1.20000004768372) /* WeaponDefense */
+     , (24206,  29,     1.2) /* WeaponDefense */
      , (24206,  39,       1) /* DefaultScale */
-     , (24206,  62, 1.21000003814697) /* WeaponOffense */
+     , (24206,  62,    1.21) /* WeaponOffense */
      , (24206,  63,       1) /* DamageMod */
-     , (24206, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (24206, 138,     3.4) /* SlayerDamageBonus */
      , (24206, 151,       1) /* IgnoreShield */
      , (24206, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25607 Acidic Weeping Axe.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25607 Acidic Weeping Axe.sql
@@ -21,7 +21,6 @@ VALUES (25607,   1,          1) /* ItemType - MeleeWeapon */
      , (25607,  48,         45) /* WeaponSkill - LightWeapons */
      , (25607,  49,         25) /* WeaponTime */
      , (25607,  51,          1) /* CombatUse - Melee */
-     , (25607,  53,        101) /* PlacementPosition */
      , (25607,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25607, 106,        300) /* ItemSpellcraft */
      , (25607, 107,        800) /* ItemCurMana */
@@ -36,23 +35,18 @@ VALUES (25607,   1,          1) /* ItemType - MeleeWeapon */
      , (25607, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25607,  11, True ) /* IgnoreCollisions */
-     , (25607,  13, True ) /* Ethereal */
-     , (25607,  14, True ) /* GravityStatus */
-     , (25607,  19, True ) /* Attackable */
-     , (25607,  22, True ) /* Inscribable */
-     , (25607,  23, True ) /* DestroyOnSell */
+VALUES (25607,  22, True ) /* Inscribable */
      , (25607,  69, False) /* IsSellable */
      , (25607,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25607,   5, -0.025000000372529) /* ManaRate */
+VALUES (25607,   5,  -0.025) /* ManaRate */
      , (25607,  21,    0.75) /* WeaponLength */
-     , (25607,  22, 0.400000005960464) /* DamageVariance */
-     , (25607,  29, 1.17999994754791) /* WeaponDefense */
+     , (25607,  22,     0.4) /* DamageVariance */
+     , (25607,  29,    1.18) /* WeaponDefense */
      , (25607,  39,       1) /* DefaultScale */
-     , (25607,  62, 1.23000001907349) /* WeaponOffense */
-     , (25607, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25607,  62,    1.23) /* WeaponOffense */
+     , (25607, 138,     3.4) /* SlayerDamageBonus */
      , (25607, 151,       1) /* IgnoreShield */
      , (25607, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25608 Electric Weeping Axe.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25608 Electric Weeping Axe.sql
@@ -21,7 +21,6 @@ VALUES (25608,   1,          1) /* ItemType - MeleeWeapon */
      , (25608,  48,         45) /* WeaponSkill - LightWeapons */
      , (25608,  49,         25) /* WeaponTime */
      , (25608,  51,          1) /* CombatUse - Melee */
-     , (25608,  53,        101) /* PlacementPosition */
      , (25608,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25608, 106,        300) /* ItemSpellcraft */
      , (25608, 107,        800) /* ItemCurMana */
@@ -36,23 +35,18 @@ VALUES (25608,   1,          1) /* ItemType - MeleeWeapon */
      , (25608, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25608,  11, True ) /* IgnoreCollisions */
-     , (25608,  13, True ) /* Ethereal */
-     , (25608,  14, True ) /* GravityStatus */
-     , (25608,  19, True ) /* Attackable */
-     , (25608,  22, True ) /* Inscribable */
-     , (25608,  23, True ) /* DestroyOnSell */
+VALUES (25608,  22, True ) /* Inscribable */
      , (25608,  69, False) /* IsSellable */
      , (25608,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25608,   5, -0.025000000372529) /* ManaRate */
+VALUES (25608,   5,  -0.025) /* ManaRate */
      , (25608,  21,    0.75) /* WeaponLength */
-     , (25608,  22, 0.400000005960464) /* DamageVariance */
-     , (25608,  29, 1.17999994754791) /* WeaponDefense */
+     , (25608,  22,     0.4) /* DamageVariance */
+     , (25608,  29,    1.18) /* WeaponDefense */
      , (25608,  39,       1) /* DefaultScale */
-     , (25608,  62, 1.23000001907349) /* WeaponOffense */
-     , (25608, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25608,  62,    1.23) /* WeaponOffense */
+     , (25608, 138,     3.4) /* SlayerDamageBonus */
      , (25608, 151,       1) /* IgnoreShield */
      , (25608, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25609 Flaming Weeping Axe.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25609 Flaming Weeping Axe.sql
@@ -21,7 +21,6 @@ VALUES (25609,   1,          1) /* ItemType - MeleeWeapon */
      , (25609,  48,         45) /* WeaponSkill - LightWeapons */
      , (25609,  49,         25) /* WeaponTime */
      , (25609,  51,          1) /* CombatUse - Melee */
-     , (25609,  53,        101) /* PlacementPosition */
      , (25609,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25609, 106,        300) /* ItemSpellcraft */
      , (25609, 107,        800) /* ItemCurMana */
@@ -36,23 +35,18 @@ VALUES (25609,   1,          1) /* ItemType - MeleeWeapon */
      , (25609, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25609,  11, True ) /* IgnoreCollisions */
-     , (25609,  13, True ) /* Ethereal */
-     , (25609,  14, True ) /* GravityStatus */
-     , (25609,  19, True ) /* Attackable */
-     , (25609,  22, True ) /* Inscribable */
-     , (25609,  23, True ) /* DestroyOnSell */
+VALUES (25609,  22, True ) /* Inscribable */
      , (25609,  69, False) /* IsSellable */
      , (25609,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25609,   5, -0.025000000372529) /* ManaRate */
+VALUES (25609,   5,  -0.025) /* ManaRate */
      , (25609,  21,    0.75) /* WeaponLength */
-     , (25609,  22, 0.400000005960464) /* DamageVariance */
-     , (25609,  29, 1.17999994754791) /* WeaponDefense */
+     , (25609,  22,     0.4) /* DamageVariance */
+     , (25609,  29,    1.18) /* WeaponDefense */
      , (25609,  39,       1) /* DefaultScale */
-     , (25609,  62, 1.23000001907349) /* WeaponOffense */
-     , (25609, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25609,  62,    1.23) /* WeaponOffense */
+     , (25609, 138,     3.4) /* SlayerDamageBonus */
      , (25609, 151,       1) /* IgnoreShield */
      , (25609, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25610 Frozen Weeping Axe.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25610 Frozen Weeping Axe.sql
@@ -21,7 +21,6 @@ VALUES (25610,   1,          1) /* ItemType - MeleeWeapon */
      , (25610,  48,         45) /* WeaponSkill - LightWeapons */
      , (25610,  49,         25) /* WeaponTime */
      , (25610,  51,          1) /* CombatUse - Melee */
-     , (25610,  53,        101) /* PlacementPosition */
      , (25610,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25610, 106,        300) /* ItemSpellcraft */
      , (25610, 107,        800) /* ItemCurMana */
@@ -36,23 +35,18 @@ VALUES (25610,   1,          1) /* ItemType - MeleeWeapon */
      , (25610, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25610,  11, True ) /* IgnoreCollisions */
-     , (25610,  13, True ) /* Ethereal */
-     , (25610,  14, True ) /* GravityStatus */
-     , (25610,  19, True ) /* Attackable */
-     , (25610,  22, True ) /* Inscribable */
-     , (25610,  23, True ) /* DestroyOnSell */
+VALUES (25610,  22, True ) /* Inscribable */
      , (25610,  69, False) /* IsSellable */
      , (25610,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25610,   5, -0.025000000372529) /* ManaRate */
+VALUES (25610,   5,  -0.025) /* ManaRate */
      , (25610,  21,    0.75) /* WeaponLength */
-     , (25610,  22, 0.400000005960464) /* DamageVariance */
-     , (25610,  29, 1.17999994754791) /* WeaponDefense */
+     , (25610,  22,     0.4) /* DamageVariance */
+     , (25610,  29,    1.18) /* WeaponDefense */
      , (25610,  39,       1) /* DefaultScale */
-     , (25610,  62, 1.23000001907349) /* WeaponOffense */
-     , (25610, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25610,  62,    1.23) /* WeaponOffense */
+     , (25610, 138,     3.4) /* SlayerDamageBonus */
      , (25610, 151,       1) /* IgnoreShield */
      , (25610, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25611 Acidic Weeping Claw.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25611 Acidic Weeping Claw.sql
@@ -21,8 +21,6 @@ VALUES (25611,   1,          1) /* ItemType - MeleeWeapon */
      , (25611,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25611,  49,          1) /* WeaponTime */
      , (25611,  51,          1) /* CombatUse - Melee */
-     , (25611,  52,          1) /* ParentLocation */
-     , (25611,  53,        101) /* PlacementPosition */
      , (25611,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25611, 106,        300) /* ItemSpellcraft */
      , (25611, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25611,   1,          1) /* ItemType - MeleeWeapon */
      , (25611, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25611,  11, True ) /* IgnoreCollisions */
-     , (25611,  13, True ) /* Ethereal */
-     , (25611,  14, True ) /* GravityStatus */
-     , (25611,  19, True ) /* Attackable */
-     , (25611,  22, True ) /* Inscribable */
-     , (25611,  23, True ) /* DestroyOnSell */
+VALUES (25611,  22, True ) /* Inscribable */
      , (25611,  69, False) /* IsSellable */
      , (25611,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25611,   5, -0.025000000372529) /* ManaRate */
-     , (25611,  21, 0.550000011920929) /* WeaponLength */
+VALUES (25611,   5,  -0.025) /* ManaRate */
+     , (25611,  21,    0.55) /* WeaponLength */
      , (25611,  22,     0.5) /* DamageVariance */
      , (25611,  26,       0) /* MaximumVelocity */
-     , (25611,  29, 1.17999994754791) /* WeaponDefense */
+     , (25611,  29,    1.18) /* WeaponDefense */
      , (25611,  39,       1) /* DefaultScale */
-     , (25611,  62, 1.23000001907349) /* WeaponOffense */
+     , (25611,  62,    1.23) /* WeaponOffense */
      , (25611,  63,       1) /* DamageMod */
-     , (25611, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25611, 138,     3.4) /* SlayerDamageBonus */
      , (25611, 151,       1) /* IgnoreShield */
      , (25611, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25612 Electric Weeping Claw.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25612 Electric Weeping Claw.sql
@@ -21,8 +21,6 @@ VALUES (25612,   1,          1) /* ItemType - MeleeWeapon */
      , (25612,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25612,  49,          1) /* WeaponTime */
      , (25612,  51,          1) /* CombatUse - Melee */
-     , (25612,  52,          1) /* ParentLocation */
-     , (25612,  53,        101) /* PlacementPosition */
      , (25612,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25612, 106,        300) /* ItemSpellcraft */
      , (25612, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25612,   1,          1) /* ItemType - MeleeWeapon */
      , (25612, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25612,  11, True ) /* IgnoreCollisions */
-     , (25612,  13, True ) /* Ethereal */
-     , (25612,  14, True ) /* GravityStatus */
-     , (25612,  19, True ) /* Attackable */
-     , (25612,  22, True ) /* Inscribable */
-     , (25612,  23, True ) /* DestroyOnSell */
-     , (25612,  69, False) /* IsSellable */
+VALUES (25612,  22, True ) /* Inscribable */
+-     , (25612,  69, False) /* IsSellable */
      , (25612,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25612,   5, -0.025000000372529) /* ManaRate */
-     , (25612,  21, 0.550000011920929) /* WeaponLength */
+VALUES (25612,   5,  -0.025) /* ManaRate */
+     , (25612,  21,    0.55) /* WeaponLength */
      , (25612,  22,     0.5) /* DamageVariance */
      , (25612,  26,       0) /* MaximumVelocity */
-     , (25612,  29, 1.17999994754791) /* WeaponDefense */
+     , (25612,  29,    1.18) /* WeaponDefense */
      , (25612,  39,       1) /* DefaultScale */
-     , (25612,  62, 1.23000001907349) /* WeaponOffense */
+     , (25612,  62,    1.23) /* WeaponOffense */
      , (25612,  63,       1) /* DamageMod */
-     , (25612, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25612, 138,     3.4) /* SlayerDamageBonus */
      , (25612, 151,       1) /* IgnoreShield */
      , (25612, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25612 Electric Weeping Claw.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25612 Electric Weeping Claw.sql
@@ -36,7 +36,7 @@ VALUES (25612,   1,          1) /* ItemType - MeleeWeapon */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (25612,  22, True ) /* Inscribable */
--     , (25612,  69, False) /* IsSellable */
+     , (25612,  69, False) /* IsSellable */
      , (25612,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25613 Flaming Weeping Claw.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25613 Flaming Weeping Claw.sql
@@ -21,8 +21,6 @@ VALUES (25613,   1,          1) /* ItemType - MeleeWeapon */
      , (25613,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25613,  49,          1) /* WeaponTime */
      , (25613,  51,          1) /* CombatUse - Melee */
-     , (25613,  52,          1) /* ParentLocation */
-     , (25613,  53,        101) /* PlacementPosition */
      , (25613,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25613, 106,        300) /* ItemSpellcraft */
      , (25613, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25613,   1,          1) /* ItemType - MeleeWeapon */
      , (25613, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25613,  11, True ) /* IgnoreCollisions */
-     , (25613,  13, True ) /* Ethereal */
-     , (25613,  14, True ) /* GravityStatus */
-     , (25613,  19, True ) /* Attackable */
-     , (25613,  22, True ) /* Inscribable */
-     , (25613,  23, True ) /* DestroyOnSell */
+VALUES (25613,  22, True ) /* Inscribable */
      , (25613,  69, False) /* IsSellable */
      , (25613,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25613,   5, -0.025000000372529) /* ManaRate */
-     , (25613,  21, 0.550000011920929) /* WeaponLength */
+VALUES (25613,   5,  -0.025) /* ManaRate */
+     , (25613,  21,    0.55) /* WeaponLength */
      , (25613,  22,     0.5) /* DamageVariance */
      , (25613,  26,       0) /* MaximumVelocity */
-     , (25613,  29, 1.17999994754791) /* WeaponDefense */
+     , (25613,  29,    1.18) /* WeaponDefense */
      , (25613,  39,       1) /* DefaultScale */
-     , (25613,  62, 1.23000001907349) /* WeaponOffense */
+     , (25613,  62,    1.23) /* WeaponOffense */
      , (25613,  63,       1) /* DamageMod */
-     , (25613, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25613, 138,     3.4) /* SlayerDamageBonus */
      , (25613, 151,       1) /* IgnoreShield */
      , (25613, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25614 Frozen Weeping Claw.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25614 Frozen Weeping Claw.sql
@@ -21,8 +21,6 @@ VALUES (25614,   1,          1) /* ItemType - MeleeWeapon */
      , (25614,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25614,  49,          1) /* WeaponTime */
      , (25614,  51,          1) /* CombatUse - Melee */
-     , (25614,  52,          1) /* ParentLocation */
-     , (25614,  53,        101) /* PlacementPosition */
      , (25614,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25614, 106,        300) /* ItemSpellcraft */
      , (25614, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25614,   1,          1) /* ItemType - MeleeWeapon */
      , (25614, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25614,  11, True ) /* IgnoreCollisions */
-     , (25614,  13, True ) /* Ethereal */
-     , (25614,  14, True ) /* GravityStatus */
-     , (25614,  19, True ) /* Attackable */
-     , (25614,  22, True ) /* Inscribable */
-     , (25614,  23, True ) /* DestroyOnSell */
+VALUES (25614,  22, True ) /* Inscribable */
      , (25614,  69, False) /* IsSellable */
      , (25614,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25614,   5, -0.025000000372529) /* ManaRate */
-     , (25614,  21, 0.550000011920929) /* WeaponLength */
+VALUES (25614,   5,  -0.025) /* ManaRate */
+     , (25614,  21,    0.55) /* WeaponLength */
      , (25614,  22,     0.5) /* DamageVariance */
      , (25614,  26,       0) /* MaximumVelocity */
-     , (25614,  29, 1.17999994754791) /* WeaponDefense */
+     , (25614,  29,    1.18) /* WeaponDefense */
      , (25614,  39,       1) /* DefaultScale */
-     , (25614,  62, 1.23000001907349) /* WeaponOffense */
+     , (25614,  62,    1.23) /* WeaponOffense */
      , (25614,  63,       1) /* DamageMod */
-     , (25614, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25614, 138,     3.4) /* SlayerDamageBonus */
      , (25614, 151,       1) /* IgnoreShield */
      , (25614, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25615 Acidic Weeping Dagger.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25615 Acidic Weeping Dagger.sql
@@ -21,8 +21,6 @@ VALUES (25615,   1,          1) /* ItemType - MeleeWeapon */
      , (25615,  48,         45) /* WeaponSkill - LightWeapons */
      , (25615,  49,          1) /* WeaponTime */
      , (25615,  51,          1) /* CombatUse - Melee */
-     , (25615,  52,          1) /* ParentLocation */
-     , (25615,  53,          1) /* PlacementPosition */
      , (25615,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25615, 106,        300) /* ItemSpellcraft */
      , (25615, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25615,   1,          1) /* ItemType - MeleeWeapon */
      , (25615, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25615,  11, True ) /* IgnoreCollisions */
-     , (25615,  13, True ) /* Ethereal */
-     , (25615,  14, True ) /* GravityStatus */
-     , (25615,  19, True ) /* Attackable */
-     , (25615,  22, True ) /* Inscribable */
-     , (25615,  23, True ) /* DestroyOnSell */
+VALUES (25615,  22, True ) /* Inscribable */
      , (25615,  69, False) /* IsSellable */
      , (25615,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25615,   5, -0.025000000372529) /* ManaRate */
-     , (25615,  21, 0.400000005960464) /* WeaponLength */
-     , (25615,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25615,   5,  -0.025) /* ManaRate */
+     , (25615,  21,     0.4) /* WeaponLength */
+     , (25615,  22,     0.3) /* DamageVariance */
      , (25615,  26,       0) /* MaximumVelocity */
-     , (25615,  29, 1.21000003814697) /* WeaponDefense */
+     , (25615,  29,    1.21) /* WeaponDefense */
      , (25615,  39,       1) /* DefaultScale */
-     , (25615,  62, 1.20000004768372) /* WeaponOffense */
+     , (25615,  62,     1.2) /* WeaponOffense */
      , (25615,  63,       1) /* DamageMod */
-     , (25615, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25615, 138,     3.4) /* SlayerDamageBonus */
      , (25615, 151,       1) /* IgnoreShield */
      , (25615, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25616 Electric Weeping Dagger.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25616 Electric Weeping Dagger.sql
@@ -21,8 +21,6 @@ VALUES (25616,   1,          1) /* ItemType - MeleeWeapon */
      , (25616,  48,         45) /* WeaponSkill - LightWeapons */
      , (25616,  49,          1) /* WeaponTime */
      , (25616,  51,          1) /* CombatUse - Melee */
-     , (25616,  52,          1) /* ParentLocation */
-     , (25616,  53,          1) /* PlacementPosition */
      , (25616,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25616, 106,        300) /* ItemSpellcraft */
      , (25616, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25616,   1,          1) /* ItemType - MeleeWeapon */
      , (25616, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25616,  11, True ) /* IgnoreCollisions */
-     , (25616,  13, True ) /* Ethereal */
-     , (25616,  14, True ) /* GravityStatus */
-     , (25616,  19, True ) /* Attackable */
-     , (25616,  22, True ) /* Inscribable */
-     , (25616,  23, True ) /* DestroyOnSell */
+VALUES (25616,  22, True ) /* Inscribable */
      , (25616,  69, False) /* IsSellable */
      , (25616,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25616,   5, -0.025000000372529) /* ManaRate */
-     , (25616,  21, 0.400000005960464) /* WeaponLength */
-     , (25616,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25616,   5,  -0.025) /* ManaRate */
+     , (25616,  21,     0.4) /* WeaponLength */
+     , (25616,  22,     0.3) /* DamageVariance */
      , (25616,  26,       0) /* MaximumVelocity */
-     , (25616,  29, 1.21000003814697) /* WeaponDefense */
+     , (25616,  29,    1.21) /* WeaponDefense */
      , (25616,  39,       1) /* DefaultScale */
-     , (25616,  62, 1.20000004768372) /* WeaponOffense */
+     , (25616,  62,     1.2) /* WeaponOffense */
      , (25616,  63,       1) /* DamageMod */
-     , (25616, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25616, 138,     3.4) /* SlayerDamageBonus */
      , (25616, 151,       1) /* IgnoreShield */
      , (25616, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25617 Flaming Weeping Dagger.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25617 Flaming Weeping Dagger.sql
@@ -21,8 +21,6 @@ VALUES (25617,   1,          1) /* ItemType - MeleeWeapon */
      , (25617,  48,         45) /* WeaponSkill - LightWeapons */
      , (25617,  49,          1) /* WeaponTime */
      , (25617,  51,          1) /* CombatUse - Melee */
-     , (25617,  52,          1) /* ParentLocation */
-     , (25617,  53,          1) /* PlacementPosition */
      , (25617,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25617, 106,        300) /* ItemSpellcraft */
      , (25617, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25617,   1,          1) /* ItemType - MeleeWeapon */
      , (25617, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25617,  11, True ) /* IgnoreCollisions */
-     , (25617,  13, True ) /* Ethereal */
-     , (25617,  14, True ) /* GravityStatus */
-     , (25617,  19, True ) /* Attackable */
-     , (25617,  22, True ) /* Inscribable */
-     , (25617,  23, True ) /* DestroyOnSell */
+VALUES (25617,  22, True ) /* Inscribable */
      , (25617,  69, False) /* IsSellable */
      , (25617,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25617,   5, -0.025000000372529) /* ManaRate */
-     , (25617,  21, 0.400000005960464) /* WeaponLength */
-     , (25617,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25617,   5,  -0.025) /* ManaRate */
+     , (25617,  21,     0.4) /* WeaponLength */
+     , (25617,  22,     0.3) /* DamageVariance */
      , (25617,  26,       0) /* MaximumVelocity */
-     , (25617,  29, 1.21000003814697) /* WeaponDefense */
+     , (25617,  29,    1.21) /* WeaponDefense */
      , (25617,  39,       1) /* DefaultScale */
-     , (25617,  62, 1.20000004768372) /* WeaponOffense */
+     , (25617,  62,     1.2) /* WeaponOffense */
      , (25617,  63,       1) /* DamageMod */
-     , (25617, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25617, 138,     3.4) /* SlayerDamageBonus */
      , (25617, 151,       1) /* IgnoreShield */
      , (25617, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25618 Frozen Weeping Dagger.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25618 Frozen Weeping Dagger.sql
@@ -21,8 +21,6 @@ VALUES (25618,   1,          1) /* ItemType - MeleeWeapon */
      , (25618,  48,         45) /* WeaponSkill - LightWeapons */
      , (25618,  49,          1) /* WeaponTime */
      , (25618,  51,          1) /* CombatUse - Melee */
-     , (25618,  52,          1) /* ParentLocation */
-     , (25618,  53,          1) /* PlacementPosition */
      , (25618,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25618, 106,        300) /* ItemSpellcraft */
      , (25618, 107,        800) /* ItemCurMana */
@@ -37,25 +35,20 @@ VALUES (25618,   1,          1) /* ItemType - MeleeWeapon */
      , (25618, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25618,  11, True ) /* IgnoreCollisions */
-     , (25618,  13, True ) /* Ethereal */
-     , (25618,  14, True ) /* GravityStatus */
-     , (25618,  19, True ) /* Attackable */
-     , (25618,  22, True ) /* Inscribable */
-     , (25618,  23, True ) /* DestroyOnSell */
+VALUES (25618,  22, True ) /* Inscribable */
      , (25618,  69, False) /* IsSellable */
      , (25618,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25618,   5, -0.025000000372529) /* ManaRate */
-     , (25618,  21, 0.400000005960464) /* WeaponLength */
-     , (25618,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25618,   5,  -0.025) /* ManaRate */
+     , (25618,  21,     0.4) /* WeaponLength */
+     , (25618,  22,     0.3) /* DamageVariance */
      , (25618,  26,       0) /* MaximumVelocity */
-     , (25618,  29, 1.21000003814697) /* WeaponDefense */
+     , (25618,  29,    1.21) /* WeaponDefense */
      , (25618,  39,       1) /* DefaultScale */
-     , (25618,  62, 1.20000004768372) /* WeaponOffense */
+     , (25618,  62,     1.2) /* WeaponOffense */
      , (25618,  63,       1) /* DamageMod */
-     , (25618, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25618, 138,     3.4) /* SlayerDamageBonus */
      , (25618, 151,       1) /* IgnoreShield */
      , (25618, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25619 Acidic Weeping Mace.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25619 Acidic Weeping Mace.sql
@@ -21,7 +21,6 @@ VALUES (25619,   1,          1) /* ItemType - MeleeWeapon */
      , (25619,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25619,  49,          5) /* WeaponTime */
      , (25619,  51,          1) /* CombatUse - Melee */
-     , (25619,  53,        101) /* PlacementPosition */
      , (25619,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25619, 106,        300) /* ItemSpellcraft */
      , (25619, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25619,   1,          1) /* ItemType - MeleeWeapon */
      , (25619, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25619,  11, True ) /* IgnoreCollisions */
-     , (25619,  13, True ) /* Ethereal */
-     , (25619,  14, True ) /* GravityStatus */
-     , (25619,  19, True ) /* Attackable */
-     , (25619,  22, True ) /* Inscribable */
-     , (25619,  23, True ) /* DestroyOnSell */
+VALUES (25619,  22, True ) /* Inscribable */
      , (25619,  69, False) /* IsSellable */
      , (25619,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25619,   5, -0.025000000372529) /* ManaRate */
-     , (25619,  21, 0.600000023841858) /* WeaponLength */
-     , (25619,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25619,   5,  -0.025) /* ManaRate */
+     , (25619,  21,     0.6) /* WeaponLength */
+     , (25619,  22,     0.3) /* DamageVariance */
      , (25619,  26,       0) /* MaximumVelocity */
-     , (25619,  29, 1.21000003814697) /* WeaponDefense */
+     , (25619,  29,    1.21) /* WeaponDefense */
      , (25619,  39,       1) /* DefaultScale */
-     , (25619,  62, 1.20000004768372) /* WeaponOffense */
+     , (25619,  62,     1.2) /* WeaponOffense */
      , (25619,  63,       1) /* DamageMod */
-     , (25619, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25619, 138,     3.4) /* SlayerDamageBonus */
      , (25619, 151,       1) /* IgnoreShield */
      , (25619, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25620 Electric Weeping Mace.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25620 Electric Weeping Mace.sql
@@ -21,7 +21,6 @@ VALUES (25620,   1,          1) /* ItemType - MeleeWeapon */
      , (25620,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25620,  49,          5) /* WeaponTime */
      , (25620,  51,          1) /* CombatUse - Melee */
-     , (25620,  53,        101) /* PlacementPosition */
      , (25620,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25620, 106,        300) /* ItemSpellcraft */
      , (25620, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25620,   1,          1) /* ItemType - MeleeWeapon */
      , (25620, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25620,  11, True ) /* IgnoreCollisions */
-     , (25620,  13, True ) /* Ethereal */
-     , (25620,  14, True ) /* GravityStatus */
-     , (25620,  19, True ) /* Attackable */
-     , (25620,  22, True ) /* Inscribable */
-     , (25620,  23, True ) /* DestroyOnSell */
+VALUES (25620,  22, True ) /* Inscribable */
      , (25620,  69, False) /* IsSellable */
      , (25620,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25620,   5, -0.025000000372529) /* ManaRate */
-     , (25620,  21, 0.600000023841858) /* WeaponLength */
-     , (25620,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25620,   5,  -0.025) /* ManaRate */
+     , (25620,  21,     0.6) /* WeaponLength */
+     , (25620,  22,     0.3) /* DamageVariance */
      , (25620,  26,       0) /* MaximumVelocity */
-     , (25620,  29, 1.21000003814697) /* WeaponDefense */
+     , (25620,  29,    1.21) /* WeaponDefense */
      , (25620,  39,       1) /* DefaultScale */
-     , (25620,  62, 1.20000004768372) /* WeaponOffense */
+     , (25620,  62,     1.2) /* WeaponOffense */
      , (25620,  63,       1) /* DamageMod */
-     , (25620, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25620, 138,     3.4) /* SlayerDamageBonus */
      , (25620, 151,       1) /* IgnoreShield */
      , (25620, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25621 Flaming Weeping Mace.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25621 Flaming Weeping Mace.sql
@@ -21,7 +21,6 @@ VALUES (25621,   1,          1) /* ItemType - MeleeWeapon */
      , (25621,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25621,  49,          5) /* WeaponTime */
      , (25621,  51,          1) /* CombatUse - Melee */
-     , (25621,  53,        101) /* PlacementPosition */
      , (25621,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25621, 106,        300) /* ItemSpellcraft */
      , (25621, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25621,   1,          1) /* ItemType - MeleeWeapon */
      , (25621, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25621,  11, True ) /* IgnoreCollisions */
-     , (25621,  13, True ) /* Ethereal */
-     , (25621,  14, True ) /* GravityStatus */
-     , (25621,  19, True ) /* Attackable */
-     , (25621,  22, True ) /* Inscribable */
-     , (25621,  23, True ) /* DestroyOnSell */
+VALUES (25621,  22, True ) /* Inscribable */
      , (25621,  69, False) /* IsSellable */
      , (25621,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25621,   5, -0.025000000372529) /* ManaRate */
-     , (25621,  21, 0.600000023841858) /* WeaponLength */
-     , (25621,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25621,   5,  -0.025) /* ManaRate */
+     , (25621,  21,     0.6) /* WeaponLength */
+     , (25621,  22,     0.3) /* DamageVariance */
      , (25621,  26,       0) /* MaximumVelocity */
-     , (25621,  29, 1.21000003814697) /* WeaponDefense */
+     , (25621,  29,    1.21) /* WeaponDefense */
      , (25621,  39,       1) /* DefaultScale */
-     , (25621,  62, 1.20000004768372) /* WeaponOffense */
+     , (25621,  62,     1.2) /* WeaponOffense */
      , (25621,  63,       1) /* DamageMod */
-     , (25621, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25621, 138,     3.4) /* SlayerDamageBonus */
      , (25621, 151,       1) /* IgnoreShield */
      , (25621, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25622 Frozen Weeping Mace.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25622 Frozen Weeping Mace.sql
@@ -21,7 +21,6 @@ VALUES (25622,   1,          1) /* ItemType - MeleeWeapon */
      , (25622,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (25622,  49,          5) /* WeaponTime */
      , (25622,  51,          1) /* CombatUse - Melee */
-     , (25622,  53,        101) /* PlacementPosition */
      , (25622,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25622, 106,        300) /* ItemSpellcraft */
      , (25622, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25622,   1,          1) /* ItemType - MeleeWeapon */
      , (25622, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25622,  11, True ) /* IgnoreCollisions */
-     , (25622,  13, True ) /* Ethereal */
-     , (25622,  14, True ) /* GravityStatus */
-     , (25622,  19, True ) /* Attackable */
-     , (25622,  22, True ) /* Inscribable */
-     , (25622,  23, True ) /* DestroyOnSell */
+VALUES (25622,  22, True ) /* Inscribable */
      , (25622,  69, False) /* IsSellable */
      , (25622,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25622,   5, -0.025000000372529) /* ManaRate */
-     , (25622,  21, 0.600000023841858) /* WeaponLength */
-     , (25622,  22, 0.300000011920929) /* DamageVariance */
+VALUES (25622,   5,  -0.025) /* ManaRate */
+     , (25622,  21,     0.6) /* WeaponLength */
+     , (25622,  22,     0.3) /* DamageVariance */
      , (25622,  26,       0) /* MaximumVelocity */
-     , (25622,  29, 1.21000003814697) /* WeaponDefense */
+     , (25622,  29,    1.21) /* WeaponDefense */
      , (25622,  39,       1) /* DefaultScale */
-     , (25622,  62, 1.20000004768372) /* WeaponOffense */
+     , (25622,  62,     1.2) /* WeaponOffense */
      , (25622,  63,       1) /* DamageMod */
-     , (25622, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25622, 138,     3.4) /* SlayerDamageBonus */
      , (25622, 151,       1) /* IgnoreShield */
      , (25622, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25623 Acidic Weeping Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25623 Acidic Weeping Spear.sql
@@ -21,7 +21,6 @@ VALUES (25623,   1,          1) /* ItemType - MeleeWeapon */
      , (25623,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25623,  49,          1) /* WeaponTime */
      , (25623,  51,          1) /* CombatUse - Melee */
-     , (25623,  53,        101) /* PlacementPosition */
      , (25623,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25623, 106,        300) /* ItemSpellcraft */
      , (25623, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25623,   1,          1) /* ItemType - MeleeWeapon */
      , (25623, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25623,  11, True ) /* IgnoreCollisions */
-     , (25623,  13, True ) /* Ethereal */
-     , (25623,  14, True ) /* GravityStatus */
-     , (25623,  19, True ) /* Attackable */
-     , (25623,  22, True ) /* Inscribable */
-     , (25623,  23, True ) /* DestroyOnSell */
+VALUES (25623,  22, True ) /* Inscribable */
      , (25623,  69, False) /* IsSellable */
      , (25623,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25623,   5, -0.025000000372529) /* ManaRate */
+VALUES (25623,   5,  -0.025) /* ManaRate */
      , (25623,  21,     1.5) /* WeaponLength */
-     , (25623,  22, 0.449999988079071) /* DamageVariance */
+     , (25623,  22,    0.45) /* DamageVariance */
      , (25623,  26,       0) /* MaximumVelocity */
-     , (25623,  29, 1.17999994754791) /* WeaponDefense */
+     , (25623,  29,    1.18) /* WeaponDefense */
      , (25623,  39,       1) /* DefaultScale */
-     , (25623,  62, 1.23000001907349) /* WeaponOffense */
+     , (25623,  62,    1.23) /* WeaponOffense */
      , (25623,  63,       1) /* DamageMod */
-     , (25623, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25623, 138,     3.4) /* SlayerDamageBonus */
      , (25623, 151,       1) /* IgnoreShield */
      , (25623, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25624 Electric Weeping Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25624 Electric Weeping Spear.sql
@@ -21,7 +21,6 @@ VALUES (25624,   1,          1) /* ItemType - MeleeWeapon */
      , (25624,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25624,  49,          1) /* WeaponTime */
      , (25624,  51,          1) /* CombatUse - Melee */
-     , (25624,  53,        101) /* PlacementPosition */
      , (25624,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25624, 106,        300) /* ItemSpellcraft */
      , (25624, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25624,   1,          1) /* ItemType - MeleeWeapon */
      , (25624, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25624,  11, True ) /* IgnoreCollisions */
-     , (25624,  13, True ) /* Ethereal */
-     , (25624,  14, True ) /* GravityStatus */
-     , (25624,  19, True ) /* Attackable */
-     , (25624,  22, True ) /* Inscribable */
-     , (25624,  23, True ) /* DestroyOnSell */
+VALUES (25624,  22, True ) /* Inscribable */
      , (25624,  69, False) /* IsSellable */
      , (25624,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25624,   5, -0.025000000372529) /* ManaRate */
+VALUES (25624,   5,  -0.025) /* ManaRate */
      , (25624,  21,     1.5) /* WeaponLength */
-     , (25624,  22, 0.449999988079071) /* DamageVariance */
+     , (25624,  22,    0.45) /* DamageVariance */
      , (25624,  26,       0) /* MaximumVelocity */
-     , (25624,  29, 1.17999994754791) /* WeaponDefense */
+     , (25624,  29,    1.18) /* WeaponDefense */
      , (25624,  39,       1) /* DefaultScale */
-     , (25624,  62, 1.23000001907349) /* WeaponOffense */
+     , (25624,  62,    1.23) /* WeaponOffense */
      , (25624,  63,       1) /* DamageMod */
-     , (25624, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25624, 138,     3.4) /* SlayerDamageBonus */
      , (25624, 151,       1) /* IgnoreShield */
      , (25624, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25625 Flaming Weeping Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25625 Flaming Weeping Spear.sql
@@ -21,7 +21,6 @@ VALUES (25625,   1,          1) /* ItemType - MeleeWeapon */
      , (25625,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25625,  49,          1) /* WeaponTime */
      , (25625,  51,          1) /* CombatUse - Melee */
-     , (25625,  53,        101) /* PlacementPosition */
      , (25625,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25625, 106,        300) /* ItemSpellcraft */
      , (25625, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25625,   1,          1) /* ItemType - MeleeWeapon */
      , (25625, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25625,  11, True ) /* IgnoreCollisions */
-     , (25625,  13, True ) /* Ethereal */
-     , (25625,  14, True ) /* GravityStatus */
-     , (25625,  19, True ) /* Attackable */
-     , (25625,  22, True ) /* Inscribable */
-     , (25625,  23, True ) /* DestroyOnSell */
+VALUES (25625,  22, True ) /* Inscribable */
      , (25625,  69, False) /* IsSellable */
      , (25625,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25625,   5, -0.025000000372529) /* ManaRate */
+VALUES (25625,   5,  -0.025) /* ManaRate */
      , (25625,  21,     1.5) /* WeaponLength */
-     , (25625,  22, 0.449999988079071) /* DamageVariance */
+     , (25625,  22,    0.45) /* DamageVariance */
      , (25625,  26,       0) /* MaximumVelocity */
-     , (25625,  29, 1.17999994754791) /* WeaponDefense */
+     , (25625,  29,    1.18) /* WeaponDefense */
      , (25625,  39,       1) /* DefaultScale */
-     , (25625,  62, 1.23000001907349) /* WeaponOffense */
+     , (25625,  62,    1.23) /* WeaponOffense */
      , (25625,  63,       1) /* DamageMod */
-     , (25625, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25625, 138,     3.4) /* SlayerDamageBonus */
      , (25625, 151,       1) /* IgnoreShield */
      , (25625, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25626 Frozen Weeping Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25626 Frozen Weeping Spear.sql
@@ -21,7 +21,6 @@ VALUES (25626,   1,          1) /* ItemType - MeleeWeapon */
      , (25626,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25626,  49,          1) /* WeaponTime */
      , (25626,  51,          1) /* CombatUse - Melee */
-     , (25626,  53,        101) /* PlacementPosition */
      , (25626,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25626, 106,        300) /* ItemSpellcraft */
      , (25626, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25626,   1,          1) /* ItemType - MeleeWeapon */
      , (25626, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25626,  11, True ) /* IgnoreCollisions */
-     , (25626,  13, True ) /* Ethereal */
-     , (25626,  14, True ) /* GravityStatus */
-     , (25626,  19, True ) /* Attackable */
-     , (25626,  22, True ) /* Inscribable */
-     , (25626,  23, True ) /* DestroyOnSell */
+VALUES (25626,  22, True ) /* Inscribable */
      , (25626,  69, False) /* IsSellable */
      , (25626,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25626,   5, -0.025000000372529) /* ManaRate */
+VALUES (25626,   5,  -0.025) /* ManaRate */
      , (25626,  21,     1.5) /* WeaponLength */
-     , (25626,  22, 0.449999988079071) /* DamageVariance */
+     , (25626,  22,    0.45) /* DamageVariance */
      , (25626,  26,       0) /* MaximumVelocity */
-     , (25626,  29, 1.17999994754791) /* WeaponDefense */
+     , (25626,  29,    1.18) /* WeaponDefense */
      , (25626,  39,       1) /* DefaultScale */
-     , (25626,  62, 1.23000001907349) /* WeaponOffense */
+     , (25626,  62,    1.23) /* WeaponOffense */
      , (25626,  63,       1) /* DamageMod */
-     , (25626, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25626, 138,     3.4) /* SlayerDamageBonus */
      , (25626, 151,       1) /* IgnoreShield */
      , (25626, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25627 Acidic Weeping Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25627 Acidic Weeping Staff.sql
@@ -21,8 +21,6 @@ VALUES (25627,   1,          1) /* ItemType - MeleeWeapon */
      , (25627,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25627,  49,          1) /* WeaponTime */
      , (25627,  51,          1) /* CombatUse - Melee */
-     , (25627,  52,          1) /* ParentLocation */
-     , (25627,  53,        101) /* PlacementPosition */
      , (25627,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25627, 106,        300) /* ItemSpellcraft */
      , (25627, 107,        800) /* ItemCurMana */
@@ -37,23 +35,18 @@ VALUES (25627,   1,          1) /* ItemType - MeleeWeapon */
      , (25627, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25627,  11, True ) /* IgnoreCollisions */
-     , (25627,  13, True ) /* Ethereal */
-     , (25627,  14, True ) /* GravityStatus */
-     , (25627,  19, True ) /* Attackable */
-     , (25627,  22, True ) /* Inscribable */
-     , (25627,  23, True ) /* DestroyOnSell */
+VALUES (25627,  22, True ) /* Inscribable */
      , (25627,  69, False) /* IsSellable */
      , (25627,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25627,   5, -0.025000000372529) /* ManaRate */
-     , (25627,  21, 1.33000004291534) /* WeaponLength */
-     , (25627,  22, 0.300000011920929) /* DamageVariance */
-     , (25627,  29, 1.17999994754791) /* WeaponDefense */
+VALUES (25627,   5,  -0.025) /* ManaRate */
+     , (25627,  21,    1.33) /* WeaponLength */
+     , (25627,  22,     0.3) /* DamageVariance */
+     , (25627,  29,    1.18) /* WeaponDefense */
      , (25627,  39,       1) /* DefaultScale */
-     , (25627,  62, 1.23000001907349) /* WeaponOffense */
-     , (25627, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25627,  62,    1.23) /* WeaponOffense */
+     , (25627, 138,     3.4) /* SlayerDamageBonus */
      , (25627, 151,       1) /* IgnoreShield */
      , (25627, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25628 Electric Weeping Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25628 Electric Weeping Staff.sql
@@ -21,8 +21,6 @@ VALUES (25628,   1,          1) /* ItemType - MeleeWeapon */
      , (25628,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25628,  49,          1) /* WeaponTime */
      , (25628,  51,          1) /* CombatUse - Melee */
-     , (25628,  52,          1) /* ParentLocation */
-     , (25628,  53,        101) /* PlacementPosition */
      , (25628,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25628, 106,        300) /* ItemSpellcraft */
      , (25628, 107,        800) /* ItemCurMana */
@@ -37,23 +35,18 @@ VALUES (25628,   1,          1) /* ItemType - MeleeWeapon */
      , (25628, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25628,  11, True ) /* IgnoreCollisions */
-     , (25628,  13, True ) /* Ethereal */
-     , (25628,  14, True ) /* GravityStatus */
-     , (25628,  19, True ) /* Attackable */
-     , (25628,  22, True ) /* Inscribable */
-     , (25628,  23, True ) /* DestroyOnSell */
+VALUES (25628,  22, True ) /* Inscribable */
      , (25628,  69, False) /* IsSellable */
      , (25628,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25628,   5, -0.025000000372529) /* ManaRate */
-     , (25628,  21, 1.33000004291534) /* WeaponLength */
-     , (25628,  22, 0.300000011920929) /* DamageVariance */
-     , (25628,  29, 1.17999994754791) /* WeaponDefense */
+VALUES (25628,   5,  -0.025) /* ManaRate */
+     , (25628,  21,    1.33) /* WeaponLength */
+     , (25628,  22,     0.3) /* DamageVariance */
+     , (25628,  29,    1.18) /* WeaponDefense */
      , (25628,  39,       1) /* DefaultScale */
-     , (25628,  62, 1.23000001907349) /* WeaponOffense */
-     , (25628, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25628,  62,    1.23) /* WeaponOffense */
+     , (25628, 138,     3.4) /* SlayerDamageBonus */
      , (25628, 151,       1) /* IgnoreShield */
      , (25628, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25629 Flaming Weeping Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25629 Flaming Weeping Staff.sql
@@ -21,8 +21,6 @@ VALUES (25629,   1,          1) /* ItemType - MeleeWeapon */
      , (25629,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25629,  49,          1) /* WeaponTime */
      , (25629,  51,          1) /* CombatUse - Melee */
-     , (25629,  52,          1) /* ParentLocation */
-     , (25629,  53,        101) /* PlacementPosition */
      , (25629,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25629, 106,        300) /* ItemSpellcraft */
      , (25629, 107,        800) /* ItemCurMana */
@@ -37,23 +35,18 @@ VALUES (25629,   1,          1) /* ItemType - MeleeWeapon */
      , (25629, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25629,  11, True ) /* IgnoreCollisions */
-     , (25629,  13, True ) /* Ethereal */
-     , (25629,  14, True ) /* GravityStatus */
-     , (25629,  19, True ) /* Attackable */
-     , (25629,  22, True ) /* Inscribable */
-     , (25629,  23, True ) /* DestroyOnSell */
+VALUES (25629,  22, True ) /* Inscribable */
      , (25629,  69, False) /* IsSellable */
      , (25629,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25629,   5, -0.025000000372529) /* ManaRate */
-     , (25629,  21, 1.33000004291534) /* WeaponLength */
-     , (25629,  22, 0.300000011920929) /* DamageVariance */
-     , (25629,  29, 1.17999994754791) /* WeaponDefense */
+VALUES (25629,   5,  -0.025) /* ManaRate */
+     , (25629,  21,    1.33) /* WeaponLength */
+     , (25629,  22,     0.3) /* DamageVariance */
+     , (25629,  29,    1.18) /* WeaponDefense */
      , (25629,  39,       1) /* DefaultScale */
-     , (25629,  62, 1.23000001907349) /* WeaponOffense */
-     , (25629, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25629,  62,    1.23) /* WeaponOffense */
+     , (25629, 138,     3.4) /* SlayerDamageBonus */
      , (25629, 151,       1) /* IgnoreShield */
      , (25629, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25630 Frozen Weeping Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25630 Frozen Weeping Staff.sql
@@ -21,8 +21,6 @@ VALUES (25630,   1,          1) /* ItemType - MeleeWeapon */
      , (25630,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25630,  49,          1) /* WeaponTime */
      , (25630,  51,          1) /* CombatUse - Melee */
-     , (25630,  52,          1) /* ParentLocation */
-     , (25630,  53,        101) /* PlacementPosition */
      , (25630,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25630, 106,        300) /* ItemSpellcraft */
      , (25630, 107,        800) /* ItemCurMana */
@@ -37,23 +35,18 @@ VALUES (25630,   1,          1) /* ItemType - MeleeWeapon */
      , (25630, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25630,  11, True ) /* IgnoreCollisions */
-     , (25630,  13, True ) /* Ethereal */
-     , (25630,  14, True ) /* GravityStatus */
-     , (25630,  19, True ) /* Attackable */
-     , (25630,  22, True ) /* Inscribable */
-     , (25630,  23, True ) /* DestroyOnSell */
+VALUES (25630,  22, True ) /* Inscribable */
      , (25630,  69, False) /* IsSellable */
      , (25630,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25630,   5, -0.025000000372529) /* ManaRate */
-     , (25630,  21, 1.33000004291534) /* WeaponLength */
-     , (25630,  22, 0.300000011920929) /* DamageVariance */
-     , (25630,  29, 1.17999994754791) /* WeaponDefense */
+VALUES (25630,   5,  -0.025) /* ManaRate */
+     , (25630,  21,    1.33) /* WeaponLength */
+     , (25630,  22,     0.3) /* DamageVariance */
+     , (25630,  29,    1.18) /* WeaponDefense */
      , (25630,  39,       1) /* DefaultScale */
-     , (25630,  62, 1.23000001907349) /* WeaponOffense */
-     , (25630, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25630,  62,    1.23) /* WeaponOffense */
+     , (25630, 138,     3.4) /* SlayerDamageBonus */
      , (25630, 151,       1) /* IgnoreShield */
      , (25630, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25631 Acidic Weeping Sword.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25631 Acidic Weeping Sword.sql
@@ -21,7 +21,6 @@ VALUES (25631,   1,          1) /* ItemType - MeleeWeapon */
      , (25631,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25631,  49,          5) /* WeaponTime */
      , (25631,  51,          1) /* CombatUse - Melee */
-     , (25631,  53,        101) /* PlacementPosition */
      , (25631,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25631, 106,        300) /* ItemSpellcraft */
      , (25631, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25631,   1,          1) /* ItemType - MeleeWeapon */
      , (25631, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25631,  11, True ) /* IgnoreCollisions */
-     , (25631,  13, True ) /* Ethereal */
-     , (25631,  14, True ) /* GravityStatus */
-     , (25631,  19, True ) /* Attackable */
-     , (25631,  22, True ) /* Inscribable */
-     , (25631,  23, True ) /* DestroyOnSell */
+VALUES (25631,  22, True ) /* Inscribable */
      , (25631,  69, False) /* IsSellable */
      , (25631,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25631,   5, -0.025000000372529) /* ManaRate */
+VALUES (25631,   5,  -0.025) /* ManaRate */
      , (25631,  21,       1) /* WeaponLength */
-     , (25631,  22, 0.400000005960464) /* DamageVariance */
+     , (25631,  22,     0.4) /* DamageVariance */
      , (25631,  26,       0) /* MaximumVelocity */
-     , (25631,  29, 1.20000004768372) /* WeaponDefense */
+     , (25631,  29,     1.2) /* WeaponDefense */
      , (25631,  39,       1) /* DefaultScale */
-     , (25631,  62, 1.21000003814697) /* WeaponOffense */
+     , (25631,  62,    1.21) /* WeaponOffense */
      , (25631,  63,       1) /* DamageMod */
-     , (25631, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25631, 138,     3.4) /* SlayerDamageBonus */
      , (25631, 151,       1) /* IgnoreShield */
      , (25631, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25632 Electric Weeping Sword.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25632 Electric Weeping Sword.sql
@@ -21,7 +21,6 @@ VALUES (25632,   1,          1) /* ItemType - MeleeWeapon */
      , (25632,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25632,  49,          5) /* WeaponTime */
      , (25632,  51,          1) /* CombatUse - Melee */
-     , (25632,  53,        101) /* PlacementPosition */
      , (25632,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25632, 106,        300) /* ItemSpellcraft */
      , (25632, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25632,   1,          1) /* ItemType - MeleeWeapon */
      , (25632, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25632,  11, True ) /* IgnoreCollisions */
-     , (25632,  13, True ) /* Ethereal */
-     , (25632,  14, True ) /* GravityStatus */
-     , (25632,  19, True ) /* Attackable */
-     , (25632,  22, True ) /* Inscribable */
-     , (25632,  23, True ) /* DestroyOnSell */
+VALUES (25632,  22, True ) /* Inscribable */
      , (25632,  69, False) /* IsSellable */
      , (25632,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25632,   5, -0.025000000372529) /* ManaRate */
+VALUES (25632,   5,  -0.025) /* ManaRate */
      , (25632,  21,       1) /* WeaponLength */
-     , (25632,  22, 0.400000005960464) /* DamageVariance */
+     , (25632,  22,     0.4) /* DamageVariance */
      , (25632,  26,       0) /* MaximumVelocity */
-     , (25632,  29, 1.20000004768372) /* WeaponDefense */
+     , (25632,  29,     1.2) /* WeaponDefense */
      , (25632,  39,       1) /* DefaultScale */
-     , (25632,  62, 1.21000003814697) /* WeaponOffense */
+     , (25632,  62,    1.21) /* WeaponOffense */
      , (25632,  63,       1) /* DamageMod */
-     , (25632, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25632, 138,     3.4) /* SlayerDamageBonus */
      , (25632, 151,       1) /* IgnoreShield */
      , (25632, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25633 Flaming Weeping Sword.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25633 Flaming Weeping Sword.sql
@@ -21,7 +21,6 @@ VALUES (25633,   1,          1) /* ItemType - MeleeWeapon */
      , (25633,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25633,  49,          5) /* WeaponTime */
      , (25633,  51,          1) /* CombatUse - Melee */
-     , (25633,  53,        101) /* PlacementPosition */
      , (25633,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25633, 106,        300) /* ItemSpellcraft */
      , (25633, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25633,   1,          1) /* ItemType - MeleeWeapon */
      , (25633, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25633,  11, True ) /* IgnoreCollisions */
-     , (25633,  13, True ) /* Ethereal */
-     , (25633,  14, True ) /* GravityStatus */
-     , (25633,  19, True ) /* Attackable */
-     , (25633,  22, True ) /* Inscribable */
-     , (25633,  23, True ) /* DestroyOnSell */
+VALUES (25633,  22, True ) /* Inscribable */
      , (25633,  69, False) /* IsSellable */
      , (25633,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25633,   5, -0.025000000372529) /* ManaRate */
+VALUES (25633,   5,  -0.025) /* ManaRate */
      , (25633,  21,       1) /* WeaponLength */
-     , (25633,  22, 0.400000005960464) /* DamageVariance */
+     , (25633,  22,     0.4) /* DamageVariance */
      , (25633,  26,       0) /* MaximumVelocity */
-     , (25633,  29, 1.20000004768372) /* WeaponDefense */
+     , (25633,  29,     1.2) /* WeaponDefense */
      , (25633,  39,       1) /* DefaultScale */
-     , (25633,  62, 1.21000003814697) /* WeaponOffense */
+     , (25633,  62,    1.21) /* WeaponOffense */
      , (25633,  63,       1) /* DamageMod */
-     , (25633, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25633, 138,     3.4) /* SlayerDamageBonus */
      , (25633, 151,       1) /* IgnoreShield */
      , (25633, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25634 Frozen Weeping Sword.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/25634 Frozen Weeping Sword.sql
@@ -21,7 +21,6 @@ VALUES (25634,   1,          1) /* ItemType - MeleeWeapon */
      , (25634,  48,         46) /* WeaponSkill - FinesseWeapons */
      , (25634,  49,          5) /* WeaponTime */
      , (25634,  51,          1) /* CombatUse - Melee */
-     , (25634,  53,        101) /* PlacementPosition */
      , (25634,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (25634, 106,        300) /* ItemSpellcraft */
      , (25634, 107,        800) /* ItemCurMana */
@@ -36,25 +35,20 @@ VALUES (25634,   1,          1) /* ItemType - MeleeWeapon */
      , (25634, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (25634,  11, True ) /* IgnoreCollisions */
-     , (25634,  13, True ) /* Ethereal */
-     , (25634,  14, True ) /* GravityStatus */
-     , (25634,  19, True ) /* Attackable */
-     , (25634,  22, True ) /* Inscribable */
-     , (25634,  23, True ) /* DestroyOnSell */
+VALUES (25634,  22, True ) /* Inscribable */
      , (25634,  69, False) /* IsSellable */
      , (25634,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (25634,   5, -0.025000000372529) /* ManaRate */
+VALUES (25634,   5,  -0.025) /* ManaRate */
      , (25634,  21,       1) /* WeaponLength */
-     , (25634,  22, 0.400000005960464) /* DamageVariance */
+     , (25634,  22,     0.4) /* DamageVariance */
      , (25634,  26,       0) /* MaximumVelocity */
-     , (25634,  29, 1.20000004768372) /* WeaponDefense */
+     , (25634,  29,     1.2) /* WeaponDefense */
      , (25634,  39,       1) /* DefaultScale */
-     , (25634,  62, 1.21000003814697) /* WeaponOffense */
+     , (25634,  62,    1.21) /* WeaponOffense */
      , (25634,  63,       1) /* DamageMod */
-     , (25634, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (25634, 138,     3.4) /* SlayerDamageBonus */
      , (25634, 151,       1) /* IgnoreShield */
      , (25634, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/35297 Greatsword of Flame and Light.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/35297 Greatsword of Flame and Light.sql
@@ -19,8 +19,6 @@ VALUES (35297,   1,          1) /* ItemType - MeleeWeapon */
      , (35297,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (35297,  49,          1) /* WeaponTime */
      , (35297,  51,          1) /* CombatUse - Melee */
-     , (35297,  52,          1) /* ParentLocation */
-     , (35297,  53,          1) /* PlacementPosition */
      , (35297,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (35297, 106,        400) /* ItemSpellcraft */
      , (35297, 108,       2000) /* ItemMaxMana */
@@ -34,20 +32,17 @@ VALUES (35297,   1,          1) /* ItemType - MeleeWeapon */
      , (35297, 353,          2) /* WeaponType - Sword */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (35297,  11, True ) /* IgnoreCollisions */
-     , (35297,  13, True ) /* Ethereal */
-     , (35297,  14, True ) /* GravityStatus */
-     , (35297,  19, True ) /* Attackable */
-     , (35297,  69, False) /* IsSellable */;
+VALUES (35297,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (35297,   5, -0.0500000007450581) /* ManaRate */
+VALUES (35297,   5,   -0.05) /* ManaRate */
      , (35297,  21,       2) /* WeaponLength */
      , (35297,  22,     0.5) /* DamageVariance */
      , (35297,  26,       0) /* MaximumVelocity */
-     , (35297,  29, 1.17999994754791) /* WeaponDefense */
-     , (35297,  62, 1.48000001907349) /* WeaponOffense */
-     , (35297,  63,       1) /* DamageMod */;
+     , (35297,  29,    1.18) /* WeaponDefense */
+     , (35297,  62,    1.48) /* WeaponOffense */
+     , (35297,  63,       1) /* DamageMod */
+     , (35297, 138,       3) /* SlayerDamageBonus */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35297,   1, 'Greatsword of Flame and Light') /* Name */

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41638 Weeping Two Handed Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41638 Weeping Two Handed Spear.sql
@@ -19,8 +19,6 @@ VALUES (41638,   1,          1) /* ItemType - MeleeWeapon */
      , (41638,  48,         41) /* WeaponSkill - TwoHandedCombat */
      , (41638,  49,          1) /* WeaponTime */
      , (41638,  51,          5) /* CombatUse - TwoHanded */
-     , (41638,  52,          1) /* ParentLocation */
-     , (41638,  53,        101) /* PlacementPosition */
      , (41638,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (41638, 106,        300) /* ItemSpellcraft */
      , (41638, 107,        800) /* ItemCurMana */
@@ -31,27 +29,22 @@ VALUES (41638,   1,          1) /* ItemType - MeleeWeapon */
      , (41638, 158,          2) /* WieldRequirements - RawSkill */
      , (41638, 159,         41) /* WieldSkillType - TwoHandedCombat */
      , (41638, 160,        325) /* WieldDifficulty */
-     , (41638, 166,         31) /* SlayerCreatureType - Human */
-	 , (41638, 353,         11) /* WeaponType - TwoHanded */;
+     , (41638, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (41638,  11, True ) /* IgnoreCollisions */
-     , (41638,  13, True ) /* Ethereal */
-     , (41638,  14, True ) /* GravityStatus */
-     , (41638,  19, True ) /* Attackable */
-     , (41638,  22, True ) /* Inscribable */
+VALUES (41638,  22, True ) /* Inscribable */
      , (41638,  69, False) /* IsSellable */
      , (41638,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (41638,   5, -0.025000000372529) /* ManaRate */
+VALUES (41638,   5,  -0.025) /* ManaRate */
      , (41638,  21,       0) /* WeaponLength */
      , (41638,  22,     0.5) /* DamageVariance */
      , (41638,  26,       0) /* MaximumVelocity */
-     , (41638,  29, 1.17999994754791) /* WeaponDefense */
-     , (41638,  62, 1.23000001907349) /* WeaponOffense */
+     , (41638,  29,    1.18) /* WeaponDefense */
+     , (41638,  62,    1.23) /* WeaponOffense */
      , (41638,  63,       1) /* DamageMod */
-     , (41638, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (41638, 138,     3.4) /* SlayerDamageBonus */
      , (41638, 151,       1) /* IgnoreShield */
      , (41638, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41639 Acidic Weeping Two Handed Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41639 Acidic Weeping Two Handed Spear.sql
@@ -20,8 +20,6 @@ VALUES (41639,   1,          1) /* ItemType - MeleeWeapon */
      , (41639,  48,         41) /* WeaponSkill - TwoHandedCombat */
      , (41639,  49,          1) /* WeaponTime */
      , (41639,  51,          5) /* CombatUse - TwoHanded */
-     , (41639,  52,          1) /* ParentLocation */
-     , (41639,  53,        101) /* PlacementPosition */
      , (41639,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (41639, 106,        300) /* ItemSpellcraft */
      , (41639, 107,        800) /* ItemCurMana */
@@ -32,27 +30,22 @@ VALUES (41639,   1,          1) /* ItemType - MeleeWeapon */
      , (41639, 158,          2) /* WieldRequirements - RawSkill */
      , (41639, 159,         41) /* WieldSkillType - TwoHandedCombat */
      , (41639, 160,        325) /* WieldDifficulty */
-     , (41639, 166,         31) /* SlayerCreatureType - Human */
-	 , (41639, 353,         11) /* WeaponType - TwoHanded */;
+     , (41639, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (41639,  11, True ) /* IgnoreCollisions */
-     , (41639,  13, True ) /* Ethereal */
-     , (41639,  14, True ) /* GravityStatus */
-     , (41639,  19, True ) /* Attackable */
-     , (41639,  22, True ) /* Inscribable */
+VALUES (41639,  22, True ) /* Inscribable */
      , (41639,  69, False) /* IsSellable */
      , (41639,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (41639,   5, -0.025000000372529) /* ManaRate */
+VALUES (41639,   5,  -0.025) /* ManaRate */
      , (41639,  21,       0) /* WeaponLength */
      , (41639,  22,     0.5) /* DamageVariance */
      , (41639,  26,       0) /* MaximumVelocity */
-     , (41639,  29, 1.17999994754791) /* WeaponDefense */
-     , (41639,  62, 1.23000001907349) /* WeaponOffense */
+     , (41639,  29,    1.18) /* WeaponDefense */
+     , (41639,  62,    1.23) /* WeaponOffense */
      , (41639,  63,       1) /* DamageMod */
-     , (41639, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (41639, 138,     3.4) /* SlayerDamageBonus */
      , (41639, 151,       1) /* IgnoreShield */
      , (41639, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41640 Electric Weeping Two Handed Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41640 Electric Weeping Two Handed Spear.sql
@@ -20,8 +20,6 @@ VALUES (41640,   1,          1) /* ItemType - MeleeWeapon */
      , (41640,  48,         41) /* WeaponSkill - TwoHandedCombat */
      , (41640,  49,          1) /* WeaponTime */
      , (41640,  51,          5) /* CombatUse - TwoHanded */
-     , (41640,  52,          1) /* ParentLocation */
-     , (41640,  53,        101) /* PlacementPosition */
      , (41640,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (41640, 106,        300) /* ItemSpellcraft */
      , (41640, 107,        800) /* ItemCurMana */
@@ -32,27 +30,22 @@ VALUES (41640,   1,          1) /* ItemType - MeleeWeapon */
      , (41640, 158,          2) /* WieldRequirements - RawSkill */
      , (41640, 159,         41) /* WieldSkillType - TwoHandedCombat */
      , (41640, 160,        325) /* WieldDifficulty */
-     , (41640, 166,         31) /* SlayerCreatureType - Human */
-	 , (41640, 353,         11) /* WeaponType - TwoHanded */;
+     , (41640, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (41640,  11, True ) /* IgnoreCollisions */
-     , (41640,  13, True ) /* Ethereal */
-     , (41640,  14, True ) /* GravityStatus */
-     , (41640,  19, True ) /* Attackable */
-     , (41640,  22, True ) /* Inscribable */
+VALUES (41640,  22, True ) /* Inscribable */
      , (41640,  69, False) /* IsSellable */
      , (41640,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (41640,   5, -0.025000000372529) /* ManaRate */
+VALUES (41640,   5,  -0.025) /* ManaRate */
      , (41640,  21,       0) /* WeaponLength */
      , (41640,  22,     0.5) /* DamageVariance */
      , (41640,  26,       0) /* MaximumVelocity */
-     , (41640,  29, 1.17999994754791) /* WeaponDefense */
-     , (41640,  62, 1.23000001907349) /* WeaponOffense */
+     , (41640,  29,    1.18) /* WeaponDefense */
+     , (41640,  62,    1.23) /* WeaponOffense */
      , (41640,  63,       1) /* DamageMod */
-     , (41640, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (41640, 138,     3.4) /* SlayerDamageBonus */
      , (41640, 151,       1) /* IgnoreShield */
      , (41640, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41641 Flaming Weeping Two Handed Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41641 Flaming Weeping Two Handed Spear.sql
@@ -20,8 +20,6 @@ VALUES (41641,   1,          1) /* ItemType - MeleeWeapon */
      , (41641,  48,         41) /* WeaponSkill - TwoHandedCombat */
      , (41641,  49,          1) /* WeaponTime */
      , (41641,  51,          5) /* CombatUse - TwoHanded */
-     , (41641,  52,          1) /* ParentLocation */
-     , (41641,  53,        101) /* PlacementPosition */
      , (41641,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (41641, 106,        300) /* ItemSpellcraft */
      , (41641, 107,        800) /* ItemCurMana */
@@ -32,27 +30,22 @@ VALUES (41641,   1,          1) /* ItemType - MeleeWeapon */
      , (41641, 158,          2) /* WieldRequirements - RawSkill */
      , (41641, 159,         41) /* WieldSkillType - TwoHandedCombat */
      , (41641, 160,        325) /* WieldDifficulty */
-     , (41641, 166,         31) /* SlayerCreatureType - Human */
-	 , (41641, 353,         11) /* WeaponType - TwoHanded */;
+     , (41641, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (41641,  11, True ) /* IgnoreCollisions */
-     , (41641,  13, True ) /* Ethereal */
-     , (41641,  14, True ) /* GravityStatus */
-     , (41641,  19, True ) /* Attackable */
-     , (41641,  22, True ) /* Inscribable */
+VALUES (41641,  22, True ) /* Inscribable */
      , (41641,  69, False) /* IsSellable */
      , (41641,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (41641,   5, -0.025000000372529) /* ManaRate */
+VALUES (41641,   5,  -0.025) /* ManaRate */
      , (41641,  21,       0) /* WeaponLength */
      , (41641,  22,     0.5) /* DamageVariance */
      , (41641,  26,       0) /* MaximumVelocity */
-     , (41641,  29, 1.17999994754791) /* WeaponDefense */
-     , (41641,  62, 1.23000001907349) /* WeaponOffense */
+     , (41641,  29,    1.18) /* WeaponDefense */
+     , (41641,  62,    1.23) /* WeaponOffense */
      , (41641,  63,       1) /* DamageMod */
-     , (41641, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (41641, 138,     3.4) /* SlayerDamageBonus */
      , (41641, 151,       1) /* IgnoreShield */
      , (41641, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41642 Frozen Weeping Two Handed Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/41642 Frozen Weeping Two Handed Spear.sql
@@ -20,8 +20,6 @@ VALUES (41642,   1,          1) /* ItemType - MeleeWeapon */
      , (41642,  48,         41) /* WeaponSkill - TwoHandedCombat */
      , (41642,  49,          1) /* WeaponTime */
      , (41642,  51,          5) /* CombatUse - TwoHanded */
-     , (41642,  52,          1) /* ParentLocation */
-     , (41642,  53,        101) /* PlacementPosition */
      , (41642,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (41642, 106,        300) /* ItemSpellcraft */
      , (41642, 107,        800) /* ItemCurMana */
@@ -32,27 +30,22 @@ VALUES (41642,   1,          1) /* ItemType - MeleeWeapon */
      , (41642, 158,          2) /* WieldRequirements - RawSkill */
      , (41642, 159,         41) /* WieldSkillType - TwoHandedCombat */
      , (41642, 160,        325) /* WieldDifficulty */
-     , (41642, 166,         31) /* SlayerCreatureType - Human */
-	 , (41642, 353,         11) /* WeaponType - TwoHanded */;
+     , (41642, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (41642,  11, True ) /* IgnoreCollisions */
-     , (41642,  13, True ) /* Ethereal */
-     , (41642,  14, True ) /* GravityStatus */
-     , (41642,  19, True ) /* Attackable */
-     , (41642,  22, True ) /* Inscribable */
+VALUES (41642,  22, True ) /* Inscribable */
      , (41642,  69, False) /* IsSellable */
      , (41642,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (41642,   5, -0.025000000372529) /* ManaRate */
+VALUES (41642,   5,  -0.025) /* ManaRate */
      , (41642,  21,       0) /* WeaponLength */
      , (41642,  22,     0.5) /* DamageVariance */
      , (41642,  26,       0) /* MaximumVelocity */
-     , (41642,  29, 1.17999994754791) /* WeaponDefense */
-     , (41642,  62, 1.23000001907349) /* WeaponOffense */
+     , (41642,  29,    1.18) /* WeaponDefense */
+     , (41642,  62,    1.23) /* WeaponOffense */
      , (41642,  63,       1) /* DamageMod */
-     , (41642, 138, 3.40000009536743) /* SlayerDamageBonus */
+     , (41642, 138,     3.4) /* SlayerDamageBonus */
      , (41642, 151,       1) /* IgnoreShield */
      , (41642, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46208 Enhanced Shimmering Isparian Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46208 Enhanced Shimmering Isparian Spear.sql
@@ -1,0 +1,67 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46208;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46208, 'ace46208-enhancedshimmeringisparianspear', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46208,   1,          1) /* ItemType - MeleeWeapon */
+     , (46208,   5,        650) /* EncumbranceVal */
+     , (46208,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46208,  16,          1) /* ItemUseable - No */
+     , (46208,  18,          1) /* UiEffects - Magical */
+     , (46208,  19,       8000) /* Value */
+     , (46208,  33,          1) /* Bonded - Bonded */
+     , (46208,  44,         55) /* Damage */
+     , (46208,  45,          3) /* DamageType - Slash, Pierce */
+     , (46208,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46208,  47,          6) /* AttackType - Thrust, Slash */
+     , (46208,  48,         45) /* WeaponSkill - LightWeapons */
+     , (46208,  49,         12) /* WeaponTime */
+     , (46208,  51,          1) /* CombatUse - Melee */
+     , (46208,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46208, 106,        350) /* ItemSpellcraft */
+     , (46208, 107,        750) /* ItemCurMana */
+     , (46208, 108,        750) /* ItemMaxMana */
+     , (46208, 109,        250) /* ItemDifficulty */
+     , (46208, 114,          1) /* Attuned - Attuned */
+     , (46208, 151,          2) /* HookType - Wall */
+     , (46208, 158,          2) /* WieldRequirements - RawSkill */
+     , (46208, 159,         45) /* WieldSkillType - LightWeapons */
+     , (46208, 160,        400) /* WieldDifficulty */
+     , (46208, 166,         62) /* SlayerCreatureType - Elemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46208,  22, True ) /* Inscribable */
+     , (46208,  69, False) /* IsSellable */
+     , (46208,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46208,   5,  -0.033) /* ManaRate */
+     , (46208,  12,       0) /* Shade */
+     , (46208,  21,       0) /* WeaponLength */
+     , (46208,  22,    0.45) /* DamageVariance */
+     , (46208,  26,       0) /* MaximumVelocity */
+     , (46208,  29,    1.14) /* WeaponDefense */
+     , (46208,  62,    1.14) /* WeaponOffense */
+     , (46208,  63,       1) /* DamageMod */
+     , (46208, 138,       4) /* SlayerDamageBonus */
+     , (46208, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46208,   1, 'Enhanced Shimmering Isparian Spear') /* Name */
+     , (46208,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46208,   1,   33556260) /* Setup */
+     , (46208,   3,  536870932) /* SoundTable */
+     , (46208,   7,  268436424) /* ClothingBase */
+     , (46208,   8,  100673208) /* Icon */
+     , (46208,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46208,  2096,      2)  /* Aura of Infected Caress */
+     , (46208,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46208,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46208,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46208,  2504,      2)  /* Major Light Weapon Aptitude */
+     , (46208,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46210 Enhanced Shimmering Isparian Two Handed Sword.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46210 Enhanced Shimmering Isparian Two Handed Sword.sql
@@ -1,0 +1,69 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46210;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46210, 'ace46210-enhancedshimmeringispariantwohandedsword', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46210,   1,          1) /* ItemType - MeleeWeapon */
+     , (46210,   5,        650) /* EncumbranceVal */
+     , (46210,   9,   33554432) /* ValidLocations - TwoHanded */
+     , (46210,  16,          1) /* ItemUseable - No */
+     , (46210,  18,          1) /* UiEffects - Magical */
+     , (46210,  19,       8000) /* Value */
+     , (46210,  33,          1) /* Bonded - Bonded */
+     , (46210,  44,         43) /* Damage */
+     , (46210,  45,          1) /* DamageType - Slash */
+     , (46210,  46,          8) /* DefaultCombatStyle - TwoHanded */
+     , (46210,  47,          4) /* AttackType - Slash */
+     , (46210,  48,         41) /* WeaponSkill - TwoHandedCombat */
+     , (46210,  49,         50) /* WeaponTime */
+     , (46210,  51,          5) /* CombatUse - TwoHanded */
+     , (46210,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46210, 106,        350) /* ItemSpellcraft */
+     , (46210, 107,        400) /* ItemCurMana */
+     , (46210, 108,        400) /* ItemMaxMana */
+     , (46210, 109,        250) /* ItemDifficulty */
+     , (46210, 114,          1) /* Attuned - Attuned */
+     , (46210, 151,          2) /* HookType - Wall */
+     , (46210, 158,          2) /* WieldRequirements - RawSkill */
+     , (46210, 159,         41) /* WieldSkillType - TwoHandedCombat */
+     , (46210, 160,        400) /* WieldDifficulty */
+     , (46210, 166,         62) /* SlayerCreatureType - Elemental */
+     , (46210, 292,          2) /* Cleaving */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46210,  22, True ) /* Inscribable */
+     , (46210,  69, False) /* IsSellable */
+     , (46210,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46210,   5,  -0.025) /* ManaRate */
+     , (46210,  12,       0) /* Shade */
+     , (46210,  21,       0) /* WeaponLength */
+     , (46210,  22,    0.29) /* DamageVariance */
+     , (46210,  26,       0) /* MaximumVelocity */
+     , (46210,  29,    1.14) /* WeaponDefense */
+     , (46210,  39,    1.15) /* DefaultScale */
+     , (46210,  62,    1.14) /* WeaponOffense */
+     , (46210,  63,       1) /* DamageMod */
+     , (46210, 138,       4) /* SlayerDamageBonus */
+     , (46210, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46210,   1, 'Enhanced Shimmering Isparian Two Handed Sword') /* Name */
+     , (46210,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46210,   1,   33556262) /* Setup */
+     , (46210,   3,  536870932) /* SoundTable */
+     , (46210,   7,  268436426) /* ClothingBase */
+     , (46210,   8,  100692947) /* Icon */
+     , (46210,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46210,  2096,      2)  /* Aura of Infected Caress */
+     , (46210,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46210,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46210,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46210,  2586,      2)  /* Major Blood Thirst */
+     , (46210,  5070,      2)  /* Major Two Handed Combat Aptitude */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46212 Enhanced Shimmering Isparian Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46212 Enhanced Shimmering Isparian Staff.sql
@@ -1,0 +1,66 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46212;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46212, 'ace46212-enhancedshimmeringisparianstaff', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46212,   1,          1) /* ItemType - MeleeWeapon */
+     , (46212,   5,        450) /* EncumbranceVal */
+     , (46212,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46212,  16,          1) /* ItemUseable - No */
+     , (46212,  18,          1) /* UiEffects - Magical */
+     , (46212,  19,       8000) /* Value */
+     , (46212,  33,          1) /* Bonded - Bonded */
+     , (46212,  44,         68) /* Damage */
+     , (46212,  45,          4) /* DamageType - Bludgeon */
+     , (46212,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46212,  47,          6) /* AttackType - Thrust, Slash */
+     , (46212,  48,         44) /* WeaponSkill - HeavyWeapons */
+     , (46212,  49,         20) /* WeaponTime */
+     , (46212,  51,          1) /* CombatUse - Melee */
+     , (46212,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46212, 106,        350) /* ItemSpellcraft */
+     , (46212, 107,        750) /* ItemCurMana */
+     , (46212, 108,        750) /* ItemMaxMana */
+     , (46212, 109,        250) /* ItemDifficulty */
+     , (46212, 114,          1) /* Attuned - Attuned */
+     , (46212, 151,          2) /* HookType - Wall */
+     , (46212, 158,          2) /* WieldRequirements - RawSkill */
+     , (46212, 159,         44) /* WieldSkillType - HeavyWeapons */
+     , (46212, 160,        400) /* WieldDifficulty */
+     , (46212, 166,         62) /* SlayerCreatureType - Elemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46212,  22, True ) /* Inscribable */
+     , (46212,  69, False) /* IsSellable */
+     , (46212,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46212,   5,  -0.033) /* ManaRate */
+     , (46212,  21,       0) /* WeaponLength */
+     , (46212,  22,    0.43) /* DamageVariance */
+     , (46212,  26,       0) /* MaximumVelocity */
+     , (46212,  29,    1.14) /* WeaponDefense */
+     , (46212,  62,    1.14) /* WeaponOffense */
+     , (46212,  63,       1) /* DamageMod */
+     , (46212, 138,       4) /* SlayerDamageBonus */
+     , (46212, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46212,   1, 'Enhanced Shimmering Isparian Staff') /* Name */
+     , (46212,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46212,   1,   33556261) /* Setup */
+     , (46212,   3,  536870932) /* SoundTable */
+     , (46212,   7,  268436425) /* ClothingBase */
+     , (46212,   8,  100673241) /* Icon */
+     , (46212,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46212,  2096,      2)  /* Aura of Infected Caress */
+     , (46212,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46212,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46212,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46212,  2531,      2)  /* Major Heavy Weapon Aptitude */
+     , (46212,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46234 Enhanced Chilling Isparian Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46234 Enhanced Chilling Isparian Spear.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46234;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46234, 'ace46234-enhancedchillingisparianspear', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46234,   1,          1) /* ItemType - MeleeWeapon */
+     , (46234,   3,          2) /* PaletteTemplate - Blue */
+     , (46234,   5,        650) /* EncumbranceVal */
+     , (46234,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46234,  16,          1) /* ItemUseable - No */
+     , (46234,  18,          1) /* UiEffects - Magical */
+     , (46234,  19,       8000) /* Value */
+     , (46234,  33,          1) /* Bonded - Bonded */
+     , (46234,  44,         55) /* Damage */
+     , (46234,  45,          8) /* DamageType - Cold */
+     , (46234,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46234,  47,          6) /* AttackType - Thrust, Slash */
+     , (46234,  48,         45) /* WeaponSkill - LightWeapons */
+     , (46234,  49,         35) /* WeaponTime */
+     , (46234,  51,          1) /* CombatUse - Melee */
+     , (46234,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46234, 106,        350) /* ItemSpellcraft */
+     , (46234, 107,        750) /* ItemCurMana */
+     , (46234, 108,        750) /* ItemMaxMana */
+     , (46234, 109,        250) /* ItemDifficulty */
+     , (46234, 114,          1) /* Attuned - Attuned */
+     , (46234, 151,          2) /* HookType - Wall */
+     , (46234, 158,          2) /* WieldRequirements - RawSkill */
+     , (46234, 159,         45) /* WieldSkillType - LightWeapons */
+     , (46234, 160,        400) /* WieldDifficulty */
+     , (46234, 166,         61) /* SlayerCreatureType - FrostElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46234,  22, True ) /* Inscribable */
+     , (46234,  69, False) /* IsSellable */
+     , (46234,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46234,   5,  -0.033) /* ManaRate */
+     , (46234,  12,       0) /* Shade */
+     , (46234,  21,       0) /* WeaponLength */
+     , (46234,  22,    0.45) /* DamageVariance */
+     , (46234,  26,       0) /* MaximumVelocity */
+     , (46234,  29,    1.14) /* WeaponDefense */
+     , (46234,  62,    1.14) /* WeaponOffense */
+     , (46234,  63,       1) /* DamageMod */
+     , (46234, 138,       4) /* SlayerDamageBonus */
+     , (46234, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46234,   1, 'Enhanced Chilling Isparian Spear') /* Name */
+     , (46234,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46234,   1,   33556383) /* Setup */
+     , (46234,   3,  536870932) /* SoundTable */
+     , (46234,   6,   67111919) /* PaletteBase */
+     , (46234,   7,  268436383) /* ClothingBase */
+     , (46234,   8,  100672924) /* Icon */
+     , (46234,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46234,  2081,      2)  /* Hastening */
+     , (46234,  2096,      2)  /* Aura of Infected Caress */
+     , (46234,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46234,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46234,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46234,  2155,      2)  /* Icy Blessing */
+     , (46234,  2504,      2)  /* Major Light Weapon Aptitude */
+     , (46234,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46236 Enhanced Flaming Isparian Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46236 Enhanced Flaming Isparian Spear.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46236;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46236, 'ace46236-enhancedflamingisparianspear', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46236,   1,          1) /* ItemType - MeleeWeapon */
+     , (46236,   3,         14) /* PaletteTemplate - Red */
+     , (46236,   5,        650) /* EncumbranceVal */
+     , (46236,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46236,  16,          1) /* ItemUseable - No */
+     , (46236,  18,          1) /* UiEffects - Magical */
+     , (46236,  19,       8000) /* Value */
+     , (46236,  33,          1) /* Bonded - Bonded */
+     , (46236,  44,         55) /* Damage */
+     , (46236,  45,         16) /* DamageType - Fire */
+     , (46236,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46236,  47,          6) /* AttackType - Thrust, Slash */
+     , (46236,  48,         45) /* WeaponSkill - LightWeapons */
+     , (46236,  49,         35) /* WeaponTime */
+     , (46236,  51,          1) /* CombatUse - Melee */
+     , (46236,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46236, 106,        350) /* ItemSpellcraft */
+     , (46236, 107,        750) /* ItemCurMana */
+     , (46236, 108,        750) /* ItemMaxMana */
+     , (46236, 109,        250) /* ItemDifficulty */
+     , (46236, 114,          1) /* Attuned - Attuned */
+     , (46236, 151,          2) /* HookType - Wall */
+     , (46236, 158,          2) /* WieldRequirements - RawSkill */
+     , (46236, 159,         45) /* WieldSkillType - LightWeapons */
+     , (46236, 160,        400) /* WieldDifficulty */
+     , (46236, 166,         61) /* SlayerCreatureType - FrostElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46236,  22, True ) /* Inscribable */
+     , (46236,  69, False) /* IsSellable */
+     , (46236,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46236,   5,  -0.033) /* ManaRate */
+     , (46236,  12,       0) /* Shade */
+     , (46236,  21,       0) /* WeaponLength */
+     , (46236,  22,    0.45) /* DamageVariance */
+     , (46236,  26,       0) /* MaximumVelocity */
+     , (46236,  29,    1.14) /* WeaponDefense */
+     , (46236,  62,    1.14) /* WeaponOffense */
+     , (46236,  63,       1) /* DamageMod */
+     , (46236, 138,       4) /* SlayerDamageBonus */
+     , (46236, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46236,   1, 'Enhanced Flaming Isparian Spear') /* Name */
+     , (46236,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46236,   1,   33556369) /* Setup */
+     , (46236,   3,  536870932) /* SoundTable */
+     , (46236,   6,   67111919) /* PaletteBase */
+     , (46236,   7,  268436383) /* ClothingBase */
+     , (46236,   8,  100672931) /* Icon */
+     , (46236,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46236,  2087,      2)  /* Might of the Lugians */
+     , (46236,  2096,      2)  /* Aura of Infected Caress */
+     , (46236,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46236,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46236,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46236,  2157,      2)  /* Fiery Blessing */
+     , (46236,  2504,      2)  /* Major Light Weapon Aptitude */
+     , (46236,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46238 Enhanced Coruscating Isparian Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46238 Enhanced Coruscating Isparian Spear.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46238;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46238, 'ace46238-enhancedcoruscatingisparianspear', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46238,   1,          1) /* ItemType - MeleeWeapon */
+     , (46238,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (46238,   5,        650) /* EncumbranceVal */
+     , (46238,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46238,  16,          1) /* ItemUseable - No */
+     , (46238,  18,          1) /* UiEffects - Magical */
+     , (46238,  19,       8000) /* Value */
+     , (46238,  33,          1) /* Bonded - Bonded */
+     , (46238,  44,         55) /* Damage */
+     , (46238,  45,         64) /* DamageType - Electric */
+     , (46238,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46238,  47,          6) /* AttackType - Thrust, Slash */
+     , (46238,  48,         45) /* WeaponSkill - LightWeapons */
+     , (46238,  49,         35) /* WeaponTime */
+     , (46238,  51,          1) /* CombatUse - Melee */
+     , (46238,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46238, 106,        350) /* ItemSpellcraft */
+     , (46238, 107,        750) /* ItemCurMana */
+     , (46238, 108,        750) /* ItemMaxMana */
+     , (46238, 109,        250) /* ItemDifficulty */
+     , (46238, 114,          1) /* Attuned - Attuned */
+     , (46238, 151,          2) /* HookType - Wall */
+     , (46238, 158,          2) /* WieldRequirements - RawSkill */
+     , (46238, 159,         45) /* WieldSkillType - LightWeapons */
+     , (46238, 160,        400) /* WieldDifficulty */
+     , (46238, 166,         60) /* SlayerCreatureType - AcidElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46238,  22, True ) /* Inscribable */
+     , (46238,  69, False) /* IsSellable */
+     , (46238,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46238,   5,  -0.033) /* ManaRate */
+     , (46238,  12,       0) /* Shade */
+     , (46238,  21,       0) /* WeaponLength */
+     , (46238,  22,    0.45) /* DamageVariance */
+     , (46238,  26,       0) /* MaximumVelocity */
+     , (46238,  29,    1.14) /* WeaponDefense */
+     , (46238,  62,    1.14) /* WeaponOffense */
+     , (46238,  63,       1) /* DamageMod */
+     , (46238, 138,       4) /* SlayerDamageBonus */
+     , (46238, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46238,   1, 'Enhanced Coruscating Isparian Spear') /* Name */
+     , (46238,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46238,   1,   33556368) /* Setup */
+     , (46238,   3,  536870932) /* SoundTable */
+     , (46238,   6,   67111919) /* PaletteBase */
+     , (46238,   7,  268436383) /* ClothingBase */
+     , (46238,   8,  100672927) /* Icon */
+     , (46238,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46238,  2061,      2)  /* Perseverance */
+     , (46238,  2096,      2)  /* Aura of Infected Caress */
+     , (46238,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46238,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46238,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46238,  2159,      2)  /* Storm's Blessing */
+     , (46238,  2504,      2)  /* Major Light Weapon Aptitude */
+     , (46238,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46240 Enhanced Dissolving Isparian Spear.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46240 Enhanced Dissolving Isparian Spear.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46240;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46240, 'ace46240-enhanceddissolvingisparianspear', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46240,   1,          1) /* ItemType - MeleeWeapon */
+     , (46240,   3,          8) /* PaletteTemplate - Green */
+     , (46240,   5,        650) /* EncumbranceVal */
+     , (46240,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46240,  16,          1) /* ItemUseable - No */
+     , (46240,  18,          1) /* UiEffects - Magical */
+     , (46240,  19,       8000) /* Value */
+     , (46240,  33,          1) /* Bonded - Bonded */
+     , (46240,  44,         55) /* Damage */
+     , (46240,  45,         32) /* DamageType - Acid */
+     , (46240,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46240,  47,          6) /* AttackType - Thrust, Slash */
+     , (46240,  48,         45) /* WeaponSkill - LightWeapons */
+     , (46240,  49,         35) /* WeaponTime */
+     , (46240,  51,          1) /* CombatUse - Melee */
+     , (46240,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46240, 106,        350) /* ItemSpellcraft */
+     , (46240, 107,        750) /* ItemCurMana */
+     , (46240, 108,        750) /* ItemMaxMana */
+     , (46240, 109,        250) /* ItemDifficulty */
+     , (46240, 114,          1) /* Attuned - Attuned */
+     , (46240, 151,          2) /* HookType - Wall */
+     , (46240, 158,          2) /* WieldRequirements - RawSkill */
+     , (46240, 159,         45) /* WieldSkillType - LightWeapons */
+     , (46240, 160,        400) /* WieldDifficulty */
+     , (46240, 166,         42) /* SlayerCreatureType - LightningElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46240,  22, True ) /* Inscribable */
+     , (46240,  69, False) /* IsSellable */
+     , (46240,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46240,   5,  -0.033) /* ManaRate */
+     , (46240,  12,       0) /* Shade */
+     , (46240,  21,       0) /* WeaponLength */
+     , (46240,  22,    0.45) /* DamageVariance */
+     , (46240,  26,       0) /* MaximumVelocity */
+     , (46240,  29,    1.14) /* WeaponDefense */
+     , (46240,  62,    1.14) /* WeaponOffense */
+     , (46240,  63,       1) /* DamageMod */
+     , (46240, 138,       4) /* SlayerDamageBonus */
+     , (46240, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46240,   1, 'Enhanced Dissolving Isparian Spear') /* Name */
+     , (46240,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46240,   1,   33556367) /* Setup */
+     , (46240,   3,  536870932) /* SoundTable */
+     , (46240,   6,   67111919) /* PaletteBase */
+     , (46240,   7,  268436383) /* ClothingBase */
+     , (46240,   8,  100672930) /* Icon */
+     , (46240,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46240,  2059,      2)  /* Honed Control */
+     , (46240,  2096,      2)  /* Aura of Infected Caress */
+     , (46240,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46240,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46240,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46240,  2149,      2)  /* Caustic Blessing */
+     , (46240,  2504,      2)  /* Major Light Weapon Aptitude */
+     , (46240,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46250 Enhanced Chilling Isparian Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46250 Enhanced Chilling Isparian Staff.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46250;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46250, 'ace46250-enhancedchillingisparianstaff', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46250,   1,          1) /* ItemType - MeleeWeapon */
+     , (46250,   3,          2) /* PaletteTemplate - Blue */
+     , (46250,   5,        450) /* EncumbranceVal */
+     , (46250,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46250,  16,          1) /* ItemUseable - No */
+     , (46250,  18,          1) /* UiEffects - Magical */
+     , (46250,  19,       8000) /* Value */
+     , (46250,  33,          1) /* Bonded - Bonded */
+     , (46250,  44,         68) /* Damage */
+     , (46250,  45,          8) /* DamageType - Cold */
+     , (46250,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46250,  47,          6) /* AttackType - Thrust, Slash */
+     , (46250,  48,         44) /* WeaponSkill - HeavyWeapons */
+     , (46250,  49,         35) /* WeaponTime */
+     , (46250,  51,          1) /* CombatUse - Melee */
+     , (46250,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46250, 106,        350) /* ItemSpellcraft */
+     , (46250, 107,        750) /* ItemCurMana */
+     , (46250, 108,        750) /* ItemMaxMana */
+     , (46250, 109,        250) /* ItemDifficulty */
+     , (46250, 114,          1) /* Attuned - Attuned */
+     , (46250, 151,          2) /* HookType - Wall */
+     , (46250, 158,          2) /* WieldRequirements - RawSkill */
+     , (46250, 159,         44) /* WieldSkillType - HeavyWeapons */
+     , (46250, 160,        400) /* WieldDifficulty */
+     , (46250, 166,         38) /* SlayerCreatureType - FireElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46250,  22, True ) /* Inscribable */
+     , (46250,  69, False) /* IsSellable */
+     , (46250,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46250,   5,  -0.033) /* ManaRate */
+     , (46250,  12,       0) /* Shade */
+     , (46250,  21,       0) /* WeaponLength */
+     , (46250,  22,    0.43) /* DamageVariance */
+     , (46250,  26,       0) /* MaximumVelocity */
+     , (46250,  29,    1.14) /* WeaponDefense */
+     , (46250,  62,    1.14) /* WeaponOffense */
+     , (46250,  63,       1) /* DamageMod */
+     , (46250, 138,       4) /* SlayerDamageBonus */
+     , (46250, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46250,   1, 'Enhanced Chilling Isparian Staff') /* Name */
+     , (46250,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46250,   1,   33556384) /* Setup */
+     , (46250,   3,  536870932) /* SoundTable */
+     , (46250,   6,   67111919) /* PaletteBase */
+     , (46250,   7,  268436384) /* ClothingBase */
+     , (46250,   8,  100672934) /* Icon */
+     , (46250,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46250,  2081,      2)  /* Hastening */
+     , (46250,  2096,      2)  /* Aura of Infected Caress */
+     , (46250,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46250,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46250,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46250,  2155,      2)  /* Icy Blessing */
+     , (46250,  2531,      2)  /* Major Heavy Weapon Aptitude */
+     , (46250,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46252 Enhanced Flaming Isparian Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46252 Enhanced Flaming Isparian Staff.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46252;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46252, 'ace46252-enhancedflamingisparianstaff', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46252,   1,          1) /* ItemType - MeleeWeapon */
+     , (46252,   3,         14) /* PaletteTemplate - Red */
+     , (46252,   5,        450) /* EncumbranceVal */
+     , (46252,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46252,  16,          1) /* ItemUseable - No */
+     , (46252,  18,          1) /* UiEffects - Magical */
+     , (46252,  19,       8000) /* Value */
+     , (46252,  33,          1) /* Bonded - Bonded */
+     , (46252,  44,         68) /* Damage */
+     , (46252,  45,         16) /* DamageType - Fire */
+     , (46252,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46252,  47,          6) /* AttackType - Thrust, Slash */
+     , (46252,  48,         44) /* WeaponSkill - HeavyWeapons */
+     , (46252,  49,         35) /* WeaponTime */
+     , (46252,  51,          1) /* CombatUse - Melee */
+     , (46252,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46252, 106,        350) /* ItemSpellcraft */
+     , (46252, 107,        750) /* ItemCurMana */
+     , (46252, 108,        750) /* ItemMaxMana */
+     , (46252, 109,        250) /* ItemDifficulty */
+     , (46252, 114,          1) /* Attuned - Attuned */
+     , (46252, 151,          2) /* HookType - Wall */
+     , (46252, 158,          2) /* WieldRequirements - RawSkill */
+     , (46252, 159,         44) /* WieldSkillType - HeavyWeapons */
+     , (46252, 160,        400) /* WieldDifficulty */
+     , (46252, 166,         61) /* SlayerCreatureType - FrostElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46252,  22, True ) /* Inscribable */
+     , (46252,  69, False) /* IsSellable */
+     , (46252,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46252,   5,  -0.033) /* ManaRate */
+     , (46252,  12,       0) /* Shade */
+     , (46252,  21,       0) /* WeaponLength */
+     , (46252,  22,    0.43) /* DamageVariance */
+     , (46252,  26,       0) /* MaximumVelocity */
+     , (46252,  29,    1.14) /* WeaponDefense */
+     , (46252,  62,    1.14) /* WeaponOffense */
+     , (46252,  63,       1) /* DamageMod */
+     , (46252, 138,       4) /* SlayerDamageBonus */
+     , (46252, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46252,   1, 'Enhanced Flaming Isparian Staff') /* Name */
+     , (46252,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46252,   1,   33556373) /* Setup */
+     , (46252,   3,  536870932) /* SoundTable */
+     , (46252,   6,   67111919) /* PaletteBase */
+     , (46252,   7,  268436384) /* ClothingBase */
+     , (46252,   8,  100672941) /* Icon */
+     , (46252,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46252,  2087,      2)  /* Might of the Lugians */
+     , (46252,  2096,      2)  /* Aura of Infected Caress */
+     , (46252,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46252,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46252,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46252,  2157,      2)  /* Fiery Blessing */
+     , (46252,  2531,      2)  /* Major Heavy Weapon Aptitude */
+     , (46252,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46254 Enhanced Coruscating Isparian Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46254 Enhanced Coruscating Isparian Staff.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46254;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46254, 'ace46254-enhancedcoruscatingisparianstaff', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46254,   1,          1) /* ItemType - MeleeWeapon */
+     , (46254,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (46254,   5,        450) /* EncumbranceVal */
+     , (46254,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46254,  16,          1) /* ItemUseable - No */
+     , (46254,  18,          1) /* UiEffects - Magical */
+     , (46254,  19,       8000) /* Value */
+     , (46254,  33,          1) /* Bonded - Bonded */
+     , (46254,  44,         68) /* Damage */
+     , (46254,  45,         64) /* DamageType - Electric */
+     , (46254,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46254,  47,          6) /* AttackType - Thrust, Slash */
+     , (46254,  48,         44) /* WeaponSkill - HeavyWeapons */
+     , (46254,  49,         35) /* WeaponTime */
+     , (46254,  51,          1) /* CombatUse - Melee */
+     , (46254,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46254, 106,        350) /* ItemSpellcraft */
+     , (46254, 107,        750) /* ItemCurMana */
+     , (46254, 108,        750) /* ItemMaxMana */
+     , (46254, 109,        250) /* ItemDifficulty */
+     , (46254, 114,          1) /* Attuned - Attuned */
+     , (46254, 151,          2) /* HookType - Wall */
+     , (46254, 158,          2) /* WieldRequirements - RawSkill */
+     , (46254, 159,         44) /* WieldSkillType - HeavyWeapons */
+     , (46254, 160,        400) /* WieldDifficulty */
+     , (46254, 166,         60) /* SlayerCreatureType - AcidElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46254,  22, True ) /* Inscribable */
+     , (46254,  69, False) /* IsSellable */
+     , (46254,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46254,   5,  -0.033) /* ManaRate */
+     , (46254,  12,       0) /* Shade */
+     , (46254,  21,       0) /* WeaponLength */
+     , (46254,  22,    0.43) /* DamageVariance */
+     , (46254,  26,       0) /* MaximumVelocity */
+     , (46254,  29,    1.14) /* WeaponDefense */
+     , (46254,  62,    1.14) /* WeaponOffense */
+     , (46254,  63,       1) /* DamageMod */
+     , (46254, 138,       4) /* SlayerDamageBonus */
+     , (46254, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46254,   1, 'Enhanced Coruscating Isparian Staff') /* Name */
+     , (46254,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46254,   1,   33556372) /* Setup */
+     , (46254,   3,  536870932) /* SoundTable */
+     , (46254,   6,   67111919) /* PaletteBase */
+     , (46254,   7,  268436384) /* ClothingBase */
+     , (46254,   8,  100672937) /* Icon */
+     , (46254,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46254,  2061,      2)  /* Perseverance */
+     , (46254,  2096,      2)  /* Aura of Infected Caress */
+     , (46254,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46254,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46254,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46254,  2159,      2)  /* Storm's Blessing */
+     , (46254,  2531,      2)  /* Major Heavy Weapon Aptitude */
+     , (46254,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46256 Enhanced Dissolving Isparian Staff.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46256 Enhanced Dissolving Isparian Staff.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46256;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46256, 'ace46256-enhanceddissolvingisparianstaff', 6, '2020-11-25 23:48:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46256,   1,          1) /* ItemType - MeleeWeapon */
+     , (46256,   3,          8) /* PaletteTemplate - Green */
+     , (46256,   5,        450) /* EncumbranceVal */
+     , (46256,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (46256,  16,          1) /* ItemUseable - No */
+     , (46256,  18,          1) /* UiEffects - Magical */
+     , (46256,  19,       8000) /* Value */
+     , (46256,  33,          1) /* Bonded - Bonded */
+     , (46256,  44,         68) /* Damage */
+     , (46256,  45,         32) /* DamageType - Acid */
+     , (46256,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (46256,  47,          6) /* AttackType - Thrust, Slash */
+     , (46256,  48,         44) /* WeaponSkill - HeavyWeapons */
+     , (46256,  49,         35) /* WeaponTime */
+     , (46256,  51,          1) /* CombatUse - Melee */
+     , (46256,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46256, 106,        350) /* ItemSpellcraft */
+     , (46256, 107,        750) /* ItemCurMana */
+     , (46256, 108,        750) /* ItemMaxMana */
+     , (46256, 109,        250) /* ItemDifficulty */
+     , (46256, 114,          1) /* Attuned - Attuned */
+     , (46256, 151,          2) /* HookType - Wall */
+     , (46256, 158,          2) /* WieldRequirements - RawSkill */
+     , (46256, 159,         44) /* WieldSkillType - HeavyWeapons */
+     , (46256, 160,        400) /* WieldDifficulty */
+     , (46256, 166,         42) /* SlayerCreatureType - LightningElemental */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46256,  22, True ) /* Inscribable */
+     , (46256,  69, False) /* IsSellable */
+     , (46256,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46256,   5,  -0.033) /* ManaRate */
+     , (46256,  12,       0) /* Shade */
+     , (46256,  21,       0) /* WeaponLength */
+     , (46256,  22,    0.43) /* DamageVariance */
+     , (46256,  26,       0) /* MaximumVelocity */
+     , (46256,  29,    1.14) /* WeaponDefense */
+     , (46256,  62,    1.14) /* WeaponOffense */
+     , (46256,  63,       1) /* DamageMod */
+     , (46256, 138,       4) /* SlayerDamageBonus */
+     , (46256, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46256,   1, 'Enhanced Dissolving Isparian Staff') /* Name */
+     , (46256,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46256,   1,   33556371) /* Setup */
+     , (46256,   3,  536870932) /* SoundTable */
+     , (46256,   6,   67111919) /* PaletteBase */
+     , (46256,   7,  268436384) /* ClothingBase */
+     , (46256,   8,  100672940) /* Icon */
+     , (46256,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46256,  2059,      2)  /* Honed Control */
+     , (46256,  2096,      2)  /* Aura of Infected Caress */
+     , (46256,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46256,  2106,      2)  /* Aura of Elysa's Sight */
+     , (46256,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46256,  2149,      2)  /* Caustic Blessing */
+     , (46256,  2531,      2)  /* Major Heavy Weapon Aptitude */
+     , (46256,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46828 Purified Mouryou Katana.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46828 Purified Mouryou Katana.sql
@@ -18,8 +18,6 @@ VALUES (46828,   1,          1) /* ItemType - MeleeWeapon */
      , (46828,  48,         44) /* WeaponSkill - HeavyWeapons */
      , (46828,  49,         25) /* WeaponTime */
      , (46828,  51,          1) /* CombatUse - Melee */
-     , (46828,  52,          1) /* ParentLocation */
-     , (46828,  53,          1) /* PlacementPosition */
      , (46828,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
      , (46828, 106,        475) /* ItemSpellcraft */
      , (46828, 107,       3000) /* ItemCurMana */
@@ -34,25 +32,20 @@ VALUES (46828,   1,          1) /* ItemType - MeleeWeapon */
 	 , (46828, 353,         11) /* WeaponType - TwoHanded */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46828,  11, True ) /* IgnoreCollisions */
-     , (46828,  13, True ) /* Ethereal */
-     , (46828,  14, True ) /* GravityStatus */
-     , (46828,  15, True ) /* LightsStatus */
-     , (46828,  19, True ) /* Attackable */
-     , (46828,  22, True ) /* Inscribable */
+VALUES (46828,  22, True ) /* Inscribable */
      , (46828,  69, False) /* IsSellable */
-     , (46828,  91, False) /* Retained */
      , (46828,  99, False) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46828,   5, -0.0500000007450581) /* ManaRate */
+VALUES (46828,   5,   -0.05) /* ManaRate */
      , (46828,  21,       0) /* WeaponLength */
-     , (46828,  22, 0.349999994039536) /* DamageVariance */
+     , (46828,  22,    0.35) /* DamageVariance */
      , (46828,  26,       0) /* MaximumVelocity */
-     , (46828,  29, 1.14999997615814) /* WeaponDefense */
+     , (46828,  29,    1.15) /* WeaponDefense */
      , (46828,  62,    1.25) /* WeaponOffense */
      , (46828,  63,       1) /* DamageMod */
      , (46828, 136,       1) /* CriticalMultiplier */
+     , (46828, 138,       3) /* SlayerDamageBonus */
      , (46828, 155,       1) /* IgnoreArmor */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46830 Purified Mouryou Nodachi.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MeleeWeapon/46830 Purified Mouryou Nodachi.sql
@@ -18,7 +18,6 @@ VALUES (46830,   1,          1) /* ItemType - MeleeWeapon */
      , (46830,  48,         41) /* WeaponSkill - TwoHandedCombat */
      , (46830,  49,         35) /* WeaponTime */
      , (46830,  51,          5) /* CombatUse - TwoHanded */
-     , (46830,  52,          1) /* ParentLocation */
      , (46830,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
      , (46830, 106,        475) /* ItemSpellcraft */
      , (46830, 107,          0) /* ItemCurMana */
@@ -43,14 +42,15 @@ VALUES (46830,  11, True ) /* IgnoreCollisions */
      , (46830,  99, False) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46830,   5, -0.0500000007450581) /* ManaRate */
+VALUES (46830,   5,   -0.05) /* ManaRate */
      , (46830,  21,       0) /* WeaponLength */
-     , (46830,  22, 0.400000005960464) /* DamageVariance */
+     , (46830,  22,     0.4) /* DamageVariance */
      , (46830,  26,       0) /* MaximumVelocity */
-     , (46830,  29, 1.14999997615814) /* WeaponDefense */
+     , (46830,  29,    1.15) /* WeaponDefense */
      , (46830,  62,    1.25) /* WeaponOffense */
      , (46830,  63,       1) /* DamageMod */
      , (46830, 136,       1) /* CriticalMultiplier */
+     , (46830, 138,       3) /* SlayerDamageBonus */
      , (46830, 155,       1) /* IgnoreArmor */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/24197 Weeping Atlatl.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/24197 Weeping Atlatl.sql
@@ -18,9 +18,7 @@ VALUES (24197,   1,        256) /* ItemType - MissileWeapon */
      , (24197,  48,         47) /* WeaponSkill - MissileWeapons */
      , (24197,  49,          1) /* WeaponTime */
      , (24197,  50,          4) /* AmmoType - Atlatl */
-     , (24197,  51,          2) /* CombatUse - Missle */
-     , (24197,  52,          1) /* ParentLocation */
-     , (24197,  53,        101) /* PlacementPosition */
+     , (24197,  51,          2) /* CombatUse - Missile */
      , (24197,  60,        120) /* WeaponRange */
      , (24197,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24197, 106,        300) /* ItemSpellcraft */
@@ -33,27 +31,21 @@ VALUES (24197,   1,        256) /* ItemType - MissileWeapon */
      , (24197, 158,          2) /* WieldRequirements - RawSkill */
      , (24197, 159,         47) /* WieldSkillType - MissileWeapons */
      , (24197, 160,        290) /* WieldDifficulty */
-     , (24197, 166,         31) /* SlayerCreatureType - Human */
-     , (24197, 353,         10) /* WeaponType - Thrown */;
+     , (24197, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24197,  11, True ) /* IgnoreCollisions */
-     , (24197,  13, True ) /* Ethereal */
-     , (24197,  14, True ) /* GravityStatus */
-     , (24197,  19, True ) /* Attackable */
-     , (24197,  22, True ) /* Inscribable */
-     , (24197,  23, True ) /* DestroyOnSell */
+VALUES (24197,  22, True ) /* Inscribable */
      , (24197,  69, False) /* IsSellable */
      , (24197,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24197,   5, -0.025000000372529) /* ManaRate */
+VALUES (24197,   5,  -0.025) /* ManaRate */
      , (24197,  26,      50) /* MaximumVelocity */
-     , (24197,  29, 1.17999994754791) /* WeaponDefense */
+     , (24197,  29,    1.18) /* WeaponDefense */
      , (24197,  39,       1) /* DefaultScale */
      , (24197,  62,       1) /* WeaponOffense */
-     , (24197,  63, 2.4300000667572) /* DamageMod */
-     , (24197, 138, 2.90000009536743) /* SlayerDamageBonus */
+     , (24197,  63,    2.43) /* DamageMod */
+     , (24197, 138,     2.9) /* SlayerDamageBonus */
      , (24197, 151,       1) /* IgnoreShield */
      , (24197, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/24199 Weeping Bow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/24199 Weeping Bow.sql
@@ -18,9 +18,7 @@ VALUES (24199,   1,        256) /* ItemType - MissileWeapon */
      , (24199,  48,         47) /* WeaponSkill - MissileWeapons */
      , (24199,  49,         10) /* WeaponTime */
      , (24199,  50,          1) /* AmmoType - Arrow */
-     , (24199,  51,          2) /* CombatUse - Missle */
-     , (24199,  52,          2) /* ParentLocation */
-     , (24199,  53,        101) /* PlacementPosition */
+     , (24199,  51,          2) /* CombatUse - Missile */
      , (24199,  60,        175) /* WeaponRange */
      , (24199,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24199, 106,        300) /* ItemSpellcraft */
@@ -33,28 +31,22 @@ VALUES (24199,   1,        256) /* ItemType - MissileWeapon */
      , (24199, 158,          2) /* WieldRequirements - RawSkill */
      , (24199, 159,         47) /* WieldSkillType - MissileWeapons */
      , (24199, 160,        290) /* WieldDifficulty */
-     , (24199, 166,         31) /* SlayerCreatureType - Human */
-     , (24199, 353,          8) /* WeaponType - Bow */;
+     , (24199, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24199,  11, True ) /* IgnoreCollisions */
-     , (24199,  13, True ) /* Ethereal */
-     , (24199,  14, True ) /* GravityStatus */
-     , (24199,  19, True ) /* Attackable */
-     , (24199,  22, True ) /* Inscribable */
-     , (24199,  23, True ) /* DestroyOnSell */
+VALUES (24199,  22, True ) /* Inscribable */
      , (24199,  69, False) /* IsSellable */
      , (24199,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24199,   5, -0.025000000372529) /* ManaRate */
+VALUES (24199,   5,  -0.025) /* ManaRate */
      , (24199,  21,       0) /* WeaponLength */
      , (24199,  22,       0) /* DamageVariance */
      , (24199,  26,      50) /* MaximumVelocity */
-     , (24199,  29, 1.17999994754791) /* WeaponDefense */
+     , (24199,  29,    1.18) /* WeaponDefense */
      , (24199,  62,       1) /* WeaponOffense */
-     , (24199,  63, 2.1800000667572) /* DamageMod */
-     , (24199, 138, 2.90000009536743) /* SlayerDamageBonus */
+     , (24199,  63,    2.18) /* DamageMod */
+     , (24199, 138,     2.9) /* SlayerDamageBonus */
      , (24199, 151,       1) /* IgnoreShield */
      , (24199, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/24201 Weeping Crossbow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/24201 Weeping Crossbow.sql
@@ -18,9 +18,7 @@ VALUES (24201,   1,        256) /* ItemType - MissileWeapon */
      , (24201,  48,         47) /* WeaponSkill - MissileWeapons */
      , (24201,  49,         60) /* WeaponTime */
      , (24201,  50,          2) /* AmmoType - Bolt */
-     , (24201,  51,          2) /* CombatUse - Missle */
-     , (24201,  52,          2) /* ParentLocation */
-     , (24201,  53,        101) /* PlacementPosition */
+     , (24201,  51,          2) /* CombatUse - Missile */
      , (24201,  60,        195) /* WeaponRange */
      , (24201,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (24201, 106,        300) /* ItemSpellcraft */
@@ -33,29 +31,23 @@ VALUES (24201,   1,        256) /* ItemType - MissileWeapon */
      , (24201, 158,          2) /* WieldRequirements - RawSkill */
      , (24201, 159,         47) /* WieldSkillType - MissileWeapons */
      , (24201, 160,        290) /* WieldDifficulty */
-     , (24201, 166,         31) /* SlayerCreatureType - Human */
-     , (24201, 353,          9) /* WeaponType - Crossbow */;
+     , (24201, 166,         31) /* SlayerCreatureType - Human */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (24201,  11, True ) /* IgnoreCollisions */
-     , (24201,  13, True ) /* Ethereal */
-     , (24201,  14, True ) /* GravityStatus */
-     , (24201,  19, True ) /* Attackable */
-     , (24201,  22, True ) /* Inscribable */
-     , (24201,  23, True ) /* DestroyOnSell */
+VALUES (24201,  22, True ) /* Inscribable */
      , (24201,  69, False) /* IsSellable */
      , (24201,  99, True ) /* Ivoryable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (24201,   5, -0.025000000372529) /* ManaRate */
+VALUES (24201,   5,  -0.025) /* ManaRate */
      , (24201,  21,       0) /* WeaponLength */
      , (24201,  22,       0) /* DamageVariance */
      , (24201,  26,      50) /* MaximumVelocity */
-     , (24201,  29, 1.17999994754791) /* WeaponDefense */
+     , (24201,  29,    1.18) /* WeaponDefense */
      , (24201,  39,    1.25) /* DefaultScale */
      , (24201,  62,       1) /* WeaponOffense */
-     , (24201,  63, 2.4300000667572) /* DamageMod */
-     , (24201, 138, 2.90000009536743) /* SlayerDamageBonus */
+     , (24201,  63,    2.43) /* DamageMod */
+     , (24201, 138,     2.9) /* SlayerDamageBonus */
      , (24201, 151,       1) /* IgnoreShield */
      , (24201, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/46204 Enhanced Shimmering Isparian Crossbow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/46204 Enhanced Shimmering Isparian Crossbow.sql
@@ -1,0 +1,66 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46204;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46204, 'ace46204-enhancedshimmeringispariancrossbow', 3, '2020-11-25 23:48:00') /* MissileLauncher */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46204,   1,        256) /* ItemType - MissileWeapon */
+     , (46204,   5,       1400) /* EncumbranceVal */
+     , (46204,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (46204,  16,          1) /* ItemUseable - No */
+     , (46204,  18,          1) /* UiEffects - Magical */
+     , (46204,  19,       8000) /* Value */
+     , (46204,  33,          1) /* Bonded - Bonded */
+     , (46204,  44,          8) /* Damage */
+     , (46204,  45,          2) /* DamageType - Pierce */
+     , (46204,  46,         32) /* DefaultCombatStyle - Crossbow */
+     , (46204,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (46204,  49,         45) /* WeaponTime */
+     , (46204,  50,          2) /* AmmoType - Bolt */
+     , (46204,  51,          2) /* CombatUse - Missile */
+     , (46204,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46204, 106,        350) /* ItemSpellcraft */
+     , (46204, 107,        400) /* ItemCurMana */
+     , (46204, 108,        400) /* ItemMaxMana */
+     , (46204, 109,        250) /* ItemDifficulty */
+     , (46204, 114,          1) /* Attuned - Attuned */
+     , (46204, 151,          2) /* HookType - Wall */
+     , (46204, 158,          2) /* WieldRequirements - RawSkill */
+     , (46204, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (46204, 160,        360) /* WieldDifficulty */
+     , (46204, 166,         62) /* SlayerCreatureType - Elemental */
+     , (46204, 204,         11) /* ElementalDamageBonus */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46204,  22, True ) /* Inscribable */
+     , (46204,  69, False) /* IsSellable */
+     , (46204,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46204,   5,  -0.025) /* ManaRate */
+     , (46204,  21,       0) /* WeaponLength */
+     , (46204,  22,       0) /* DamageVariance */
+     , (46204,  26,    27.3) /* MaximumVelocity */
+     , (46204,  29,    1.14) /* WeaponDefense */
+     , (46204,  39,    1.25) /* DefaultScale */
+     , (46204,  62,       1) /* WeaponOffense */
+     , (46204,  63,     2.5) /* DamageMod */
+     , (46204, 138,       4) /* SlayerDamageBonus */
+     , (46204, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46204,   1, 'Enhanced Shimmering Isparian Crossbow') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46204,   1,   33557730) /* Setup */
+     , (46204,   3,  536870932) /* SoundTable */
+     , (46204,   7,  268436428) /* ClothingBase */
+     , (46204,   8,  100673202) /* Icon */
+     , (46204,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46204,  2096,      2)  /* Aura of Infected Caress */
+     , (46204,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46204,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46204,  2505,      2)  /* Major Missile Weapon Aptitude */
+     , (46204,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/46218 Enhanced Chilling Isparian Crossbow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/46218 Enhanced Chilling Isparian Crossbow.sql
@@ -1,0 +1,72 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46218;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46218, 'ace46218-enhancedchillingispariancrossbow', 3, '2020-11-25 23:48:00') /* MissileLauncher */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46218,   1,        256) /* ItemType - MissileWeapon */
+     , (46218,   3,          2) /* PaletteTemplate - Blue */
+     , (46218,   5,       1400) /* EncumbranceVal */
+     , (46218,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (46218,  16,          1) /* ItemUseable - No */
+     , (46218,  18,          1) /* UiEffects - Magical */
+     , (46218,  19,       8000) /* Value */
+     , (46218,  33,          1) /* Bonded - Bonded */
+     , (46218,  44,          8) /* Damage */
+     , (46218,  45,          8) /* DamageType - Cold */
+     , (46218,  46,         32) /* DefaultCombatStyle - Crossbow */
+     , (46218,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (46218,  49,         45) /* WeaponTime */
+     , (46218,  50,          2) /* AmmoType - Bolt */
+     , (46218,  51,          2) /* CombatUse - Missile */
+     , (46218,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (46218, 106,        350) /* ItemSpellcraft */
+     , (46218, 107,        400) /* ItemCurMana */
+     , (46218, 108,        400) /* ItemMaxMana */
+     , (46218, 109,        250) /* ItemDifficulty */
+     , (46218, 114,          1) /* Attuned - Attuned */
+     , (46218, 151,          2) /* HookType - Wall */
+     , (46218, 158,          2) /* WieldRequirements - RawSkill */
+     , (46218, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (46218, 160,        360) /* WieldDifficulty */
+     , (46218, 166,         38) /* SlayerCreatureType - FireElemental */
+     , (46218, 204,         11) /* ElementalDamageBonus */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46218,  22, True ) /* Inscribable */
+     , (46218,  69, False) /* IsSellable */
+     , (46218,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46218,   5,  -0.025) /* ManaRate */
+     , (46218,  12,       0) /* Shade */
+     , (46218,  21,       0) /* WeaponLength */
+     , (46218,  22,       0) /* DamageVariance */
+     , (46218,  26,    27.3) /* MaximumVelocity */
+     , (46218,  29,    1.14) /* WeaponDefense */
+     , (46218,  39,    1.25) /* DefaultScale */
+     , (46218,  62,       1) /* WeaponOffense */
+     , (46218,  63,     2.5) /* DamageMod */
+     , (46218, 138,       4) /* SlayerDamageBonus */
+     , (46218, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46218,   1, 'Enhanced Chilling Isparian Crossbow') /* Name */
+     , (46218,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46218,   1,   33557767) /* Setup */
+     , (46218,   3,  536870932) /* SoundTable */
+     , (46218,   6,   67111919) /* PaletteBase */
+     , (46218,   7,  268436396) /* ClothingBase */
+     , (46218,   8,  100673019) /* Icon */
+     , (46218,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46218,  2087,      2)  /* Might of the Lugians */
+     , (46218,  2096,      2)  /* Aura of Infected Caress */
+     , (46218,  2101,      2)  /* Aura of Cragstone's Will */
+     , (46218,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (46218,  2155,      2)  /* Icy Blessing */
+     , (46218,  2505,      2)  /* Major Missile Weapon Aptitude */
+     , (46218,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/71210 Enhanced Dissolving Isparian Crossbow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/71210 Enhanced Dissolving Isparian Crossbow.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 71210;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (71210, 'ace71210-enhanceddissolvingispariancrossbow', 3, '2020-11-25 23:48:00') /* MissileLauncher */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (71210,   1,        256) /* ItemType - MissileWeapon */
+     , (71210,   3,          8) /* PaletteTemplate - Green */
+     , (71210,   5,       1400) /* EncumbranceVal */
+     , (71210,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (71210,  16,          1) /* ItemUseable - No */
+     , (71210,  18,          1) /* UiEffects - Magical */
+     , (71210,  19,       8000) /* Value */
+     , (71210,  33,          1) /* Bonded - Bonded */
+     , (71210,  44,          8) /* Damage */
+     , (71210,  45,         32) /* DamageType - Acid */
+     , (71210,  46,         32) /* DefaultCombatStyle - Crossbow */
+     , (71210,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (71210,  49,         45) /* WeaponTime */
+     , (71210,  50,          2) /* AmmoType - Bolt */
+     , (71210,  51,          2) /* CombatUse - Missile */
+     , (71210,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (71210, 106,        350) /* ItemSpellcraft */
+     , (71210, 107,        400) /* ItemCurMana */
+     , (71210, 108,        400) /* ItemMaxMana */
+     , (71210, 109,        250) /* ItemDifficulty */
+     , (71210, 114,          1) /* Attuned - Attuned */
+     , (71210, 151,          2) /* HookType - Wall */
+     , (71210, 158,          2) /* WieldRequirements - RawSkill */
+     , (71210, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (71210, 160,        360) /* WieldDifficulty */
+     , (71210, 166,         42) /* SlayerCreatureType - LightningElemental */
+     , (71210, 204,         11) /* ElementalDamageBonus */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (71210,  22, True ) /* Inscribable */
+     , (71210,  69, False) /* IsSellable */
+     , (71210,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (71210,   5,  -0.025) /* ManaRate */
+     , (71210,  21,       0) /* WeaponLength */
+     , (71210,  22,       0) /* DamageVariance */
+     , (71210,  26,    27.3) /* MaximumVelocity */
+     , (71210,  29,    1.14) /* WeaponDefense */
+     , (71210,  39,    1.25) /* DefaultScale */
+     , (71210,  62,       1) /* WeaponOffense */
+     , (71210,  63,     2.5) /* DamageMod */
+     , (71210, 138,       4) /* SlayerDamageBonus */
+     , (71210, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (71210,   1, 'Enhanced Dissolving Isparian Crossbow') /* Name */
+     , (71210,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (71210,   1,   33557769) /* Setup */
+     , (71210,   3,  536870932) /* SoundTable */
+     , (71210,   6,   67111919) /* PaletteBase */
+     , (71210,   7,  268436396) /* ClothingBase */
+     , (71210,   8,  100673025) /* Icon */
+     , (71210,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (71210,  2087,      2)  /* Might of the Lugians */
+     , (71210,  2096,      2)  /* Aura of Infected Caress */
+     , (71210,  2101,      2)  /* Aura of Cragstone's Will */
+     , (71210,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (71210,  2149,      2)  /* Caustic Blessing */
+     , (71210,  2505,      2)  /* Major Missile Weapon Aptitude */
+     , (71210,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/71211 Enhanced Coruscating Isparian Crossbow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/71211 Enhanced Coruscating Isparian Crossbow.sql
@@ -1,0 +1,70 @@
+DELETE FROM `weenie` WHERE `class_Id` = 71211;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (71211, 'ace71211-enhancedcoruscatingispariancrossbow', 3, '2020-11-25 23:48:00') /* MissileLauncher */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (71211,   1,        256) /* ItemType - MissileWeapon */
+     , (71211,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (71211,   5,       1400) /* EncumbranceVal */
+     , (71211,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (71211,  16,          1) /* ItemUseable - No */
+     , (71211,  18,          1) /* UiEffects - Magical */
+     , (71211,  19,       8000) /* Value */
+     , (71211,  33,          1) /* Bonded - Bonded */
+     , (71211,  44,          8) /* Damage */
+     , (71211,  45,         64) /* DamageType - Electric */
+     , (71211,  46,         32) /* DefaultCombatStyle - Crossbow */
+     , (71211,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (71211,  49,         45) /* WeaponTime */
+     , (71211,  50,          2) /* AmmoType - Bolt */
+     , (71211,  51,          2) /* CombatUse - Missile */
+     , (71211,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (71211, 106,        350) /* ItemSpellcraft */
+     , (71211, 107,        400) /* ItemCurMana */
+     , (71211, 108,        400) /* ItemMaxMana */
+     , (71211, 109,        250) /* ItemDifficulty */
+     , (71211, 114,          1) /* Attuned - Attuned */
+     , (71211, 158,          2) /* WieldRequirements - RawSkill */
+     , (71211, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (71211, 160,        360) /* WieldDifficulty */
+     , (71211, 166,         60) /* SlayerCreatureType - AcidElemental */
+     , (71211, 204,         11) /* ElementalDamageBonus */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (71211,  22, True ) /* Inscribable */
+     , (71211,  69, False) /* IsSellable */
+     , (71211,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (71211,   5,  -0.025) /* ManaRate */
+     , (71211,  21,       0) /* WeaponLength */
+     , (71211,  22,       0) /* DamageVariance */
+     , (71211,  26,    27.3) /* MaximumVelocity */
+     , (71211,  29,    1.14) /* WeaponDefense */
+     , (71211,  39,    1.25) /* DefaultScale */
+     , (71211,  62,       1) /* WeaponOffense */
+     , (71211,  63,     2.5) /* DamageMod */
+     , (71211, 138,       4) /* SlayerDamageBonus */
+     , (71211, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (71211,   1, 'Enhanced Coruscating Isparian Crossbow') /* Name */
+     , (71211,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (71211,   1,   33557772) /* Setup */
+     , (71211,   3,  536870932) /* SoundTable */
+     , (71211,   6,   67111919) /* PaletteBase */
+     , (71211,   7,  268436396) /* ClothingBase */
+     , (71211,   8,  100673022) /* Icon */
+     , (71211,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (71211,  2087,      2)  /* Might of the Lugians */
+     , (71211,  2096,      2)  /* Aura of Infected Caress */
+     , (71211,  2101,      2)  /* Aura of Cragstone's Will */
+     , (71211,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (71211,  2159,      2)  /* Storm's Blessing */
+     , (71211,  2505,      2)  /* Major Missile Weapon Aptitude */
+     , (71211,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/71212 Enhanced Flaming Isparian Crossbow.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/MissileLauncher/71212 Enhanced Flaming Isparian Crossbow.sql
@@ -1,0 +1,71 @@
+DELETE FROM `weenie` WHERE `class_Id` = 71212;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (71212, 'ace71212-enhancedflamingispariancrossbow', 3, '2020-11-25 23:48:00') /* MissileLauncher */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (71212,   1,        256) /* ItemType - MissileWeapon */
+     , (71212,   3,         14) /* PaletteTemplate - Red */
+     , (71212,   5,       1400) /* EncumbranceVal */
+     , (71212,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (71212,  16,          1) /* ItemUseable - No */
+     , (71212,  18,          1) /* UiEffects - Magical */
+     , (71212,  19,       8000) /* Value */
+     , (71212,  33,          1) /* Bonded - Bonded */
+     , (71212,  44,          8) /* Damage */
+     , (71212,  45,         16) /* DamageType - Fire */
+     , (71212,  46,         32) /* DefaultCombatStyle - Crossbow */
+     , (71212,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (71212,  49,         45) /* WeaponTime */
+     , (71212,  50,          2) /* AmmoType - Bolt */
+     , (71212,  51,          2) /* CombatUse - Missile */
+     , (71212,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (71212, 106,        350) /* ItemSpellcraft */
+     , (71212, 107,        400) /* ItemCurMana */
+     , (71212, 108,        400) /* ItemMaxMana */
+     , (71212, 109,        250) /* ItemDifficulty */
+     , (71212, 114,          1) /* Attuned - Attuned */
+     , (71212, 151,          2) /* HookType - Wall */
+     , (71212, 158,          2) /* WieldRequirements - RawSkill */
+     , (71212, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (71212, 160,        360) /* WieldDifficulty */
+     , (71212, 166,         61) /* SlayerCreatureType - FrostElemental */
+     , (71212, 204,         11) /* ElementalDamageBonus */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (71212,  22, True ) /* Inscribable */
+     , (71212,  69, False) /* IsSellable */
+     , (71212,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (71212,   5,  -0.025) /* ManaRate */
+     , (71212,  21,       0) /* WeaponLength */
+     , (71212,  22,       0) /* DamageVariance */
+     , (71212,  26,    27.3) /* MaximumVelocity */
+     , (71212,  29,    1.14) /* WeaponDefense */
+     , (71212,  39,    1.25) /* DefaultScale */
+     , (71212,  62,       1) /* WeaponOffense */
+     , (71212,  63,     2.5) /* DamageMod */
+     , (71212, 138,       4) /* SlayerDamageBonus */
+     , (71212, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (71212,   1, 'Enhanced Flaming Isparian Crossbow') /* Name */
+     , (71212,  16, 'This weapon seems tough to master.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (71212,   1,   33557774) /* Setup */
+     , (71212,   3,  536870932) /* SoundTable */
+     , (71212,   6,   67111919) /* PaletteBase */
+     , (71212,   7,  268436396) /* ClothingBase */
+     , (71212,   8,  100673026) /* Icon */
+     , (71212,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (71212,  2087,      2)  /* Might of the Lugians */
+     , (71212,  2096,      2)  /* Aura of Infected Caress */
+     , (71212,  2101,      2)  /* Aura of Cragstone's Will */
+     , (71212,  2116,      2)  /* Aura of Atlan's Alacrity */
+     , (71212,  2157,      2)  /* Fiery Blessing */
+     , (71212,  2505,      2)  /* Major Missile Weapon Aptitude */
+     , (71212,  2586,      2)  /* Major Blood Thirst */;

--- a/Database/Patches/2005-12-ThroughSacrificeStrength/9 WeenieDefaults/MeleeWeapon/32495 Mace of Winter Flame.sql
+++ b/Database/Patches/2005-12-ThroughSacrificeStrength/9 WeenieDefaults/MeleeWeapon/32495 Mace of Winter Flame.sql
@@ -41,6 +41,7 @@ VALUES (32495,   5, -0.0333329997956753) /* ManaRate */
      , (32495,  62,       1) /* WeaponOffense */
      , (32495,  63,       1) /* DamageMod */
      , (32495, 136,       2) /* CriticalMultiplier */
+     , (32495, 138,       3) /* SlayerDamageBonus */
      , (32495, 147,     0.2) /* CriticalFrequency */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-12-ThroughSacrificeStrength/9 WeenieDefaults/MeleeWeapon/32497 Spear of Winter Flame.sql
+++ b/Database/Patches/2005-12-ThroughSacrificeStrength/9 WeenieDefaults/MeleeWeapon/32497 Spear of Winter Flame.sql
@@ -41,6 +41,7 @@ VALUES (32497,   5,  -0.033) /* ManaRate */
      , (32497,  62,       1) /* WeaponOffense */
      , (32497,  63,       1) /* DamageMod */
      , (32497, 136,       2) /* CriticalMultiplier */
+     , (32497, 138,       3) /* SlayerDamageBonus */
      , (32497, 147,     0.2) /* CriticalFrequency */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2005-12-ThroughSacrificeStrength/9 WeenieDefaults/MeleeWeapon/32499 Axe of Winter Flame.sql
+++ b/Database/Patches/2005-12-ThroughSacrificeStrength/9 WeenieDefaults/MeleeWeapon/32499 Axe of Winter Flame.sql
@@ -41,6 +41,7 @@ VALUES (32499,   5,  -0.033) /* ManaRate */
      , (32499,  62,       1) /* WeaponOffense */
      , (32499,  63,       1) /* DamageMod */
      , (32499, 136,       2) /* CriticalMultiplier */
+     , (32499, 138,       3) /* SlayerDamageBonus */
      , (32499, 147,     0.2) /* CriticalFrequency */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2006-03-DownTwistingPaths/9 WeenieDefaults/MeleeWeapon/32769 Replica Sword of Bellenesse.sql
+++ b/Database/Patches/2006-03-DownTwistingPaths/9 WeenieDefaults/MeleeWeapon/32769 Replica Sword of Bellenesse.sql
@@ -43,6 +43,7 @@ VALUES (32769,   5, -0.033) /* ManaRate */
      , (32769,  62,   1.15) /* WeaponOffense */
      , (32769,  63,      1) /* DamageMod */
      , (32769, 136,    2.5) /* CriticalMultiplier */
+     , (32769, 138,      3) /* SlayerDamageBonus */
      , (32769, 147,   0.20) /* CriticalFrequency */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)


### PR DESCRIPTION
- Remove WeaponType from Weeping Wand
- Add SlayerDamageBonus, where missing
- Property and float values cleanup
- Add missing Enhanced Isparian Weapons