### PR TITLE
Nanjou shou jen armor quest update

### DIFF
--- a/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Lugian/31003 Tukora Commander.sql
+++ b/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Lugian/31003 Tukora Commander.sql
@@ -1,0 +1,127 @@
+DELETE FROM `weenie` WHERE `class_Id` = 31003;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (31003, 'lugiantukoracommanderhighyield', 10, '2021-05-23 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (31003,   1,         16) /* ItemType - Creature */
+     , (31003,   2,          5) /* CreatureType - Lugian */
+     , (31003,   3,          8) /* PaletteTemplate - Green */
+     , (31003,   6,        255) /* ItemsCapacity */
+     , (31003,   7,        255) /* ContainersCapacity */
+     , (31003,  16,          1) /* ItemUseable - No */
+     , (31003,  25,        220) /* Level */
+     , (31003,  40,          2) /* CombatMode - Melee */
+     , (31003,  81,          2) /* MaxGeneratedObjects */
+     , (31003,  82,          0) /* InitGeneratedObjects */
+     , (31003,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (31003, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (31003, 103,          1) /* GeneratorDestructionType - Nothing */
+     , (31003, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (31003, 146,    1400000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (31003,   1, True ) /* Stuck */
+     , (31003, 101, True ) /* CanGenerateRare */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (31003,   1,       5) /* HeartbeatInterval */
+     , (31003,   2,       0) /* HeartbeatTimestamp */
+     , (31003,   3, 0.899999976158142) /* HealthRate */
+     , (31003,   4,       4) /* StaminaRate */
+     , (31003,   5,       2) /* ManaRate */
+     , (31003,  12,     0.5) /* Shade */
+     , (31003,  13, 0.600000023841858) /* ArmorModVsSlash */
+     , (31003,  14, 0.600000023841858) /* ArmorModVsPierce */
+     , (31003,  15, 0.600000023841858) /* ArmorModVsBludgeon */
+     , (31003,  16, 0.349999994039536) /* ArmorModVsCold */
+     , (31003,  17,    0.25) /* ArmorModVsFire */
+     , (31003,  18, 0.850000023841858) /* ArmorModVsAcid */
+     , (31003,  19, 0.800000011920929) /* ArmorModVsElectric */
+     , (31003,  31,      23) /* VisualAwarenessRange */
+     , (31003,  34,       3) /* PowerupTime */
+     , (31003,  36,       1) /* ChargeSpeed */
+     , (31003,  64, 0.649999976158142) /* ResistSlash */
+     , (31003,  65, 0.649999976158142) /* ResistPierce */
+     , (31003,  66, 0.649999976158142) /* ResistBludgeon */
+     , (31003,  67,    0.25) /* ResistFire */
+     , (31003,  68, 0.400000005960464) /* ResistCold */
+     , (31003,  69, 0.899999976158142) /* ResistAcid */
+     , (31003,  70,       1) /* ResistElectric */
+     , (31003,  71,       1) /* ResistHealthBoost */
+     , (31003,  72,       1) /* ResistStaminaDrain */
+     , (31003,  73,       1) /* ResistStaminaBoost */
+     , (31003,  74,       1) /* ResistManaDrain */
+     , (31003,  75,       1) /* ResistManaBoost */
+     , (31003, 104,      10) /* ObviousRadarRange */
+     , (31003, 117,     0.5) /* FocusedProbability */
+     , (31003, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (31003,   1, 'Tukora Commander') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (31003,   1,   33557003) /* Setup */
+     , (31003,   2,  150994950) /* MotionTable */
+     , (31003,   3,  536870922) /* SoundTable */
+     , (31003,   4,  805306371) /* CombatTable */
+     , (31003,   6,   67113158) /* PaletteBase */
+     , (31003,   7,  268436618) /* ClothingBase */
+     , (31003,   8,  100667447) /* Icon */
+     , (31003,  22,  872415262) /* PhysicsEffectTable */
+     , (31003,  32,        425) /* WieldedTreasureType - 
+                                   Wield 10x Rock (23133) | Probability: 80%
+                                   Wield Lugian Morning Star (23134) | Probability: 10%
+                                   Wield Lugian Axe (23132) | Probability: 10% */
+     , (31003,  35,       1000) /* DeathTreasureType */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (31003,   1, 380, 0, 0) /* Strength */
+     , (31003,   2, 340, 0, 0) /* Endurance */
+     , (31003,   3, 300, 0, 0) /* Quickness */
+     , (31003,   4, 300, 0, 0) /* Coordination */
+     , (31003,   5, 200, 0, 0) /* Focus */
+     , (31003,   6, 240, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (31003,   1,  4500, 0, 0, 4670) /* MaxHealth */
+     , (31003,   3,  5660, 0, 0, 6000) /* MaxStamina */
+     , (31003,   5,     0, 0, 0, 240) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (31003,  6, 0, 3, 0, 465, 0, 0) /* MeleeDefense        Specialized */
+     , (31003,  7, 0, 3, 0, 483, 0, 0) /* MissileDefense      Specialized */
+     , (31003, 47, 0, 3, 0, 310, 0, 0) /* MissileWeapons      Specialized */
+     , (31003, 45, 0, 3, 0, 380, 0, 0) /* LightWeapons        Specialized */
+     , (31003, 15, 0, 3, 0, 375, 0, 0) /* MagicDefense        Specialized */
+     , (31003, 20, 0, 2, 0,  45, 0, 0) /* Deception           Trained */
+     , (31003, 22, 0, 2, 0, 120, 0, 0) /* Jump                Trained */
+     , (31003, 24, 0, 2, 0, 180, 0, 0) /* Run                 Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (31003,  0,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31003,  1,  4, 280,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31003,  2,  4, 280,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31003,  3,  4, 280,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31003,  4,  4, 280,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31003,  5,  4, 140, 0.75,  440,  264,  264,  264,  154,  110,  374,  352,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31003,  6,  4,  2,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31003,  7,  4, 25,  0.3,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31003,  8,  4, 140, 0.75,  440,  264,  264,  264,  154,  110,  374,  352,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31003,  3 /* Death */,   0.02, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (31003, 9, 31346,  0, 0, 0.02, False) /* Create Lugian Commander's Insignia (31346) for ContainTreasure */
+     , (31003, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (31003, 9, 24477,  0, 0, 0.05, False) /* Create Sturdy Steel Key (24477) for ContainTreasure */
+     , (31003, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (31003, 1, 34014, 0, 2, 2, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Tanada Nanjou Shou-jen (34014) (x2 up to max of 2) - Regenerate upon Death - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Mosswart/31010 Mosswart Elder.sql
+++ b/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Mosswart/31010 Mosswart Elder.sql
@@ -1,0 +1,197 @@
+DELETE FROM `weenie` WHERE `class_Id` = 31010;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (31010, 'mosswartelderhighyield', 10, '2021-05-23 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (31010,   1,         16) /* ItemType - Creature */
+     , (31010,   2,          4) /* CreatureType - Mosswart */
+     , (31010,   3,         77) /* PaletteTemplate - BlueGreen */
+     , (31010,   6,         -1) /* ItemsCapacity */
+     , (31010,   7,         -1) /* ContainersCapacity */
+     , (31010,  16,          1) /* ItemUseable - No */
+     , (31010,  25,        185) /* Level */
+     , (31010,  27,          0) /* ArmorType - None */
+     , (31010,  40,          2) /* CombatMode - Melee */
+     , (31010,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (31010,  72,         50) /* FriendType - Idol */
+     , (31010,  81,          2) /* MaxGeneratedObjects */
+     , (31010,  82,          0) /* InitGeneratedObjects */     
+     , (31010,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (31010, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (31010, 103,          1) /* GeneratorDestructionType - Nothing */
+     , (31010, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (31010, 140,          1) /* AiOptions - CanOpenDoors */
+     , (31010, 146,     800000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (31010,   1, True ) /* Stuck */
+     , (31010,   6, False) /* AiUsesMana */
+     , (31010,  11, False) /* IgnoreCollisions */
+     , (31010,  12, True ) /* ReportCollisions */
+     , (31010,  13, False) /* Ethereal */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (31010,   1,       5) /* HeartbeatInterval */
+     , (31010,   2,       0) /* HeartbeatTimestamp */
+     , (31010,   3,     0.5) /* HealthRate */
+     , (31010,   4,       5) /* StaminaRate */
+     , (31010,   5,       2) /* ManaRate */
+     , (31010,  12,       0) /* Shade */
+     , (31010,  13,     1.3) /* ArmorModVsSlash */
+     , (31010,  14,     1.5) /* ArmorModVsPierce */
+     , (31010,  15,     1.4) /* ArmorModVsBludgeon */
+     , (31010,  16,       1) /* ArmorModVsCold */
+     , (31010,  17,     0.7) /* ArmorModVsFire */
+     , (31010,  18,     1.3) /* ArmorModVsAcid */
+     , (31010,  19,     0.9) /* ArmorModVsElectric */
+     , (31010,  31,      24) /* VisualAwarenessRange */
+     , (31010,  34,     0.9) /* PowerupTime */
+     , (31010,  36,       1) /* ChargeSpeed */
+     , (31010,  39,     1.2) /* DefaultScale */
+     , (31010,  64,     0.5) /* ResistSlash */
+     , (31010,  65,     0.8) /* ResistPierce */
+     , (31010,  66,     0.8) /* ResistBludgeon */
+     , (31010,  67,       1) /* ResistFire */
+     , (31010,  68,     0.4) /* ResistCold */
+     , (31010,  69,     0.7) /* ResistAcid */
+     , (31010,  70,     1.1) /* ResistElectric */
+     , (31010,  71,       1) /* ResistHealthBoost */
+     , (31010,  72,       1) /* ResistStaminaDrain */
+     , (31010,  73,       1) /* ResistStaminaBoost */
+     , (31010,  74,       1) /* ResistManaDrain */
+     , (31010,  75,       1) /* ResistManaBoost */
+     , (31010, 104,      10) /* ObviousRadarRange */
+     , (31010, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (31010,   1, 'Mosswart Elder') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (31010,   1,   33557327) /* Setup */
+     , (31010,   2,  150994953) /* MotionTable */
+     , (31010,   3,  536870959) /* SoundTable */
+     , (31010,   4,  805306373) /* CombatTable */
+     , (31010,   6,   67113400) /* PaletteBase */
+     , (31010,   7,  268436295) /* ClothingBase */
+     , (31010,   8,  100667449) /* Icon */
+     , (31010,  22,  872415264) /* PhysicsEffectTable */
+     , (31010,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (31010,   1, 250, 0, 0) /* Strength */
+     , (31010,   2, 240, 0, 0) /* Endurance */
+     , (31010,   3, 215, 0, 0) /* Quickness */
+     , (31010,   4, 230, 0, 0) /* Coordination */
+     , (31010,   5, 185, 0, 0) /* Focus */
+     , (31010,   6, 175, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (31010,   1,   700, 0, 0, 820) /* MaxHealth */
+     , (31010,   3,   800, 0, 0, 1040) /* MaxStamina */
+     , (31010,   5,   500, 0, 0, 675) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (31010, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (31010, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */
+     , (31010, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (31010,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (31010,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (31010, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (31010, 14, 0, 3, 0, 250, 0, 0) /* ArcaneLore          Specialized */
+     , (31010, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (31010, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (31010, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (31010, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (31010,  0,  4,  0,    0,  340,  420,  440,  440,  440,  355,  440,  440,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31010,  1,  4,  0,    0,  340,  420,  440,  440,  440,  355,  440,  440,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31010,  2,  4,  0,    0,  340,  420,  440,  440,  440,  355,  440,  440,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31010,  3,  4,  0,    0,  340,  440,  440,  440,  440,  355,  440,  440,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31010,  4,  4,  0,    0,  340,  440,  440,  440,  440,  355,  440,  440,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31010,  5,  4, 60, 0.75,  340,  440,  440,  440,  440,  355,  440,  440,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31010,  6,  4,  0,    0,  340,  420,  440,  440,  440,  355,  440,  440,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31010,  7,  4,  0,    0,  340,  420,  440,  440,  440,  355,  440,  440,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31010,  8,  4, 60, 0.75,  340,  420,  440,  440,  440,  355,  440,  440,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (31010,  1089,   2.06)  /* Lightning Vulnerability Other VI */
+     , (31010,  1108,   2.06)  /* Fire Vulnerability Other VI */
+     , (31010,  1161,   2.05)  /* Heal Self VI */
+     , (31010,  2128,   2.08)  /* Ilservian's Flame */
+     , (31010,  2140,   2.08)  /* Alset's Coil */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  3 /* Death */,   0.02, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,  0.045, NULL, 2147483708 /* HandCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435539 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,  0.095, NULL, 2147483708 /* HandCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435538 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,    0.1, NULL, 2147483708 /* HandCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,   0.05, NULL, 2147483710 /* SwordCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,  0.045, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435539 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,  0.095, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435538 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31010,  5 /* HeartBeat */,    0.1, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (31010, 9, 31349,  0, 0, 0.02, False) /* Create Mosswart Armband (31349) for ContainTreasure */
+     , (31010, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (31010, 2, 32123,  0, 0, 0.5, True) /* Create Acid Spear (32123) for Wield */
+     , (31010, 2, 32124,  0, 0, 0.5, True) /* Create Frost Spear (32124) for Wield */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (31010, 1, 34014, 0, 2, 2, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Tanada Nanjou Shou-jen (34014) (x2 up to max of 2) - Regenerate upon Death - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Undead/31015 Mu-miyah Sentinel.sql
+++ b/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Undead/31015 Mu-miyah Sentinel.sql
@@ -1,0 +1,163 @@
+DELETE FROM `weenie` WHERE `class_Id` = 31015;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (31015, 'mumiyahsentinelhighyield', 10, '2021-05-23 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (31015,   1,         16) /* ItemType - Creature */
+     , (31015,   2,         14) /* CreatureType - Undead */
+     , (31015,   3,         44) /* PaletteTemplate - Tanred */
+     , (31015,   6,         -1) /* ItemsCapacity */
+     , (31015,   7,         -1) /* ContainersCapacity */
+     , (31015,  16,          1) /* ItemUseable - No */
+     , (31015,  25,        160) /* Level */
+     , (31015,  27,          0) /* ArmorType - None */
+     , (31015,  40,          1) /* CombatMode - NonCombat */
+     , (31015,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (31015,  72,         14) /* FriendType - Undead */
+     , (31015,  81,          2) /* MaxGeneratedObjects */
+     , (31015,  82,          0) /* InitGeneratedObjects */     
+     , (31015,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (31015, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (31015, 103,          1) /* GeneratorDestructionType - Nothing */
+     , (31015, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (31015, 140,          1) /* AiOptions - CanOpenDoors */
+     , (31015, 146,     500000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (31015,   1, True ) /* Stuck */
+     , (31015,   6, True ) /* AiUsesMana */
+     , (31015,  11, False) /* IgnoreCollisions */
+     , (31015,  12, True ) /* ReportCollisions */
+     , (31015,  13, False) /* Ethereal */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (31015,   1,       5) /* HeartbeatInterval */
+     , (31015,   2,       0) /* HeartbeatTimestamp */
+     , (31015,   3, 0.800000011920929) /* HealthRate */
+     , (31015,   4,     0.5) /* StaminaRate */
+     , (31015,   5,       2) /* ManaRate */
+     , (31015,  12,     0.5) /* Shade */
+     , (31015,  13, 0.850000023841858) /* ArmorModVsSlash */
+     , (31015,  14, 0.899999976158142) /* ArmorModVsPierce */
+     , (31015,  15, 0.649999976158142) /* ArmorModVsBludgeon */
+     , (31015,  16, 0.889999985694885) /* ArmorModVsCold */
+     , (31015,  17, 0.949999988079071) /* ArmorModVsFire */
+     , (31015,  18, 1.20000004768372) /* ArmorModVsAcid */
+     , (31015,  19, 1.10000002384186) /* ArmorModVsElectric */
+     , (31015,  31,      18) /* VisualAwarenessRange */
+     , (31015,  34,       1) /* PowerupTime */
+     , (31015,  36,       1) /* ChargeSpeed */
+     , (31015,  39, 1.10000002384186) /* DefaultScale */
+     , (31015,  64, 1.10000002384186) /* ResistSlash */
+     , (31015,  65, 1.14999997615814) /* ResistPierce */
+     , (31015,  66, 1.33000004291534) /* ResistBludgeon */
+     , (31015,  67, 0.949999988079071) /* ResistFire */
+     , (31015,  68, 0.899999976158142) /* ResistCold */
+     , (31015,  69, 0.400000005960464) /* ResistAcid */
+     , (31015,  70, 0.850000023841858) /* ResistElectric */
+     , (31015,  71,       1) /* ResistHealthBoost */
+     , (31015,  72,       1) /* ResistStaminaDrain */
+     , (31015,  73,       1) /* ResistStaminaBoost */
+     , (31015,  74,       1) /* ResistManaDrain */
+     , (31015,  75,       1) /* ResistManaBoost */
+     , (31015,  80,       3) /* AiUseMagicDelay */
+     , (31015, 104,      10) /* ObviousRadarRange */
+     , (31015, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (31015,   1, 'Mu-miyah Sentinel') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (31015,   1,   33554433) /* Setup */
+     , (31015,   2,  150994981) /* MotionTable */
+     , (31015,   3,  536870942) /* SoundTable */
+     , (31015,   4,  805306368) /* CombatTable */
+     , (31015,   6,   67108990) /* PaletteBase */
+     , (31015,   7,  268435645) /* ClothingBase */
+     , (31015,   8,  100669122) /* Icon */
+     , (31015,  22,  872415272) /* PhysicsEffectTable */
+     , (31015,  35,        449) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (31015,   1, 160, 0, 0) /* Strength */
+     , (31015,   2, 170, 0, 0) /* Endurance */
+     , (31015,   3, 180, 0, 0) /* Quickness */
+     , (31015,   4, 170, 0, 0) /* Coordination */
+     , (31015,   5, 250, 0, 0) /* Focus */
+     , (31015,   6, 260, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (31015,   1,  1320, 0, 0, 1405) /* MaxHealth */
+     , (31015,   3,  1460, 0, 0, 1630) /* MaxStamina */
+     , (31015,   5,   500, 0, 0, 760) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (31015, 45, 0, 3, 0, 303, 0, 0) /* LightWeapons        Specialized */
+     , (31015, 47, 0, 3, 0, 200, 0, 0) /* MissileWeapons      Specialized */
+     , (31015, 46, 0, 3, 0, 303, 0, 0) /* FinesseWeapons      Specialized */
+     , (31015,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
+     , (31015,  7, 0, 3, 0, 425, 0, 0) /* MissileDefense      Specialized */
+     , (31015, 44, 0, 3, 0, 303, 0, 0) /* HeavyWeapons        Specialized */
+     , (31015, 48, 0, 3, 0, 303, 0, 0) /* Shield              Specialized */
+     , (31015, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
+     , (31015, 15, 0, 3, 0, 304, 0, 0) /* MagicDefense        Specialized */
+     , (31015, 20, 0, 3, 0, 140, 0, 0) /* Deception           Specialized */
+     , (31015, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (31015,  0,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31015,  1,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31015,  2,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31015,  3,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31015,  4,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31015,  5,  4, 185, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31015,  6,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31015,  7,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31015,  8,  4, 185, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (31015,  4312,   2.02)  /* Incantation of Imperil Other */
+     , (31015,  4477,   2.02)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (31015,  4481,   2.02)  /* Incantation of Fire Vulnerability Other */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31015,  3 /* Death */,   0.02, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31015,  5 /* HeartBeat */,  0.025, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 318767226 /* Beckon */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31015,  5 /* HeartBeat */,   0.05, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 318767254 /* Slouch */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31015,  5 /* HeartBeat */,   0.15, NULL, 2147483710 /* SwordCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (31015, 9, 31345,  0, 0, 0.06, False) /* Create Rotting Bandage (31345) for ContainTreasure */
+     , (31015, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
+     , (31015, 9, 24477,  0, 0, 0.06, False) /* Create Sturdy Steel Key (24477) for ContainTreasure */
+     , (31015, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (31015, 1, 34014, 0, 2, 2, 4, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Tanada Nanjou Shou-jen (34014) (x2 up to max of 2) - Regenerate upon Death - Location to (re)Generate: OnTop */;

--- a/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Zefir/31017 Kirit Zefir.sql
+++ b/Database/Patches/2006-09-ComeWhatFollows/9 WeenieDefaults/Creature/Zefir/31017 Kirit Zefir.sql
@@ -1,0 +1,170 @@
+DELETE FROM `weenie` WHERE `class_Id` = 31017;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (31017, 'zefirkirithighyield', 10, '2021-05-23 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (31017,   1,         16) /* ItemType - Creature */
+     , (31017,   2,         29) /* CreatureType - Zefir */
+     , (31017,   3,         19) /* PaletteTemplate - Copper */
+     , (31017,   6,         -1) /* ItemsCapacity */
+     , (31017,   7,         -1) /* ContainersCapacity */
+     , (31017,  16,          1) /* ItemUseable - No */
+     , (31017,  25,        105) /* Level */
+     , (31017,  40,          2) /* CombatMode - Melee */
+     , (31017,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (31017,  72,         29) /* FriendType - Zefir */
+     , (31017,  81,          2) /* MaxGeneratedObjects */
+     , (31017,  82,          0) /* InitGeneratedObjects */
+     , (31017,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (31017, 103,          1) /* GeneratorDestructionType - Nothing */
+     , (31017, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (31017, 146,     500000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (31017,   1, True ) /* Stuck */
+     , (31017,   6, True ) /* AiUsesMana */
+     , (31017,  11, False) /* IgnoreCollisions */
+     , (31017,  12, True ) /* ReportCollisions */
+     , (31017,  13, False) /* Ethereal */
+     , (31017,  19, True ) /* Attackable */
+     , (31017,  50, True ) /* NeverFailCasting */
+     , (31017, 101, True ) /* CanGenerateRare */
+     , (31017, 102, True ) /* CorpseGeneratedRare */
+     , (31017, 103, True ) /* NonProjectileMagicImmune */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (31017,   1,       5) /* HeartbeatInterval */
+     , (31017,   2,       0) /* HeartbeatTimestamp */
+     , (31017,   3, 1.20000004768372) /* HealthRate */
+     , (31017,   4,     0.5) /* StaminaRate */
+     , (31017,   5,     2.5) /* ManaRate */
+     , (31017,  12,       0) /* Shade */
+     , (31017,  13, 0.800000011920929) /* ArmorModVsSlash */
+     , (31017,  14, 0.589999973773956) /* ArmorModVsPierce */
+     , (31017,  15, 0.689999997615814) /* ArmorModVsBludgeon */
+     , (31017,  16, 0.589999973773956) /* ArmorModVsCold */
+     , (31017,  17, 0.319999992847443) /* ArmorModVsFire */
+     , (31017,  18, 0.589999973773956) /* ArmorModVsAcid */
+     , (31017,  19,     0.5) /* ArmorModVsElectric */
+     , (31017,  31,      25) /* VisualAwarenessRange */
+     , (31017,  34,       2) /* PowerupTime */
+     , (31017,  36,       1) /* ChargeSpeed */
+     , (31017,  39, 0.899999976158142) /* DefaultScale */
+     , (31017,  64,       1) /* ResistSlash */
+     , (31017,  65,    0.75) /* ResistPierce */
+     , (31017,  66, 0.860000014305115) /* ResistBludgeon */
+     , (31017,  67, 0.00999999977648258) /* ResistFire */
+     , (31017,  68,    0.75) /* ResistCold */
+     , (31017,  69,    0.75) /* ResistAcid */
+     , (31017,  70,    0.25) /* ResistElectric */
+     , (31017,  71,       1) /* ResistHealthBoost */
+     , (31017,  72,       1) /* ResistStaminaDrain */
+     , (31017,  73,       1) /* ResistStaminaBoost */
+     , (31017,  74,       1) /* ResistManaDrain */
+     , (31017,  75,       1) /* ResistManaBoost */
+     , (31017,  80,       3) /* AiUseMagicDelay */
+     , (31017, 104,      10) /* ObviousRadarRange */
+     , (31017, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (31017,   1, 'Kirit Zefir') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (31017,   1,   33555610) /* Setup */
+     , (31017,   2,  150995049) /* MotionTable */
+     , (31017,   3,  536870975) /* SoundTable */
+     , (31017,   4,  805306396) /* CombatTable */
+     , (31017,   6,   67109305) /* PaletteBase */
+     , (31017,   7,  268436729) /* ClothingBase */
+     , (31017,   8,  100669123) /* Icon */
+     , (31017,  22,  872415279) /* PhysicsEffectTable */
+     , (31017,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (31017,   1, 400, 0, 0) /* Strength */
+     , (31017,   2, 400, 0, 0) /* Endurance */
+     , (31017,   3, 400, 0, 0) /* Quickness */
+     , (31017,   4, 400, 0, 0) /* Coordination */
+     , (31017,   5, 260, 0, 0) /* Focus */
+     , (31017,   6, 260, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (31017,   1,  1800, 0, 0, 2000) /* MaxHealth */
+     , (31017,   3,  7600, 0, 0, 8000) /* MaxStamina */
+     , (31017,   5,  7740, 0, 0, 8000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (31017,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
+     , (31017,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
+     , (31017, 45, 0, 3, 0, 320, 0, 0) /* LightWeapons        Specialized */
+     , (31017, 15, 0, 3, 0, 275, 0, 0) /* MagicDefense        Specialized */
+     , (31017, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (31017, 22, 0, 3, 0,  70, 0, 0) /* Jump                Specialized */
+     , (31017, 24, 0, 3, 0,  10, 0, 0) /* Run                 Specialized */
+     , (31017, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
+     , (31017, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (31017,  0,  1, 250,  0.5,  350,  180,  250,  275,  250,  300,  250,  225,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (31017, 16,  4,  0,    0,  350,  180,  250,  275,  250,  300,  250,  225,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
+     , (31017, 17,  1, 250,  0.6,  350,  180,  250,  275,  250,  300,  250,  225,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
+     , (31017, 21,  4,  0,    0,  350,  180,  250,  275,  250,  300,  250,  225,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (31017,    68,   2.05)  /* Shock Wave V */
+     , (31017,    89,   2.05)  /* Force Bolt IV */
+     , (31017,    96,   2.06)  /* Whirling Blade V */
+     , (31017,   285,   2.04)  /* Magic Yield Other VI */
+     , (31017,   651,   2.03)  /* War Magic Ineptitude Other V */
+     , (31017,  1372,   2.04)  /* Frailty Other VI */
+     , (31017,  2084,   2.04)  /* Belly of Lead */
+     , (31017,  2132,   2.05)  /* The Spike */
+     , (31017,  2146,   2.06)  /* Evisceration */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31017,  3 /* Death */,   0.02, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31017,  5 /* HeartBeat */,  0.085, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435537 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31017,  5 /* HeartBeat */,    0.1, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435538 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31017,  5 /* HeartBeat */,   0.15, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435539 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (31017,  5 /* HeartBeat */,    0.2, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 268435540 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (31017, 9, 31359,  1, 0, 0.1, True) /* Create Kirit Zefir Wing (31359) for ContainTreasure */
+     , (31017, 9,     0,  0, 0, 0.9, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (31017, 1, 34014, 0, 2, 2, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tanada Nanjou Shou-jen (34014) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;


### PR DESCRIPTION
   Update the Nanjou Shou-Jen Armor Quest.
   Currently only Olthoi Rippers 31005 and Kirit Zefir 31017 generate Tanada Nanjou Shou-jen 34014.
   Added 31010 Mosswart Elder, 31003 Tukora Commander, and 31015 Mu-miyah Sentinel to generate them.
   Based on mobtracker numbers fixed all spawn rates at 2% which is the same as original contributor used on Olthoi Ripper 31005.
   Kirit Zefir was changed from 15% down to 2%.  Olthoi Ripper 31005 has not been changed.
   Weenies currently located in ACE-World-16PY-Patches/Database/Patches/2005-07-ThroneOfDestiny/9 WeenieDefaults/Creature/