### PR TITLE
Disable Weeping to Isparian Arms

### DIFF
--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03606 Good Diamond Infused Pyreal Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03606 Good Diamond Infused Pyreal Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3606;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03606 Good Diamond Infused Pyreal Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03606 Good Diamond Infused Pyreal Ingot.sql
@@ -1,1 +1,0 @@
-DELETE FROM `recipe` WHERE `id` = 3606;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03609 Good Isparian Atlatl Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03609 Good Isparian Atlatl Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3609;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03610 Quality Isparian Atlatl Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03610 Quality Isparian Atlatl Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3610;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03611 Superb Isparian Atlatl Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03611 Superb Isparian Atlatl Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3611;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03612 Quality Isparian Axe Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03612 Quality Isparian Axe Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3612;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03613 Good Isparian Axe Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03613 Good Isparian Axe Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3613;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03615 Superb Isparian Axe Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03615 Superb Isparian Axe Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3615;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03616 Quality Isparian Bow Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03616 Quality Isparian Bow Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3616;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03617 Good Isparian Bow Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03617 Good Isparian Bow Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3617;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03619 Superb Isparian Bow Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03619 Superb Isparian Bow Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3619;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03620 Quality Isparian Claw Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03620 Quality Isparian Claw Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3620;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03621 Good Isparian Claw Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03621 Good Isparian Claw Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3621;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03623 Superb Isparian Claw Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03623 Superb Isparian Claw Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3623;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03624 Quality Isparian Crossbow Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03624 Quality Isparian Crossbow Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3624;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03625 Good Isparian Crossbow Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03625 Good Isparian Crossbow Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3625;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03627 Superb Isparian Crossbow Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03627 Superb Isparian Crossbow Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3627;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03628 Quality Isparian Dagger Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03628 Quality Isparian Dagger Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3628;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03629 Good Isparian Dagger Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03629 Good Isparian Dagger Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3629;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03631 Superb Isparian Dagger Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03631 Superb Isparian Dagger Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3631;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03632 Quality Isparian Mace Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03632 Quality Isparian Mace Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3632;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03633 Good Isparian Mace Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03633 Good Isparian Mace Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3633;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03635 Superb Isparian Mace Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03635 Superb Isparian Mace Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3635;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03636 Quality Isparian Spear Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03636 Quality Isparian Spear Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3636;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03637 Good Isparian Spear Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03637 Good Isparian Spear Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3637;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03639 Superb Isparian Spear Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03639 Superb Isparian Spear Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3639;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03640 Quality Isparian Staff Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03640 Quality Isparian Staff Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3640;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03641 Good Isparian Staff Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03641 Good Isparian Staff Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3641;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03643 Superb Isparian Staff Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03643 Superb Isparian Staff Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3643;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03644 Quality Isparian Sword Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03644 Quality Isparian Sword Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3644;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03645 Good Isparian Sword Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03645 Good Isparian Sword Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3645;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03647 Superb Isparian Sword Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03647 Superb Isparian Sword Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3647;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03648 Quality Isparian Wand Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03648 Quality Isparian Wand Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3648;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03649 Good Isparian Wand Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03649 Good Isparian Wand Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3649;

--- a/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03651 Superb Isparian Wand Ingot.sql
+++ b/Database/Patches/2005-07-ThroneOfDestiny/4 CraftTable/03651 Superb Isparian Wand Ingot.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 3651;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04381 Perfect Isparian Atlatl.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04381 Perfect Isparian Atlatl.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4381;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04383 Perfect Isparian Axe.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04383 Perfect Isparian Axe.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4383;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04385 Perfect Isparian Bow.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04385 Perfect Isparian Bow.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4385;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04387 Perfect Isparian Claw.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04387 Perfect Isparian Claw.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4387;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04389 Perfect Isparian Crossbow.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04389 Perfect Isparian Crossbow.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4389;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04391 Perfect Isparian Dagger.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04391 Perfect Isparian Dagger.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4391;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04393 Perfect Isparian Mace.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04393 Perfect Isparian Mace.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4393;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04395 Perfect Isparian Spear.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04395 Perfect Isparian Spear.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4395;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04397 Perfect Isparian Staff.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04397 Perfect Isparian Staff.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4397;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04399 Perfect Isparian Sword.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04399 Perfect Isparian Sword.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4399;

--- a/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04401 Perfect Isparian Wand.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/4 CraftTable/04401 Perfect Isparian Wand.sql
@@ -1,0 +1,1 @@
+DELETE FROM `recipe` WHERE `id` = 4401;


### PR DESCRIPTION
- Disable converting weeping weapons back to Isparian Arms weapons, as the weeping weapons now have a different build path and are unrelated to Isparian Arms weapons
- Disable old Isparian Arms ingot recipes that were retired