### PR TITLE
Bloodstone Investigation Update

### DIFF
--- a/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/79E9.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/79E9.sql
@@ -10,7 +10,6 @@ VALUES (0x779E9001,  7924, 0x79E90392, 7.1562, 32.3872, 138.456, 0.696707, 0, 0,
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x779E9001, 0x779E9002, '2020-06-17 12:15:18') /* Gurog Minion (43395) */
-     , (0x779E9001, 0x779E9003, '2020-06-17 12:15:23') /* Gurog Minion (43395) */
      , (0x779E9001, 0x779E9004, '2020-06-17 12:15:29') /* Gurog Minion (43395) */
      , (0x779E9001, 0x779E9005, '2020-06-17 12:15:34') /* Gurog Minion (43395) */
      , (0x779E9001, 0x779E9006, '2020-06-17 12:16:00') /* Frozen Wight Sorcerer (43823) */
@@ -58,33 +57,26 @@ VALUES (0x779E9001, 0x779E9002, '2020-06-17 12:15:18') /* Gurog Minion (43395) *
      , (0x779E9001, 0x779E9030, '2020-06-17 12:27:01') /* Frozen Wight (43822) */
      , (0x779E9001, 0x779E9031, '2020-06-17 12:27:07') /* Frozen Wight (43822) */
      , (0x779E9001, 0x779E9032, '2020-06-17 12:27:20') /* Frozen Wight Sorcerer (43823) */
-     , (0x779E9001, 0x779E9033, '2020-06-17 12:27:25') /* Frozen Wight Sorcerer (43823) */
-     , (0x779E9001, 0x779E9034, '2020-06-17 12:27:29') /* Frozen Wight Sorcerer (43823) */
-     , (0x779E9001, 0x779E9035, '2020-06-17 12:27:34') /* Frozen Wight Sorcerer (43823) */
      , (0x779E9001, 0x779E9036, '2020-06-17 12:27:44') /* Frozen Wight Sorcerer (43823) */
      , (0x779E9001, 0x779E9037, '2020-06-17 12:27:48') /* Frozen Wight Sorcerer (43823) */
      , (0x779E9001, 0x779E9038, '2020-06-17 12:28:10') /* Gurog Minion (43395) */
      , (0x779E9001, 0x779E9039, '2020-06-17 12:28:16') /* Gurog Minion (43395) */
-     , (0x779E9001, 0x779E903A, '2020-06-17 12:28:27') /* Gurog Minion (43395) */
-     , (0x779E9001, 0x779E903B, '2020-06-17 12:28:35') /* Gurog Minion (43395) */
-     , (0x779E9001, 0x779E903C, '2020-06-17 12:29:17') /* Bloodstone Shard (51354) */
-     , (0x779E9001, 0x779E903D, '2020-06-17 12:29:20') /* Bloodstone Shard (51354) */
-     , (0x779E9001, 0x779E903E, '2020-06-17 12:29:27') /* Bloodstone Shard (51354) */
-     , (0x779E9001, 0x779E903F, '2020-06-17 12:29:30') /* Bloodstone Shard (51354) */
-     , (0x779E9001, 0x779E9040, '2020-06-17 12:29:42') /* Bloodstone Fragment (51353) */
-     , (0x779E9001, 0x779E9041, '2020-06-17 12:29:47') /* Bloodstone Fragment (51353) */
-     , (0x779E9001, 0x779E9042, '2020-06-17 12:30:02') /* Bloodstone Fragment (51353) */
-     , (0x779E9001, 0x779E9043, '2020-06-17 12:30:09') /* Bloodstone Fragment (51353) */
      , (0x779E9001, 0x779E9044, '2020-06-17 12:30:41') /* Bloodstone Fragment (51353) */
-     , (0x779E9001, 0x779E9045, '2020-06-17 12:30:49') /* Bloodstone Fragment (51353) */;
+     , (0x779E9001, 0x779E9045, '2020-06-17 12:30:49') /* Bloodstone Fragment (51353) */
+     , (0x779E9001, 0x779E90AF, '2021-09-05 17:08:02') /* Frozen Wight Sorcerer (43823) */
+     , (0x779E9001, 0x779E90B0, '2021-09-05 17:09:11') /* Gurog Henchman (43394) */
+     , (0x779E9001, 0x779E90B1, '2021-09-05 17:13:21') /* Frozen Wight Captain (43821) */
+     , (0x779E9001, 0x779E90B2, '2021-09-05 17:14:18') /* Frozen Wight Sorcerer (43823) */
+     , (0x779E9001, 0x779E90B3, '2021-09-05 17:15:37') /* Bloodstone Shard (51354) */
+     , (0x779E9001, 0x779E90B4, '2021-09-05 17:16:16') /* Bloodstone Shard (51354) */
+     , (0x779E9001, 0x779E90B5, '2021-09-05 17:17:39') /* Bloodstone Shard (51354) */
+     , (0x779E9001, 0x779E90B6, '2021-09-05 17:18:22') /* Bloodstone Shard (51354) */
+     , (0x779E9001, 0x779E90C9, '2021-09-06 13:47:55') /* Gurog Minion (43395) */
+     , (0x779E9001, 0x779E90CA, '2021-09-06 13:48:59') /* Gurog Minion (43395) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E9002, 43395, 0x79E90385, 2.56408, 34.7188, 138.406, 0.696706, 0, 0, -0.717356,  True, '2020-06-17 12:15:18'); /* Gurog Minion */
 /* @teleloc 0x79E90385 [2.564080 34.718800 138.406006] 0.696706 0.000000 0.000000 -0.717356 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9003, 43395, 0x79E903AA, 22.4607, 34.2089, 138.406, 0.714421, 0, 0, 0.699716,  True, '2020-06-17 12:15:23'); /* Gurog Minion */
-/* @teleloc 0x79E903AA [22.460699 34.208900 138.406006] 0.714421 0.000000 0.000000 0.699716 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E9004, 43395, 0x79E9037E, 2.44499, 45.1814, 138.406, -0.696985, 0, 0, 0.717086,  True, '2020-06-17 12:15:29'); /* Gurog Minion */
@@ -275,18 +267,6 @@ VALUES (0x779E9032, 43823, 0x79E9014F, -3.49144, 46.9691, 114.408, -0.973396, 0,
 /* @teleloc 0x79E9014F [-3.491440 46.969101 114.407997] -0.973396 0.000000 0.000000 0.229131 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9033, 43823, 0x79E9017F, 28.6408, 46.5804, 114.408, -0.929031, 0, 0, -0.370001,  True, '2020-06-17 12:27:25'); /* Frozen Wight Sorcerer */
-/* @teleloc 0x79E9017F [28.640800 46.580399 114.407997] -0.929031 0.000000 0.000000 -0.370001 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9034, 43823, 0x79E90179, 21.2981, 45.6383, 114.408, -0.997481, 0, 0, 0.0709297,  True, '2020-06-17 12:27:29'); /* Frozen Wight Sorcerer */
-/* @teleloc 0x79E90179 [21.298100 45.638302 114.407997] -0.997481 0.000000 0.000000 0.070930 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9035, 43823, 0x79E9015B, 3.80593, 47.1166, 114.408, -0.998428, 0, 0, 0.0560537,  True, '2020-06-17 12:27:34'); /* Frozen Wight Sorcerer */
-/* @teleloc 0x79E9015B [3.805930 47.116600 114.407997] -0.998428 0.000000 0.000000 0.056054 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E9036, 43823, 0x79E90175, 21.2538, 105.38, 114.408, -0.915254, 0, 0, -0.402877,  True, '2020-06-17 12:27:44'); /* Frozen Wight Sorcerer */
 /* @teleloc 0x79E90175 [21.253799 105.379997 114.407997] -0.915254 0.000000 0.000000 -0.402877 */
 
@@ -303,46 +283,6 @@ VALUES (0x779E9039, 43395, 0x79E90162, 12.0291, 115.555, 114.407, 0.999795, 0, 0
 /* @teleloc 0x79E90162 [12.029100 115.555000 114.406998] 0.999795 0.000000 0.000000 0.020236 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E903A, 43395, 0x79E9016C, 10.0388, 55.095, 114.407, 0.705543, 0, 0, -0.708667,  True, '2020-06-17 12:28:27'); /* Gurog Minion */
-/* @teleloc 0x79E9016C [10.038800 55.095001 114.406998] 0.705543 0.000000 0.000000 -0.708667 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E903B, 43395, 0x79E9016C, 14.3321, 55.2895, 114.407, 0.694295, 0, 0, 0.719691,  True, '2020-06-17 12:28:35'); /* Gurog Minion */
-/* @teleloc 0x79E9016C [14.332100 55.289501 114.406998] 0.694295 0.000000 0.000000 0.719691 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E903C, 51354, 0x79E9016B, 10.5968, 64.1059, 114.388, 0.999852, 0, 0, 0.0172008,  True, '2020-06-17 12:29:17'); /* Bloodstone Shard */
-/* @teleloc 0x79E9016B [10.596800 64.105904 114.388000] 0.999852 0.000000 0.000000 0.017201 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E903D, 51354, 0x79E9016B, 13.7847, 64.2156, 114.388, 0.999852, 0, 0, 0.0172008,  True, '2020-06-17 12:29:20'); /* Bloodstone Shard */
-/* @teleloc 0x79E9016B [13.784700 64.215599 114.388000] 0.999852 0.000000 0.000000 0.017201 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E903E, 51354, 0x79E9016D, 15.7478, 43.8517, 114.388, 0.0026936, 0, 0, -0.999996,  True, '2020-06-17 12:29:27'); /* Bloodstone Shard */
-/* @teleloc 0x79E9016D [15.747800 43.851700 114.388000] 0.002694 0.000000 0.000000 -0.999996 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E903F, 51354, 0x79E9016D, 7.86226, 43.8093, 114.388, 0.0026936, 0, 0, -0.999996,  True, '2020-06-17 12:29:30'); /* Bloodstone Shard */
-/* @teleloc 0x79E9016D [7.862260 43.809299 114.388000] 0.002694 0.000000 0.000000 -0.999996 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9040, 51353, 0x79E9014E, -10.2494, 55.0159, 114.39, -0.709783, 0, 0, -0.70442,  True, '2020-06-17 12:29:42'); /* Bloodstone Fragment */
-/* @teleloc 0x79E9014E [-10.249400 55.015900 114.389999] -0.709783 0.000000 0.000000 -0.704420 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9041, 51353, 0x79E9017E, 32.3735, 54.9263, 114.39, -0.72614, 0, 0, 0.687547,  True, '2020-06-17 12:29:47'); /* Bloodstone Fragment */
-/* @teleloc 0x79E9017E [32.373501 54.926300 114.389999] -0.726140 0.000000 0.000000 0.687547 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9042, 51353, 0x79E90165, 12.0992, 105.118, 114.39, 0.999827, 0, 0, 0.0185914,  True, '2020-06-17 12:30:02'); /* Bloodstone Fragment */
-/* @teleloc 0x79E90165 [12.099200 105.117996 114.389999] 0.999827 0.000000 0.000000 0.018591 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9043, 51353, 0x79E9015F, 11.9447, 124.732, 114.39, 0.999517, 0, 0, 0.0310874,  True, '2020-06-17 12:30:09'); /* Bloodstone Fragment */
-/* @teleloc 0x79E9015F [11.944700 124.732002 114.389999] 0.999517 0.000000 0.000000 0.031087 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E9044, 51353, 0x79E901BC, -7.80045, 85.1166, 126.39, -0.909833, 0, 0, 0.414974,  True, '2020-06-17 12:30:41'); /* Bloodstone Fragment */
 /* @teleloc 0x79E901BC [-7.800450 85.116600 126.389999] -0.909833 0.000000 0.000000 0.414974 */
 
@@ -351,15 +291,11 @@ VALUES (0x779E9045, 51353, 0x79E901FA, 31.1846, 85.7705, 126.39, 0.926328, 0, 0,
 /* @teleloc 0x79E901FA [31.184601 85.770500 126.389999] 0.926328 0.000000 0.000000 0.376717 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9046,  7925, 0x79E9016D, 14.0142, 44.7682, 114.456, -0.0338345, 0, 0, -0.999427, False, '2020-06-17 12:32:47'); /* Linkable Monster Generator ( 10 Min.) */
+VALUES (0x779E9046,  7924, 0x79E9016D, 14.0142, 44.7682, 114.456, -0.0338345, 0, 0, -0.999427, False, '2020-06-17 12:32:47'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x79E9016D [14.014200 44.768200 114.456001] -0.033834 0.000000 0.000000 -0.999427 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x779E9046, 0x779E9047, '2020-06-17 12:33:16') /* Lord Kastellar (70364) */;
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9047, 70364, 0x79E9016D, 11.9905, 42.8112, 114.407, 0.999561, 0, 0, -0.0296329,  True, '2020-06-17 12:33:16'); /* Lord Kastellar */
-/* @teleloc 0x79E9016D [11.990500 42.811199 114.406998] 0.999561 0.000000 0.000000 -0.029633 */
+VALUES (0x779E9046, 0x779E90CB, '2021-09-06 13:51:16') /* Lord Kastellar (70364) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E9048,  7924, 0x79E90346, -140.143, 23.4111, 138.456, 0.999473, 0, 0, 0.0324692, False, '2020-06-17 12:49:36'); /* Linkable Monster Generator ( 5 Min.) */
@@ -442,7 +378,9 @@ VALUES (0x779E9048, 0x779E9049, '2020-06-17 12:50:40') /* Gurog Henchman (43394)
      , (0x779E9048, 0x779E9092, '2020-06-17 13:10:09') /* Frozen Wight (43822) */
      , (0x779E9048, 0x779E9093, '2020-06-17 13:10:31') /* Frozen Wight Sorcerer (43823) */
      , (0x779E9048, 0x779E9094, '2020-06-17 13:11:00') /* Gurog Soldier (43396) */
-     , (0x779E9048, 0x779E9095, '2020-06-17 13:11:06') /* Gurog Soldier (43396) */;
+     , (0x779E9048, 0x779E9095, '2020-06-17 13:11:06') /* Gurog Soldier (43396) */
+     , (0x779E9048, 0x779E90C3, '2021-09-05 18:40:50') /* Bloodstone Fragment (51353) */
+     , (0x779E9048, 0x779E90C4, '2021-09-05 18:42:22') /* Bloodstone Shard (51354) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E9049, 43394, 0x79E90346, -138.263, 23.5334, 138.406, 0.999473, 0, 0, 0.0324692,  True, '2020-06-17 12:50:40'); /* Gurog Henchman */
@@ -757,87 +695,161 @@ VALUES (0x779E9096,  7926, 0x79E90129, -142.644, 4.29587, 90.456, 0.223518, 0, 0
 /* @teleloc 0x79E90129 [-142.643997 4.295870 90.456001] 0.223518 0.000000 0.000000 0.974700 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x779E9096, 0x779E9097, '2020-06-17 13:14:35') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E9098, '2020-06-17 13:14:42') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E9099, '2020-06-17 13:14:52') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E909A, '2020-06-17 13:14:55') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E909B, '2020-06-17 13:14:57') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E909C, '2020-06-17 13:15:04') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E909D, '2020-06-17 13:15:10') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E909E, '2020-06-17 13:15:17') /* Bloodstone Shard (51354) */
-     , (0x779E9096, 0x779E90A1, '2020-06-17 13:22:08') /* Frozen Wight Captain (43821) */
-     , (0x779E9096, 0x779E90A2, '2020-06-17 13:22:11') /* Frozen Wight Captain (43821) */
-     , (0x779E9096, 0x779E90A3, '2020-06-17 13:22:15') /* Frozen Wight Captain (43821) */
-     , (0x779E9096, 0x779E90A4, '2020-06-17 13:22:23') /* Frozen Wight Sorcerer (43823) */
-     , (0x779E9096, 0x779E90A5, '2020-06-17 13:22:33') /* Frozen Wight Sorcerer (43823) */
-     , (0x779E9096, 0x779E90A6, '2020-06-17 13:22:47') /* Frozen Wight (43822) */
-     , (0x779E9096, 0x779E90A7, '2020-06-17 13:22:53') /* Frozen Wight (43822) */
-     , (0x779E9096, 0x779E90A8, '2020-06-17 16:30:13') /* Bloodstone Crystal Stockpile Gen (80067) */;
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9097, 51354, 0x79E90128, -140.548, 13.1312, 90.388, 0.055891, 0, 0, -0.998437,  True, '2020-06-17 13:14:35'); /* Bloodstone Shard */
-/* @teleloc 0x79E90128 [-140.548004 13.131200 90.388000] 0.055891 0.000000 0.000000 -0.998437 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9098, 51354, 0x79E9012E, -131.098, 9.53876, 90.388, 0.867009, 0, 0, 0.498293,  True, '2020-06-17 13:14:42'); /* Bloodstone Shard */
-/* @teleloc 0x79E9012E [-131.098007 9.538760 90.388000] 0.867009 0.000000 0.000000 0.498293 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E9099, 51354, 0x79E9012E, -131.206, 5.48287, 90.388, 0.926729, 0, 0, 0.375731,  True, '2020-06-17 13:14:52'); /* Bloodstone Shard */
-/* @teleloc 0x79E9012E [-131.205994 5.482870 90.388000] 0.926729 0.000000 0.000000 0.375731 */
+VALUES (0x779E9096, 0x779E909A, '2020-06-17 13:14:55') /* Bloodstone Shard (51354) */
+     , (0x779E9096, 0x779E90A8, '2020-06-17 16:30:13') /* Bloodstone Crystal Stockpile Gen (80067) */
+     , (0x779E9096, 0x779E90C5, '2021-09-05 18:54:05') /* Frozen Wight Captain (43821) */
+     , (0x779E9096, 0x779E90C6, '2021-09-05 18:54:58') /* Bloodstone Shard (51354) */
+     , (0x779E9096, 0x779E90C7, '2021-09-05 18:57:33') /* Gurog Henchman (43394) */
+     , (0x779E9096, 0x779E90C8, '2021-09-05 19:10:58') /* Frozen Wight Sorcerer (43823) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E909A, 51354, 0x79E90129, -138.238, 2.1444, 90.388, 0.542854, 0, 0, 0.839827,  True, '2020-06-17 13:14:55'); /* Bloodstone Shard */
 /* @teleloc 0x79E90129 [-138.238007 2.144400 90.388000] 0.542854 0.000000 0.000000 0.839827 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E909B, 51354, 0x79E90122, -149.208, 8.89803, 90.388, 0.996624, 0, 0, -0.0821008,  True, '2020-06-17 13:14:57'); /* Bloodstone Shard */
-/* @teleloc 0x79E90122 [-149.207993 8.898030 90.388000] 0.996624 0.000000 0.000000 -0.082101 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E909C, 51354, 0x79E9011E, -145.776, 44.6962, 90.388, 0.866769, 0, 0, -0.498709,  True, '2020-06-17 13:15:04'); /* Bloodstone Shard */
-/* @teleloc 0x79E9011E [-145.776001 44.696201 90.388000] 0.866769 0.000000 0.000000 -0.498709 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E909D, 51354, 0x79E9012B, -130.662, 39.1836, 90.388, -0.545381, 0, 0, -0.838188,  True, '2020-06-17 13:15:10'); /* Bloodstone Shard */
-/* @teleloc 0x79E9012B [-130.662003 39.183601 90.388000] -0.545381 0.000000 0.000000 -0.838188 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E909E, 51354, 0x79E90127, -133.129, 21.6199, 90.388, -0.720127, 0, 0, -0.693843,  True, '2020-06-17 13:15:17'); /* Bloodstone Shard */
-/* @teleloc 0x79E90127 [-133.128998 21.619900 90.388000] -0.720127 0.000000 0.000000 -0.693843 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E90A0, 70367, 0x79E90122, -143.553, 8.83099, 90.456, 0.799656, 0, 0, -0.600458, False, '2020-06-17 13:21:15'); /* Master Bloodstone Gen */
 /* @teleloc 0x79E90122 [-143.552994 8.830990 90.456001] 0.799656 0.000000 0.000000 -0.600458 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A1, 43821, 0x79E9011F, -146.948, 33.0707, 90.4082, 0.385016, 0, 0, -0.92291,  True, '2020-06-17 13:22:08'); /* Frozen Wight Captain */
-/* @teleloc 0x79E9011F [-146.947998 33.070702 90.408203] 0.385016 0.000000 0.000000 -0.922910 */
+VALUES (0x779E90A8, 80067, 0x79E90128, -136.464, 16.7587, 90.4, -0.116387, 0, 0, 0.993204,  True, '2020-06-17 16:30:13'); /* Bloodstone Crystal Stockpile Gen */
+/* @teleloc 0x79E90128 [-136.464005 16.758699 90.400002] -0.116387 0.000000 0.000000 0.993204 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A2, 43821, 0x79E90126, -135.505, 37.8883, 90.4082, -0.0979429, 0, 0, -0.995192,  True, '2020-06-17 13:22:11'); /* Frozen Wight Captain */
-/* @teleloc 0x79E90126 [-135.505005 37.888302 90.408203] -0.097943 0.000000 0.000000 -0.995192 */
+VALUES (0x779E90A9,  4455, 0x79E90124, -138, 50.1016, 90.455, 1, 0, 0, 0, False, '2021-09-05 13:16:13'); /* Door */
+/* @teleloc 0x79E90124 [-138.000000 50.101601 90.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A3, 43821, 0x79E9012F, -122.866, 34.981, 90.4082, -0.309254, 0, 0, -0.950979,  True, '2020-06-17 13:22:15'); /* Frozen Wight Captain */
-/* @teleloc 0x79E9012F [-122.865997 34.980999 90.408203] -0.309254 0.000000 0.000000 -0.950979 */
+VALUES (0x779E90AA, 72634, 0x79E9017F, 30.6133, 45.9414, 114.337, 0.92388, 0, 0, 0.382683, False, '2021-09-05 13:31:33'); /* Surface */
+/* @teleloc 0x79E9017F [30.613300 45.941399 114.336998] 0.923880 0.000000 0.000000 0.382683 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A4, 43823, 0x79E90130, -116.203, 27.8962, 90.4082, -0.534916, 0, 0, -0.844905,  True, '2020-06-17 13:22:23'); /* Frozen Wight Sorcerer */
-/* @teleloc 0x79E90130 [-116.203003 27.896200 90.408203] -0.534916 0.000000 0.000000 -0.844905 */
+VALUES (0x779E90AB, 72634, 0x79E903AA, 22, 35, 138.337, 0.707107, 0, 0, 0.707107, False, '2021-09-05 13:36:04'); /* Surface */
+/* @teleloc 0x79E903AA [22.000000 35.000000 138.337006] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A5, 43823, 0x79E9011C, -159.809, 27.8445, 90.4082, 0.698627, 0, 0, -0.715487,  True, '2020-06-17 13:22:33'); /* Frozen Wight Sorcerer */
-/* @teleloc 0x79E9011C [-159.809006 27.844500 90.408203] 0.698627 0.000000 0.000000 -0.715487 */
+VALUES (0x779E90AC, 72634, 0x79E9033A, -148.084, 12.2344, 138.337, 1, 0, 0, 0, False, '2021-09-05 13:49:35'); /* Surface */
+/* @teleloc 0x79E9033A [-148.084000 12.234400 138.337006] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A6, 43822, 0x79E9011C, -159.937, 22.482, 90.4082, 0.698627, 0, 0, -0.715487,  True, '2020-06-17 13:22:47'); /* Frozen Wight */
-/* @teleloc 0x79E9011C [-159.936996 22.482000 90.408203] 0.698627 0.000000 0.000000 -0.715487 */
+VALUES (0x779E90AD, 72634, 0x79E90107, -138.096, 121.125, 78.337, -4.37114E-08, 0, 0, -1, False, '2021-09-05 13:50:09'); /* Surface */
+/* @teleloc 0x79E90107 [-138.095993 121.125000 78.336998] -0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A7, 43822, 0x79E90130, -116.343, 21.3318, 90.4082, -0.534591, 0, 0, -0.845111,  True, '2020-06-17 13:22:53'); /* Frozen Wight */
-/* @teleloc 0x79E90130 [-116.343002 21.331800 90.408203] -0.534591 0.000000 0.000000 -0.845111 */
+VALUES (0x779E90AE,  4453, 0x79E90392, 12, 30.0039, 138.455, 1, 0, 0, 0, False, '2021-09-05 14:04:54'); /* Door */
+/* @teleloc 0x79E90392 [12.000000 30.003901 138.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A8, 80067, 0x79E90128, -136.46428, 16.758718, 90.4, -0.116387464, 0, 0, 0.9932039,  True, '2020-06-17 16:30:13'); /* Bloodstone Crystal Stockpile Gen */
-/* @teleloc 0x79E90128 [-136.464279 16.758718 90.400002] -0.116387 0.000000 0.000000 0.993204 */
+VALUES (0x779E90AF, 43823, 0x79E9016A, 11.9216, 78.7572, 114.408, 1, 0, 0, 0,  True, '2021-09-05 17:08:02'); /* Frozen Wight Sorcerer */
+/* @teleloc 0x79E9016A [11.921600 78.757202 114.407997] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B0, 43394, 0x79E9016A, 11.9875, 74.0825, 114.407, 1, 0, 0, 0,  True, '2021-09-05 17:09:11'); /* Gurog Henchman */
+/* @teleloc 0x79E9016A [11.987500 74.082497 114.406998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B1, 43821, 0x79E90177, 22.7596, 65.9855, 114.408, 1, 0, 0, 0,  True, '2021-09-05 17:13:21'); /* Frozen Wight Captain */
+/* @teleloc 0x79E90177 [22.759600 65.985497 114.407997] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B2, 43823, 0x79E90159, 1.18144, 65.8926, 114.408, 1, 0, 0, 0,  True, '2021-09-05 17:14:18'); /* Frozen Wight Sorcerer */
+/* @teleloc 0x79E90159 [1.181440 65.892601 114.407997] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B3, 51354, 0x79E9014E, -7.09032, 55.1116, 114.388, 0.707107, 0, 0, -0.707107,  True, '2021-09-05 17:15:37'); /* Bloodstone Shard */
+/* @teleloc 0x79E9014E [-7.090320 55.111599 114.388000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B4, 51354, 0x79E9017E, 30.0494, 55.0077, 114.388, 0.707107, 0, 0, 0.707107,  True, '2021-09-05 17:16:16'); /* Bloodstone Shard */
+/* @teleloc 0x79E9017E [30.049400 55.007702 114.388000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B5, 51354, 0x79E90165, 12.0301, 105.124, 114.388, 1, 0, 0, 0,  True, '2021-09-05 17:17:39'); /* Bloodstone Shard */
+/* @teleloc 0x79E90165 [12.030100 105.124001 114.388000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B6, 51354, 0x79E9015F, 11.9473, 124.949, 114.388, 1, 0, 0, 0,  True, '2021-09-05 17:18:22'); /* Bloodstone Shard */
+/* @teleloc 0x79E9015F [11.947300 124.948997 114.388000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B7, 48741, 0x79E90106, -147, 99, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:22:03'); /* Legendary Armor Chest */
+/* @teleloc 0x79E90106 [-147.000000 99.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B8, 48741, 0x79E90105, -147, 102, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:22:23'); /* Legendary Armor Chest */
+/* @teleloc 0x79E90105 [-147.000000 102.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90B9, 48741, 0x79E90110, -129, 99, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:22:36'); /* Legendary Armor Chest */
+/* @teleloc 0x79E90110 [-129.000000 99.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90BA, 48741, 0x79E9010F, -129, 102, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:22:45'); /* Legendary Armor Chest */
+/* @teleloc 0x79E9010F [-129.000000 102.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90BB, 48744, 0x79E90105, -147, 105, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:23:23'); /* Legendary Weapon Chest */
+/* @teleloc 0x79E90105 [-147.000000 105.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90BC, 48744, 0x79E90105, -147, 108, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:23:34'); /* Legendary Weapon Chest */
+/* @teleloc 0x79E90105 [-147.000000 108.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90BD, 48744, 0x79E9010F, -129, 105, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:23:49'); /* Legendary Weapon Chest */
+/* @teleloc 0x79E9010F [-129.000000 105.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90BE, 48744, 0x79E9010F, -129, 108, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:23:58'); /* Legendary Weapon Chest */
+/* @teleloc 0x79E9010F [-129.000000 108.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90BF, 48742, 0x79E90104, -147, 114, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:24:22'); /* Legendary Magic Chest */
+/* @teleloc 0x79E90104 [-147.000000 114.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C0, 48742, 0x79E90104, -147, 111, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:24:32'); /* Legendary Magic Chest */
+/* @teleloc 0x79E90104 [-147.000000 111.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C1, 48742, 0x79E9010E, -129, 114, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:24:47'); /* Legendary Magic Chest */
+/* @teleloc 0x79E9010E [-129.000000 114.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C2, 48742, 0x79E9010E, -129, 111, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:24:57'); /* Legendary Magic Chest */
+/* @teleloc 0x79E9010E [-129.000000 111.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C3, 51353, 0x79E9018C, -147.169, 25.0458, 120.39, 0.707107, 0, 0, 0.707107,  True, '2021-09-05 18:40:50'); /* Bloodstone Fragment */
+/* @teleloc 0x79E9018C [-147.169006 25.045799 120.389999] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C4, 51354, 0x79E90183, -157.982, 10.4428, 120.388, -4.37114E-08, 0, 0, -1,  True, '2021-09-05 18:42:22'); /* Bloodstone Shard */
+/* @teleloc 0x79E90183 [-157.981995 10.442800 120.388000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C5, 43821, 0x79E90130, -117.384, 25.3018, 90.4082, 0.707107, 0, 0, 0.707107,  True, '2021-09-05 18:54:05'); /* Frozen Wight Captain */
+/* @teleloc 0x79E90130 [-117.384003 25.301800 90.408203] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C6, 51354, 0x79E9011C, -159.501, 24.5347, 90.388, 0.707107, 0, 0, -0.707107,  True, '2021-09-05 18:54:58'); /* Bloodstone Shard */
+/* @teleloc 0x79E9011C [-159.501007 24.534700 90.388000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C7, 43394, 0x79E90125, -138.012, 40.2436, 90.4065, -4.37114E-08, 0, 0, -1,  True, '2021-09-05 18:57:33'); /* Gurog Henchman */
+/* @teleloc 0x79E90125 [-138.011993 40.243599 90.406502] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C8, 43823, 0x79E9011F, -149.69, 38.0874, 90.4082, -0.330827, 0, 0, 0.943691,  True, '2021-09-05 19:10:58'); /* Frozen Wight Sorcerer */
+/* @teleloc 0x79E9011F [-149.690002 38.087399 90.408203] -0.330827 0.000000 0.000000 0.943691 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90C9, 43395, 0x79E9015B, 1.28516, 46.5, 114.407, 1, 0, 0, 0,  True, '2021-09-06 13:47:55'); /* Gurog Minion */
+/* @teleloc 0x79E9015B [1.285160 46.521198 114.406998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90CA, 43395, 0x79E90179, 22.4941, 46.5, 114.4065, 1, 0, 0, 0,  True, '2021-09-06 13:48:59'); /* Gurog Minion */
+/* @teleloc 0x79E90179 [22.494101 46.821800 114.406502] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x779E90CB, 70364, 0x79E9016D, 12.0203, 45.5235, 114.407, 1, 0, 0, 0,  True, '2021-09-06 13:51:16'); /* Lord Kastellar */
+/* @teleloc 0x79E9016D [12.020300 45.523499 114.406998] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/2010-11-FromDarknessLight/8 QuestDefDB/BloodstoneFactoryKeyPickup.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/8 QuestDefDB/BloodstoneFactoryKeyPickup.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'BloodstoneFactoryKeyPickup';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('BloodstoneFactoryKeyPickup', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51340 Bloodstone Fragment.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51340 Bloodstone Fragment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 51340;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (51340, 'ace51340-bloodstonefragment', 10, '2020-05-18 00:00:00') /* Creature */;
+VALUES (51340, 'ace51340-bloodstonefragment', 10, '2021-09-05 03:58:25') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51340,   1,         16) /* ItemType - Creature */
@@ -16,7 +16,7 @@ VALUES (51340,   1,         16) /* ItemType - Creature */
      , (51340,  69,          4) /* CombatTactic - LastDamager */
      , (51340,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
      , (51340, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (51340, 146,     1000000) /* XpOverride */;
+     , (51340, 146,    1000000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (51340,   1, True ) /* Stuck */
@@ -29,40 +29,40 @@ VALUES (51340,   1, True ) /* Stuck */
      , (51340, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (51340,   1,  5) /* HeartbeatInterval */
-     , (51340,   2,  0) /* HeartbeatTimestamp */
-     , (51340,   3,0.2) /* HealthRate */
-     , (51340,   4,0.5) /* StaminaRate */
-     , (51340,   5,  2) /* ManaRate */
-     , (51340,  12,  0) /* Shade */
-     , (51340,  13,  0.8) /* ArmorModVsSlash */
-     , (51340,  14,  0.5) /* ArmorModVsPierce */
-     , (51340,  15,  0.4) /* ArmorModVsBludgeon */
-     , (51340,  16,  0.8) /* ArmorModVsCold */
-     , (51340,  17,  0.8) /* ArmorModVsFire */
-     , (51340,  18,  0.8) /* ArmorModVsAcid */
-     , (51340,  19,  0.8) /* ArmorModVsElectric */
-     , (51340,  27,    3) /* RotationSpeed */
-     , (51340,  31,   33) /* VisualAwarenessRange */
-     , (51340,  34,    2) /* PowerupTime */
-     , (51340,  36,    1) /* ChargeSpeed */
-     , (51340,  39,  1.0) /* DefaultScale */
-     , (51340,  64,  0.4) /* ResistSlash */
-     , (51340,  65,  0.4) /* ResistPierce */
-     , (51340,  66,  0.86) /* ResistBludgeon */
-     , (51340,  67,  0.4) /* ResistFire */
-     , (51340,  68,  0.4) /* ResistCold */
-     , (51340,  69,  0.4) /* ResistAcid */
-     , (51340,  70,  0.4) /* ResistElectric */
-     , (51340,  71,  1) /* ResistHealthBoost */
-     , (51340,  72,  1) /* ResistStaminaDrain */
-     , (51340,  73,  1) /* ResistStaminaBoost */
-     , (51340,  74,  1) /* ResistManaDrain */
-     , (51340,  75,  1) /* ResistManaBoost */
-     , (51340,  80,  4) /* AiUseMagicDelay */
-     , (51340, 104, 10) /* ObviousRadarRange */
-     , (51340, 122,  2) /* AiAcquireHealth */
-     , (51340, 125,  1) /* ResistHealthDrain */;
+VALUES (51340,   1,       5) /* HeartbeatInterval */
+     , (51340,   2,       0) /* HeartbeatTimestamp */
+     , (51340,   3,     0.2) /* HealthRate */
+     , (51340,   4,     0.5) /* StaminaRate */
+     , (51340,   5,       2) /* ManaRate */
+     , (51340,  12,       0) /* Shade */
+     , (51340,  13,     0.8) /* ArmorModVsSlash */
+     , (51340,  14,     0.5) /* ArmorModVsPierce */
+     , (51340,  15,     0.4) /* ArmorModVsBludgeon */
+     , (51340,  16,     0.8) /* ArmorModVsCold */
+     , (51340,  17,     0.8) /* ArmorModVsFire */
+     , (51340,  18,     0.8) /* ArmorModVsAcid */
+     , (51340,  19,     0.8) /* ArmorModVsElectric */
+     , (51340,  27,       3) /* RotationSpeed */
+     , (51340,  31,      33) /* VisualAwarenessRange */
+     , (51340,  34,       2) /* PowerupTime */
+     , (51340,  36,       1) /* ChargeSpeed */
+     , (51340,  39,       1) /* DefaultScale */
+     , (51340,  64,     0.4) /* ResistSlash */
+     , (51340,  65,     0.4) /* ResistPierce */
+     , (51340,  66,    0.86) /* ResistBludgeon */
+     , (51340,  67,     0.4) /* ResistFire */
+     , (51340,  68,     0.4) /* ResistCold */
+     , (51340,  69,     0.4) /* ResistAcid */
+     , (51340,  70,     0.4) /* ResistElectric */
+     , (51340,  71,       1) /* ResistHealthBoost */
+     , (51340,  72,       1) /* ResistStaminaDrain */
+     , (51340,  73,       1) /* ResistStaminaBoost */
+     , (51340,  74,       1) /* ResistManaDrain */
+     , (51340,  75,       1) /* ResistManaBoost */
+     , (51340,  80,       4) /* AiUseMagicDelay */
+     , (51340, 104,      10) /* ObviousRadarRange */
+     , (51340, 122,       2) /* AiAcquireHealth */
+     , (51340, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (51340,   1, 'Bloodstone Fragment') /* Name */;
@@ -70,15 +70,22 @@ VALUES (51340,   1, 'Bloodstone Fragment') /* Name */;
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (51340,   1,   33561168) /* Setup */
      , (51340,   2,  150995096) /* MotionTable */
-     , (51340,   4,  805306407) /* CombatTable */      
      , (51340,   3,  536871001) /* SoundTable */
+     , (51340,   4,  805306407) /* CombatTable */
      , (51340,   8,  100691499) /* Icon */
      , (51340,  22,  872415348) /* PhysicsEffectTable */
-     , (51340,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;     
+     , (51340,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
-INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (51340, 8040, 2028470288, 42.82618, 171.0648, 105.99, -0.4956508, 0, 0, -0.8685219) /* PCAPRecordedLocation */
-/* @teleloc 0x78E80010 [42.826180 171.064800 105.990000] -0.495651 0.000000 0.000000 -0.868522 */;
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (51340,  0,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (51340,  1,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (51340,  2,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (51340,  3,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (51340,  4,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (51340,  5,  4, 400, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (51340,  6,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (51340,  7,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (51340,  8,  4, 400, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (51340,   1, 220, 0, 0) /* Strength */
@@ -94,32 +101,18 @@ VALUES (51340,   1,  2875, 0, 0, 3000) /* MaxHealth */
      , (51340,   5,  4520, 0, 0, 5000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (51340,  6, 0, 3, 0, 360, 0,    0) /* MeleeDefense        Specialized */
-     , (51340,  7, 0, 3, 0, 367, 0,    0) /* MissileDefense      Specialized */
-     , (51340, 15, 0, 3, 0, 395, 0,    0) /* MagicDefense        Specialized */
-     , (51340, 20, 0, 3, 0, 420, 0,    0) /* Deception           Specialized */
-     , (51340, 33, 0, 3, 0, 460, 0,    0) /* LifeMagic           Specialized */
-     , (51340, 34, 0, 3, 0, 395, 0,    0) /* WarMagic            Specialized */
-     , (51340, 41, 0, 3, 0, 445, 0,    0) /* Two Handed          Specialized */
-     , (51340, 44, 0, 3, 0, 445, 0,    0) /* Heavy Weapons       Specialized */
-     , (51340, 45, 0, 3, 0, 445, 0,    0) /* Light Weapons       Specialized */
-     , (51340, 46, 0, 3, 0, 445, 0,    0) /* Finesse Weapons     Specialized */
-     , (51340, 47, 0, 3, 0, 445, 0,    0) /* Missile Weapons     Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (51340,  0,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (51340,  1,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (51340,  2,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (51340,  3,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (51340,  4,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (51340,  5,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (51340,  6,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (51340,  7,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (51340,  8,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (51340,  6, 0, 3, 0, 340, 0, 0) /* MeleeDefense        Specialized */
+     , (51340,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Specialized */
+     , (51340, 15, 0, 3, 0, 375, 0, 0) /* MagicDefense        Specialized */
+     , (51340, 20, 0, 3, 0, 400, 0, 0) /* Deception           Specialized */
+     , (51340, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
+     , (51340, 34, 0, 3, 0, 220, 0, 0) /* WarMagic            Specialized */
+     , (51340, 45, 0, 3, 0, 375, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51340,  6193,    2.1)  /* Halo of Frost II */
-     , (51340,  2138,    2.1)  /* Blizzard */
-     , (51340,  2136,    2.1)  /* Icy Torment */;
-     
-     
+VALUES (51340,  2162,   2.08) /* Olthoi's Gift */
+     , (51340,  1242,  2.087) /* Drain Health Other VI */
+     , (51340,  1265,  2.095) /* Drain Mana Other VI*/
+     , (51340,  1254,  2.197) /* Drain Stamina Other VI */
+     , (51340,  5530,  2.295) /* Bloodstone Bolt VI */
+     , (51340,  5535,  2.419) /* Acidic Blood */;

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51353 Bloodstone Fragment.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51353 Bloodstone Fragment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 51353;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (51353, 'ace51353-bloodstonefragment', 10, '2019-02-10 00:00:00') /* Creature */;
+VALUES (51353, 'ace51353-bloodstonefragment', 10, '2021-09-05 03:58:25') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51353,   1,         16) /* ItemType - Creature */
@@ -16,7 +16,7 @@ VALUES (51353,   1,         16) /* ItemType - Creature */
      , (51353,  69,          4) /* CombatTactic - LastDamager */
      , (51353,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
      , (51353, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (51353, 146,     1000000) /* XpOverride */;
+     , (51353, 146,    1000000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (51353,   1, True ) /* Stuck */
@@ -29,40 +29,40 @@ VALUES (51353,   1, True ) /* Stuck */
      , (51353, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (51353,   1,  5) /* HeartbeatInterval */
-     , (51353,   2,  0) /* HeartbeatTimestamp */
-     , (51353,   3,0.2) /* HealthRate */
-     , (51353,   4,0.5) /* StaminaRate */
-     , (51353,   5,  2) /* ManaRate */
-     , (51353,  12,  0) /* Shade */
-     , (51353,  13,  0.8) /* ArmorModVsSlash */
-     , (51353,  14,  0.5) /* ArmorModVsPierce */
-     , (51353,  15,  0.4) /* ArmorModVsBludgeon */
-     , (51353,  16,  0.8) /* ArmorModVsCold */
-     , (51353,  17,  0.8) /* ArmorModVsFire */
-     , (51353,  18,  0.8) /* ArmorModVsAcid */
-     , (51353,  19,  0.8) /* ArmorModVsElectric */
-     , (51353,  27,    3) /* RotationSpeed */
-     , (51353,  31,   33) /* VisualAwarenessRange */
-     , (51353,  34,    2) /* PowerupTime */
-     , (51353,  36,    1) /* ChargeSpeed */
-     , (51353,  39,  1.0) /* DefaultScale */
-     , (51353,  64,  0.4) /* ResistSlash */
-     , (51353,  65,  0.4) /* ResistPierce */
-     , (51353,  66,  0.86) /* ResistBludgeon */
-     , (51353,  67,  0.4) /* ResistFire */
-     , (51353,  68,  0.4) /* ResistCold */
-     , (51353,  69,  0.4) /* ResistAcid */
-     , (51353,  70,  0.4) /* ResistElectric */
-     , (51353,  71,  1) /* ResistHealthBoost */
-     , (51353,  72,  1) /* ResistStaminaDrain */
-     , (51353,  73,  1) /* ResistStaminaBoost */
-     , (51353,  74,  1) /* ResistManaDrain */
-     , (51353,  75,  1) /* ResistManaBoost */
-     , (51353,  80,  4) /* AiUseMagicDelay */
-     , (51353, 104, 10) /* ObviousRadarRange */
-     , (51353, 122,  2) /* AiAcquireHealth */
-     , (51353, 125,  1) /* ResistHealthDrain */;
+VALUES (51353,   1,       5) /* HeartbeatInterval */
+     , (51353,   2,       0) /* HeartbeatTimestamp */
+     , (51353,   3,     0.2) /* HealthRate */
+     , (51353,   4,     0.5) /* StaminaRate */
+     , (51353,   5,       2) /* ManaRate */
+     , (51353,  12,       0) /* Shade */
+     , (51353,  13,     0.8) /* ArmorModVsSlash */
+     , (51353,  14,     0.5) /* ArmorModVsPierce */
+     , (51353,  15,     0.4) /* ArmorModVsBludgeon */
+     , (51353,  16,     0.8) /* ArmorModVsCold */
+     , (51353,  17,     0.8) /* ArmorModVsFire */
+     , (51353,  18,     0.8) /* ArmorModVsAcid */
+     , (51353,  19,     0.8) /* ArmorModVsElectric */
+     , (51353,  27,       3) /* RotationSpeed */
+     , (51353,  31,      33) /* VisualAwarenessRange */
+     , (51353,  34,       2) /* PowerupTime */
+     , (51353,  36,       1) /* ChargeSpeed */
+     , (51353,  39,       1) /* DefaultScale */
+     , (51353,  64,     0.4) /* ResistSlash */
+     , (51353,  65,     0.4) /* ResistPierce */
+     , (51353,  66,    0.86) /* ResistBludgeon */
+     , (51353,  67,     0.4) /* ResistFire */
+     , (51353,  68,     0.4) /* ResistCold */
+     , (51353,  69,     0.4) /* ResistAcid */
+     , (51353,  70,     0.4) /* ResistElectric */
+     , (51353,  71,       1) /* ResistHealthBoost */
+     , (51353,  72,       1) /* ResistStaminaDrain */
+     , (51353,  73,       1) /* ResistStaminaBoost */
+     , (51353,  74,       1) /* ResistManaDrain */
+     , (51353,  75,       1) /* ResistManaBoost */
+     , (51353,  80,       4) /* AiUseMagicDelay */
+     , (51353, 104,      10) /* ObviousRadarRange */
+     , (51353, 122,       2) /* AiAcquireHealth */
+     , (51353, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (51353,   1, 'Bloodstone Fragment') /* Name */;
@@ -70,15 +70,22 @@ VALUES (51353,   1, 'Bloodstone Fragment') /* Name */;
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (51353,   1,   33561168) /* Setup */
      , (51353,   2,  150995096) /* MotionTable */
-     , (51353,   4,  805306407) /* CombatTable */      
      , (51353,   3,  536871001) /* SoundTable */
+     , (51353,   4,  805306407) /* CombatTable */
      , (51353,   8,  100691499) /* Icon */
      , (51353,  22,  872415348) /* PhysicsEffectTable */
-     , (51353,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;     
+     , (51353,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
-INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (51353, 8040, 1498350374, 231.0365, -91.64219, -0.00999999, -0.08065922, 0, 0, -0.9967417) /* PCAPRecordedLocation */
-/* @teleloc 0x594F0326 [231.036500 -91.642190 -0.010000] -0.080659 0.000000 0.000000 -0.996742 */;
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (51353,  0,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (51353,  1,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (51353,  2,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (51353,  3,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (51353,  4,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (51353,  5,  4, 400, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (51353,  6,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (51353,  7,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (51353,  8,  4, 400, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (51353,   1, 220, 0, 0) /* Strength */
@@ -94,32 +101,18 @@ VALUES (51353,   1,  2875, 0, 0, 3000) /* MaxHealth */
      , (51353,   5,  4520, 0, 0, 5000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (51353,  6, 0, 3, 0, 360, 0,    0) /* MeleeDefense        Specialized */
-     , (51353,  7, 0, 3, 0, 367, 0,    0) /* MissileDefense      Specialized */
-     , (51353, 15, 0, 3, 0, 395, 0,    0) /* MagicDefense        Specialized */
-     , (51353, 20, 0, 3, 0, 420, 0,    0) /* Deception           Specialized */
-     , (51353, 33, 0, 3, 0, 460, 0,    0) /* LifeMagic           Specialized */
-     , (51353, 34, 0, 3, 0, 395, 0,    0) /* WarMagic            Specialized */
-     , (51353, 41, 0, 3, 0, 445, 0,    0) /* Two Handed          Specialized */
-     , (51353, 44, 0, 3, 0, 445, 0,    0) /* Heavy Weapons       Specialized */
-     , (51353, 45, 0, 3, 0, 445, 0,    0) /* Light Weapons       Specialized */
-     , (51353, 46, 0, 3, 0, 445, 0,    0) /* Finesse Weapons     Specialized */
-     , (51353, 47, 0, 3, 0, 445, 0,    0) /* Missile Weapons     Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (51353,  0,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (51353,  1,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (51353,  2,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (51353,  3,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (51353,  4,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (51353,  5,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (51353,  6,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (51353,  7,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (51353,  8,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (51353,  6, 0, 3, 0, 340, 0, 0) /* MeleeDefense        Specialized */
+     , (51353,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Specialized */
+     , (51353, 15, 0, 3, 0, 375, 0, 0) /* MagicDefense        Specialized */
+     , (51353, 20, 0, 3, 0, 400, 0, 0) /* Deception           Specialized */
+     , (51353, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
+     , (51353, 34, 0, 3, 0, 220, 0, 0) /* WarMagic            Specialized */
+     , (51353, 45, 0, 3, 0, 375, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51353,  6193,    2.1)  /* Halo of Frost II */
-     , (51353,  2138,    2.1)  /* Blizzard */
-     , (51353,  2136,    2.1)  /* Icy Torment */;
-     
-     
+VALUES (51353,  2162,   2.08) /* Olthoi's Gift */
+     , (51353,  1242,  2.087) /* Drain Health Other VI */
+     , (51353,  1265,  2.095) /* Drain Mana Other VI*/
+     , (51353,  1254,  2.197) /* Drain Stamina Other VI */
+     , (51353,  5530,  2.295) /* Bloodstone Bolt VI */
+     , (51353,  5535,  2.419) /* Acidic Blood */;

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51354 Bloodstone Shard.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51354 Bloodstone Shard.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 51354;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (51354, 'ace51354-bloodstoneshard', 10, '2020-05-18 00:00:00') /* Creature */;
+VALUES (51354, 'ace51354-bloodstoneshard', 10, '2021-09-06 10:08:26') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51354,   1,         16) /* ItemType - Creature */
@@ -14,9 +14,11 @@ VALUES (51354,   1,         16) /* ItemType - Creature */
      , (51354,  40,          2) /* CombatMode - Melee */
      , (51354,  68,          5) /* TargetingTactic - Random, LastDamager */
      , (51354,  69,          4) /* CombatTactic - LastDamager */
+     , (51354,  81,          2) /* MaxGeneratedObjects */
+     , (51354,  82,          0) /* InitGeneratedObjects */
      , (51354,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
      , (51354, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (51354, 146,     1300000) /* XpOverride */;
+     , (51354, 146,    1300000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (51354,   1, True ) /* Stuck */
@@ -29,40 +31,42 @@ VALUES (51354,   1, True ) /* Stuck */
      , (51354, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (51354,   1,  5) /* HeartbeatInterval */
-     , (51354,   2,  0) /* HeartbeatTimestamp */
-     , (51354,   3,0.2) /* HealthRate */
-     , (51354,   4,0.5) /* StaminaRate */
-     , (51354,   5,  2) /* ManaRate */
-     , (51354,  12,  0) /* Shade */
-     , (51354,  13,  0.8) /* ArmorModVsSlash */
-     , (51354,  14,  0.5) /* ArmorModVsPierce */
-     , (51354,  15,  0.4) /* ArmorModVsBludgeon */
-     , (51354,  16,  0.8) /* ArmorModVsCold */
-     , (51354,  17,  0.8) /* ArmorModVsFire */
-     , (51354,  18,  0.8) /* ArmorModVsAcid */
-     , (51354,  19,  0.8) /* ArmorModVsElectric */
-     , (51354,  27,    3) /* RotationSpeed */
-     , (51354,  31,   33) /* VisualAwarenessRange */
-     , (51354,  34,    2) /* PowerupTime */
-     , (51354,  36,    1) /* ChargeSpeed */
-     , (51354,  39,  1.2) /* DefaultScale */
-     , (51354,  64,  0.4) /* ResistSlash */
-     , (51354,  65,  0.4) /* ResistPierce */
-     , (51354,  66,  0.86) /* ResistBludgeon */
-     , (51354,  67,  0.4) /* ResistFire */
-     , (51354,  68,  0.4) /* ResistCold */
-     , (51354,  69,  0.4) /* ResistAcid */
-     , (51354,  70,  0.4) /* ResistElectric */
-     , (51354,  71,  1) /* ResistHealthBoost */
-     , (51354,  72,  1) /* ResistStaminaDrain */
-     , (51354,  73,  1) /* ResistStaminaBoost */
-     , (51354,  74,  1) /* ResistManaDrain */
-     , (51354,  75,  1) /* ResistManaBoost */
-     , (51354,  80,  4) /* AiUseMagicDelay */
-     , (51354, 104, 10) /* ObviousRadarRange */
-     , (51354, 122,  2) /* AiAcquireHealth */
-     , (51354, 125,  1) /* ResistHealthDrain */;
+VALUES (51354,   1,       5) /* HeartbeatInterval */
+     , (51354,   2,       0) /* HeartbeatTimestamp */
+     , (51354,   3,     0.2) /* HealthRate */
+     , (51354,   4,     0.5) /* StaminaRate */
+     , (51354,   5,       2) /* ManaRate */
+     , (51354,  12,       0) /* Shade */
+     , (51354,  13,     0.8) /* ArmorModVsSlash */
+     , (51354,  14,     0.5) /* ArmorModVsPierce */
+     , (51354,  15,     0.4) /* ArmorModVsBludgeon */
+     , (51354,  16,     0.8) /* ArmorModVsCold */
+     , (51354,  17,     0.8) /* ArmorModVsFire */
+     , (51354,  18,     0.8) /* ArmorModVsAcid */
+     , (51354,  19,     0.8) /* ArmorModVsElectric */
+     , (51354,  27,       3) /* RotationSpeed */
+     , (51354,  31,      33) /* VisualAwarenessRange */
+     , (51354,  34,       2) /* PowerupTime */
+     , (51354,  36,       1) /* ChargeSpeed */
+     , (51354,  39,     1.2) /* DefaultScale */
+     , (51354,  41,       0) /* RegenerationInterval */
+     , (51354,  43,       5) /* GeneratorRadius */
+     , (51354,  64,     0.4) /* ResistSlash */
+     , (51354,  65,     0.4) /* ResistPierce */
+     , (51354,  66,    0.86) /* ResistBludgeon */
+     , (51354,  67,     0.4) /* ResistFire */
+     , (51354,  68,     0.4) /* ResistCold */
+     , (51354,  69,     0.4) /* ResistAcid */
+     , (51354,  70,     0.4) /* ResistElectric */
+     , (51354,  71,       1) /* ResistHealthBoost */
+     , (51354,  72,       1) /* ResistStaminaDrain */
+     , (51354,  73,       1) /* ResistStaminaBoost */
+     , (51354,  74,       1) /* ResistManaDrain */
+     , (51354,  75,       1) /* ResistManaBoost */
+     , (51354,  80,       4) /* AiUseMagicDelay */
+     , (51354, 104,      10) /* ObviousRadarRange */
+     , (51354, 122,       2) /* AiAcquireHealth */
+     , (51354, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (51354,   1, 'Bloodstone Shard') /* Name */;
@@ -74,7 +78,18 @@ VALUES (51354,   1,   33561556) /* Setup */
      , (51354,   4,  805306407) /* CombatTable */
      , (51354,   8,  100691499) /* Icon */
      , (51354,  22,  872415348) /* PhysicsEffectTable */
-     , (51354,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;     
+     , (51354,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (51354,  0,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (51354,  1,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (51354,  2,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (51354,  3,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (51354,  4,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (51354,  5,  4, 500, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (51354,  6,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (51354,  7,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (51354,  8,  4, 500, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (51354,   1, 220, 0, 0) /* Strength */
@@ -90,36 +105,30 @@ VALUES (51354,   1,  4875, 0, 0, 5000) /* MaxHealth */
      , (51354,   5,  4755, 0, 0, 5000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (51354,  6, 0, 3, 0, 360, 0,    0) /* MeleeDefense        Specialized */
-     , (51354,  7, 0, 3, 0, 367, 0,    0) /* MissileDefense      Specialized */
-     , (51354, 15, 0, 3, 0, 395, 0,    0) /* MagicDefense        Specialized */
-     , (51354, 20, 0, 3, 0, 420, 0,    0) /* Deception           Specialized */
-     , (51354, 33, 0, 3, 0, 460, 0,    0) /* LifeMagic           Specialized */
-     , (51354, 34, 0, 3, 0, 395, 0,    0) /* WarMagic            Specialized */
-     , (51354, 41, 0, 3, 0, 445, 0,    0) /* Two Handed          Specialized */
-     , (51354, 44, 0, 3, 0, 445, 0,    0) /* Heavy Weapons       Specialized */
-     , (51354, 45, 0, 3, 0, 445, 0,    0) /* Light Weapons       Specialized */
-     , (51354, 46, 0, 3, 0, 445, 0,    0) /* Finesse Weapons     Specialized */
-     , (51354, 47, 0, 3, 0, 445, 0,    0) /* Missile Weapons     Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (51354,  0,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (51354,  1,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (51354,  2,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (51354,  3,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (51354,  4,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (51354,  5,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (51354,  6,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (51354,  7,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (51354,  8,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (51354,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
+     , (51354,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (51354, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
+     , (51354, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
+     , (51354, 33, 0, 3, 0, 220, 0, 0) /* LifeMagic           Specialized */
+     , (51354, 34, 0, 3, 0, 240, 0, 0) /* WarMagic            Specialized */
+     , (51354, 45, 0, 3, 0, 395, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51354,  6193,    2.1)  /* Halo of Frost II */
-     , (51354,  2138,    2.1)  /* Blizzard */
-     , (51354,  2136,    2.1)  /* Icy Torment */
-     , (51354,  2125,    2.1)  /* Incantation of Frost Arc */
-     , (51354,  4446,    2.1)  /* Incantation of Frost Blast */
-     , (51354,  4447,    2.1)  /* Incantation of Frost Bolt */
-     , (51354,  2168,    2.1)  /* Gelidite's Gift */
-     , (51354,  4449,    2.1)  /* Incantation of Frost Volley */;
+VALUES (51354,  2162,   2.08) /* Olthoi's Gift */
+     , (51354,  2328,  2.087) /* Vitality Siphon */
+     , (51354,  2329,  2.095) /* Essence Void */
+     , (51354,  2330,  2.197) /* Vigor Siphon */
+     , (51354,  5531,  2.295) /* Bloodstone Bolt VII */
+     , (51354,  5535,  2.419) /* Acidic Blood */;
 
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (51354, 3 /* Death */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'As the Bloodstone Shard shatters, two of the fragments spring to life!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (51354, 1, 51353, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bloodstone Fragment (72636) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51355 Bloodstone Shard.es
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51355 Bloodstone Shard.es
@@ -1,0 +1,3 @@
+Death: Probability: 0.5
+    - LocalBroadcast: As the Bloodstone Shard shatters, two of the fragments spring to life!
+    - Generate

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51355 Bloodstone Shard.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/51355 Bloodstone Shard.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 51355;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (51355, 'ace51355-bloodstoneshard', 10, '2020-05-17 00:00:00') /* Creature */;
+VALUES (51355, 'ace51355-bloodstoneshard', 10, '2021-09-06 10:08:26') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51355,   1,         16) /* ItemType - Creature */
@@ -14,9 +14,11 @@ VALUES (51355,   1,         16) /* ItemType - Creature */
      , (51355,  40,          2) /* CombatMode - Melee */
      , (51355,  68,          5) /* TargetingTactic - Random, LastDamager */
      , (51355,  69,          4) /* CombatTactic - LastDamager */
+     , (51355,  81,          2) /* MaxGeneratedObjects */
+     , (51355,  82,          0) /* InitGeneratedObjects */
      , (51355,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
      , (51355, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (51355, 146,     1300000) /* XpOverride */;
+     , (51355, 146,    1300000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (51355,   1, True ) /* Stuck */
@@ -29,40 +31,42 @@ VALUES (51355,   1, True ) /* Stuck */
      , (51355, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (51355,   1,  5) /* HeartbeatInterval */
-     , (51355,   2,  0) /* HeartbeatTimestamp */
-     , (51355,   3,0.2) /* HealthRate */
-     , (51355,   4,0.5) /* StaminaRate */
-     , (51355,   5,  2) /* ManaRate */
-     , (51355,  12,  0) /* Shade */
-     , (51355,  13,  0.8) /* ArmorModVsSlash */
-     , (51355,  14,  0.5) /* ArmorModVsPierce */
-     , (51355,  15,  0.4) /* ArmorModVsBludgeon */
-     , (51355,  16,  0.8) /* ArmorModVsCold */
-     , (51355,  17,  0.8) /* ArmorModVsFire */
-     , (51355,  18,  0.8) /* ArmorModVsAcid */
-     , (51355,  19,  0.8) /* ArmorModVsElectric */
-     , (51355,  27,    3) /* RotationSpeed */
-     , (51355,  31,   33) /* VisualAwarenessRange */
-     , (51355,  34,    2) /* PowerupTime */
-     , (51355,  36,    1) /* ChargeSpeed */
-     , (51355,  39,  1.2) /* DefaultScale */
-     , (51355,  64,  0.4) /* ResistSlash */
-     , (51355,  65,  0.4) /* ResistPierce */
-     , (51355,  66,  0.86) /* ResistBludgeon */
-     , (51355,  67,  0.4) /* ResistFire */
-     , (51355,  68,  0.4) /* ResistCold */
-     , (51355,  69,  0.4) /* ResistAcid */
-     , (51355,  70,  0.4) /* ResistElectric */
-     , (51355,  71,  1) /* ResistHealthBoost */
-     , (51355,  72,  1) /* ResistStaminaDrain */
-     , (51355,  73,  1) /* ResistStaminaBoost */
-     , (51355,  74,  1) /* ResistManaDrain */
-     , (51355,  75,  1) /* ResistManaBoost */
-     , (51355,  80,  4) /* AiUseMagicDelay */
-     , (51355, 104, 10) /* ObviousRadarRange */
-     , (51355, 122,  2) /* AiAcquireHealth */
-     , (51355, 125,  1) /* ResistHealthDrain */;
+VALUES (51355,   1,       5) /* HeartbeatInterval */
+     , (51355,   2,       0) /* HeartbeatTimestamp */
+     , (51355,   3,     0.2) /* HealthRate */
+     , (51355,   4,     0.5) /* StaminaRate */
+     , (51355,   5,       2) /* ManaRate */
+     , (51355,  12,       0) /* Shade */
+     , (51355,  13,     0.8) /* ArmorModVsSlash */
+     , (51355,  14,     0.5) /* ArmorModVsPierce */
+     , (51355,  15,     0.4) /* ArmorModVsBludgeon */
+     , (51355,  16,     0.8) /* ArmorModVsCold */
+     , (51355,  17,     0.8) /* ArmorModVsFire */
+     , (51355,  18,     0.8) /* ArmorModVsAcid */
+     , (51355,  19,     0.8) /* ArmorModVsElectric */
+     , (51355,  27,       3) /* RotationSpeed */
+     , (51355,  31,      33) /* VisualAwarenessRange */
+     , (51355,  34,       2) /* PowerupTime */
+     , (51355,  36,       1) /* ChargeSpeed */
+     , (51355,  39,     1.2) /* DefaultScale */
+     , (51355,  41,       0) /* RegenerationInterval */
+     , (51355,  43,       5) /* GeneratorRadius */
+     , (51355,  64,     0.4) /* ResistSlash */
+     , (51355,  65,     0.4) /* ResistPierce */
+     , (51355,  66,    0.86) /* ResistBludgeon */
+     , (51355,  67,     0.4) /* ResistFire */
+     , (51355,  68,     0.4) /* ResistCold */
+     , (51355,  69,     0.4) /* ResistAcid */
+     , (51355,  70,     0.4) /* ResistElectric */
+     , (51355,  71,       1) /* ResistHealthBoost */
+     , (51355,  72,       1) /* ResistStaminaDrain */
+     , (51355,  73,       1) /* ResistStaminaBoost */
+     , (51355,  74,       1) /* ResistManaDrain */
+     , (51355,  75,       1) /* ResistManaBoost */
+     , (51355,  80,       4) /* AiUseMagicDelay */
+     , (51355, 104,      10) /* ObviousRadarRange */
+     , (51355, 122,       2) /* AiAcquireHealth */
+     , (51355, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (51355,   1, 'Bloodstone Shard') /* Name */
@@ -75,7 +79,18 @@ VALUES (51355,   1,   33561556) /* Setup */
      , (51355,   4,  805306407) /* CombatTable */
      , (51355,   8,  100691499) /* Icon */
      , (51355,  22,  872415348) /* PhysicsEffectTable */
-     , (51355,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;     
+     , (51355,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (51355,  0,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (51355,  1,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (51355,  2,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (51355,  3,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (51355,  4,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (51355,  5,  4, 500, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (51355,  6,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (51355,  7,  4, 500,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (51355,  8,  4, 500, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (51355,   1, 220, 0, 0) /* Strength */
@@ -91,35 +106,30 @@ VALUES (51355,   1,  4875, 0, 0, 5000) /* MaxHealth */
      , (51355,   5,  4755, 0, 0, 5000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (51355,  6, 0, 3, 0, 360, 0,    0) /* MeleeDefense        Specialized */
-     , (51355,  7, 0, 3, 0, 367, 0,    0) /* MissileDefense      Specialized */
-     , (51355, 15, 0, 3, 0, 395, 0,    0) /* MagicDefense        Specialized */
-     , (51355, 20, 0, 3, 0, 420, 0,    0) /* Deception           Specialized */
-     , (51355, 33, 0, 3, 0, 460, 0,    0) /* LifeMagic           Specialized */
-     , (51355, 34, 0, 3, 0, 395, 0,    0) /* WarMagic            Specialized */
-     , (51355, 41, 0, 3, 0, 445, 0,    0) /* Two Handed          Specialized */
-     , (51355, 44, 0, 3, 0, 445, 0,    0) /* Heavy Weapons       Specialized */
-     , (51355, 45, 0, 3, 0, 445, 0,    0) /* Light Weapons       Specialized */
-     , (51355, 46, 0, 3, 0, 445, 0,    0) /* Finesse Weapons     Specialized */
-     , (51355, 47, 0, 3, 0, 445, 0,    0) /* Missile Weapons     Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (51355,  0,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (51355,  1,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (51355,  2,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (51355,  3,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (51355,  4,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (51355,  5,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (51355,  6,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (51355,  7,  4,  0,    0,  225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (51355,  8,  4, 400, 0.75, 225,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (51355,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
+     , (51355,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (51355, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
+     , (51355, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
+     , (51355, 33, 0, 3, 0, 220, 0, 0) /* LifeMagic           Specialized */
+     , (51355, 34, 0, 3, 0, 240, 0, 0) /* WarMagic            Specialized */
+     , (51355, 45, 0, 3, 0, 395, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (51355,  6193,    2.1)  /* Halo of Frost II */
-     , (51355,  2138,    2.1)  /* Blizzard */
-     , (51355,  2136,    2.1)  /* Icy Torment */
-     , (51355,  2125,    2.1)  /* Incantation of Frost Arc */
-     , (51355,  4446,    2.1)  /* Incantation of Frost Blast */
-     , (51355,  4447,    2.1)  /* Incantation of Frost Bolt */
-     , (51355,  2168,    2.1)  /* Gelidite's Gift */
-     , (51355,  4449,    2.1)  /* Incantation of Frost Volley */;
+VALUES (51355,  2162,   2.08) /* Olthoi's Gift */
+     , (51355,  2328,  2.087) /* Vitality Siphon */
+     , (51355,  2329,  2.095) /* Essence Void */
+     , (51355,  2330,  2.197) /* Vigor Siphon */
+     , (51355,  5531,  2.295) /* Bloodstone Bolt VII */
+     , (51355,  5535,  2.419) /* Acidic Blood */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (51355, 3 /* Death */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'As the Bloodstone Shard shatters, two of the fragments spring to life!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (51355, 1, 51353, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bloodstone Fragment (72636) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/70368 Master Bloodstone.es
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/70368 Master Bloodstone.es
@@ -1,4 +1,4 @@
 Death:
-    - Act: The Unstable Master Bloodstone Satellite shatters with a resounding explosion!
+    - Activate
     - StartEvent: bloodstonestockpilealive
     - StopEvent: bloodstonestockpiledead

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/70368 Master Bloodstone.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/70368 Master Bloodstone.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 70368;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (70368, 'ace70368-masterbloodstone', 10, '2020-06-17 00:00:00') /* Creature */;
+VALUES (70368, 'ace70368-masterbloodstone', 10, '2021-09-05 05:53:34') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (70368,   1,         16) /* ItemType - Creature */
@@ -9,14 +9,17 @@ VALUES (70368,   1,         16) /* ItemType - Creature */
      , (70368,   6,         -1) /* ItemsCapacity */
      , (70368,   7,         -1) /* ContainersCapacity */
      , (70368,  16,          1) /* ItemUseable - No */
-     , (70368,  25,        220) /* Level */
+     , (70368,  25,        265) /* Level */
      , (70368,  27,          0) /* ArmorType - None */
      , (70368,  40,          2) /* CombatMode - Melee */
      , (70368,  68,          5) /* TargetingTactic - Random, LastDamager */
      , (70368,  69,          4) /* CombatTactic - LastDamager */
+     , (70368,  81,          4) /* MaxGeneratedObjects */
+     , (70368,  82,          4) /* InitGeneratedObjects */
      , (70368,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (70368, 103,          2) /* GeneratorDestructionType - Destroy */
      , (70368, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (70368, 146,     1000000) /* XpOverride */;
+     , (70368, 146,    1000000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70368,   1, True ) /* Stuck */
@@ -29,52 +32,68 @@ VALUES (70368,   1, True ) /* Stuck */
      , (70368, 120, True ) /* TreasureCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (70368,   1,  5) /* HeartbeatInterval */
-     , (70368,   2,  0) /* HeartbeatTimestamp */
-     , (70368,   3,0.2) /* HealthRate */
-     , (70368,   4,0.5) /* StaminaRate */
-     , (70368,   5,  2) /* ManaRate */
-     , (70368,  12,  0) /* Shade */
-     , (70368,  13,  0.8) /* ArmorModVsSlash */
-     , (70368,  14,  0.5) /* ArmorModVsPierce */
-     , (70368,  15,  0.4) /* ArmorModVsBludgeon */
-     , (70368,  16,  0.8) /* ArmorModVsCold */
-     , (70368,  17,  0.8) /* ArmorModVsFire */
-     , (70368,  18,  0.8) /* ArmorModVsAcid */
-     , (70368,  19,  0.8) /* ArmorModVsElectric */
-     , (70368,  27,    3) /* RotationSpeed */
-     , (70368,  31,   25) /* VisualAwarenessRange */
-     , (70368,  34,    2) /* PowerupTime */
-     , (70368,  36,    1) /* ChargeSpeed */
-     , (70368,  39,  1.3) /* DefaultScale */
-     , (70368,  64,  0.4) /* ResistSlash */
-     , (70368,  65,  0.4) /* ResistPierce */
-     , (70368,  66,  0.86) /* ResistBludgeon */
-     , (70368,  67,  0.4) /* ResistFire */
-     , (70368,  68,  0.4) /* ResistCold */
-     , (70368,  69,  0.4) /* ResistAcid */
-     , (70368,  70,  0.4) /* ResistElectric */
-     , (70368,  71,  1) /* ResistHealthBoost */
-     , (70368,  72,  1) /* ResistStaminaDrain */
-     , (70368,  73,  1) /* ResistStaminaBoost */
-     , (70368,  74,  1) /* ResistManaDrain */
-     , (70368,  75,  1) /* ResistManaBoost */
-     , (70368,  80,  4) /* AiUseMagicDelay */
-     , (70368, 104, 10) /* ObviousRadarRange */
-     , (70368, 122,  2) /* AiAcquireHealth */
-     , (70368, 125,  1) /* ResistHealthDrain */;
+VALUES (70368,   1,       5) /* HeartbeatInterval */
+     , (70368,   2,       0) /* HeartbeatTimestamp */
+     , (70368,   3,     0.2) /* HealthRate */
+     , (70368,   4,     0.5) /* StaminaRate */
+     , (70368,   5,       2) /* ManaRate */
+     , (70368,  12,       0) /* Shade */
+     , (70368,  13,     0.8) /* ArmorModVsSlash */
+     , (70368,  14,     0.5) /* ArmorModVsPierce */
+     , (70368,  15,     0.4) /* ArmorModVsBludgeon */
+     , (70368,  16,     0.8) /* ArmorModVsCold */
+     , (70368,  17,     0.8) /* ArmorModVsFire */
+     , (70368,  18,     0.8) /* ArmorModVsAcid */
+     , (70368,  19,     0.8) /* ArmorModVsElectric */
+     , (70368,  27,       3) /* RotationSpeed */
+     , (70368,  31,      25) /* VisualAwarenessRange */
+     , (70368,  34,       2) /* PowerupTime */
+     , (70368,  36,       1) /* ChargeSpeed */
+     , (70368,  39,     1.3) /* DefaultScale */
+     , (70368,  41,     180) /* RegenerationInterval */
+     , (70368,  43,       5) /* GeneratorRadius */
+     , (70368,  64,     0.4) /* ResistSlash */
+     , (70368,  65,     0.4) /* ResistPierce */
+     , (70368,  66,    0.86) /* ResistBludgeon */
+     , (70368,  67,     0.4) /* ResistFire */
+     , (70368,  68,     0.4) /* ResistCold */
+     , (70368,  69,     0.4) /* ResistAcid */
+     , (70368,  70,     0.4) /* ResistElectric */
+     , (70368,  71,       1) /* ResistHealthBoost */
+     , (70368,  72,       1) /* ResistStaminaDrain */
+     , (70368,  73,       1) /* ResistStaminaBoost */
+     , (70368,  74,       1) /* ResistManaDrain */
+     , (70368,  75,       1) /* ResistManaBoost */
+     , (70368,  80,       4) /* AiUseMagicDelay */
+     , (70368, 104,      10) /* ObviousRadarRange */
+     , (70368, 122,       2) /* AiAcquireHealth */
+     , (70368, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70368,   1, 'Master Bloodstone') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (70368,   1,   33561555) /* Setup */
+VALUES (70368,   1,   33561125) /* Setup */
      , (70368,   2,  150995096) /* MotionTable */
      , (70368,   3,  536871001) /* SoundTable */
      , (70368,   4,  805306407) /* CombatTable */
      , (70368,   8,  100691499) /* Icon */
      , (70368,  22,  872415347) /* PhysicsEffectTable */
      , (70368,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (70368,  16, 0x779E90A9) /* ActivationTarget */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (70368,  0,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (70368,  1,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (70368,  2,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (70368,  3,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (70368,  4,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (70368,  5,  4, 600, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (70368,  6,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (70368,  7,  4, 600,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (70368,  8,  4, 600, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (70368,   1, 220, 0, 0) /* Strength */
@@ -85,49 +104,25 @@ VALUES (70368,   1, 220, 0, 0) /* Strength */
      , (70368,   6, 490, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (70368,   1,  140875, 0, 0, 150000) /* MaxHealth */
+VALUES (70368,   1,140875, 0, 0,150000) /* MaxHealth */
      , (70368,   3,  5000, 0, 0, 5250) /* MaxStamina */
      , (70368,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (70368,  6, 0, 3, 0, 360, 0,    0) /* MeleeDefense        Specialized */
-     , (70368,  7, 0, 3, 0, 367, 0,    0) /* MissileDefense      Specialized */
-     , (70368, 15, 0, 3, 0, 395, 0,    0) /* MagicDefense        Specialized */
-     , (70368, 20, 0, 3, 0, 420, 0,    0) /* Deception           Specialized */
-     , (70368, 33, 0, 3, 0, 460, 0,    0) /* LifeMagic           Specialized */
-     , (70368, 34, 0, 3, 0, 395, 0,    0) /* WarMagic            Specialized */
-     , (70368, 41, 0, 3, 0, 445, 0,    0) /* Two Handed          Specialized */
-     , (70368, 44, 0, 3, 0, 445, 0,    0) /* Heavy Weapons       Specialized */
-     , (70368, 45, 0, 3, 0, 445, 0,    0) /* Light Weapons       Specialized */
-     , (70368, 46, 0, 3, 0, 445, 0,    0) /* Finesse Weapons     Specialized */
-     , (70368, 47, 0, 3, 0, 445, 0,    0) /* Missile Weapons     Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (70368,  0,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (70368,  1,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (70368,  2,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (70368,  3,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (70368,  4,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (70368,  5,  4, 500, 0.75, 400,  400,  400,  400,  400,  400,  400,  400,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (70368,  6,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (70368,  7,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (70368,  8,  4, 500, 0.75, 400,  400,  400,  400,  400,  400,  400,  400,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (70368,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
+     , (70368,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (70368, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
+     , (70368, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
+     , (70368, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (70368, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (70368, 45, 0, 3, 0, 415, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (70368,  6193,    2.1)  /* Halo of Frost II */
-     , (70368,  2138,    2.1)  /* Blizzard */
-     , (70368,  2136,    2.1)  /* Icy Torment */;
-
-INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */
-     , (70368, 9, 43826,  0, 0, 0, False) /* Create Shattered Bloodstone Shard (43826) for ContainTreasure */;
+VALUES (70368,  4473,  2.1) /* Incantation of Acid Vulnerability */
+     , (70368,  4311,  2.111) /* Incantation of Heal Self */
+     , (70368,  4643,  2.188) /* Incantation of Drain Health Other */     
+     , (70368,  5532,  2.308) /* Incantation of Bloodstone Bolt */
+     , (70368,  5535,  2.444) /* Acidic Blood */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (70368, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -135,6 +130,29 @@ VALUES (70368, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 1 /* Act */, 0, 1, NULL, 'The Unstable Master Bloodstone Satellite shatters with a resounding explosion!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 1, 23 /* StartEvent */, 0, 1, NULL, 'bloodstonestockpilealive', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 2, 24 /* StopEvent */, 0, 1, NULL, 'bloodstonestockpiledead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 72635,  0, 0,    1, False) /* Create Legendary Key (72635) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */
+     , (70368, 9, 43826,  0, 0,    1, False) /* Create Shattered Master Bloodstone Shard (43826) for Contain */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (70368, 1, 72636, 0, 4, 4, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Unstable Master Bloodstone Satellite (70368) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/72636 Unstable Master Bloodstone Satellite.es
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/72636 Unstable Master Bloodstone Satellite.es
@@ -1,0 +1,3 @@
+Death:
+    - LocalBroadcast: The Unstable Master Bloodstone satellite shatters with a resounding explosion!
+    - CastSpellInstant: 1789

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/72636 Unstable Master Bloodstone Satellite.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Creature/Crystal/72636 Unstable Master Bloodstone Satellite.sql
@@ -1,0 +1,126 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72636;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72636, 'ace72636-bloodstonesatellite', 10, '2021-09-05 07:23:40') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72636,   1,         16) /* ItemType - Creature */
+     , (72636,   2,         47) /* CreatureType - Crystal */
+     , (72636,   6,         -1) /* ItemsCapacity */
+     , (72636,   7,         -1) /* ContainersCapacity */
+     , (72636,  16,          1) /* ItemUseable - No */
+     , (72636,  25,        220) /* Level */
+     , (72636,  27,          0) /* ArmorType - None */
+     , (72636,  40,          2) /* CombatMode - Melee */
+     , (72636,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (72636,  69,          4) /* CombatTactic - LastDamager */
+     , (72636,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (72636, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (72636, 146,          0) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72636,   1, True ) /* Stuck */
+     , (72636,   6, True ) /* AiUsesMana */
+     , (72636,  11, False) /* IgnoreCollisions */
+     , (72636,  12, True ) /* ReportCollisions */
+     , (72636,  13, False) /* Ethereal */
+     , (72636,  19, True ) /* Attackable */
+     , (72636,  29, True ) /* NoCorpse */
+     , (72636,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72636,   1,       5) /* HeartbeatInterval */
+     , (72636,   2,       0) /* HeartbeatTimestamp */
+     , (72636,   3,    -200) /* HealthRate */
+     , (72636,   4,     0.5) /* StaminaRate */
+     , (72636,   5,       2) /* ManaRate */
+     , (72636,  12,       0) /* Shade */
+     , (72636,  13,     0.8) /* ArmorModVsSlash */
+     , (72636,  14,     0.5) /* ArmorModVsPierce */
+     , (72636,  15,     0.4) /* ArmorModVsBludgeon */
+     , (72636,  16,     0.8) /* ArmorModVsCold */
+     , (72636,  17,     0.8) /* ArmorModVsFire */
+     , (72636,  18,     0.8) /* ArmorModVsAcid */
+     , (72636,  19,     0.8) /* ArmorModVsElectric */
+     , (72636,  27,       3) /* RotationSpeed */
+     , (72636,  31,      33) /* VisualAwarenessRange */
+     , (72636,  34,       2) /* PowerupTime */
+     , (72636,  36,       1) /* ChargeSpeed */
+     , (72636,  39,       1) /* DefaultScale */
+     , (72636,  64,     0.4) /* ResistSlash */
+     , (72636,  65,     0.4) /* ResistPierce */
+     , (72636,  66,    0.86) /* ResistBludgeon */
+     , (72636,  67,     0.4) /* ResistFire */
+     , (72636,  68,     0.4) /* ResistCold */
+     , (72636,  69,     0.4) /* ResistAcid */
+     , (72636,  70,     0.4) /* ResistElectric */
+     , (72636,  71,       1) /* ResistHealthBoost */
+     , (72636,  72,       1) /* ResistStaminaDrain */
+     , (72636,  73,       1) /* ResistStaminaBoost */
+     , (72636,  74,       1) /* ResistManaDrain */
+     , (72636,  75,       1) /* ResistManaBoost */
+     , (72636,  80,       4) /* AiUseMagicDelay */
+     , (72636, 104,      10) /* ObviousRadarRange */
+     , (72636, 122,       2) /* AiAcquireHealth */
+     , (72636, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72636,   1, 'Unstable Master Bloodstone Satellite') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72636,   1,   33561168) /* Setup */
+     , (72636,   2,  150995096) /* MotionTable */
+     , (72636,   3,  536871001) /* SoundTable */
+     , (72636,   4,  805306407) /* CombatTable */
+     , (72636,   8,  100691499) /* Icon */
+     , (72636,  22,  872415348) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72636,  0,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72636,  1,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72636,  2,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72636,  3,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72636,  4,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72636,  5,  4, 400, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72636,  6,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72636,  7,  4, 400,    0,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72636,  8,  4, 400, 0.75,  225,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72636,   1, 220, 0, 0) /* Strength */
+     , (72636,   2, 250, 0, 0) /* Endurance */
+     , (72636,   3, 500, 0, 0) /* Quickness */
+     , (72636,   4, 350, 0, 0) /* Coordination */
+     , (72636,   5, 480, 0, 0) /* Focus */
+     , (72636,   6, 480, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72636,   1,  2875, 0, 0, 3000) /* MaxHealth */
+     , (72636,   3,  4750, 0, 0, 5000) /* MaxStamina */
+     , (72636,   5,  4520, 0, 0, 5000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72636,  6, 0, 3, 0, 340, 0, 0) /* MeleeDefense        Specialized */
+     , (72636,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Specialized */
+     , (72636, 15, 0, 3, 0, 375, 0, 0) /* MagicDefense        Specialized */
+     , (72636, 20, 0, 3, 0, 400, 0, 0) /* Deception           Specialized */
+     , (72636, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
+     , (72636, 34, 0, 3, 0, 220, 0, 0) /* WarMagic            Specialized */
+     , (72636, 45, 0, 3, 0, 375, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (72636,  2162,  2.1) /* Olthoi's Gift */
+     , (72636,  2073,  2.111) /* Adja's Intervention */
+     , (72636,  2328,  2.188) /* Vitality Siphon */     
+     , (72636,  5531,  2.308) /* Bloodstone Bolt VII */
+     , (72636,  5535,  2.444) /* Acidic Blood */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72636, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'The Unstable Master Bloodstone satellite shatters with a resounding explosion!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1789 /* Tectonic Rifts */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Key/72635 Legendary Key.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Key/72635 Legendary Key.sql
@@ -1,0 +1,42 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72635;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72635, 'ace72635-legendarykey', 22, '2019-02-10 00:00:00') /* Key */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72635,   1,   16384) /* ItemType - Key */
+     , (72635,   5,      30) /* EncumbranceVal */
+     , (72635,  16, 2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (72635,  18,      64) /* UiEffects - Lightning */
+     , (72635,  19,   10000) /* Value */
+     , (72635,  33,       1) /* Bonded - Normal */
+     , (72635,  65,     101) /* Placement - Resting */
+     , (72635,  91,       3) /* MaxStructure */
+     , (72635,  92,       3) /* Structure */
+     , (72635,  93,    1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72635,  94,     640) /* TargetType - LockableMagicTarget */
+     , (72635, 267,   86400) /* Lifespan */
+     , (72635, 369,     150) /* UseRequiresLevel */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72635,  1, False) /* Stuck */
+     , (72635, 11,  True) /* IgnoreCollisions */
+     , (72635, 13,  True) /* Ethereal */
+     , (72635, 14,  True) /* GravityStatus */
+     , (72635, 19,  True) /* Attackable */
+     , (72635, 22,  True) /* Inscribable */
+     , (72635, 69, False) /* IsSellable */
+     , (72635, 99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72635,  1, 'Legendary Key') /* Name */
+     , (72635, 13, 'legarmormagicweaponchest') /* KeyCode */
+     , (72635, 14, 'Use this key to open a Legendary Armor, Magic, or Weapon Chest.') /* Use */
+     , (72635, 16, 'A key only heard about in whispers and myths.') /* LongDesc */
+     , (72635, 33, 'BloodstoneFactoryKeyPickup') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72635,   1,   33554784) /* Setup */
+     , (72635,   3,  536870932) /* SoundTable */
+     , (72635,   8,  100693001) /* Icon */
+     , (72635,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Portal/72634 Surface Bloodstone Factory.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/9 WeenieDefaults/Portal/72634 Surface Bloodstone Factory.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72634;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72634, 'ace72634-surface', 7, '2020-02-20 17:18:58') /* Portal */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72634,   1,      65536) /* ItemType - Portal */
+     , (72634,  16,         32) /* ItemUseable - Remote */
+     , (72634,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
+     , (72634, 111,         49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
+     , (72634, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72634,   1, True ) /* Stuck */
+     , (72634,  12, True ) /* ReportCollisions */
+     , (72634,  13, True ) /* Ethereal */
+     , (72634,  14, True ) /* GravityStatus */
+     , (72634,  15, True ) /* LightsStatus */
+     , (72634,  19, True ) /* Attackable */
+     , (72634,  88, True ) /* PortalShowDestination */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72634,  54, -0.1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72634,   1, 'Surface') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72634,   1,   33554867) /* Setup */
+     , (72634,   2,  150994947) /* MotionTable */
+     , (72634,   8,  100667499) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72634, 2, 2011628285, 94.000000, -19.500000, 142.809998, 0.707107, 0.000000, 0.000000, 0.707107) /* Destination */
+/* @teleloc 0x77E702FD [94.000000 -19.500000 142.809998] 0.707107 0.000000 0.000000 0.707107 */;


### PR DESCRIPTION
Added missing door and legendary chests at the end of the Bloodstone Factory dungeon.
Added missing 3-use legendary key from the Master Bloodstone.
Added missing Master Bloodstone Satellites.
Corrected bloodstone spellbooks based on pcap spell info and available video.
Added missing surface portals.
Revised spawns in Lord Kastellar's room based on teaser screenshot.
Revised spawns in tunnel before the jump and Master Bloodstone room based on video and retail screenshots.
Bloodstone Shards now have a 50% chance to spawn 2 Bloodstone Fragments on death, as seen on video.