### PR TITLE
Viridian Rise Weapon Revisions

### DIFF
--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/Caster/53330 Oak Stormwood Wand.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/Caster/53330 Oak Stormwood Wand.sql
@@ -38,7 +38,7 @@ VALUES (53330,   5,  -0.025) /* ManaRate */
      , (53330, 152,    1.18) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53330,   1, 'Oak Stormwood Wand') /* Name */
+VALUES (53330,   1, 'Stormwood Wand') /* Name */
      , (53330,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53330,  16, 'A wand imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/Caster/53333 Oak Derubloom Wand.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/Caster/53333 Oak Derubloom Wand.sql
@@ -38,7 +38,7 @@ VALUES (53333,   5,  -0.025) /* ManaRate */
      , (53333, 152,    1.16) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53333,   1, 'Oak Derubloom Wand') /* Name */
+VALUES (53333,   1, 'Derubloom Wand') /* Name */
      , (53333,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53333,  16, 'A wand imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/Caster/53334 Oak Corrupted Heartwood Wand.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/Caster/53334 Oak Corrupted Heartwood Wand.sql
@@ -38,7 +38,7 @@ VALUES (53334,   5,  -0.025) /* ManaRate */
      , (53334, 152,    1.18) /* ElementalDamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53334,   1, 'Oak Corrupted Heartwood Wand') /* Name */
+VALUES (53334,   1, 'Corrupted Heartwood Wand') /* Name */
      , (53334,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53334,  16, 'A wand imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53320 Oak Stormwood Axe.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53320 Oak Stormwood Axe.sql
@@ -45,7 +45,7 @@ VALUES (53320,   5,  -0.025) /* ManaRate */
      , (53320, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53320,   1, 'Oak Stormwood Axe') /* Name */
+VALUES (53320,   1, 'Stormwood Axe') /* Name */
      , (53320,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53320,  16, 'An axe imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53323 Oak Stormwood Dagger.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53323 Oak Stormwood Dagger.sql
@@ -44,7 +44,7 @@ VALUES (53323,   5,  -0.025) /* ManaRate */
      , (53323, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53323,   1, 'Oak Stormwood Dagger') /* Name */
+VALUES (53323,   1, 'Stormwood Dagger') /* Name */
      , (53323,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53323,  16, 'A dagger imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53324 Oak Stormwood Mace.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53324 Oak Stormwood Mace.sql
@@ -45,7 +45,7 @@ VALUES (53324,   5,  -0.025) /* ManaRate */
      , (53324, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53324,   1, 'Oak Stormwood Mace') /* Name */
+VALUES (53324,   1, 'Stormwood Mace') /* Name */
      , (53324,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53324,  16, 'A mace imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53325 Oak Stormwood Spear.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53325 Oak Stormwood Spear.sql
@@ -44,7 +44,7 @@ VALUES (53325,   5, -0.025) /* ManaRate */
      , (53325, 150,    1.0) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53325,   1, 'Oak Stormwood Spear') /* Name */
+VALUES (53325,   1, 'Stormwood Spear') /* Name */
      , (53325,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53325,  16, 'A spear imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53327 Oak Stormwood Greatsword.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53327 Oak Stormwood Greatsword.sql
@@ -46,7 +46,7 @@ VALUES (53327,   5, -0.025) /* ManaRate */
      , (53327, 150,   1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53327,   1, 'Oak Stormwood Greatsword') /* Name */
+VALUES (53327,   1, 'Stormwood Greatsword') /* Name */
      , (53327,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53327,  16, 'A two handed sword imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53328 Oak Stormwood Sword.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53328 Oak Stormwood Sword.sql
@@ -46,7 +46,7 @@ VALUES (53328,   5,  -0.025) /* ManaRate */
      , (53328, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53328,   1, 'Oak Stormwood Sword') /* Name */
+VALUES (53328,   1, 'Stormwood Sword') /* Name */
      , (53328,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53328,  16, 'A sword imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53329 Oak Stormwood Claw.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/53329 Oak Stormwood Claw.sql
@@ -44,7 +44,7 @@ VALUES (53329,   5,  -0.025) /* ManaRate */
      , (53329,  63,       1) /* DamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53329,   1, 'Oak Stormwood Claw') /* Name */
+VALUES (53329,   1, 'Stormwood Claw') /* Name */
      , (53329,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53329,  16, 'A claw imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/72005 Oak Stormwood Staff.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MeleeWeapon/72005 Oak Stormwood Staff.sql
@@ -46,7 +46,7 @@ VALUES (72005,   5,  -0.025) /* ManaRate */
      , (72005, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72005,   1, 'Oak Stormwood Staff') /* Name */
+VALUES (72005,   1, 'Stormwood Staff') /* Name */
      , (72005,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (72005,  16, 'A staff imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/52732 Storming Portal Axe.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/52732 Storming Portal Axe.sql
@@ -17,7 +17,6 @@ VALUES (52732,   1,        256) /* ItemType - MissileWeapon */
 	 , (52732,  44,         75) /* Damage */
      , (52732,  45,         64) /* DamageType - Electric */
 	 , (52732,  46,        128) /* DefaultCombatStyle - ThrownWeapon */
-     , (52732,  47,         47) /* DefaultCombatStyle - ThrownWeapon */
 	 , (52732,  48,         47) /* WeaponSkill - MissileWeapons */
 	 , (52732,  49,         10) /* WeaponTime */
      , (52732,  51,          2) /* CombatUse - Missle */

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/53321 Oak Stormwood Bow.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/53321 Oak Stormwood Bow.sql
@@ -47,7 +47,7 @@ VALUES (53321,   5,  -0.025) /* ManaRate */
      , (53321, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53321,   1, 'Oak Stormwood Bow') /* Name */
+VALUES (53321,   1, 'Stormwood Bow') /* Name */
      , (53321,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53321,  16, 'A bow imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/53322 Oak Stormwood Crossbow.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/53322 Oak Stormwood Crossbow.sql
@@ -47,7 +47,7 @@ VALUES (53322,   5,  -0.025) /* ManaRate */
      , (53322, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (53322,   1, 'Oak Stormwood Crossbow') /* Name */
+VALUES (53322,   1, 'Stormwood Crossbow') /* Name */
      , (53322,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (53322,  16, 'A crossbow imbued with the energies of the Viridian Rise.') /* LongDesc */;
 

--- a/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/72004 Oak Stormwood Atlatl.sql
+++ b/Database/Patches/2014-01-ForcesOfNature/9 WeenieDefaults/MissileLauncher/72004 Oak Stormwood Atlatl.sql
@@ -47,7 +47,7 @@ VALUES (72004,   5,  -0.025) /* ManaRate */
      , (72004, 150,    1.01) /* WeaponMagicDefense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72004,   1, 'Oak Stormwood Atlatl') /* Name */
+VALUES (72004,   1, 'Stormwood Atlatl') /* Name */
      , (72004,  14, 'This item may be tinkered and imbued like any loot-generated weapon.') /* Use */
      , (72004,  16, 'An atlatl imbued with the energies of the Viridian Rise.') /* LongDesc */;
 


### PR DESCRIPTION
Removed Oak from the name string of all superior versions of the weapons. Removed int 47 from Storming Portal Axe.