### PR TITLE
Hamud's Demise Dungeon Updates

### DIFF
--- a/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/011C.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/011C.sql
@@ -1,0 +1,544 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x011C;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C000, 23091, 0x011C0108, 78.201, -130.712, -41.995, -0.646035, 0, 0, 0.763308,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0108 [78.200996 -130.712006 -41.994999] -0.646035 0.000000 0.000000 0.763308 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C001,  6030, 0x011C010F, 86.5, -107, -41.9366, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* The Fallen Master of Shagar Zharala */
+/* @teleloc 0x011C010F [86.500000 -107.000000 -41.936600] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C002,  6025, 0x011C010F, 91.6932, -108.339, -41.995, 0.051491, 0, 0, 0.998673,  True, '2005-02-09 10:00:00'); /* Hamud ibn Rafik */
+/* @teleloc 0x011C010F [91.693199 -108.338997 -41.994999] 0.051491 0.000000 0.000000 0.998673 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C003,  6828, 0x011C010F, 92.5709, -110.33, -41.921, 0.867999, 0, 0, -0.496566, False, '2005-02-09 10:00:00'); /* A letter to Devana */
+/* @teleloc 0x011C010F [92.570900 -110.330002 -41.921001] 0.867999 0.000000 0.000000 -0.496566 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C004,   278, 0x011C0111, 90.0038, -114.737, -42, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0111 [90.003799 -114.737000 -42.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C005,   278, 0x011C0112, 90, -105.25, -42, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0112 [90.000000 -105.250000 -42.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C006, 23091, 0x011C0113, 87.4167, -119.202, -41.995, 0.005176, 0, 0, 0.999987,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0113 [87.416702 -119.202003 -41.994999] 0.005176 0.000000 0.000000 0.999987 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C007, 23091, 0x011C0113, 92.6388, -120.898, -41.995, -0.102045, 0, 0, 0.99478,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0113 [92.638802 -120.898003 -41.994999] -0.102045 0.000000 0.000000 0.994780 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C008,  6029, 0x011C0113, 89.982, -121, -41.9366, -0.999843, 0, 0, -0.017714, False, '2005-02-09 10:00:00'); /* Precepts of the Tenebrous Edge */
+/* @teleloc 0x011C0113 [89.982002 -121.000000 -41.936600] -0.999843 0.000000 0.000000 -0.017714 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C009,  6034, 0x011C011B, 90, -134.75, -41.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C011B [90.000000 -134.750000 -41.994999] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C00A, 23091, 0x011C011F, 90.2527, -138.751, -41.995, 0.023111, 0, 0, 0.999733,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C011F [90.252701 -138.751007 -41.994999] 0.023111 0.000000 0.000000 0.999733 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C00B, 23091, 0x011C011F, 90.1764, -140.401, -41.995, 0.023111, 0, 0, 0.999733,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C011F [90.176399 -140.401001 -41.994999] 0.023111 0.000000 0.000000 0.999733 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C00C,  1944, 0x011C0120, 100, -120, -41.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x011C0120 [100.000000 -120.000000 -41.994999] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C00D, 23091, 0x011C0120, 98.7326, -118.957, -41.995, 0.685744, 0, 0, 0.727843,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0120 [98.732597 -118.957001 -41.994999] 0.685744 0.000000 0.000000 0.727843 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C00E, 23091, 0x011C0124, 103.239, -132.723, -41.995, -0.809044, 0, 0, -0.587749,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0124 [103.238998 -132.723007 -41.994999] -0.809044 0.000000 0.000000 -0.587749 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C00F,  6115, 0x011C012E, 20, -69, -35.995, 1, 0, 0, -4.37114E-08, False, '2005-02-09 10:00:00'); /* Surface */
+/* @teleloc 0x011C012E [20.000000 -69.000000 -35.994999] 1.000000 0.000000 0.000000 -0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C010, 23091, 0x011C013C, 52.0077, -60.3417, -35.995, 0.73699, 0, 0, -0.675903,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C013C [52.007702 -60.341702 -35.994999] 0.736990 0.000000 0.000000 -0.675903 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C011, 23091, 0x011C013C, 48.7691, -61.7097, -35.995, 0.942095, 0, 0, -0.335347,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C013C [48.769100 -61.709702 -35.994999] 0.942095 0.000000 0.000000 -0.335347 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C012, 23091, 0x011C013C, 49.0769, -58.2053, -35.995, 0.999119, 0, 0, -0.0419619,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C013C [49.076900 -58.205299 -35.994999] 0.999119 0.000000 0.000000 -0.041962 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C013, 23091, 0x011C0149, 57.3625, -110.892, -35.995, 0.974794, 0, 0, -0.223106,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0149 [57.362499 -110.891998 -35.994999] 0.974794 0.000000 0.000000 -0.223106 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C014, 23091, 0x011C0150, 70, -10, -35.995, 0.659983, 0, 0, -0.751281,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0150 [70.000000 -10.000000 -35.994999] 0.659983 0.000000 0.000000 -0.751281 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C015, 23091, 0x011C0150, 69.9869, -6.05491, -35.995, 0.148976, 0, 0, -0.988841,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0150 [69.986900 -6.054910 -35.994999] 0.148976 0.000000 0.000000 -0.988841 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C016, 23091, 0x011C0165, 71.4865, -118.734, -35.995, 0.982274, 0, 0, 0.18745,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0165 [71.486504 -118.734001 -35.994999] 0.982274 0.000000 0.000000 0.187450 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C017, 23091, 0x011C0169, 68.5079, -133.963, -35.995, 0.939, 0, 0, -0.343916,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0169 [68.507896 -133.962997 -35.994999] 0.939000 0.000000 0.000000 -0.343916 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C018, 23091, 0x011C0179, 79.6876, -79.5563, -35.995, 0.696707, 0, 0, 0.717356,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0179 [79.687599 -79.556297 -35.994999] 0.696707 0.000000 0.000000 0.717356 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C019, 23091, 0x011C017A, 78.3244, -79.5961, -35.995, 0.696707, 0, 0, 0.717356,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C017A [78.324402 -79.596100 -35.994999] 0.696707 0.000000 0.000000 0.717356 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C01A, 23091, 0x011C0183, 75.25, -120.95, -35.995, 0.974794, 0, 0, -0.223106,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0183 [75.250000 -120.949997 -35.994999] 0.974794 0.000000 0.000000 -0.223106 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C01B, 23091, 0x011C01A1, 86.6222, -131.727, -35.995, 0.846639, 0, 0, 0.532168,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01A1 [86.622200 -131.727005 -35.994999] 0.846639 0.000000 0.000000 0.532168 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C01C, 23091, 0x011C01AE, 90.8936, -162.231, -35.995, 0.69507, 0, 0, -0.718942,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01AE [90.893600 -162.231003 -35.994999] 0.695070 0.000000 0.000000 -0.718942 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C01D, 23091, 0x011C01B4, 100.244, -39.8324, -35.995, -0.405021, 0, 0, 0.914307,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01B4 [100.244003 -39.832401 -35.994999] -0.405021 0.000000 0.000000 0.914307 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C01E, 23091, 0x011C01BC, 100, -80.7805, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01BC [100.000000 -80.780502 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C01F, 23091, 0x011C01BC, 100, -82.8054, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01BC [100.000000 -82.805397 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C020, 23091, 0x011C01BC, 98.7642, -82.2132, -35.995, 0.966817, 0, 0, -0.25547,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01BC [98.764198 -82.213203 -35.994999] 0.966817 0.000000 0.000000 -0.255470 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C021, 23091, 0x011C01BC, 102.489, -82.103, -35.995, 0.969821, 0, 0, 0.243818,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01BC [102.488998 -82.102997 -35.994999] 0.969821 0.000000 0.000000 0.243818 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C022, 23091, 0x011C01C5, 103.318, -129.024, -35.995, -0.957598, 0, 0, -0.288108,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01C5 [103.318001 -129.024002 -35.994999] -0.957598 0.000000 0.000000 -0.288108 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C023, 23091, 0x011C01D9, 110.733, -120.887, -35.995, 0.731689, 0, 0, 0.681639,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01D9 [110.733002 -120.887001 -35.994999] 0.731689 0.000000 0.000000 0.681639 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C024, 23091, 0x011C01DB, 112.034, -126.106, -35.995, -0.926961, 0, 0, -0.375157,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01DB [112.033997 -126.106003 -35.994999] -0.926961 0.000000 0.000000 -0.375157 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C025, 23091, 0x011C01DE, 107.997, -150.602, -35.995, 0.547264, 0, 0, -0.83696,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01DE [107.997002 -150.602005 -35.994999] 0.547264 0.000000 0.000000 -0.836960 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C026, 23091, 0x011C01E3, 109.501, -156.805, -35.995, -0.999928, 0, 0, 0.0119947,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01E3 [109.500999 -156.804993 -35.994999] -0.999928 0.000000 0.000000 0.011995 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C027, 23091, 0x011C01EE, 120.463, -50.0185, -35.995, 0.031291, 0, 0, -0.99951,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01EE [120.462997 -50.018501 -35.994999] 0.031291 0.000000 0.000000 -0.999510 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C028, 23091, 0x011C01EE, 118.575, -50.1858, -35.995, 0.169173, 0, 0, -0.985586,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C01EE [118.574997 -50.185799 -35.994999] 0.169173 0.000000 0.000000 -0.985586 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C029, 23091, 0x011C0205, 131.179, -29.9228, -35.995, -0.021591, 0, 0, 0.999767,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0205 [131.179001 -29.922800 -35.994999] -0.021591 0.000000 0.000000 0.999767 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C02A, 23091, 0x011C022B, 150.267, -87.8248, -35.995, 0.587232, 0, 0, 0.809419,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C022B [150.266998 -87.824799 -35.994999] 0.587232 0.000000 0.000000 0.809419 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C02B, 23091, 0x011C022B, 147.793, -89.7819, -35.995, 0.725572, 0, 0, 0.688146,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C022B [147.792999 -89.781898 -35.994999] 0.725572 0.000000 0.000000 0.688146 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C02C, 23091, 0x011C022B, 150.424, -86.1009, -35.995, 1, 0, 0, -0.000486,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C022B [150.423996 -86.100899 -35.994999] 1.000000 0.000000 0.000000 -0.000486 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C02D, 23091, 0x011C0247, 173.599, -10.5134, -35.995, 0.685572, 0, 0, 0.728005,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0247 [173.598999 -10.513400 -35.994999] 0.685572 0.000000 0.000000 0.728005 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C02E,  1293, 0x011C025B, 190, -74.75, -35.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C025B [190.000000 -74.750000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C02F, 23091, 0x011C025C, 187.287, -81.7817, -35.995, 0.98438, 0, 0, -0.176058,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C025C [187.287003 -81.781700 -35.994999] 0.984380 0.000000 0.000000 -0.176058 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C030, 23091, 0x011C025C, 190.388, -81.5923, -35.995, 0.999609, 0, 0, 0.027948,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C025C [190.388000 -81.592300 -35.994999] 0.999609 0.000000 0.000000 0.027948 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C031, 23091, 0x011C025C, 193.274, -81.3147, -35.995, 0.993714, 0, 0, 0.111947,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C025C [193.274002 -81.314697 -35.994999] 0.993714 0.000000 0.000000 0.111947 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C032, 23091, 0x011C025D, 190.133, -88.0104, -35.995, -0.999481, 0, 0, -0.032207,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C025D [190.132996 -88.010399 -35.994999] -0.999481 0.000000 0.000000 -0.032207 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C033,  1947, 0x011C025E, 190, -101, -35.995, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x011C025E [190.000000 -101.000000 -35.994999] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C034, 23091, 0x011C025E, 190.285, -96.3128, -35.995, -0.995513, 0, 0, 0.094626,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C025E [190.285004 -96.312798 -35.994999] -0.995513 0.000000 0.000000 0.094626 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C035, 23091, 0x011C0269, 120, -80, -29.995, 0.678557, 0, 0, 0.734548,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0269 [120.000000 -80.000000 -29.995001] 0.678557 0.000000 0.000000 0.734548 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C036, 23091, 0x011C0276, 80, -110, -17.995, 0.696707, 0, 0, -0.717356,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0276 [80.000000 -110.000000 -17.995001] 0.696707 0.000000 0.000000 -0.717356 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C037, 23091, 0x011C0276, 81.4032, -111.478, -17.995, 0.710382, 0, 0, -0.703816,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0276 [81.403198 -111.477997 -17.995001] 0.710382 0.000000 0.000000 -0.703816 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C038, 23091, 0x011C0276, 82.1634, -108.332, -17.995, 0.309855, 0, 0, -0.950784,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C0276 [82.163399 -108.332001 -17.995001] 0.309855 0.000000 0.000000 -0.950784 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C039, 23091, 0x011C028D, 99.0489, -119.435, -17.995, 0.992198, 0, 0, -0.124675,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C028D [99.048897 -119.434998 -17.995001] 0.992198 0.000000 0.000000 -0.124675 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C03A, 23091, 0x011C028D, 101.479, -119.93, -17.995, 0.775496, 0, 0, -0.631353,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C028D [101.478996 -119.930000 -17.995001] 0.775496 0.000000 0.000000 -0.631353 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C03B, 23091, 0x011C029B, 117.818, -79.1201, -17.995, -0.279145, 0, 0, -0.960249,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C029B [117.818001 -79.120102 -17.995001] -0.279145 0.000000 0.000000 -0.960249 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C03C, 23091, 0x011C02A2, 122.147, -87.0805, -17.995, -0.797934, 0, 0, -0.602744,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C02A2 [122.147003 -87.080498 -17.995001] -0.797934 0.000000 0.000000 -0.602744 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C03D, 23091, 0x011C02A9, 121.279, -99.631, -17.995, 0.999688, 0, 0, 0.024997,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C02A9 [121.278999 -99.630997 -17.995001] 0.999688 0.000000 0.000000 0.024997 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C03E, 23091, 0x011C02A9, 118.506, -98.8416, -17.995, 0.984727, 0, 0, -0.174108,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C02A9 [118.505997 -98.841599 -17.995001] 0.984727 0.000000 0.000000 -0.174108 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C03F, 23091, 0x011C02B8, 132.369, -90.2042, -17.995, -0.23244, 0, 0, -0.972611,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C02B8 [132.369003 -90.204201 -17.995001] -0.232440 0.000000 0.000000 -0.972611 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C040, 23091, 0x011C02C5, 139.843, -105.814, -17.995, -0.998933, 0, 0, -0.046181,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C02C5 [139.843002 -105.814003 -17.995001] -0.998933 0.000000 0.000000 -0.046181 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C041, 23091, 0x011C02DA, 157.471, -127.111, -17.995, -0.299419, 0, 0, -0.954122,  True, '2005-02-09 10:00:00'); /* Shadow Wraith */
+/* @teleloc 0x011C02DA [157.470993 -127.111000 -17.995001] -0.299419 0.000000 0.000000 -0.954122 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C042, 11534, 0x011C02DF, 120.022, -130.722, -11.985, 0.033152, 0, 0, 0.99945,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02DF [120.022003 -130.722000 -11.985000] 0.033152 0.000000 0.000000 0.999450 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C043, 11534, 0x011C02DF, 120.824, -131.663, -11.985, 0.132765, 0, 0, 0.991148,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02DF [120.823997 -131.662994 -11.985000] 0.132765 0.000000 0.000000 0.991148 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C044, 11534, 0x011C02E0, 119.396, -132.058, -11.941, 0.063534, 0, 0, 0.99798,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02E0 [119.396004 -132.057999 -11.941000] 0.063534 0.000000 0.000000 0.997980 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C045,   278, 0x011C02E1, 120, -128, -11.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C02E1 [120.000000 -128.000000 -11.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C046, 11534, 0x011C02E8, 120.841, -200.526, -11.985, 0.958675, 0, 0, -0.284505,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02E8 [120.841003 -200.526001 -11.985000] 0.958675 0.000000 0.000000 -0.284505 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C047, 11534, 0x011C02EC, 128.671, -201.557, -11.985, 0.999938, 0, 0, 0.011173,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02EC [128.671005 -201.557007 -11.985000] 0.999938 0.000000 0.000000 0.011173 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C048, 11534, 0x011C02EC, 131.422, -199.161, -11.985, 0.9897, 0, 0, -0.143154,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02EC [131.421997 -199.160995 -11.985000] 0.989700 0.000000 0.000000 -0.143154 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C049, 11534, 0x011C02EC, 128.852, -200.221, -11.985, 0.915047, 0, 0, -0.403347,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C02EC [128.852005 -200.220993 -11.985000] 0.915047 0.000000 0.000000 -0.403347 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C04A, 11534, 0x011C0303, 90.6494, -120.331, 0.015, -0.351466, 0, 0, 0.936201,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0303 [90.649399 -120.331001 0.015000] -0.351466 0.000000 0.000000 0.936201 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C04B, 11534, 0x011C0303, 92.735, -121.106, 0.015, -0.343652, 0, 0, 0.939097,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0303 [92.735001 -121.106003 0.015000] -0.343652 0.000000 0.000000 0.939097 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C04C, 11534, 0x011C0303, 91.8105, -123.481, 0.015, -0.623978, 0, 0, 0.781442,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0303 [91.810501 -123.481003 0.015000] -0.623978 0.000000 0.000000 0.781442 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C04D, 11534, 0x011C030F, 100.643, -161.27, 0.015, -0.658775, 0, 0, -0.75234,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C030F [100.642998 -161.270004 0.015000] -0.658775 0.000000 0.000000 -0.752340 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C04E, 11534, 0x011C030F, 98.2538, -159.213, 0.015, -0.793499, 0, 0, -0.608572,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C030F [98.253799 -159.212997 0.015000] -0.793499 0.000000 0.000000 -0.608572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C04F,   568, 0x011C0311, 95.25, -160, 0, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0311 [95.250000 -160.000000 0.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C053,   278, 0x011C0319, 114.755, -140, 0, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0319 [114.754997 -140.000000 0.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C054,   143, 0x011C0320, 110.62, -175.925, 0, -1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x011C0320 [110.620003 -175.925003 0.000000] -1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C055,   278, 0x011C0322, 114.755, -180, 0, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0322 [114.754997 -180.000000 0.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C056, 11534, 0x011C0338, 129.363, -161.866, 0.015, 0.03759, 0, 0, -0.999293,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0338 [129.363007 -161.865997 0.015000] 0.037590 0.000000 0.000000 -0.999293 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C057, 11534, 0x011C0338, 130.33, -157.481, 0.015, 0.994152, 0, 0, -0.107986,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0338 [130.330002 -157.481003 0.015000] 0.994152 0.000000 0.000000 -0.107986 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C058,  6115, 0x011C0341, 130, -211, 0.005, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Surface */
+/* @teleloc 0x011C0341 [130.000000 -211.000000 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C059, 11534, 0x011C035D, 150.005, -180.317, 0.015, -0.942896, 0, 0, -0.333086,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C035D [150.005005 -180.317001 0.015000] -0.942896 0.000000 0.000000 -0.333086 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C05A, 11534, 0x011C035D, 149.892, -178.22, 0.015, -0.956619, 0, 0, -0.291341,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C035D [149.891998 -178.220001 0.015000] -0.956619 0.000000 0.000000 -0.291341 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C05B, 11534, 0x011C0369, 160.968, -186.822, 0.015, -0.956205, 0, 0, -0.292698,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0369 [160.968002 -186.822006 0.015000] -0.956205 0.000000 0.000000 -0.292698 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C05C, 11534, 0x011C0369, 159.013, -191.622, 0.015, -0.78665, 0, 0, -0.617399,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0369 [159.013000 -191.621994 0.015000] -0.786650 0.000000 0.000000 -0.617399 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C05D, 11534, 0x011C037C, 119.979, -104.25, 6.062, -0.727539, 0, 0, 0.686066,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C037C [119.978996 -104.250000 6.062000] -0.727539 0.000000 0.000000 0.686066 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C05E, 11534, 0x011C037F, 122.037, -148.854, 6.015, 0.225466, 0, 0, -0.974251,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C037F [122.037003 -148.854004 6.015000] 0.225466 0.000000 0.000000 -0.974251 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C05F, 11534, 0x011C037F, 121.13, -147, 6.015, 0.225466, 0, 0, -0.974251,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C037F [121.129997 -147.000000 6.015000] 0.225466 0.000000 0.000000 -0.974251 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C060,  1919, 0x011C0387, 130, -85.5, 6.005, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x011C0387 [130.000000 -85.500000 6.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C061, 11534, 0x011C0387, 128.734, -87.9229, 6.015, 0.0591771, 0, 0, -0.998248,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0387 [128.733994 -87.922897 6.015000] 0.059177 0.000000 0.000000 -0.998248 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C062, 11534, 0x011C0388, 130.379, -99.355, 6.015, -0.0421825, 0, 0, 0.99911,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0388 [130.378998 -99.355003 6.015000] -0.042183 0.000000 0.000000 0.999110 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C063,   568, 0x011C0393, 130, -164.75, 6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0393 [130.000000 -164.750000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C064,   568, 0x011C0394, 125.25, -160, 6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0394 [125.250000 -160.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C065,   568, 0x011C0395, 134.75, -160, 6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0395 [134.750000 -160.000000 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C066,   568, 0x011C0396, 130, -155.25, 6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011C0396 [130.000000 -155.250000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C067, 11534, 0x011C0397, 127.571, -168.895, 6.015, -0.0486539, 0, 0, -0.998816,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0397 [127.570999 -168.895004 6.015000] -0.048654 0.000000 0.000000 -0.998816 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C068, 11534, 0x011C0397, 132.449, -168.931, 6.015, -0.198834, 0, 0, -0.980033,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C0397 [132.449005 -168.931000 6.015000] -0.198834 0.000000 0.000000 -0.980033 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C069, 11534, 0x011C039C, 130.277, -223.022, 6.015, 0.998611, 0, 0, -0.0526795,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C039C [130.276993 -223.022003 6.015000] 0.998611 0.000000 0.000000 -0.052680 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C06A, 11534, 0x011C039C, 129.597, -219.849, 6.015, 0.999878, 0, 0, -0.015632,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C039C [129.597000 -219.848999 6.015000] 0.999878 0.000000 0.000000 -0.015632 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C06B, 11534, 0x011C039C, 130.992, -220.216, 6.015, 0.992326, 0, 0, -0.12365,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C039C [130.992004 -220.216003 6.015000] 0.992326 0.000000 0.000000 -0.123650 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C06C, 11534, 0x011C039F, 136.773, -103.277, 6.015, 0.67256, 0, 0, 0.740042,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C039F [136.772995 -103.277000 6.015000] 0.672560 0.000000 0.000000 0.740042 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C06D, 11534, 0x011C03A2, 140.503, -148.479, 6.015, -0.115778, 0, 0, -0.993275,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C03A2 [140.503006 -148.479004 6.015000] -0.115778 0.000000 0.000000 -0.993275 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C06E, 11534, 0x011C03A2, 139.424, -150.118, 6.015, -0.286947, 0, 0, -0.957946,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011C03A2 [139.423996 -150.117996 6.015000] -0.286947 0.000000 0.000000 -0.957946 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C06F,  7925, 0x011C0314, 104.518, -192.524, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 10 Min.) */
+/* @teleloc 0x011C0314 [104.517998 -192.524002 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011C06F, 0x7011C002, '2005-02-09 10:00:00') /* Hamud ibn Rafik (6025) */
+     , (0x7011C06F, 0x7011C00D, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C013, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C016, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C017, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C01A, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C01B, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C01C, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C01E, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C01F, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C020, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C021, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C022, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C023, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C024, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C025, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C026, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C02A, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C02B, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C02C, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C06F, 0x7011C059, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C06F, 0x7011C05B, '2005-02-09 10:00:00') /* Enku Zefir (11534) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C070,  7925, 0x011C0314, 104.504, -193.198, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 10 Min.) */
+/* @teleloc 0x011C0314 [104.503998 -193.197998 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011C070, 0x7011C042, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C043, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C044, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C046, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C047, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C048, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C049, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C04A, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C04B, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C04C, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C04D, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C04E, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C05A, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C05C, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C05E, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C05F, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C067, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C068, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C069, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C06B, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C06D, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C070, 0x7011C06E, '2005-02-09 10:00:00') /* Enku Zefir (11534) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C071,  7925, 0x011C0314, 104.522, -193.869, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 10 Min.) */
+/* @teleloc 0x011C0314 [104.522003 -193.869003 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011C071, 0x7011C02F, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C030, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C031, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C034, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C036, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C037, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C038, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C039, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C03A, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C03B, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C03C, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C03D, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C03E, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C03F, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C040, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C041, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C071, 0x7011C056, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C071, 0x7011C057, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C071, 0x7011C05D, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C071, 0x7011C062, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C071, 0x7011C06A, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011C071, 0x7011C06C, '2005-02-09 10:00:00') /* Enku Zefir (11534) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011C072,  7925, 0x011C0314, 104.522, -194.563, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 10 Min.) */
+/* @teleloc 0x011C0314 [104.522003 -194.563004 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011C072, 0x7011C000, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C006, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C007, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C00A, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C00B, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C00E, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C010, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C011, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C012, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C014, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C015, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C018, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C019, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C01D, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C027, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C028, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C029, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C02D, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C032, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C035, '2005-02-09 10:00:00') /* Shadow Wraith (23091) */
+     , (0x7011C072, 0x7011C061, '2005-02-09 10:00:00') /* Enku Zefir (11534) */;

--- a/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/0136.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/0136.sql
@@ -1,0 +1,886 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x0136;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136000, 34045, 0x01360103, 38.2473, -28.3405, -47.995, -0.095426, 0, 0, -0.995436,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360103 [38.247299 -28.340500 -47.994999] -0.095426 0.000000 0.000000 -0.995436 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136001, 34045, 0x01360105, 36.5957, -29.1595, -47.995, 0.012463, 0, 0, -0.999922,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360105 [36.595699 -29.159500 -47.994999] 0.012463 0.000000 0.000000 -0.999922 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136002, 34045, 0x01360106, 38.001, -32.105, -47.995, 0.065928, 0, 0, -0.997824,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360106 [38.000999 -32.105000 -47.994999] 0.065928 0.000000 0.000000 -0.997824 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136003, 34045, 0x01360113, 61.9033, -11.5468, -47.995, -0.374168, 0, 0, -0.927361,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360113 [61.903301 -11.546800 -47.994999] -0.374168 0.000000 0.000000 -0.927361 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136004, 34045, 0x01360115, 63.5784, -9.80887, -47.995, -0.374168, 0, 0, -0.927361,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360115 [63.578400 -9.808870 -47.994999] -0.374168 0.000000 0.000000 -0.927361 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136005, 34045, 0x01360129, 69.6861, -13.3716, -47.995, 0.0133593, 0, 0, -0.999911,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360129 [69.686096 -13.371600 -47.994999] 0.013359 0.000000 0.000000 -0.999911 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136006, 34045, 0x0136012A, 68.7762, -12.4058, -47.995, 0.017846, 0, 0, -0.999841,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136012A [68.776199 -12.405800 -47.994999] 0.017846 0.000000 0.000000 -0.999841 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136007,  6085, 0x01360154, 100, -40, -47.995, 1, 0, 0, -4.37114E-08, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01360154 [100.000000 -40.000000 -47.994999] 1.000000 0.000000 0.000000 -0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136008,  5489, 0x01360155, 120, -120, -48, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01360155 [120.000000 -120.000000 -48.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136009,  5489, 0x01360156, 120, -130, -48, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01360156 [120.000000 -130.000000 -48.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013600A,  5489, 0x01360157, 120, -140, -48, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01360157 [120.000000 -140.000000 -48.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013600B,  5489, 0x01360158, 120, -180, -48, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01360158 [120.000000 -180.000000 -48.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013600C,  5489, 0x01360159, 120, -190, -48, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01360159 [120.000000 -190.000000 -48.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013600D,  5489, 0x0136015A, 120, -200, -48, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x0136015A [120.000000 -200.000000 -48.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013600E, 34045, 0x0136015E, 67.5619, -88.6542, -41.995, 0.144693, 0, 0, -0.989477,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136015E [67.561897 -88.654198 -41.994999] 0.144693 0.000000 0.000000 -0.989477 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013600F, 34045, 0x0136015E, 73.219, -87.2427, -41.995, 0.139441, 0, 0, -0.99023,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136015E [73.219002 -87.242699 -41.994999] 0.139441 0.000000 0.000000 -0.990230 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136010, 34045, 0x0136015E, 69.9563, -91.4135, -41.995, 0.002672, 0, 0, -0.999996,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136015E [69.956299 -91.413498 -41.994999] 0.002672 0.000000 0.000000 -0.999996 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136011, 34045, 0x01360162, 80.8264, -99.9665, -41.995, -0.0527551, 0, 0, -0.998607,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360162 [80.826401 -99.966499 -41.994999] -0.052755 0.000000 0.000000 -0.998607 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136012, 34045, 0x01360163, 80.2051, -111.094, -41.995, 0.017021, 0, 0, 0.999855,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360163 [80.205101 -111.094002 -41.994999] 0.017021 0.000000 0.000000 0.999855 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136013, 34045, 0x01360163, 77.2968, -109.509, -41.995, -0.00497695, 0, 0, 0.999988,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360163 [77.296799 -109.509003 -41.994999] -0.004977 0.000000 0.000000 0.999988 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136014, 34045, 0x01360166, 89.7474, -131.599, -41.995, 0.017234, 0, 0, -0.999851,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360166 [89.747398 -131.598999 -41.994999] 0.017234 0.000000 0.000000 -0.999851 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136015, 34045, 0x01360166, 91.4781, -130.483, -41.995, -0.057733, 0, 0, -0.998332,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360166 [91.478104 -130.483002 -41.994999] -0.057733 0.000000 0.000000 -0.998332 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136016, 34045, 0x01360167, 90.8819, -132.828, -41.995, 0.052946, 0, 0, -0.998597,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360167 [90.881897 -132.828003 -41.994999] 0.052946 0.000000 0.000000 -0.998597 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136017, 34045, 0x0136016B, 90.1735, -184.501, -41.995, 0.998936, 0, 0, 0.046123,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136016B [90.173500 -184.501007 -41.994999] 0.998936 0.000000 0.000000 0.046123 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136018, 34045, 0x0136016B, 89.0333, -182.276, -41.995, 0.977442, 0, 0, 0.211203,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136016B [89.033302 -182.276001 -41.994999] 0.977442 0.000000 0.000000 0.211203 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136019, 34045, 0x0136016B, 90.9667, -182.137, -41.995, 0.999004, 0, 0, -0.044616,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136016B [90.966698 -182.136993 -41.994999] 0.999004 0.000000 0.000000 -0.044616 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013601A, 34045, 0x01360176, 108.53, -130.195, -41.995, -0.719742, 0, 0, -0.694241,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360176 [108.529999 -130.195007 -41.994999] -0.719742 0.000000 0.000000 -0.694241 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013601B, 34045, 0x01360176, 110.179, -127.702, -41.995, -0.538298, 0, 0, -0.842755,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360176 [110.179001 -127.702003 -41.994999] -0.538298 0.000000 0.000000 -0.842755 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013601C, 34045, 0x01360176, 110.561, -133.099, -41.995, -0.844402, 0, 0, -0.535709,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360176 [110.560997 -133.098999 -41.994999] -0.844402 0.000000 0.000000 -0.535709 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013601D, 34045, 0x0136017C, 109.061, -141.505, -41.995, 0.999863, 0, 0, 0.0165421,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136017C [109.060997 -141.505005 -41.994999] 0.999863 0.000000 0.000000 0.016542 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013601E, 34045, 0x01360180, 110.915, -179.787, -41.995, 0.0975961, 0, 0, 0.995226,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360180 [110.915001 -179.787003 -41.994999] 0.097596 0.000000 0.000000 0.995226 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013601F, 34045, 0x01360180, 108.487, -180.702, -41.995, 0.203751, 0, 0, 0.979023,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360180 [108.487000 -180.701996 -41.994999] 0.203751 0.000000 0.000000 0.979023 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136020, 34045, 0x01360184, 109.644, -192.213, -41.995, 0.783857, 0, 0, 0.620941,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360184 [109.643997 -192.212997 -41.994999] 0.783857 0.000000 0.000000 0.620941 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136021, 34045, 0x01360184, 111.272, -190.469, -41.995, 0.699284, 0, 0, 0.714844,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360184 [111.272003 -190.468994 -41.994999] 0.699284 0.000000 0.000000 0.714844 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136022, 34045, 0x01360184, 110.957, -188.012, -41.995, 0.616954, 0, 0, 0.786999,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360184 [110.957001 -188.011993 -41.994999] 0.616954 0.000000 0.000000 0.786999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136023,  6032, 0x01360184, 112.063, -190.449, -41.9313, 0.291504, 0, 0, -0.95657,  True, '2005-02-09 10:00:00'); /* Ancient Pyreal Dagger */
+/* @teleloc 0x01360184 [112.063004 -190.449005 -41.931301] 0.291504 0.000000 0.000000 -0.956570 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136025, 34045, 0x0136018A, 109.641, -199.444, -41.995, 0.999181, 0, 0, -0.0404713,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136018A [109.640999 -199.444000 -41.994999] 0.999181 0.000000 0.000000 -0.040471 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136026, 34045, 0x0136018A, 111.137, -198.767, -41.995, 0.994885, 0, 0, 0.101012,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136018A [111.137001 -198.766998 -41.994999] 0.994885 0.000000 0.000000 0.101012 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136027, 34045, 0x013601A4, 78.3384, -180.839, -35.995, 0.684459, 0, 0, 0.729051,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601A4 [78.338402 -180.839005 -35.994999] 0.684459 0.000000 0.000000 0.729051 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136028, 34045, 0x013601A4, 83.1779, -180.29, -35.995, 0.538105, 0, 0, -0.842878,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601A4 [83.177902 -180.289993 -35.994999] 0.538105 0.000000 0.000000 -0.842878 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136029, 34045, 0x013601A4, 79.6522, -178.644, -35.995, -0.006813, 0, 0, -0.999977,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601A4 [79.652199 -178.643997 -35.994999] -0.006813 0.000000 0.000000 -0.999977 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013602A, 34045, 0x013601AD, 100.487, -157.614, -35.995, 0.992156, 0, 0, -0.125009,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601AD [100.487000 -157.613998 -35.994999] 0.992156 0.000000 0.000000 -0.125009 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013602B, 34045, 0x013601AD, 99.1283, -157.481, -35.995, 0.977825, 0, 0, -0.209426,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601AD [99.128304 -157.481003 -35.994999] 0.977825 0.000000 0.000000 -0.209426 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013602C, 34045, 0x013601AD, 98.3356, -159.992, -35.995, 0.977825, 0, 0, -0.209426,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601AD [98.335602 -159.992004 -35.994999] 0.977825 0.000000 0.000000 -0.209426 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013602D, 34045, 0x013601BF, 99.5769, -120.981, -29.995, 0.998325, 0, 0, -0.057853,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601BF [99.576897 -120.981003 -29.995001] 0.998325 0.000000 0.000000 -0.057853 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013602E, 34045, 0x013601BF, 100.837, -121.591, -29.995, 0.999429, 0, 0, 0.033774,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x013601BF [100.836998 -121.591003 -29.995001] 0.999429 0.000000 0.000000 0.033774 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013602F, 27423, 0x013601EC, 1.00544, -128.658, -5.9934, 0.726531, 0, 0, -0.687134,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601EC [1.005440 -128.658005 -5.993400] 0.726531 0.000000 0.000000 -0.687134 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136030, 27423, 0x013601EC, 0.274087, -131.269, -5.9934, 0.574619, 0, 0, -0.818421,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601EC [0.274087 -131.268997 -5.993400] 0.574619 0.000000 0.000000 -0.818421 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136031,   286, 0x013601EC, -4.9, -130, -4.5, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013601EC [-4.900000 -130.000000 -4.500000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136032, 27423, 0x013601EE, 7.71224, -121.767, -5.9934, 0.617718, 0, 0, -0.7864,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601EE [7.712240 -121.766998 -5.993400] 0.617718 0.000000 0.000000 -0.786400 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136033, 27423, 0x013601EE, 9.60235, -120.096, -5.9934, 0.698295, 0, 0, -0.71581,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601EE [9.602350 -120.096001 -5.993400] 0.698295 0.000000 0.000000 -0.715810 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136034, 27423, 0x013601F0, 9.68574, -138.697, -5.9934, 0.810489, 0, 0, -0.585754,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601F0 [9.685740 -138.697006 -5.993400] 0.810489 0.000000 0.000000 -0.585754 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136035, 27423, 0x013601F0, 8.72516, -139.015, -5.9934, 0.810489, 0, 0, -0.585754,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601F0 [8.725160 -139.014999 -5.993400] 0.810489 0.000000 0.000000 -0.585754 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136036, 27423, 0x013601F7, 19.7144, -102.097, -5.9934, 0.815794, 0, 0, -0.578342,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601F7 [19.714399 -102.097000 -5.993400] 0.815794 0.000000 0.000000 -0.578342 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136037, 27423, 0x013601F7, 20.4255, -97.8611, -5.9934, 0.554445, 0, 0, -0.832221,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601F7 [20.425501 -97.861099 -5.993400] 0.554445 0.000000 0.000000 -0.832221 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136038, 27423, 0x013601F7, 23.4557, -99.1224, -5.9934, 0.672585, 0, 0, -0.74002,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601F7 [23.455700 -99.122398 -5.993400] 0.672585 0.000000 0.000000 -0.740020 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136039, 27423, 0x013601FE, 20.7567, -130.057, -5.9934, 0.678557, 0, 0, -0.734548,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601FE [20.756701 -130.057007 -5.993400] 0.678557 0.000000 0.000000 -0.734548 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013603A, 27423, 0x013601FE, 21.4255, -129.311, -5.9934, 0.714421, 0, 0, -0.699716,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601FE [21.425501 -129.311005 -5.993400] 0.714421 0.000000 0.000000 -0.699716 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013603B, 27423, 0x013601FE, 16.2175, -131.734, -5.9934, 0.685716, 0, 0, -0.727869,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013601FE [16.217501 -131.733994 -5.993400] 0.685716 0.000000 0.000000 -0.727869 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013603C, 27423, 0x0136020B, 30, -109.048, -5.9934, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136020B [30.000000 -109.047997 -5.993400] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013603D, 27423, 0x0136020B, 30.5815, -111.526, -5.9934, 0.990187, 0, 0, -0.13975,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136020B [30.581499 -111.526001 -5.993400] 0.990187 0.000000 0.000000 -0.139750 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013603E, 27423, 0x0136020B, 28.3451, -108.788, -5.9934, 0.999279, 0, 0, 0.037958,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136020B [28.345100 -108.788002 -5.993400] 0.999279 0.000000 0.000000 0.037958 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013603F, 27423, 0x0136020B, 28.3338, -112.386, -5.9934, 0.996215, 0, 0, -0.086923,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136020B [28.333799 -112.386002 -5.993400] 0.996215 0.000000 0.000000 -0.086923 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136040,  1912, 0x0136021E, 39.38, -114.075, -6, 0, 0, 0, 1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x0136021E [39.380001 -114.074997 -6.000000] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136041,   278, 0x01360220, 35.245, -110, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01360220 [35.244999 -110.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136042, 27423, 0x01360223, 50.1041, -80.2747, -5.9934, 0.729215, 0, 0, -0.684284,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360223 [50.104099 -80.274696 -5.993400] 0.729215 0.000000 0.000000 -0.684284 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136043, 27423, 0x01360223, 51.3898, -82.7886, -5.9934, 0.877656, 0, 0, -0.479292,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360223 [51.389801 -82.788597 -5.993400] 0.877656 0.000000 0.000000 -0.479292 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136044, 27423, 0x01360223, 50.5005, -82.2905, -5.9934, 0.891708, 0, 0, -0.452611,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360223 [50.500500 -82.290497 -5.993400] 0.891708 0.000000 0.000000 -0.452611 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136045, 27423, 0x01360229, 49.2198, -99.9772, -5.9934, 0.748499, 0, 0, -0.663136,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360229 [49.219799 -99.977203 -5.993400] 0.748499 0.000000 0.000000 -0.663136 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136046, 27423, 0x01360229, 51.3069, -101.178, -5.9934, 0.870372, 0, 0, -0.492394,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360229 [51.306900 -101.178001 -5.993400] 0.870372 0.000000 0.000000 -0.492394 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136047, 27423, 0x0136023B, 59.6381, -109.948, -5.9934, 0.830012, 0, 0, 0.557745,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136023B [59.638100 -109.947998 -5.993400] 0.830012 0.000000 0.000000 0.557745 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136048, 27423, 0x0136023B, 62.5176, -109.547, -5.9934, 0.906343, 0, 0, -0.422542,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136023B [62.517601 -109.546997 -5.993400] 0.906343 0.000000 0.000000 -0.422542 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136049, 27423, 0x0136023B, 60.5061, -110.282, -5.9934, 0.998125, 0, 0, -0.06121,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136023B [60.506100 -110.281998 -5.993400] 0.998125 0.000000 0.000000 -0.061210 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013604A, 27423, 0x0136023D, 60.7507, -108.194, -5.945, 0.999965, 0, 0, -0.008333,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136023D [60.750702 -108.194000 -5.945000] 0.999965 0.000000 0.000000 -0.008333 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013604B,  1925, 0x0136023E, 56.0875, -121.753, -5.9875, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x0136023E [56.087502 -121.752998 -5.987500] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013604C,   278, 0x01360240, 60, -115.245, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01360240 [60.000000 -115.245003 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013604D, 27423, 0x01360242, 72.5246, -38.9972, -5.9934, 0.023037, 0, 0, 0.999735,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360242 [72.524597 -38.997200 -5.993400] 0.023037 0.000000 0.000000 0.999735 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013604E, 27423, 0x01360242, 68.7773, -40.7103, -5.9934, -0.066374, 0, 0, 0.997795,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360242 [68.777298 -40.710300 -5.993400] -0.066374 0.000000 0.000000 0.997795 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013604F, 27423, 0x01360242, 69.5909, -38.0725, -5.9934, 0.005361, 0, 0, -0.999986,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360242 [69.590897 -38.072498 -5.993400] 0.005361 0.000000 0.000000 -0.999986 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136050, 27423, 0x01360242, 71.3906, -40.9168, -5.9934, -0.061901, 0, 0, -0.998082,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360242 [71.390602 -40.916801 -5.993400] -0.061901 0.000000 0.000000 -0.998082 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136051,  1919, 0x01360242, 67, -35.5, -5.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [67.000000 -35.500000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136052,  7500, 0x01360242, 70, -35.5, -5.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [70.000000 -35.500000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136053,  1922, 0x01360242, 74.5, -38, -5.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [74.500000 -38.000000 -5.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136054,  1947, 0x01360242, 74.5, -41, -5.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [74.500000 -41.000000 -5.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136055,  1917, 0x01360242, 65.5, -41, -5.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [65.500000 -41.000000 -5.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136056,  1947, 0x01360242, 73, -35.5, -5.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [73.000000 -35.500000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136057,  1945, 0x01360242, 65.5, -38, -5.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360242 [65.500000 -38.000000 -5.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136058,  2131, 0x01360245, 69.4583, -73, -5.995, 0.008342, 0, 0, -0.999965, False, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01360245 [69.458298 -73.000000 -5.995000] 0.008342 0.000000 0.000000 -0.999965 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136059,  2131, 0x01360245, 70.5417, -70, -5.995, 0.008342, 0, 0, -0.999965, False, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01360245 [70.541702 -70.000000 -5.995000] 0.008342 0.000000 0.000000 -0.999965 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013605A,  2131, 0x01360245, 69.4583, -67, -5.995, 0.008342, 0, 0, -0.999965, False, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01360245 [69.458298 -67.000000 -5.995000] 0.008342 0.000000 0.000000 -0.999965 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013605B,  4071, 0x01360245, 69.9737, -71.5273, -5.995, -0.737873, 0, 0, 0.674939, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01360245 [69.973701 -71.527298 -5.995000] -0.737873 0.000000 0.000000 0.674939 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013605C,  4083, 0x01360245, 69.917, -68.4188, -5.995, -0.999874, 0, 0, 0.015882, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01360245 [69.917000 -68.418800 -5.995000] -0.999874 0.000000 0.000000 0.015882 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013605D,  4077, 0x01360245, 70.0253, -65.012, -5.995, -0.999874, 0, 0, 0.015882, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01360245 [70.025299 -65.012001 -5.995000] -0.999874 0.000000 0.000000 0.015882 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013605E,  2180, 0x01360247, 70, -76.65, -5.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01360247 [70.000000 -76.650002 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013605E, 0x70136031, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013605F,  1914, 0x01360250, 67.1675, -124.05, -5.9875, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01360250 [67.167503 -124.050003 -5.987500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136060,   278, 0x01360252, 70, -115.245, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01360252 [70.000000 -115.245003 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136061, 27423, 0x01360255, 80.2461, -80.0898, -5.9934, 0.00694404, 0, 0, 0.999976,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360255 [80.246101 -80.089798 -5.993400] 0.006944 0.000000 0.000000 0.999976 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136062, 27423, 0x01360255, 78.638, -80.07, -5.9934, 0.0569131, 0, 0, 0.998379,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360255 [78.638000 -80.070000 -5.993400] 0.056913 0.000000 0.000000 0.998379 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136063, 27423, 0x01360256, 80.0682, -82.1131, -5.945, -0.157901, 0, 0, 0.987455,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x01360256 [80.068199 -82.113098 -5.945000] -0.157901 0.000000 0.000000 0.987455 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136064, 27423, 0x0136025C, 80, -128.543, -5.945, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136025C [80.000000 -128.542999 -5.945000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136065, 27423, 0x0136025C, 78.8828, -130.239, -5.9934, 0.999687, 0, 0, 0.024997,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136025C [78.882797 -130.238998 -5.993400] 0.999687 0.000000 0.000000 0.024997 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136066, 27423, 0x0136025C, 80.3969, -130.051, -5.9934, 0.995004, 0, 0, 0.099834,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x0136025C [80.396896 -130.050995 -5.993400] 0.995004 0.000000 0.000000 0.099834 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136067,  1290, 0x01360260, 86, -110, -5.995, 0.727856, 0, 0, -0.68573, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01360260 [86.000000 -110.000000 -5.995000] 0.727856 0.000000 0.000000 -0.685730 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136068, 34045, 0x01360264, 85.1786, -159.283, -5.995, 0.804197, 0, 0, -0.594362,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360264 [85.178596 -159.283005 -5.995000] 0.804197 0.000000 0.000000 -0.594362 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136069, 34045, 0x01360264, 85.7294, -161.397, -5.995, 0.397989, 0, 0, -0.91739,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360264 [85.729401 -161.397003 -5.995000] 0.397989 0.000000 0.000000 -0.917390 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013606A, 34045, 0x0136026E, 98.9626, -118.727, -5.995, 0.999861, 0, 0, 0.016666,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136026E [98.962601 -118.726997 -5.995000] 0.999861 0.000000 0.000000 0.016666 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013606B, 34045, 0x0136026E, 102.496, -119.542, -5.995, 0.999926, 0, 0, 0.012145,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x0136026E [102.496002 -119.542000 -5.995000] 0.999926 0.000000 0.000000 0.012145 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013606C, 34045, 0x01360273, 102.259, -178.97, -5.995, -0.983228, 0, 0, -0.182382,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360273 [102.259003 -178.970001 -5.995000] -0.983228 0.000000 0.000000 -0.182382 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013606D, 34045, 0x01360273, 99.1127, -178.816, -5.995, -0.990472, 0, 0, 0.137715,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360273 [99.112701 -178.815994 -5.995000] -0.990472 0.000000 0.000000 0.137715 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013606E, 34045, 0x01360273, 99.6169, -181.08, -5.995, -0.993752, 0, 0, -0.111613,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360273 [99.616898 -181.080002 -5.995000] -0.993752 0.000000 0.000000 -0.111613 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013606F, 34045, 0x01360273, 104.177, -184.571, -5.995, -0.996056, 0, 0, 0.088727,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360273 [104.177002 -184.570999 -5.995000] -0.996056 0.000000 0.000000 0.088727 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136070, 34045, 0x01360276, 107.877, -118.974, -5.995, -0.720978, 0, 0, -0.692958,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360276 [107.876999 -118.973999 -5.995000] -0.720978 0.000000 0.000000 -0.692958 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136071, 34045, 0x01360276, 109.048, -120.134, -5.995, -0.78066, 0, 0, -0.624956,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360276 [109.047997 -120.134003 -5.995000] -0.780660 0.000000 0.000000 -0.624956 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136072, 34045, 0x01360281, 111.708, -138.19, -5.995, 0.922567, 0, 0, 0.385836,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360281 [111.708000 -138.190002 -5.995000] 0.922567 0.000000 0.000000 0.385836 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136073, 34045, 0x01360281, 108.872, -140.135, -5.995, 0.92001, 0, 0, 0.391895,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360281 [108.872002 -140.134995 -5.995000] 0.920010 0.000000 0.000000 0.391895 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136074, 34045, 0x01360281, 107.302, -139.737, -5.995, 0.87629, 0, 0, 0.481785,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360281 [107.302002 -139.737000 -5.995000] 0.876290 0.000000 0.000000 0.481785 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136075, 34045, 0x01360281, 110.128, -141.53, -5.995, 0.87629, 0, 0, 0.481785,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360281 [110.127998 -141.529999 -5.995000] 0.876290 0.000000 0.000000 0.481785 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136076, 34045, 0x01360286, 108.088, -179.638, -5.995, -0.722912, 0, 0, -0.69094,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360286 [108.087997 -179.638000 -5.995000] -0.722912 0.000000 0.000000 -0.690940 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136077, 34045, 0x01360286, 108.681, -180.843, -5.995, -0.756541, 0, 0, -0.653946,  True, '2005-02-09 10:00:00'); /* Siessa Sclavus */
+/* @teleloc 0x01360286 [108.681000 -180.843002 -5.995000] -0.756541 0.000000 0.000000 -0.653946 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136078,  6085, 0x0136029F, 10, -80, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x0136029F [10.000000 -80.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136079,  6035, 0x013602AA, 34.85, -100, 0.005, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602AA [34.849998 -100.000000 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013607D,  2609, 0x013602AF, 40, -90, 0.005, 1, 0, 0, -4.37114E-08,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602AF [40.000000 -90.000000 0.005000] 1.000000 0.000000 0.000000 -0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013607E,  2609, 0x013602AF, 42, -90, 0.005, 1, 0, 0, -4.37114E-08,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602AF [42.000000 -90.000000 0.005000] 1.000000 0.000000 0.000000 -0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013607F,  2609, 0x013602AF, 38, -90, 0.005, 1, 0, 0, -4.37114E-08,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602AF [38.000000 -90.000000 0.005000] 1.000000 0.000000 0.000000 -0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136080, 27423, 0x013602AF, 40.086, -91.572, 0.0066, -0.031161, 0, 0, 0.999514,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602AF [40.085999 -91.571999 0.006600] -0.031161 0.000000 0.000000 0.999514 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136081, 27423, 0x013602AF, 38.571, -91.6719, 0.0066, -0.052936, 0, 0, 0.998598,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602AF [38.570999 -91.671898 0.006600] -0.052936 0.000000 0.000000 0.998598 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136082, 27423, 0x013602AF, 40.8894, -92.0018, 0.0066, -0.00296096, 0, 0, 0.999996,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602AF [40.889400 -92.001801 0.006600] -0.002961 0.000000 0.000000 0.999996 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136083, 14549, 0x013602AF, 36.0229, -90.2397, 0.024, 0.991188, 0, 0, -0.132465, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x013602AF [36.022900 -90.239700 0.024000] 0.991188 0.000000 0.000000 -0.132465 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70136083, 0x7013607F, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136084,  4065, 0x013602AF, 43.9603, -89.992, 0.024, 0.999112, 0, 0, 0.042132, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x013602AF [43.960300 -89.991997 0.024000] 0.999112 0.000000 0.000000 0.042132 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70136084, 0x7013607E, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136085,  2180, 0x013602B1, 40, -94.85, 0.005, 1, 0, 0, -4.37114E-08, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602B1 [40.000000 -94.849998 0.005000] 1.000000 0.000000 0.000000 -0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70136085, 0x70136099, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136086,  2609, 0x013602B3, 40, -110, 0.005, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602B3 [40.000000 -110.000000 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136087,  2609, 0x013602B3, 40, -112, 0.005, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602B3 [40.000000 -112.000000 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136088,  2609, 0x013602B3, 40, -108, 0.005, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602B3 [40.000000 -108.000000 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136089, 27423, 0x013602B3, 41.2742, -110.476, 0.0066, -0.77742, 0, 0, 0.628982,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B3 [41.274200 -110.475998 0.006600] -0.777420 0.000000 0.000000 0.628982 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013608A, 27423, 0x013602B3, 41.364, -107.642, 0.0066, -0.457378, 0, 0, 0.889272,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B3 [41.363998 -107.641998 0.006600] -0.457378 0.000000 0.000000 0.889272 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013608B,  4061, 0x013602B3, 40.0233, -114.104, 0.024, -0.730879, 0, 0, -0.682507, False, '2005-02-09 10:00:00'); /* Frost Trap */
+/* @teleloc 0x013602B3 [40.023300 -114.103996 0.024000] -0.730879 0.000000 0.000000 -0.682507 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013608B, 0x70136087, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013608C,  4067, 0x013602B3, 40.0421, -106.004, 0.024, -0.755672, 0, 0, -0.65495, False, '2005-02-09 10:00:00'); /* Frost Trap */
+/* @teleloc 0x013602B3 [40.042099 -106.003998 0.024000] -0.755672 0.000000 0.000000 -0.654950 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013608C, 0x70136088, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013608D,  2180, 0x013602B5, 44.85, -110, 0.005, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602B5 [44.849998 -110.000000 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013608D, 0x7013607D, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013608E, 27423, 0x013602B7, 52.1842, -89.1928, 0.0066, -0.152234, 0, 0, -0.988344,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B7 [52.184200 -89.192802 0.006600] -0.152234 0.000000 0.000000 -0.988344 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013608F, 27423, 0x013602B7, 50.2239, -90.8699, 0.0066, -0.109447, 0, 0, -0.993993,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B7 [50.223900 -90.869904 0.006600] -0.109447 0.000000 0.000000 -0.993993 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136090, 27423, 0x013602B7, 50.57, -87.5303, 0.0066, 0.014688, 0, 0, 0.999892,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B7 [50.570000 -87.530296 0.006600] 0.014688 0.000000 0.000000 0.999892 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136091, 27423, 0x013602B8, 47.3034, -99.8219, 0.0066, 0.704328, 0, 0, 0.709875,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B8 [47.303398 -99.821899 0.006600] 0.704328 0.000000 0.000000 0.709875 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136092, 27423, 0x013602B8, 47.3171, -103.671, 0.0066, 0.752323, 0, 0, 0.658795,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B8 [47.317101 -103.670998 0.006600] 0.752323 0.000000 0.000000 0.658795 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136093, 27423, 0x013602B8, 47.5157, -96.2086, 0.0066, 0.646196, 0, 0, 0.763171,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602B8 [47.515701 -96.208603 0.006600] 0.646196 0.000000 0.000000 0.763171 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136094,  2609, 0x013602B8, 50, -97.5, 0.005, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602B8 [50.000000 -97.500000 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136095,  2609, 0x013602B8, 50, -102.5, 0.005, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602B8 [50.000000 -102.500000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136096,  4095, 0x013602B8, 50.0464, -101.286, 0.005, 0.744103, 0, 0, 0.668065, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x013602B8 [50.046398 -101.286003 0.005000] 0.744103 0.000000 0.000000 0.668065 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70136096, 0x70136095, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136097,  2609, 0x013602BB, 60, -90, 0.005, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602BB [60.000000 -90.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136098,  2609, 0x013602BB, 60, -92, 0.005, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602BB [60.000000 -92.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70136099,  2609, 0x013602BB, 60, -88, 0.005, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602BB [60.000000 -88.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013609A,  7444, 0x013602BB, 60.0338, -86.4918, 0.024, 0.698816, 0, 0, -0.715301, False, '2005-02-09 10:00:00'); /* Flame Trap */
+/* @teleloc 0x013602BB [60.033798 -86.491798 0.024000] 0.698816 0.000000 0.000000 -0.715301 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013609A, 0x70136097, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013609B,  4066, 0x013602BB, 60.059, -94.0138, 0.024, 0.999757, 0, 0, -0.0220532, False, '2005-02-09 10:00:00'); /* Flame Trap */
+/* @teleloc 0x013602BB [60.058998 -94.013802 0.024000] 0.999757 0.000000 0.000000 -0.022053 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013609B, 0x70136098, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013609C,  2180, 0x013602BD, 55.15, -90, 0.005, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602BD [55.150002 -90.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7013609C, 0x701360A1, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013609D, 27423, 0x013602BE, 60.3105, -101.641, 0.0066, -0.767536, 0, 0, -0.641006,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602BE [60.310501 -101.640999 0.006600] -0.767536 0.000000 0.000000 -0.641006 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013609E, 27423, 0x013602BE, 59.2911, -98.1514, 0.0066, -0.708227, 0, 0, -0.705985,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602BE [59.291100 -98.151398 0.006600] -0.708227 0.000000 0.000000 -0.705985 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7013609F,  2609, 0x013602BF, 60, -110, 0.005, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602BF [60.000000 -110.000000 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A0,  2609, 0x013602BF, 62, -110, 0.005, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602BF [62.000000 -110.000000 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A1,  2609, 0x013602BF, 58, -110, 0.005, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602BF [58.000000 -110.000000 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A2, 27423, 0x013602BF, 60.1664, -109.109, 0.0066, 0.977468, 0, 0, 0.211085,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602BF [60.166401 -109.109001 0.006600] 0.977468 0.000000 0.000000 0.211085 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A3, 27423, 0x013602BF, 61.4672, -107.841, 0.0066, -0.979237, 0, 0, -0.202717,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602BF [61.467201 -107.841003 0.006600] -0.979237 0.000000 0.000000 -0.202717 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A4, 14548, 0x013602BF, 56.5686, -110.002, 0.024, -0.102202, 0, 0, -0.994764, False, '2005-02-09 10:00:00'); /* Acid Trap */
+/* @teleloc 0x013602BF [56.568600 -110.001999 0.024000] -0.102202 0.000000 0.000000 -0.994764 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360A4, 0x7013609F, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A5,  4063, 0x013602BF, 63.9548, -110.082, 0.024, 0.018844, 0, 0, -0.999822, False, '2005-02-09 10:00:00'); /* Acid Trap */
+/* @teleloc 0x013602BF [63.954800 -110.082001 0.024000] 0.018844 0.000000 0.000000 -0.999822 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360A5, 0x701360A0, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A6,  2180, 0x013602C1, 60, -105.15, 0.005, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602C1 [60.000000 -105.150002 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360A6, 0x70136094, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A7,  2180, 0x013602C4, 65.15, -100, 0.005, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602C4 [65.150002 -100.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360A7, 0x70136086, '2005-02-09 10:00:00') /* Lever (2609) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A8,  2180, 0x013602C4, 72.5, -100, 0.005, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x013602C4 [72.500000 -100.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360A8, 0x701360AC, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360A9, 27423, 0x013602C4, 69.8557, -99.7614, 0.0066, 0.696144, 0, 0, 0.717903,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602C4 [69.855698 -99.761398 0.006600] 0.696144 0.000000 0.000000 0.717903 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360AA, 27423, 0x013602C4, 68.7874, -100.631, 0.0066, -0.782525, 0, 0, -0.62262,  True, '2005-02-09 10:00:00'); /* Enthralled Zealot */
+/* @teleloc 0x013602C4 [68.787399 -100.630997 0.006600] -0.782525 0.000000 0.000000 -0.622620 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360AB,   286, 0x013602C4, 70.4, -98.4333, 1.9, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602C4 [70.400002 -98.433296 1.900000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360AC,   286, 0x013602C4, 68.75, -98.4333, 1.9, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602C4 [68.750000 -98.433296 1.900000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360AD,   286, 0x013602C4, 67.1, -98.4333, 1.9, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x013602C4 [67.099998 -98.433296 1.900000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360AE,  4062, 0x013602C4, 70.4186, -98.862, 0.024, -0.999934, 0, 0, 0.0115173, False, '2005-02-09 10:00:00'); /* Shockwave Trap */
+/* @teleloc 0x013602C4 [70.418602 -98.862000 0.024000] -0.999934 0.000000 0.000000 0.011517 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360AE, 0x701360AB, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360AF,  4058, 0x013602C4, 67.1155, -98.8243, 0.024, -0.999588, 0, 0, -0.0286873, False, '2005-02-09 10:00:00'); /* Whirling Blade Trap */
+/* @teleloc 0x013602C4 [67.115501 -98.824303 0.024000] -0.999588 0.000000 0.000000 -0.028687 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360AF, 0x701360AD, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360B0,  5085, 0x01360184, 108.55, -189.83, -41.995, 0.859855, 0, 0, 0.510539, False, '2005-02-09 10:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x01360184 [108.550003 -189.830002 -41.994999] 0.859855 0.000000 0.000000 0.510539 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360B0, 0x70136023, '2005-02-09 10:00:00') /* Ancient Pyreal Dagger (6032) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360B1,  4219, 0x013602AE, 26.5585, -134.237, 0.005, 0.999973, 0, 0, 0.00736381, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+/* @teleloc 0x013602AE [26.558500 -134.237000 0.005000] 0.999973 0.000000 0.000000 0.007364 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360B1, 0x70136000, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136001, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136002, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136003, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136004, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136005, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136006, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x7013600E, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x7013600F, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136010, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136011, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136012, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136013, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x7013601E, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x7013601F, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136020, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136021, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136022, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136026, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B1, 0x70136092, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B1, 0x70136093, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360B2,  4219, 0x013602AE, 27.3479, -134.173, 0.005, 0.999973, 0, 0, 0.00736381, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+/* @teleloc 0x013602AE [27.347900 -134.173004 0.005000] 0.999973 0.000000 0.000000 0.007364 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360B2, 0x7013604D, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136061, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136062, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136063, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136064, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136065, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136066, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136080, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136081, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136082, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136089, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x7013608A, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x7013608E, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x7013608F, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136090, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x70136091, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x7013609D, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x7013609E, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x701360A2, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x701360A9, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B2, 0x701360AA, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360B3,  4219, 0x013602AE, 28.19, -134.182, 0.005, 0.999973, 0, 0, 0.00736381, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+/* @teleloc 0x013602AE [28.190001 -134.182007 0.005000] 0.999973 0.000000 0.000000 0.007364 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360B3, 0x70136036, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136037, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136038, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013603B, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013603C, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013603D, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013603E, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013603F, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136042, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136043, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136044, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136045, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136046, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136047, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136048, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136049, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013604A, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013604E, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x7013604F, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x70136050, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B3, 0x701360A3, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360B4,  4219, 0x013602AE, 28.9332, -134.167, 0.005, 0.999973, 0, 0, 0.00736381, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+/* @teleloc 0x013602AE [28.933201 -134.167007 0.005000] 0.999973 0.000000 0.000000 0.007364 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360B4, 0x7013602F, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136030, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136032, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136033, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136034, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136035, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136039, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x7013603A, '2005-02-09 10:00:00') /* Enthralled Zealot (27423) */
+     , (0x701360B4, 0x70136068, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136069, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x7013606A, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x7013606B, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x7013606C, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x7013606F, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136070, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136071, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136072, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136073, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136074, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136075, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B4, 0x70136076, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701360B5,  4219, 0x013602AE, 25.8284, -134.243, 0.005, 0.999973, 0, 0, 0.00736381, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+/* @teleloc 0x013602AE [25.828400 -134.242996 0.005000] 0.999973 0.000000 0.000000 0.007364 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701360B5, 0x70136014, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136015, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136016, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136017, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136018, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136019, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013601A, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013601B, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013601C, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013601D, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136025, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136027, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136028, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136029, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013602A, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013602B, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013602C, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013602D, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013602E, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013606D, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x7013606E, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */
+     , (0x701360B5, 0x70136077, '2005-02-09 10:00:00') /* Siessa Sclavus (34045) */;


### PR DESCRIPTION
Updated the Mountain Fortress and Empyrean Foundry dungeons to EoR spawns. These were missed when the Hamud's Demise quest was updated and were pulling from py16.