### PR TITLE
Remove Encounter from deep water landblock

### DIFF
--- a/Database/Patches/2005-06-PreTOD/1 RegionDescExtendedData/7B63.sql
+++ b/Database/Patches/2005-06-PreTOD/1 RegionDescExtendedData/7B63.sql
@@ -1,0 +1,1 @@
+DELETE FROM `encounter` WHERE `landblock` = 31587;


### PR DESCRIPTION
- Remove an three encounter generator spawns from deep water landblock off the coast of Yaraq that is causing failed spawn spam warning messages in the log file