### PR TITLE
Rynthid Fixes

### DIFF
--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51749 Rynthid Minion.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51749 Rynthid Minion.sql
@@ -120,3 +120,7 @@ INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (51749,  2074,   2.05)  /* Gossamer Flesh */
      , (51749,  2172,   2.053)  /* Astyrrian's Gift */
      , (51749,  3989,   2.056)  /* Dark Lightning */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (51749, 8, 51854,  1, 0, 0.03, False) /* Mask for Treasure */
+	 , (51749, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51750 Rynthid Minion.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51750 Rynthid Minion.sql
@@ -119,3 +119,7 @@ INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (51750,  2074,   2.05)  /* Gossamer Flesh */
      , (51750,  2172,   2.053)  /* Astyrrian's Gift */
      , (51750,  3989,   2.056)  /* Dark Lightning */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (51750, 8, 51854,  1, 0, 0.03, False) /* Mask for Treasure */
+	 , (51750, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51757 Raging Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51757 Raging Rynthid Sorcerer.sql
@@ -118,11 +118,11 @@ VALUES (51757,  0, 16,  0,    0, 650, 520, 520, 520, 520, 520, 520, 520,  600, 1
      , (51757,  8, 16, 200, 0.5, 650, 520, 520, 520, 520, 520, 520, 520,  600, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51757,  3882,   2.15)  /* Incendiary Ring */
-     , (51757,  3940,   2.176)  /* Exsanguinating Wave */
-     , (51757,  4312,   2.286)  /* Incantation of Imperil Other */
-     , (51757,  4439,   2.3)  /* Incantation of Flame Bolt */
-     , (51757,  4481,   2.429)  /* Incantation of Fire Vulnerability Other */;
+VALUES (51757,  3882,    2.21)  /* Incendiary Ring */
+     , (51757,  3940,   2.266)  /* Exsanguinating Wave */
+     , (51757,  4439,   2.414)  /* Incantation of Flame Bolt */
+     , (51757,  4312,   2.206)  /* Incantation of Imperil Other */
+     , (51757,  4481,   2.259)  /* Incantation of Fire Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (51757, 8, 51859,  1, 0, 0.03, False) /* Create Mask for Treasure */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51758 Raging Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51758 Raging Rynthid Sorcerer.sql
@@ -117,11 +117,11 @@ VALUES (51758,  0, 16,  0,    0, 650, 520, 520, 520, 520, 520, 520, 520,  600, 1
      , (51758,  8, 16, 200, 0.5, 650, 520, 520, 520, 520, 520, 520, 520,  600, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51758,  3882,   2.15)  /* Incendiary Ring */
-     , (51758,  3940,   2.176)  /* Exsanguinating Wave */
-     , (51758,  4312,   2.286)  /* Incantation of Imperil Other */
-     , (51758,  4439,   2.3)  /* Incantation of Flame Bolt */
-     , (51758,  4481,   2.429)  /* Incantation of Fire Vulnerability Other */;
+VALUES (51758,  3882,    2.21)  /* Incendiary Ring */
+     , (51758,  3940,   2.266)  /* Exsanguinating Wave */
+     , (51758,  4439,   2.414)  /* Incantation of Flame Bolt */
+     , (51758,  4312,   2.206)  /* Incantation of Imperil Other */
+     , (51758,  4481,   2.259)  /* Incantation of Fire Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (51758, 8, 51859,  1, 0, 0.03, False) /* Create Mask for Treasure */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51759 Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51759 Rynthid Sorcerer.sql
@@ -118,11 +118,11 @@ VALUES (51759,  0, 64,  0,    0, 650, 520, 520, 520, 520, 520, 520, 520,  600, 1
      , (51759,  8, 64, 200, 0.5, 650, 520, 520, 520, 520, 520, 520, 520,  600, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51759,  3940,   2.15)  /* Exsanguinating Wave */
-     , (51759,  3941,   2.176)  /* Heavy Lightning Ring */
-     , (51759,  3989,   2.286)  /* Dark Lightning */
-     , (51759,  4312,   2.3)  /* Incantation of Imperil Other */
-     , (51759,  4483,   2.429)  /* Incantation of Lightning Vulnerability Other */;
+VALUES (51759,  3940,    2.21)  /* Exsanguinating Wave */
+     , (51759,  3941,   2.266)  /* Heavy Lightning Ring */
+     , (51759,  3989,   2.414)  /* Dark Lightning */
+     , (51759,  4312,   2.206)  /* Incantation of Imperil Other */
+     , (51759,  4483,   2.259)  /* Incantation of Lightning Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (51759, 8, 51858,  1, 0, 0.03, False) /* Mask for Treasure */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51760 Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51760 Rynthid Sorcerer.sql
@@ -117,11 +117,11 @@ VALUES (51760,  0, 64,  0,    0, 650, 520, 520, 520, 520, 520, 520, 520,  600, 1
      , (51760,  8, 64, 200, 0.5, 650, 520, 520, 520, 520, 520, 520, 520,  600, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51760,  3940,   2.15)  /* Exsanguinating Wave */
-     , (51760,  3941,   2.176)  /* Heavy Lightning Ring */
-     , (51760,  3989,   2.286)  /* Dark Lightning */
-     , (51760,  4312,   2.3)  /* Incantation of Imperil Other */
-     , (51760,  4483,   2.429)  /* Incantation of Lightning Vulnerability Other */;
+VALUES (51760,  3940,    2.21)  /* Exsanguinating Wave */
+     , (51760,  3941,   2.266)  /* Heavy Lightning Ring */
+     , (51760,  3989,   2.414)  /* Dark Lightning */
+     , (51760,  4312,   2.206)  /* Incantation of Imperil Other */
+     , (51760,  4483,   2.259)  /* Incantation of Lightning Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (51760, 8, 51858,  1, 0, 0.03, False) /* Mask for Treasure */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52278 Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52278 Rynthid Sorcerer.sql
@@ -118,11 +118,11 @@ VALUES (52278,  0, 64,  0,    0, 650, 520, 520, 520, 520, 520, 520, 520,  600, 1
      , (52278,  8, 64, 200, 0.5, 650, 520, 520, 520, 520, 520, 520, 520,  600, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (52278,  3940,    2.15)  /* Exsanguinating Wave */
-     , (52278,  3941,   2.176)  /* Heavy Lightning Ring */
-     , (52278,  3989,   2.286)  /* Dark Lightning */
-     , (52278,  4312,     2.3)  /* Incantation of Imperil Other */
-     , (52278,  4483,   2.429)  /* Incantation of Lightning Vulnerability Other */;
+VALUES (52278,  3940,    2.21)  /* Exsanguinating Wave */
+     , (52278,  3941,   2.266)  /* Heavy Lightning Ring */
+     , (52278,  3989,   2.414)  /* Dark Lightning */
+     , (52278,  4312,   2.206)  /* Incantation of Imperil Other */
+     , (52278,  4483,   2.259)  /* Incantation of Lightning Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (52278, 8, 51858,  1, 0, 0.03, False) /* Mask for Treasure */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52280 Rynthid Minion.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52280 Rynthid Minion.sql
@@ -120,3 +120,7 @@ INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (52280,  2074,   2.05)  /* Gossamer Flesh */
      , (52280,  2172,   2.053)  /* Astyrrian's Gift */
      , (52280,  3989,   2.056)  /* Dark Lightning */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (52280, 8, 51854,  1, 0, 0.03, False) /* Mask for Treasure */
+	 , (52280, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51971 Sanctum Warding Crystal.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51971 Sanctum Warding Crystal.sql
@@ -24,6 +24,7 @@ VALUES (51971,   1, True ) /* Stuck */
      , (51971,  52, True ) /* AiImmobile */
      , (51971,  82, True ) /* DontTurnOrMoveWhenGiving */
      , (51971,  83, True ) /* NPCLooksLikeObject */
+     , (51971, 103, True ) /* NonProjectileMagicImmune */
      , (51971, 118, True ) /* NeverAttack */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51972 Sanctum Warding Crystal.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51972 Sanctum Warding Crystal.sql
@@ -24,6 +24,7 @@ VALUES (51972,   1, True ) /* Stuck */
      , (51972,  52, True ) /* AiImmobile */
      , (51972,  82, True ) /* DontTurnOrMoveWhenGiving */
      , (51972,  83, True ) /* NPCLooksLikeObject */
+     , (51972, 103, True ) /* NonProjectileMagicImmune */
      , (51972, 118, True ) /* NeverAttack */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51973 Sanctum Warding Crystal.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51973 Sanctum Warding Crystal.sql
@@ -24,6 +24,7 @@ VALUES (51973,   1, True ) /* Stuck */
      , (51973,  52, True ) /* AiImmobile */
      , (51973,  82, True ) /* DontTurnOrMoveWhenGiving */
      , (51973,  83, True ) /* NPCLooksLikeObject */
+     , (51973, 103, True ) /* NonProjectileMagicImmune */
      , (51973, 118, True ) /* NeverAttack */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51974 Sanctum Warding Crystal.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Crystal/51974 Sanctum Warding Crystal.sql
@@ -24,6 +24,7 @@ VALUES (51974,   1, True ) /* Stuck */
      , (51974,  52, True ) /* AiImmobile */
      , (51974,  82, True ) /* DontTurnOrMoveWhenGiving */
      , (51974,  83, True ) /* NPCLooksLikeObject */
+     , (51974, 103, True ) /* NonProjectileMagicImmune */
      , (51974, 118, True ) /* NeverAttack */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Virindi/51938 Tormented Sorcerer.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/Creature/Virindi/51938 Tormented Sorcerer.sql
@@ -113,10 +113,10 @@ VALUES (51938,  0, 64,  0,    0, 650, 520, 520, 520, 520, 520, 520, 520,  600, 1
      , (51938,  8, 64, 200, 0.5, 650, 520, 520, 520, 520, 520, 520, 520,  600, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51938,  4633,   2.080)  /* Incantation of Vulnerability Other */
-     , (51938,  4643,   2.087)  /* Incantation of Drain Health Other */
-     , (51938,  4302,   2.095)  /* Incantation of Feeblemind Other */
-     , (51938,  3941,   2.105)  /* Heavy Lightning Ring */
-     , (51938,  3989,   2.265)  /* Dark Lightning */
-     , (51938,  4312,   2.300)  /* Incantation of Imperil Other */
-     , (51938,  4483,   2.429)  /* Incantation of Lightning Vulnerability Other */;
+VALUES (51938,  4633,    2.07)  /* Incantation of Vulnerability Other */
+     , (51938,  4643,   2.075)  /* Incantation of Drain Health Other */
+     , (51938,  4302,   2.081)  /* Incantation of Feeblemind Other */
+     , (51938,  3941,   2.278)  /* Heavy Lightning Ring */
+     , (51938,  3989,   2.404)  /* Dark Lightning */
+     , (51938,  4312,   2.206)  /* Incantation of Imperil Other */
+     , (51938,  4483,   2.259)  /* Incantation of Lightning Vulnerability Other */;

--- a/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/MeleeWeapon/51968 Rynthid Tentacle Greatspear.sql
+++ b/Database/Patches/2013-10-ShatteredMasks/9 WeenieDefaults/MeleeWeapon/51968 Rynthid Tentacle Greatspear.sql
@@ -11,7 +11,7 @@ VALUES (51968,   1,          1) /* ItemType - MeleeWeapon */
      , (51968,  18,          1) /* UiEffects - Magical */
      , (51968,  19,          0) /* Value */
      , (51968,  33,          1) /* Bonded - Bonded */
-     , (51968,  44,         65) /* Damage */
+     , (51968,  44,         41) /* Damage */
      , (51968,  45,         16) /* DamageType - Fire */
      , (51968,  46,          8) /* DefaultCombatStyle - TwoHanded */
      , (51968,  47,          2) /* AttackType - Thrust */


### PR DESCRIPTION
Rynthid Tentacle Greatspear now has correct base damage (previously had buffed instead of base damage).
Added missing mask to Rynthid Minions.
Sanctum Warding Crystals now non-projectile magic immune as in retail.
Adjusted spellcasting probabilities on Rynthid sorcerer type mobs to cast more ring and war spells, less vuls.