### PR TITLE
ParadoxTouchedOlthoiSentinel

### DIFF
--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Paradox Olthoi/35875 Paradox-touched Olthoi Sentinel.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Paradox Olthoi/35875 Paradox-touched Olthoi Sentinel.sql
@@ -131,7 +131,5 @@ VALUES (@parent_id,  0,   6 /* Move */, 10, 0.5, NULL, NULL, NULL, NULL, NULL, N
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35875, 9, 35876,  1, 0, 0.95, False) /* Create  (35876) for ContainTreasure */
      , (35875, 9,     0,  1, 0, 0.05, False) /* Create nothing for ContainTreasure */
-     , (35875, 9, 36376,  1, 0, 0.8, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
-     , (35875, 9,     0,  1, 0, 0.2, False) /* Create nothing for ContainTreasure */
-     , (35875, 9, 36376,  1, 0, 0.8, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
-     , (35875, 9,     0,  1, 0, 0.2, False) /* Create nothing for ContainTreasure */;
+     , (35875, 9, 36376,  1, 0, 0.2, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
+     , (35875, 9,     0,  1, 0, 0.8, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Paradox Olthoi/35877 Paradox-touched Olthoi Sentinel.sql
+++ b/Database/Patches/2007-08-CorruptedSovereigns/9 WeenieDefaults/Creature/Paradox Olthoi/35877 Paradox-touched Olthoi Sentinel.sql
@@ -131,7 +131,5 @@ VALUES (@parent_id,  0,   6 /* Move */, 10, 0.5, NULL, NULL, NULL, NULL, NULL, N
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35877, 9, 35876,  1, 0, 0.95, False) /* Create  (35876) for ContainTreasure */
      , (35877, 9,     0,  1, 0, 0.05, False) /* Create nothing for ContainTreasure */
-     , (35877, 9, 36376,  1, 0, 0.8, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
-     , (35877, 9,     0,  1, 0, 0.2, False) /* Create nothing for ContainTreasure */
-     , (35877, 9, 36376,  1, 0, 0.8, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
-     , (35877, 9,     0,  1, 0, 0.2, False) /* Create nothing for ContainTreasure */;
+     , (35877, 9, 36376,  1, 0, 0.2, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
+     , (35877, 9,     0,  1, 0, 0.8, False) /* Create nothing for ContainTreasure */;


### PR DESCRIPTION
Update to Paradox Touched Olthoi Sentinel.  Had chance to drop 2 Venom Sacs (Alt Currency) at an 80% drop rate.  This was being abused.  Removed the double chance and reduced drop rate to 20% which is more inline with stats from Trophy Hunter (which is 14.8%).  See [http://www.trophyhunteronline.com/trophy-monster.php?trophy=Small+Olthoi+Venom+Sac](http://www.trophyhunteronline.com/trophy-monster.php?trophy=Small+Olthoi+Venom+Sac)