### PR TITLE
update foolproof salvage to match retail

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08004 Foolproof Aquamarine.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08004 Foolproof Aquamarine.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8004;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8004, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the foolproof aquamarine.', 0, 0, 'You apply the foolproof aquamarine, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8004, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the foolproof aquamarine.', 0, 0, 'You apply the foolproof aquamarine, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8004, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08005 Foolproof Black Garnet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08005 Foolproof Black Garnet.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8005;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8005, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the foolproof black garnet.', 0, 0, 'You apply the foolproof black garnet, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8005, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the foolproof black garnet.', 0, 0, 'You apply the foolproof black garnet, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8005, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08006 Foolproof Emerald.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08006 Foolproof Emerald.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8006;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8006, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the emerald.', 0, 0, 'You apply the emerald, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8006, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the emerald.', 0, 0, 'You apply the emerald, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8006, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08007 Foolproof Jet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08007 Foolproof Jet.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8007;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8007, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the jet.', 0, 0, 'You apply the jet, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8007, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the jet.', 0, 0, 'You apply the jet, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8007, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08008 Foolproof Red Garnet.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08008 Foolproof Red Garnet.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8008;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8008, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the red garnet.', 0, 0, 'You apply the red garnet, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8008, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the red garnet.', 0, 0, 'You apply the red garnet, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8008, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08009 Foolproof White Sapphire.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08009 Foolproof White Sapphire.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8009;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8009, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the white sapphire.', 0, 0, 'You apply the white sapphire, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8009, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the white sapphire.', 0, 0, 'You apply the white sapphire, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8009, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08010 Foolproof Imperial Topaz.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08010 Foolproof Imperial Topaz.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8010;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8010, 0, 28 /* WeaponTinkering */, 0, 2, 0, 0, 'You apply the imperial topaz.', 0, 0, 'You apply the imperial topaz, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-15 18:20:10');
+VALUES (8010, 0, 28 /* WeaponTinkering */, 0, 0, 0, 0, 'You apply the imperial topaz.', 0, 0, 'You apply the imperial topaz, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 18:20:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8010, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08011 Foolproof Black Opal.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08011 Foolproof Black Opal.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8011;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8011, 0, 30 /* MagicItemTinkering */, 0, 2, 0, 0, 'You apply the black opal.', 0, 0, 'You apply the black opal, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-23 05:27:10');
+VALUES (8011, 0, 30 /* MagicItemTinkering */, 0, 0, 0, 0, 'You apply the black opal.', 0, 0, 'You apply the black opal, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 05:27:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8011, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08012 Foolproof Fire Opal.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08012 Foolproof Fire Opal.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8012;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8012, 0, 30 /* MagicItemTinkering */, 0, 2, 0, 0, 'You apply the fire opal.', 0, 0, 'You apply the fire opal, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-23 05:27:10');
+VALUES (8012, 0, 30 /* MagicItemTinkering */, 0, 0, 0, 0, 'You apply the fire opal.', 0, 0, 'You apply the fire opal, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 05:27:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8012, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08013 Foolproof Sunstone.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08013 Foolproof Sunstone.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8013;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8013, 0, 30 /* MagicItemTinkering */, 0, 2, 0, 0, 'You apply the sunstone.', 0, 0, 'You apply the sunstone, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2019-04-23 05:27:10');
+VALUES (8013, 0, 30 /* MagicItemTinkering */, 0, 0, 0, 0, 'You apply the sunstone.', 0, 0, 'You apply the sunstone, but in the process you destroy the target.', 1, 1, '', 0, 0, '', 1, 1, '', 1, 1, '', 0, '2021-06-15 05:27:10');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8013, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* ItemWorkmanship */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08014 Foolproof Zircon.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08014 Foolproof Zircon.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8014;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8014, 0, 29 /* ArmorTinkering */, 0, 2, 0, 0, 'You apply the Zircon.', 0, 0, 'You apply the Zircon, but in the process you destroy the target.', 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+VALUES (8014, 0, 29 /* ArmorTinkering */, 0, 0, 0, 0, 'You apply the Zircon.', 0, 0, 'You apply the Zircon, but in the process you destroy the target.', 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-06-15 10:00:00');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8014, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* Target.ItemWorkmanship LessThan 1 */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08015 Foolproof Yellow Topaz.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08015 Foolproof Yellow Topaz.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8015;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8015, 0, 29 /* ArmorTinkering */, 0, 2, 0, 0, 'You apply the Yellow Topaz.', 0, 0, 'You apply the Yellow Topaz, but in the process you destroy the target.', 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+VALUES (8015, 0, 29 /* ArmorTinkering */, 0, 0, 0, 0, 'You apply the Yellow Topaz.', 0, 0, 'You apply the Yellow Topaz, but in the process you destroy the target.', 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-06-15 10:00:00');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8015, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* Target.ItemWorkmanship LessThan 1 */

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08016 Foolproof Peridot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/08016 Foolproof Peridot.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 8016;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (8016, 0, 29 /* ArmorTinkering */, 0, 2, 0, 0, 'You apply the Peridot.', 0, 0, 'You apply the Peridot, but in the process you destroy the target.', 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+VALUES (8016, 0, 29 /* ArmorTinkering */, 0, 0, 0, 0, 'You apply the Peridot.', 0, 0, 'You apply the Peridot, but in the process you destroy the target.', 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-06-15 10:00:00');
 
 INSERT INTO `recipe_requirements_int` (`recipe_Id`, `index`, `stat`, `value`, `enum`, `message`)
 VALUES (8016, 0, 105, 1, 2, 'The target item cannot be tinkered!') /* Target.ItemWorkmanship LessThan 1 */


### PR DESCRIPTION
Foolproof salvage did not use the tinkering difficulty formula, and did not send out broadcasts to the landblock:

https://youtu.be/V5XWzF8KuLE?t=84s

salvage_Type should be considered more like difficulty_Type, determining which difficulty formula to use (0 = standard recipe, use the recipe.difficulty, 1 = tinkering, use the tinkering difficulty formula, 2 = imbues, use the imbues difficulty formula). If you want something with a 100% success rate, then it would be salvage_Type=0, difficulty=0