### PR TITLE
remove HomeRadius from luminance granting mobs

### DIFF
--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/41963 Pyre Skeleton.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/41963 Pyre Skeleton.sql
@@ -46,7 +46,6 @@ VALUES (41963,   1,       5) /* HeartbeatInterval */
      , (41963,  31,      25) /* VisualAwarenessRange */
      , (41963,  34,       1) /* PowerupTime */
      , (41963,  36,       1) /* ChargeSpeed */
-     , (41963,  55,      75) /* HomeRadius */
      , (41963,  64,    0.58) /* ResistSlash */
      , (41963,  65,    0.58) /* ResistPierce */
      , (41963,  66,    0.66) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/41964 Pyre Champion.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/41964 Pyre Champion.sql
@@ -46,7 +46,6 @@ VALUES (41964,   1,       5) /* HeartbeatInterval */
      , (41964,  31,      25) /* VisualAwarenessRange */
      , (41964,  34,       1) /* PowerupTime */
      , (41964,  36,       1) /* ChargeSpeed */
-     , (41964,  55,      75) /* HomeRadius */
      , (41964,  64,    0.58) /* ResistSlash */
      , (41964,  65,    0.58) /* ResistPierce */
      , (41964,  66,    0.66) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/41965 Pyre Minion.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/41965 Pyre Minion.sql
@@ -46,7 +46,6 @@ VALUES (41965,   1,       5) /* HeartbeatInterval */
      , (41965,  31,      25) /* VisualAwarenessRange */
      , (41965,  34,       1) /* PowerupTime */
      , (41965,  36,       1) /* ChargeSpeed */
-     , (41965,  55,      75) /* HomeRadius */
      , (41965,  64,    0.58) /* ResistSlash */
      , (41965,  65,    0.58) /* ResistPierce */
      , (41965,  66,    0.66) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/46816 Pyre Champion.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/46816 Pyre Champion.sql
@@ -46,7 +46,6 @@ VALUES (46816,   1,       5) /* HeartbeatInterval */
      , (46816,  31,      25) /* VisualAwarenessRange */
      , (46816,  34,       1) /* PowerupTime */
      , (46816,  36,       1) /* ChargeSpeed */
-     , (46816,  55,      75) /* HomeRadius */
      , (46816,  64,    0.58) /* ResistSlash */
      , (46816,  65,    0.58) /* ResistPierce */
      , (46816,  66,    0.66) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/52308 Pyre Minion.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/52308 Pyre Minion.sql
@@ -46,7 +46,6 @@ VALUES (52308,   1,       5) /* HeartbeatInterval */
      , (52308,  31,      25) /* VisualAwarenessRange */
      , (52308,  34,       1) /* PowerupTime */
      , (52308,  36,       1) /* ChargeSpeed */
-     , (52308,  55,      75) /* HomeRadius */
      , (52308,  64,    0.58) /* ResistSlash */
      , (52308,  65,    0.58) /* ResistPierce */
      , (52308,  66,    0.66) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/52309 Pyre Champion.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Skeleton/52309 Pyre Champion.sql
@@ -46,7 +46,6 @@ VALUES (52309,   1,       5) /* HeartbeatInterval */
      , (52309,  31,      25) /* VisualAwarenessRange */
      , (52309,  34,       1) /* PowerupTime */
      , (52309,  36,       1) /* ChargeSpeed */
-     , (52309,  55,      75) /* HomeRadius */
      , (52309,  64,    0.58) /* ResistSlash */
      , (52309,  65,    0.58) /* ResistPierce */
      , (52309,  66,    0.66) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Undead/41966 Wight.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Undead/41966 Wight.sql
@@ -46,7 +46,6 @@ VALUES (41966,   1,       5) /* HeartbeatInterval */
      , (41966,  34,       2) /* PowerupTime */
      , (41966,  36,       1) /* ChargeSpeed */
      , (41966,  39,     1.1) /* DefaultScale */
-     , (41966,  55,      75) /* HomeRadius */
      , (41966,  64,    0.82) /* ResistSlash */
      , (41966,  65,     0.5) /* ResistPierce */
      , (41966,  66,     0.5) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Undead/41968 Wight Captain.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Undead/41968 Wight Captain.sql
@@ -44,7 +44,6 @@ VALUES (41968,   1,       5) /* HeartbeatInterval */
      , (41968,  34,       2) /* PowerupTime */
      , (41968,  36,       1) /* ChargeSpeed */
      , (41968,  39,     1.1) /* DefaultScale */
-     , (41968,  55,      75) /* HomeRadius */
      , (41968,  64,    0.82) /* ResistSlash */
      , (41968,  65,     0.5) /* ResistPierce */
      , (41968,  66,     0.5) /* ResistBludgeon */

--- a/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Undead/46815 Wight Blade Sorcerer.sql
+++ b/Database/Patches/2007-03-AncientEnemies/9 WeenieDefaults/Creatures/Undead/46815 Wight Blade Sorcerer.sql
@@ -45,7 +45,6 @@ VALUES (46815,   1,       5) /* HeartbeatInterval */
      , (46815,  34,       2) /* PowerupTime */
      , (46815,  36,       1) /* ChargeSpeed */
      , (46815,  39,     1.1) /* DefaultScale */
-     , (46815,  55,      75) /* HomeRadius */
      , (46815,  64,    0.82) /* ResistSlash */
      , (46815,  65,     0.5) /* ResistPierce */
      , (46815,  66,     0.5) /* ResistBludgeon */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moar/40298 Ardent Moar.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moar/40298 Ardent Moar.sql
@@ -36,7 +36,6 @@ VALUES (40298,   1,       5) /* HeartbeatInterval */
      , (40298,  34,       1) /* PowerupTime */
      , (40298,  36,       1) /* ChargeSpeed */
      , (40298,  39,       1) /* DefaultScale */
-     , (40298,  55,      60) /* HomeRadius */
      , (40298,  62,     1.5) /* WeaponOffense */
      , (40298,  64,     0.9) /* ResistSlash */
      , (40298,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moar/40300 Blessed Moar.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moar/40300 Blessed Moar.sql
@@ -36,7 +36,6 @@ VALUES (40300,   1,       5) /* HeartbeatInterval */
      , (40300,  34,       1) /* PowerupTime */
      , (40300,  36,       1) /* ChargeSpeed */
      , (40300,  39,       1) /* DefaultScale */
-     , (40300,  55,      60) /* HomeRadius */
      , (40300,  62,     1.5) /* WeaponOffense */
      , (40300,  64,     0.9) /* ResistSlash */
      , (40300,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40302 Blighted Ardent Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40302 Blighted Ardent Moarsman.sql
@@ -41,7 +41,6 @@ VALUES (40302,   1,       5) /* HeartbeatInterval */
      , (40302,  34,       1) /* PowerupTime */
      , (40302,  36,       1) /* ChargeSpeed */
      , (40302,  39,     1.6) /* DefaultScale */
-     , (40302,  55,      60) /* HomeRadius */
      , (40302,  62,     1.5) /* WeaponOffense */
      , (40302,  64,     0.9) /* ResistSlash */
      , (40302,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40303 Ardent Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40303 Ardent Moarsman.sql
@@ -41,7 +41,6 @@ VALUES (40303,   1,       5) /* HeartbeatInterval */
      , (40303,  34,       1) /* PowerupTime */
      , (40303,  36,       1) /* ChargeSpeed */
      , (40303,  39,     1.6) /* DefaultScale */
-     , (40303,  55,      60) /* HomeRadius */
      , (40303,  62,     1.5) /* WeaponOffense */
      , (40303,  64,     0.9) /* ResistSlash */
      , (40303,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40304 Blessed Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40304 Blessed Moarsman.sql
@@ -41,7 +41,6 @@ VALUES (40304,   1,       5) /* HeartbeatInterval */
      , (40304,  34,       1) /* PowerupTime */
      , (40304,  36,       1) /* ChargeSpeed */
      , (40304,  39,     1.6) /* DefaultScale */
-     , (40304,  55,      60) /* HomeRadius */
      , (40304,  62,     1.5) /* WeaponOffense */
      , (40304,  64,     0.9) /* ResistSlash */
      , (40304,  65,     0.8) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40305 Blighted Verdant Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40305 Blighted Verdant Moarsman.sql
@@ -41,7 +41,6 @@ VALUES (40305,   1,       5) /* HeartbeatInterval */
      , (40305,  34,       1) /* PowerupTime */
      , (40305,  36,       1) /* ChargeSpeed */
      , (40305,  39,    1.65) /* DefaultScale */
-     , (40305,  55,      60) /* HomeRadius */
      , (40305,  62,     1.5) /* WeaponOffense */
      , (40305,  64,     0.9) /* ResistSlash */
      , (40305,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40306 Verdant Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40306 Verdant Moarsman.sql
@@ -41,7 +41,6 @@ VALUES (40306,   1,       5) /* HeartbeatInterval */
      , (40306,  34,       1) /* PowerupTime */
      , (40306,  36,       1) /* ChargeSpeed */
      , (40306,  39,    1.65) /* DefaultScale */
-     , (40306,  55,      60) /* HomeRadius */
      , (40306,  62,     1.5) /* WeaponOffense */
      , (40306,  64,     0.9) /* ResistSlash */
      , (40306,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40472 Moarsman Adherent of T'thuun.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40472 Moarsman Adherent of T'thuun.sql
@@ -42,7 +42,6 @@ VALUES (40472,   1,       5) /* HeartbeatInterval */
      , (40472,  34,       1) /* PowerupTime */
      , (40472,  36,       1) /* ChargeSpeed */
      , (40472,  39,     1.4) /* DefaultScale */
-     , (40472,  55,      60) /* HomeRadius */
      , (40472,  62,     1.5) /* WeaponOffense */
      , (40472,  64,     0.9) /* ResistSlash */
      , (40472,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40473 Icthis Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40473 Icthis Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40473,   1,       5) /* HeartbeatInterval */
      , (40473,  34,       1) /* PowerupTime */
      , (40473,  36,       1) /* ChargeSpeed */
      , (40473,  39,     1.6) /* DefaultScale */
-     , (40473,  55,      60) /* HomeRadius */
      , (40473,  62,     1.5) /* WeaponOffense */
      , (40473,  64,     0.9) /* ResistSlash */
      , (40473,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40474 Mithmog Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40474 Mithmog Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40474,   1,       5) /* HeartbeatInterval */
      , (40474,  34,       1) /* PowerupTime */
      , (40474,  36,       1) /* ChargeSpeed */
      , (40474,  39,     1.6) /* DefaultScale */
-     , (40474,  55,      60) /* HomeRadius */
      , (40474,  62,     1.5) /* WeaponOffense */
      , (40474,  64,     0.9) /* ResistSlash */
      , (40474,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40475 Moarsman Priest of T'thuun.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40475 Moarsman Priest of T'thuun.sql
@@ -42,7 +42,6 @@ VALUES (40475,   1,       5) /* HeartbeatInterval */
      , (40475,  34,       1) /* PowerupTime */
      , (40475,  36,       1) /* ChargeSpeed */
      , (40475,  39,     1.4) /* DefaultScale */
-     , (40475,  55,      60) /* HomeRadius */
      , (40475,  62,     1.5) /* WeaponOffense */
      , (40475,  64,     0.9) /* ResistSlash */
      , (40475,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40476 Moarsman Prior.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40476 Moarsman Prior.sql
@@ -42,7 +42,6 @@ VALUES (40476,   1,       5) /* HeartbeatInterval */
      , (40476,  34,       1) /* PowerupTime */
      , (40476,  36,       1) /* ChargeSpeed */
      , (40476,  39,     1.4) /* DefaultScale */
-     , (40476,  55,      60) /* HomeRadius */
      , (40476,  62,     1.5) /* WeaponOffense */
      , (40476,  64,     0.9) /* ResistSlash */
      , (40476,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40477 Shuthis Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40477 Shuthis Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40477,   1,       5) /* HeartbeatInterval */
      , (40477,  34,       1) /* PowerupTime */
      , (40477,  36,       1) /* ChargeSpeed */
      , (40477,  39,     1.6) /* DefaultScale */
-     , (40477,  55,      60) /* HomeRadius */
      , (40477,  62,     1.5) /* WeaponOffense */
      , (40477,  64,     0.9) /* ResistSlash */
      , (40477,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40478 Magshuth Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40478 Magshuth Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40478,   1,       5) /* HeartbeatInterval */
      , (40478,  34,       1) /* PowerupTime */
      , (40478,  36,       1) /* ChargeSpeed */
      , (40478,  39,     1.4) /* DefaultScale */
-     , (40478,  55,      60) /* HomeRadius */
      , (40478,  62,     1.5) /* WeaponOffense */
      , (40478,  64,     0.9) /* ResistSlash */
      , (40478,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40479 Maguth Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40479 Maguth Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40479,   1,       5) /* HeartbeatInterval */
      , (40479,  34,       1) /* PowerupTime */
      , (40479,  36,       1) /* ChargeSpeed */
      , (40479,  39,     1.4) /* DefaultScale */
-     , (40479,  55,      60) /* HomeRadius */
      , (40479,  62,     1.5) /* WeaponOffense */
      , (40479,  64,     0.9) /* ResistSlash */
      , (40479,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40480 Mogshuth Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40480 Mogshuth Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40480,   1,       5) /* HeartbeatInterval */
      , (40480,  34,       1) /* PowerupTime */
      , (40480,  36,       1) /* ChargeSpeed */
      , (40480,  39,     1.4) /* DefaultScale */
-     , (40480,  55,      60) /* HomeRadius */
      , (40480,  62,     1.5) /* WeaponOffense */
      , (40480,  64,     0.9) /* ResistSlash */
      , (40480,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40481 Moguth Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40481 Moguth Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40481,   1,       5) /* HeartbeatInterval */
      , (40481,  34,       1) /* PowerupTime */
      , (40481,  36,       1) /* ChargeSpeed */
      , (40481,  39,     1.4) /* DefaultScale */
-     , (40481,  55,      60) /* HomeRadius */
      , (40481,  62,     1.5) /* WeaponOffense */
      , (40481,  64,     0.9) /* ResistSlash */
      , (40481,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40482 Shogshuth Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40482 Shogshuth Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40482,   1,       5) /* HeartbeatInterval */
      , (40482,  34,       1) /* PowerupTime */
      , (40482,  36,       1) /* ChargeSpeed */
      , (40482,  39,     1.4) /* DefaultScale */
-     , (40482,  55,      60) /* HomeRadius */
      , (40482,  62,     1.5) /* WeaponOffense */
      , (40482,  64,     0.9) /* ResistSlash */
      , (40482,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40483 Shoguth Moarsman.sql
+++ b/Database/Patches/2008-08-AncientPowers/9 WeenieDefaults/Creature/Moarsman/40483 Shoguth Moarsman.sql
@@ -42,7 +42,6 @@ VALUES (40483,   1,       5) /* HeartbeatInterval */
      , (40483,  34,       1) /* PowerupTime */
      , (40483,  36,       1) /* ChargeSpeed */
      , (40483,  39,     1.4) /* DefaultScale */
-     , (40483,  55,      60) /* HomeRadius */
      , (40483,  62,     1.5) /* WeaponOffense */
      , (40483,  64,     0.9) /* ResistSlash */
      , (40483,  65,    0.55) /* ResistPierce */

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Undead/43689 Frozen Wight Captain.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Undead/43689 Frozen Wight Captain.sql
@@ -46,7 +46,6 @@ VALUES (43689,   1,  5) /* HeartbeatInterval */
      , (43689,  34,       2) /* PowerupTime */
      , (43689,  36,       1) /* ChargeSpeed */
      , (43689,  39,     1.1) /* DefaultScale */
-     , (43689,  55,      75) /* HomeRadius */
      , (43689,  64,    0.82) /* ResistSlash */
      , (43689,  65,     0.5) /* ResistPierce */
      , (43689,  66,     0.5) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51878 Enraged Shadow.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51878 Enraged Shadow.sql
@@ -45,7 +45,6 @@ VALUES (51878,   1,   5) /* HeartbeatInterval */
      , (51878,  31,  30) /* VisualAwarenessRange */
      , (51878,  34, 1.1) /* PowerupTime */
      , (51878,  36,   1) /* ChargeSpeed */
-     , (51878,  55,  80) /* HomeRadius */
      , (51878,  64, 0.7) /* ResistSlash */
      , (51878,  65, 0.6) /* ResistPierce */
      , (51878,  66, 0.4) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51879 Enraged Shadow.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51879 Enraged Shadow.sql
@@ -45,7 +45,6 @@ VALUES (51879,   1,   5) /* HeartbeatInterval */
      , (51879,  31,  30) /* VisualAwarenessRange */
      , (51879,  34, 1.1) /* PowerupTime */
      , (51879,  36,   1) /* ChargeSpeed */
-     , (51879,  55, 100) /* HomeRadius */
      , (51879,  64, 0.7) /* ResistSlash */
      , (51879,  65, 0.6) /* ResistPierce */
      , (51879,  66, 0.4) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51880 Tormented Shadow.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51880 Tormented Shadow.sql
@@ -46,7 +46,6 @@ VALUES (51880,   1,   5) /* HeartbeatInterval */
      , (51880,  31,  30) /* VisualAwarenessRange */
      , (51880,  34, 1.1) /* PowerupTime */
      , (51880,  36,   1) /* ChargeSpeed */
-     , (51880,  55,  80) /* HomeRadius */
      , (51880,  64, 0.7) /* ResistSlash */
      , (51880,  65, 0.6) /* ResistPierce */
      , (51880,  66, 0.4) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51881 Tormented Shadow.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Shadow/51881 Tormented Shadow.sql
@@ -46,7 +46,6 @@ VALUES (51881,   1,   5) /* HeartbeatInterval */
      , (51881,  31,  30) /* VisualAwarenessRange */
      , (51881,  34, 1.1) /* PowerupTime */
      , (51881,  36,   1) /* ChargeSpeed */
-     , (51881,  55, 100) /* HomeRadius */
      , (51881,  64, 0.7) /* ResistSlash */
      , (51881,  65, 0.6) /* ResistPierce */
      , (51881,  66, 0.4) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51723 Rift of Blind Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51723 Rift of Blind Rage.sql
@@ -52,7 +52,6 @@ VALUES (51723,   1,   5) /* HeartbeatInterval */
      , (51723,  39, 1.5) /* DefaultScale */
      , (51723,  41,  30) /* RegenerationInterval */
      , (51723,  43,   5) /* GeneratorRadius */
-     , (51723,  55,  80) /* HomeRadius */
      , (51723,  64, 0.6) /* ResistSlash */
      , (51723,  65, 0.6) /* ResistPierce */
      , (51723,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51724 Discorporate Rynthid of Blind Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51724 Discorporate Rynthid of Blind Rage.sql
@@ -47,7 +47,6 @@ VALUES (51724,   1,   5) /* HeartbeatInterval */
      , (51724,  31,  18) /* VisualAwarenessRange */
      , (51724,  34,   1) /* PowerupTime */
      , (51724,  36,   1) /* ChargeSpeed */
-     , (51724,  55, 100) /* HomeRadius */
      , (51724,  64, 0.7) /* ResistSlash */
      , (51724,  65, 0.6) /* ResistPierce */
      , (51724,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51725 Rift of Blind Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51725 Rift of Blind Rage.sql
@@ -52,7 +52,6 @@ VALUES (51725,   1,   5) /* HeartbeatInterval */
      , (51725,  39, 1.5) /* DefaultScale */
      , (51725,  41,  30) /* RegenerationInterval */
      , (51725,  43,   5) /* GeneratorRadius */
-     , (51725,  55, 100) /* HomeRadius */
      , (51725,  64, 0.6) /* ResistSlash */
      , (51725,  65, 0.6) /* ResistPierce */
      , (51725,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51726 Discorporate Rynthid of Blind Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51726 Discorporate Rynthid of Blind Rage.sql
@@ -47,7 +47,6 @@ VALUES (51726,   1,   5) /* HeartbeatInterval */
      , (51726,  31,  18) /* VisualAwarenessRange */
      , (51726,  34,   1) /* PowerupTime */
      , (51726,  36,   1) /* ChargeSpeed */
-     , (51726,  55, 100) /* HomeRadius */
      , (51726,  64, 0.7) /* ResistSlash */
      , (51726,  65, 0.6) /* ResistPierce */
      , (51726,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51727 Rift of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51727 Rift of Rage.sql
@@ -52,7 +52,6 @@ VALUES (51727,   1,   5) /* HeartbeatInterval */
      , (51727,  39, 1.5) /* DefaultScale */
      , (51727,  41,  30) /* RegenerationInterval */
      , (51727,  43,   5) /* GeneratorRadius */
-     , (51727,  55,  80) /* HomeRadius */
      , (51727,  64, 0.6) /* ResistSlash */
      , (51727,  65, 0.6) /* ResistPierce */
      , (51727,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51728 Discorporate Rynthid of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51728 Discorporate Rynthid of Rage.sql
@@ -47,7 +47,6 @@ VALUES (51728,   1,   5) /* HeartbeatInterval */
      , (51728,  31,  18) /* VisualAwarenessRange */
      , (51728,  34,   1) /* PowerupTime */
      , (51728,  36,   1) /* ChargeSpeed */
-     , (51728,  55, 100) /* HomeRadius */
      , (51728,  64, 0.7) /* ResistSlash */
      , (51728,  65, 0.6) /* ResistPierce */
      , (51728,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51730 Discorporate Rynthid of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51730 Discorporate Rynthid of Rage.sql
@@ -47,7 +47,6 @@ VALUES (51730,   1,   5) /* HeartbeatInterval */
      , (51730,  31,  18) /* VisualAwarenessRange */
      , (51730,  34,   1) /* PowerupTime */
      , (51730,  36,   1) /* ChargeSpeed */
-     , (51730,  55, 100) /* HomeRadius */
      , (51730,  64, 0.7) /* ResistSlash */
      , (51730,  65, 0.6) /* ResistPierce */
      , (51730,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51731 Rift of Consuming Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51731 Rift of Consuming Torment.sql
@@ -52,7 +52,6 @@ VALUES (51731,   1,   5) /* HeartbeatInterval */
      , (51731,  39, 1.5) /* DefaultScale */
      , (51731,  41,  30) /* RegenerationInterval */
      , (51731,  43,   5) /* GeneratorRadius */
-     , (51731,  55,  80) /* HomeRadius */
      , (51731,  64, 0.6) /* ResistSlash */
      , (51731,  65, 0.6) /* ResistPierce */
      , (51731,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51732 Discorporate Rynthid of Consuming Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51732 Discorporate Rynthid of Consuming Torment.sql
@@ -47,7 +47,6 @@ VALUES (51732,   1,   5) /* HeartbeatInterval */
      , (51732,  31,  18) /* VisualAwarenessRange */
      , (51732,  34,   1) /* PowerupTime */
      , (51732,  36,   1) /* ChargeSpeed */
-     , (51732,  55, 100) /* HomeRadius */
      , (51732,  64, 0.7) /* ResistSlash */
      , (51732,  65, 0.6) /* ResistPierce */
      , (51732,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51733 Rift of Consuming Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51733 Rift of Consuming Torment.sql
@@ -52,7 +52,6 @@ VALUES (51733,   1,   5) /* HeartbeatInterval */
      , (51733,  39, 1.5) /* DefaultScale */
      , (51733,  41,  30) /* RegenerationInterval */
      , (51733,  43,   5) /* GeneratorRadius */
-     , (51733,  55, 100) /* HomeRadius */
      , (51733,  64, 0.6) /* ResistSlash */
      , (51733,  65, 0.6) /* ResistPierce */
      , (51733,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51734 Discorporate Rynthid of Consuming Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51734 Discorporate Rynthid of Consuming Torment.sql
@@ -47,7 +47,6 @@ VALUES (51734,   1,   5) /* HeartbeatInterval */
      , (51734,  31,  18) /* VisualAwarenessRange */
      , (51734,  34,   1) /* PowerupTime */
      , (51734,  36,   1) /* ChargeSpeed */
-     , (51734,  55, 100) /* HomeRadius */
      , (51734,  64, 0.7) /* ResistSlash */
      , (51734,  65, 0.6) /* ResistPierce */
      , (51734,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51735 Rift of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51735 Rift of Torment.sql
@@ -52,7 +52,6 @@ VALUES (51735,   1,   5) /* HeartbeatInterval */
      , (51735,  39, 1.5) /* DefaultScale */
      , (51735,  41,  30) /* RegenerationInterval */
      , (51735,  43,   5) /* GeneratorRadius */
-     , (51735,  55,  80) /* HomeRadius */
      , (51735,  64, 0.6) /* ResistSlash */
      , (51735,  65, 0.6) /* ResistPierce */
      , (51735,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51736 Discorporate Rynthid of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51736 Discorporate Rynthid of Torment.sql
@@ -47,7 +47,6 @@ VALUES (51736,   1,   5) /* HeartbeatInterval */
      , (51736,  31,  18) /* VisualAwarenessRange */
      , (51736,  34,   1) /* PowerupTime */
      , (51736,  36,   1) /* ChargeSpeed */
-     , (51736,  55, 100) /* HomeRadius */
      , (51736,  64, 0.7) /* ResistSlash */
      , (51736,  65, 0.6) /* ResistPierce */
      , (51736,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51738 Discorporate Rynthid of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51738 Discorporate Rynthid of Torment.sql
@@ -47,7 +47,6 @@ VALUES (51738,   1,   5) /* HeartbeatInterval */
      , (51738,  31,  18) /* VisualAwarenessRange */
      , (51738,  34,   1) /* PowerupTime */
      , (51738,  36,   1) /* ChargeSpeed */
-     , (51738,  55, 100) /* HomeRadius */
      , (51738,  64, 0.7) /* ResistSlash */
      , (51738,  65, 0.6) /* ResistPierce */
      , (51738,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51739 Aspect of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51739 Aspect of Rage.sql
@@ -45,7 +45,6 @@ VALUES (51739,   1,   5) /* HeartbeatInterval */
      , (51739,  34,   1) /* PowerupTime */
      , (51739,  36,   1) /* ChargeSpeed */
      , (51739,  39, 1.5) /* DefaultScale */
-     , (51739,  55,  80) /* HomeRadius */
      , (51739,  64, 0.7) /* ResistSlash */
      , (51739,  65, 0.6) /* ResistPierce */
      , (51739,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51741 Aspect of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51741 Aspect of Torment.sql
@@ -45,7 +45,6 @@ VALUES (51741,   1,   5) /* HeartbeatInterval */
      , (51741,  34,   1) /* PowerupTime */
      , (51741,  36,   1) /* ChargeSpeed */
      , (51741,  39, 1.5) /* DefaultScale */
-     , (51741,  55,  80) /* HomeRadius */
      , (51741,  64, 0.7) /* ResistSlash */
      , (51741,  65, 0.6) /* ResistPierce */
      , (51741,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51743 Rynthid Berserker.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51743 Rynthid Berserker.sql
@@ -44,7 +44,6 @@ VALUES (51743,   1,   5) /* HeartbeatInterval */
      , (51743,  31,  18) /* VisualAwarenessRange */
      , (51743,  34,   1) /* PowerupTime */
      , (51743,  36,   1) /* ChargeSpeed */
-     , (51743,  55,  80) /* HomeRadius */
      , (51743,  64, 0.7) /* ResistSlash */
      , (51743,  65, 0.6) /* ResistPierce */
      , (51743,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51745 Discorporate Rynthid of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51745 Discorporate Rynthid of Torment.sql
@@ -47,7 +47,6 @@ VALUES (51745,   1,   5) /* HeartbeatInterval */
      , (51745,  31,  18) /* VisualAwarenessRange */
      , (51745,  34,   1) /* PowerupTime */
      , (51745,  36,   1) /* ChargeSpeed */
-     , (51745,  55, 100) /* HomeRadius */
      , (51745,  64, 0.7) /* ResistSlash */
      , (51745,  65, 0.6) /* ResistPierce */
      , (51745,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51746 Discorporate Rynthid of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51746 Discorporate Rynthid of Torment.sql
@@ -47,7 +47,6 @@ VALUES (51746,   1,   5) /* HeartbeatInterval */
      , (51746,  31,  18) /* VisualAwarenessRange */
      , (51746,  34,   1) /* PowerupTime */
      , (51746,  36,   1) /* ChargeSpeed */
-     , (51746,  55, 100) /* HomeRadius */
      , (51746,  64, 0.7) /* ResistSlash */
      , (51746,  65, 0.6) /* ResistPierce */
      , (51746,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51747 Rynthid Minion of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51747 Rynthid Minion of Rage.sql
@@ -44,7 +44,6 @@ VALUES (51747,   1,   5) /* HeartbeatInterval */
      , (51747,  31,  18) /* VisualAwarenessRange */
      , (51747,  34,   1) /* PowerupTime */
      , (51747,  36,   1) /* ChargeSpeed */
-     , (51747,  55,  80) /* HomeRadius */
      , (51747,  64, 0.7) /* ResistSlash */
      , (51747,  65, 0.6) /* ResistPierce */
      , (51747,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51749 Rynthid Minion.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51749 Rynthid Minion.sql
@@ -44,7 +44,6 @@ VALUES (51749,   1,   5) /* HeartbeatInterval */
      , (51749,  31,  18) /* VisualAwarenessRange */
      , (51749,  34,   1) /* PowerupTime */
      , (51749,  36,   1) /* ChargeSpeed */
-     , (51749,  55,  80) /* HomeRadius */
      , (51749,  64, 0.7) /* ResistSlash */
      , (51749,  65, 0.6) /* ResistPierce */
      , (51749,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51751 Rynthid Rager.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51751 Rynthid Rager.sql
@@ -44,7 +44,6 @@ VALUES (51751,   1,   5) /* HeartbeatInterval */
      , (51751,  31,  18) /* VisualAwarenessRange */
      , (51751,  34,   1) /* PowerupTime */
      , (51751,  36,   1) /* ChargeSpeed */
-     , (51751,  55,  80) /* HomeRadius */
      , (51751,  64, 0.7) /* ResistSlash */
      , (51751,  65, 0.6) /* ResistPierce */
      , (51751,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51753 Rynthid Ravager.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51753 Rynthid Ravager.sql
@@ -44,7 +44,6 @@ VALUES (51753,   1,   5) /* HeartbeatInterval */
      , (51753,  31,  18) /* VisualAwarenessRange */
      , (51753,  34,   1) /* PowerupTime */
      , (51753,  36,   1) /* ChargeSpeed */
-     , (51753,  55,  80) /* HomeRadius */
      , (51753,  64, 0.7) /* ResistSlash */
      , (51753,  65, 0.6) /* ResistPierce */
      , (51753,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51755 Rynthid Slayer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51755 Rynthid Slayer.sql
@@ -45,7 +45,6 @@ VALUES (51755,   1,   5) /* HeartbeatInterval */
      , (51755,  31,  18) /* VisualAwarenessRange */
      , (51755,  34,   1) /* PowerupTime */
      , (51755,  36,   1) /* ChargeSpeed */
-     , (51755,  55,  80) /* HomeRadius */
      , (51755,  64, 0.7) /* ResistSlash */
      , (51755,  65, 0.6) /* ResistPierce */
      , (51755,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51757 Raging Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51757 Raging Rynthid Sorcerer.sql
@@ -45,7 +45,6 @@ VALUES (51757,   1,   5) /* HeartbeatInterval */
      , (51757,  31,  18) /* VisualAwarenessRange */
      , (51757,  34,   1) /* PowerupTime */
      , (51757,  36,   1) /* ChargeSpeed */
-     , (51757,  55,  80) /* HomeRadius */
      , (51757,  64, 0.7) /* ResistSlash */
      , (51757,  65, 0.6) /* ResistPierce */
      , (51757,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51759 Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51759 Rynthid Sorcerer.sql
@@ -45,7 +45,6 @@ VALUES (51759,   1,   5) /* HeartbeatInterval */
      , (51759,  31,  18) /* VisualAwarenessRange */
      , (51759,  34,   1) /* PowerupTime */
      , (51759,  36,   1) /* ChargeSpeed */
-     , (51759,  55,  80) /* HomeRadius */
      , (51759,  64, 0.7) /* ResistSlash */
      , (51759,  65, 0.6) /* ResistPierce */
      , (51759,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51761 Discorporate Rynthid of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51761 Discorporate Rynthid of Rage.sql
@@ -47,7 +47,6 @@ VALUES (51761,   1,   5) /* HeartbeatInterval */
      , (51761,  31,  18) /* VisualAwarenessRange */
      , (51761,  34,   1) /* PowerupTime */
      , (51761,  36,   1) /* ChargeSpeed */
-     , (51761,  55, 100) /* HomeRadius */
      , (51761,  64, 0.7) /* ResistSlash */
      , (51761,  65, 0.6) /* ResistPierce */
      , (51761,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51762 Discorporate Rynthid of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51762 Discorporate Rynthid of Rage.sql
@@ -47,7 +47,6 @@ VALUES (51762,   1,   5) /* HeartbeatInterval */
      , (51762,  31,  18) /* VisualAwarenessRange */
      , (51762,  34,   1) /* PowerupTime */
      , (51762,  36,   1) /* ChargeSpeed */
-     , (51762,  55, 100) /* HomeRadius */
      , (51762,  64, 0.7) /* ResistSlash */
      , (51762,  65, 0.6) /* ResistPierce */
      , (51762,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51823 Lothus Guardian of Torment.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51823 Lothus Guardian of Torment.sql
@@ -37,7 +37,6 @@ VALUES (51823,   1,   5) /* HeartbeatInterval */
      , (51823,  31,  18) /* VisualAwarenessRange */
      , (51823,  34,   1) /* PowerupTime */
      , (51823,  36,   1) /* ChargeSpeed */
-     , (51823,  55,  80) /* HomeRadius */
      , (51823,  64, 0.7) /* ResistSlash */
      , (51823,  65, 0.6) /* ResistPierce */
      , (51823,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51826 Lothus Guardian of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51826 Lothus Guardian of Rage.sql
@@ -37,7 +37,6 @@ VALUES (51826,   1,   5) /* HeartbeatInterval */
      , (51826,  31,  18) /* VisualAwarenessRange */
      , (51826,  34,   1) /* PowerupTime */
      , (51826,  36,   1) /* ChargeSpeed */
-     , (51826,  55,  80) /* HomeRadius */
      , (51826,  64, 0.7) /* ResistSlash */
      , (51826,  65, 0.6) /* ResistPierce */
      , (51826,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51828 Lothus Guardian of Sorrows.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51828 Lothus Guardian of Sorrows.sql
@@ -37,7 +37,6 @@ VALUES (51828,   1,   5) /* HeartbeatInterval */
      , (51828,  31,  18) /* VisualAwarenessRange */
      , (51828,  34,   1) /* PowerupTime */
      , (51828,  36,   1) /* ChargeSpeed */
-     , (51828,  55,  80) /* HomeRadius */
      , (51828,  64, 0.7) /* ResistSlash */
      , (51828,  65, 0.6) /* ResistPierce */
      , (51828,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51830 Lothus Guardian of Sorrows.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/51830 Lothus Guardian of Sorrows.sql
@@ -37,7 +37,6 @@ VALUES (51830,   1,   5) /* HeartbeatInterval */
      , (51830,  31,  18) /* VisualAwarenessRange */
      , (51830,  34,   1) /* PowerupTime */
      , (51830,  36,   1) /* ChargeSpeed */
-     , (51830,  55,  80) /* HomeRadius */
      , (51830,  64, 0.7) /* ResistSlash */
      , (51830,  65, 0.6) /* ResistPierce */
      , (51830,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52278 Rynthid Sorcerer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52278 Rynthid Sorcerer.sql
@@ -45,7 +45,6 @@ VALUES (52278,   1,   5) /* HeartbeatInterval */
      , (52278,  31,  18) /* VisualAwarenessRange */
      , (52278,  34,   1) /* PowerupTime */
      , (52278,  36,   1) /* ChargeSpeed */
-     , (52278,  55, 100) /* HomeRadius */
      , (52278,  64, 0.7) /* ResistSlash */
      , (52278,  65, 0.6) /* ResistPierce */
      , (52278,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52279 Rynthid Slayer.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52279 Rynthid Slayer.sql
@@ -45,7 +45,6 @@ VALUES (52279,   1,   5) /* HeartbeatInterval */
      , (52279,  31,  18) /* VisualAwarenessRange */
      , (52279,  34,   1) /* PowerupTime */
      , (52279,  36,   1) /* ChargeSpeed */
-     , (52279,  55, 100) /* HomeRadius */
      , (52279,  64, 0.7) /* ResistSlash */
      , (52279,  65, 0.6) /* ResistPierce */
      , (52279,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52280 Rynthid Minion.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Virindi/52280 Rynthid Minion.sql
@@ -44,7 +44,6 @@ VALUES (52280,   1,   5) /* HeartbeatInterval */
      , (52280,  31,  18) /* VisualAwarenessRange */
      , (52280,  34,   1) /* PowerupTime */
      , (52280,  36,   1) /* ChargeSpeed */
-     , (52280,  55, 100) /* HomeRadius */
      , (52280,  64, 0.7) /* ResistSlash */
      , (52280,  65, 0.6) /* ResistPierce */
      , (52280,  66, 0.6) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Wisp/51806 Empowered Despair Wisp.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Wisp/51806 Empowered Despair Wisp.sql
@@ -44,7 +44,6 @@ VALUES (51806,   1,   5) /* HeartbeatInterval */
      , (51806,  34,   1) /* PowerupTime */
      , (51806,  36,   1) /* ChargeSpeed */
      , (51806,  39, 1.3) /* DefaultScale */
-     , (51806,  55, 100) /* HomeRadius */
      , (51806,  64, 0.7) /* ResistSlash */
      , (51806,  65, 0.7) /* ResistPierce */
      , (51806,  66, 0.4) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Wisp/51807 Empowered Hatred Wisp.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Wisp/51807 Empowered Hatred Wisp.sql
@@ -43,7 +43,6 @@ VALUES (51807,   1,   5) /* HeartbeatInterval */
      , (51807,  34,   1) /* PowerupTime */
      , (51807,  36,   1) /* ChargeSpeed */
      , (51807,  39, 1.3) /* DefaultScale */
-     , (51807,  55, 100) /* HomeRadius */
      , (51807,  64, 0.7) /* ResistSlash */
      , (51807,  65, 0.7) /* ResistPierce */
      , (51807,  66, 0.4) /* ResistBludgeon */

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Wisp/51808 Empowered Sorrow Wisp.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Wisp/51808 Empowered Sorrow Wisp.sql
@@ -43,7 +43,6 @@ VALUES (51808,   1,   5) /* HeartbeatInterval */
      , (51808,  34,   1) /* PowerupTime */
      , (51808,  36,   1) /* ChargeSpeed */
      , (51808,  39, 1.3) /* DefaultScale */
-     , (51808,  55, 100) /* HomeRadius */
      , (51808,  64, 0.7) /* ResistSlash */
      , (51808,  65, 0.7) /* ResistPierce */
      , (51808,  66, 0.4) /* ResistBludgeon */


### PR DESCRIPTION
This fixes an exploit where luminance-granting mobs can be highly abused by ranged players

HomeRadius set to low values such as 60 is very exploitable by ranged players, where they can basically range the mob to death, with no risk of retaliation from the mob.

I would recommend reviewing the HomeRadius set to all mobs added to the db, and ensure they are within the expected values. I imagine it should be a rare instance where HomeRadius needs to be manually set. I also suspect these values might have come from copy/paste of lower level mobs possibly.

For reference, ranged missile/magic players can attack from 75 meters away, with missile players being able to attack from an even slightly longer range, depending on the situation. Anything under 75 meters is definitely abusable, and I would even question all values under 100. For reference, when this value is omitted (default, most mobs) it defaults to 192 meters (1 outdoor landblock) on the server.