### PR TITLE
Misc Bug Fixes and Updates

### DIFF
--- a/Database/Patches/2007-04-StrangeSightings/9 WeenieDefaults/Creature/Ghost/72230 Lady Tairla Mhoire NPC.sql
+++ b/Database/Patches/2007-04-StrangeSightings/9 WeenieDefaults/Creature/Ghost/72230 Lady Tairla Mhoire NPC.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72230;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72230, 'ace72230-ladytairlamhoire', 10, '2021-04-18 02:28:02') /* Creature */;
+VALUES (72230, 'ace72230-ladytairlamhoire', 10, '2021-09-17 02:30:40') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72230,   1,         16) /* ItemType - Creature */
@@ -65,7 +65,8 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'SpawnRemains', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id, 1, 24 /* StopEvent */, 0, 1, NULL, 'LadyMhoireWin', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72230, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/79E9.sql
+++ b/Database/Patches/2010-11-FromDarknessLight/6 LandBlockExtendedData/79E9.sql
@@ -707,7 +707,7 @@ VALUES (0x779E909A, 51354, 0x79E90129, -138.238, 2.1444, 90.388, 0.542854, 0, 0,
 /* @teleloc 0x79E90129 [-138.238007 2.144400 90.388000] 0.542854 0.000000 0.000000 0.839827 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A0, 70367, 0x79E90122, -143.553, 8.83099, 90.456, 0.799656, 0, 0, -0.600458, False, '2020-06-17 13:21:15'); /* Master Bloodstone Gen */
+VALUES (0x779E90A0, 70367, 0x79E90128, -136.464, 16.7587, 90.4, -0.116387, 0, 0, 0.993204, False, '2020-06-17 13:21:15'); /* Master Bloodstone Gen */
 /* @teleloc 0x79E90122 [-143.552994 8.830990 90.456001] 0.799656 0.000000 0.000000 -0.600458 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -715,7 +715,7 @@ VALUES (0x779E90A8, 80067, 0x79E90128, -136.464, 16.7587, 90.4, -0.116387, 0, 0,
 /* @teleloc 0x79E90128 [-136.464005 16.758699 90.400002] -0.116387 0.000000 0.000000 0.993204 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90A9,  4455, 0x79E90124, -138, 50.1016, 90.455, 1, 0, 0, 0, False, '2021-09-05 13:16:13'); /* Door */
+VALUES (0x779E90A9,  4454, 0x79E90124, -138, 50.1016, 90.455, 1, 0, 0, 0, False, '2021-09-05 13:16:13'); /* Door */
 /* @teleloc 0x79E90124 [-138.000000 50.101601 90.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -803,16 +803,16 @@ VALUES (0x779E90BE, 48744, 0x79E9010F, -129, 108, 78.455, 0.707107, 0, 0, -0.707
 /* @teleloc 0x79E9010F [-129.000000 108.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90BF, 48742, 0x79E90104, -147, 114, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:24:22'); /* Legendary Magic Chest */
-/* @teleloc 0x79E90104 [-147.000000 114.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x779E90BF, 48742, 0x79E90104, -143.99982, 114, 78.455, 1, 0, 0, 0, False, '2021-09-05 18:24:22'); /* Legendary Magic Chest */
+/* @teleloc 0x79E90104 [-143.999817 114.000000 78.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E90C0, 48742, 0x79E90104, -147, 111, 78.455, 0.707107, 0, 0, 0.707107, False, '2021-09-05 18:24:32'); /* Legendary Magic Chest */
 /* @teleloc 0x79E90104 [-147.000000 111.000000 78.455002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90C1, 48742, 0x79E9010E, -129, 114, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:24:47'); /* Legendary Magic Chest */
-/* @teleloc 0x79E9010E [-129.000000 114.000000 78.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x779E90C1, 48742, 0x79E9010E, -132, 114, 78.455, 1, 0, 0, 0, False, '2021-09-05 18:24:47'); /* Legendary Magic Chest */
+/* @teleloc 0x79E9010E [-132.000000 114.000000 78.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E90C2, 48742, 0x79E9010E, -129, 111, 78.455, 0.707107, 0, 0, -0.707107, False, '2021-09-05 18:24:57'); /* Legendary Magic Chest */
@@ -844,11 +844,11 @@ VALUES (0x779E90C8, 43823, 0x79E9011F, -149.69, 38.0874, 90.4082, -0.330827, 0, 
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E90C9, 43395, 0x79E9015B, 1.28516, 46.5, 114.407, 1, 0, 0, 0,  True, '2021-09-06 13:47:55'); /* Gurog Minion */
-/* @teleloc 0x79E9015B [1.285160 46.521198 114.406998] 1.000000 0.000000 0.000000 0.000000 */
+/* @teleloc 0x79E9015B [1.285160 46.500000 114.406998] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x779E90CA, 43395, 0x79E90179, 22.4941, 46.5, 114.4065, 1, 0, 0, 0,  True, '2021-09-06 13:48:59'); /* Gurog Minion */
-/* @teleloc 0x79E90179 [22.494101 46.821800 114.406502] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x779E90CA, 43395, 0x79E90179, 22.4941, 46.5, 114.407, 1, 0, 0, 0,  True, '2021-09-06 13:48:59'); /* Gurog Minion */
+/* @teleloc 0x79E90179 [22.494101 46.500000 114.406998] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x779E90CB, 70364, 0x79E9016D, 12.0203, 45.5235, 114.407, 1, 0, 0, 0,  True, '2021-09-06 13:51:16'); /* Lord Kastellar */

--- a/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Elemental/49637 Elemental Protector.sql
+++ b/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Elemental/49637 Elemental Protector.sql
@@ -27,6 +27,7 @@ VALUES (49637,   1, True ) /* Stuck */
      , (49637,  15, True ) /* LightsStatus */
      , (49637,  19, True ) /* Attackable */
      , (49637,  29, True ) /* NoCorpse */
+     , (49637,  42, True ) /* AllowEdgeSlide */
      , (49637,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Simulacrum/49641 Simulacrum Shifter.es
+++ b/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Simulacrum/49641 Simulacrum Shifter.es
@@ -1,0 +1,14 @@
+WoundedTaunt: Probability: 0.8, MinHealth: 0.24, MaxHealth: 0.26
+    - Generate
+
+WoundedTaunt: Probability: 0.8, MinHealth: 0.49, MaxHealth: 0.51
+    - Generate
+
+WoundedTaunt: Probability: 0.8, MinHealth: 0.74, MaxHealth: 0.76
+    - Generate
+ 
+ReceiveCritical: Probability: 0.2
+    - Generate
+    
+ResistSpell: Probability: 0.2
+    - Generate

--- a/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Simulacrum/49641 Simulacrum Shifter.sql
+++ b/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Simulacrum/49641 Simulacrum Shifter.sql
@@ -14,6 +14,7 @@ VALUES (49641,   1,         16) /* ItemType - Creature */
      , (49641,  81,          2) /* MaxGeneratedObjects */
      , (49641,  82,          0) /* InitGeneratedObjects */
      , (49641,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (49641, 103,          2) /* GeneratorDestructionType - Destroy */
      , (49641, 113,          1) /* Gender - Male */
      , (49641, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (49641, 146,    2500000) /* XpOverride */

--- a/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Simulacrum/49641 Simulacrum Shifter.sql
+++ b/Database/Patches/2013-03-DisturbanceInTheDesert/9 WeenieDefaults/Creature/Simulacrum/49641 Simulacrum Shifter.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 49641;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (49641, 'ace49641-simulacrumshifter', 10, '2020-10-21 21:40:23') /* Creature */;
+VALUES (49641, 'ace49641-simulacrumshifter', 10, '2021-09-17 03:13:06') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (49641,   1,         16) /* ItemType - Creature */
@@ -11,8 +11,8 @@ VALUES (49641,   1,         16) /* ItemType - Creature */
      , (49641,  16,          1) /* ItemUseable - No */
      , (49641,  25,        265) /* Level */
      , (49641,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
-     , (49641,  81,          1) /* MaxGeneratedObjects */
-     , (49641,  82,          1) /* InitGeneratedObjects */
+     , (49641,  81,          2) /* MaxGeneratedObjects */
+     , (49641,  82,          0) /* InitGeneratedObjects */
      , (49641,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (49641, 113,          1) /* Gender - Male */
      , (49641, 133,          2) /* ShowableOnRadar - ShowMovement */
@@ -20,7 +20,8 @@ VALUES (49641,   1,         16) /* ItemType - Creature */
      , (49641, 188,          2) /* HeritageGroup - Gharundim */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (49641,   1, True ) /* Stuck */;
+VALUES (49641,   1, True ) /* Stuck */
+     , (49641,  42, True ) /* AllowEdgeSlide */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (49641,   1,       5) /* HeartbeatInterval */
@@ -36,7 +37,7 @@ VALUES (49641,   1,       5) /* HeartbeatInterval */
      , (49641,  18,       1) /* ArmorModVsAcid */
      , (49641,  19,       1) /* ArmorModVsElectric */
      , (49641,  31,      22) /* VisualAwarenessRange */
-     , (49641,  41,      30) /* RegenerationInterval */
+     , (49641,  41,       0) /* RegenerationInterval */
      , (49641,  43,       4) /* GeneratorRadius */
      , (49641,  64,       1) /* ResistSlash */
      , (49641,  65,       1) /* ResistPierce */
@@ -64,9 +65,16 @@ VALUES (49641,   1,   33554433) /* Setup */
      , (49641,   8,  100667446) /* Icon */
      , (49641,  22,  872415381) /* PhysicsEffectTable */;
 
-INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (49641, 8040, 1483145542, 175.298, -120.726, -59.995, -0.707107, 0, 0, -0.707107) /* PCAPRecordedLocation */
-/* @teleloc 0x58670146 [175.298004 -120.725998 -59.994999] -0.707107 0.000000 0.000000 -0.707107 */;
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (49641,  0,  4,  0,    0,  270,  135,  135,  135,  135,  135,  135,  135,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (49641,  1,  4,  0,    0,  260,  130,  130,  130,  130,  130,  130,  130,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (49641,  2,  4,  0,    0,  260,  130,  130,  130,  130,  130,  130,  130,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (49641,  3,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (49641,  4,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (49641,  5,  4,  2, 0.75,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (49641,  6,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (49641,  7,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (49641,  8,  4,  2, 0.75,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (49641,   1, 340, 0, 0) /* Strength */
@@ -85,42 +93,68 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (49641,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
      , (49641,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
      , (49641, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
-     , (49641, 16, 0, 2, 0, 440, 0, 0) /* ManaConversion      Trained */
      , (49641, 31, 0, 2, 0, 440, 0, 0) /* CreatureEnchantment Trained */
      , (49641, 33, 0, 2, 0, 440, 0, 0) /* LifeMagic           Trained */
      , (49641, 34, 0, 2, 0, 440, 0, 0) /* WarMagic            Trained */
-     , (49641, 41, 0, 2, 0, 520, 0, 0) /* TwoHandedCombat     Trained */
-     , (49641, 43, 0, 2, 0, 440, 0, 0) /* VoidMagic           Trained */
      , (49641, 44, 0, 2, 0, 520, 0, 0) /* HeavyWeapons        Trained */
      , (49641, 45, 0, 2, 0, 520, 0, 0) /* LightWeapons        Trained */
      , (49641, 46, 0, 2, 0, 520, 0, 0) /* FinesseWeapons      Trained */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (49641,  0,  4,  0,    0,  270,  270,  270,  270,  270,  270,  270,  270,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (49641,  1,  4,  0,    0,  260,  260,  260,  260,  260,  260,  260,  260,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (49641,  2,  4,  0,    0,  260,  260,  260,  260,  260,  260,  260,  260,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (49641,  3,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (49641,  4,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (49641,  5,  4,  2, 0.75,  250,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (49641,  6,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (49641,  7,  4,  0,    0,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (49641,  8,  4,  2, 0.75,  250,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (49641,  4294,   2.06)  /* Incantation of Clumsiness Other */
-     , (49641,  4302,   2.064)  /* Incantation of Feeblemind Other */
-     , (49641,  4439,   2.114)  /* Incantation of Flame Bolt */
-     , (49641,  4451,   2.128)  /* Incantation of Lightning Bolt */
-     , (49641,  4457,   2.147)  /* Incantation of Whirling Blade */
-     , (49641,  4597,   2.103)  /* Incantation of Magic Yield Other */
-     , (49641,  2151,   2.058)  /* Blessing of the Blade Turner */
-     , (49641,  2153,   2.061)  /* Blessing of the Mace Turner */
-     , (49641,  2161,   2.065)  /* Blessing of the Arrow Turner */;
+VALUES (49641,  2151,  2.058) /* Blessing of the Blade Turner */
+     , (49641,  2153,  2.061) /* Blessing of the Mace Turner */
+     , (49641,  2161,  2.065) /* Blessing of the Arrow Turner */
+     , (49641,  4294,   2.06) /* Incantation of Clumsiness Other */
+     , (49641,  4302,  2.064) /* Incantation of Feeblemind Other */
+     , (49641,  4439,  2.114) /* Incantation of Flame Bolt */
+     , (49641,  4451,  2.128) /* Incantation of Lightning Bolt */
+     , (49641,  4457,  2.147) /* Incantation of Whirling Blade */
+     , (49641,  4597,  2.103) /* Incantation of Magic Yield Other */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (49641, 15 /* WoundedTaunt */, 0.8, NULL, NULL, NULL, NULL, NULL, 0.24, 0.26);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (49641, 15 /* WoundedTaunt */, 0.8, NULL, NULL, NULL, NULL, NULL, 0.49, 0.51);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (49641, 15 /* WoundedTaunt */, 0.8, NULL, NULL, NULL, NULL, NULL, 0.74, 0.76);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (49641, 20 /* ReceiveCritical */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (49641, 21 /* ResistSpell */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (49641, 2, 49612,  1, 0, 0, False) /* Create Sickle (49612) for Wield */
-     , (49641, 10, 5853,  1, 3, 0, True) /* Create Dho Vest and Robe (5853) for WieldTreasure */
-     , (49641, 9, 49644,  0, 0, 0, False) /* Create Door Key (49644) for ContainTreasure */;
+VALUES (49641, 2, 49612,  1, 0,    0, False) /* Create Sickle (49612) for Wield */
+     , (49641,10,  5853,  1, 3,    0, False) /* Create Dho Vest and Robe (5853) for WieldTreasure */
+     , (49641, 9, 49644,  0, 0,    0, False) /* Create Door Key (49644) for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (49641, 1, 49637, 20, 1, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate  (70705) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (49641, -1, 49637, 20, 1, 2, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Elemental Protector (49637) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Unsorted/51887 Corrupted Crystal of Torments.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Unsorted/51887 Corrupted Crystal of Torments.sql
@@ -1,7 +1,7 @@
-DELETE FROM `weenie` WHERE `class_Id` = 51887; 
+DELETE FROM `weenie` WHERE `class_Id` = 51887;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (51887, 'ace51887-corruptedcrystaloftorments', 10, '2020-09-11 01:09:32') /* Creature */;
+VALUES (51887, 'ace51887-corruptedcrystaloftorments', 10, '2021-09-17 04:17:10') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51887,   1,         16) /* ItemType - Creature */
@@ -14,11 +14,11 @@ VALUES (51887,   1,         16) /* ItemType - Creature */
      , (51887,  95,          3) /* RadarBlipColor - White */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (51887,  1,  True) /* Stuck */
-     , (51887, 19, False) /* Attackable */
-     , (51887, 52,  True) /* AiImmobile */
-     , (51887, 82,  True) /* DontTurnOrMoveWhenGiving */
-     , (51887, 83,  True) /* NpcLooksLikeObject */;
+VALUES (51887,   1, True ) /* Stuck */
+     , (51887,  19, False) /* Attackable */
+     , (51887,  52, True ) /* AiImmobile */
+     , (51887,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (51887,  83, True ) /* NpcLooksLikeObject */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (51887,  13,       1) /* ArmorModVsSlash */
@@ -48,10 +48,6 @@ VALUES (51887,   1,   33559841) /* Setup */
      , (51887,   3,  536871001) /* SoundTable */
      , (51887,   8,  100673955) /* Icon */
      , (51887,  22,  872415347) /* PhysicsEffectTable */;
-
-INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (51887,  0, 0, 0, 0, 0, 0, 0, 0, 0) /**/
-/* @teleloc 0x0 [0.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 0.000000 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (51887,   1,  50, 0, 0) /* Strength */
@@ -152,14 +148,12 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'The crystal is still too powerful for you to recover a sample.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You''ve killed %tqc out of %tqm Tormented Shadows.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 2, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id, 1, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (51887, 0.20, 51760, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Sorcerer (51760) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (51887, 0.40, 51756, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Slayer (51756) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (51887, 0.60, 51752, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Rager (51752) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+VALUES (51887, 0.2, 51760, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Sorcerer (51760) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (51887, 0.4, 51756, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Slayer (51756) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (51887, 0.6, 51752, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Rager (51752) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
      , (51887, 0.75, 51748, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Minion of Rage (51748) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (51887, 0.80, 51750, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Minion (51750) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (51887, 1.00, 51758, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Raging Rynthid Sorcerer (51758) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
-     
+     , (51887, 0.8, 51750, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Minion (51750) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (51887, 1, 51758, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Raging Rynthid Sorcerer (51758) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Unsorted/72130 Corrupted Crystal of Rage.sql
+++ b/Database/Patches/2013-08-EmotionsUnbound/9 WeenieDefaults/Creature/Unsorted/72130 Corrupted Crystal of Rage.sql
@@ -1,7 +1,7 @@
-DELETE FROM `weenie` WHERE `class_Id` = 72130; 
+DELETE FROM `weenie` WHERE `class_Id` = 72130;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72130, 'ace72130-corruptedcrystalofrage', 10, '2020-09-11 01:10:00') /* Creature */;
+VALUES (72130, 'ace72130-corruptedcrystalofrage', 10, '2021-09-17 04:18:50') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72130,   1,         16) /* ItemType - Creature */
@@ -14,11 +14,11 @@ VALUES (72130,   1,         16) /* ItemType - Creature */
      , (72130,  95,          3) /* RadarBlipColor - White */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (72130,  1,  True) /* Stuck */
-     , (72130, 19, False) /* Attackable */
-     , (72130, 52,  True) /* AiImmobile */
-     , (72130, 82,  True) /* DontTurnOrMoveWhenGiving */
-     , (72130, 83,  True) /* NpcLooksLikeObject */;
+VALUES (72130,   1, True ) /* Stuck */
+     , (72130,  19, False) /* Attackable */
+     , (72130,  52, True ) /* AiImmobile */
+     , (72130,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (72130,  83, True ) /* NpcLooksLikeObject */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (72130,  13,       1) /* ArmorModVsSlash */
@@ -148,14 +148,12 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'The crystal is still too powerful for you to recover a sample.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You''ve killed %tqc out of %tqm Tormented Shadows.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 2, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id, 1, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72130, 0.20, 51760, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Sorcerer (51760) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72130, 0.40, 51756, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Slayer (51756) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72130, 0.60, 51752, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Rager (51752) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+VALUES (72130, 0.2, 51760, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Sorcerer (51760) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72130, 0.4, 51756, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Slayer (51756) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72130, 0.6, 51752, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Rager (51752) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
      , (72130, 0.75, 51748, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Minion of Rage (51748) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72130, 0.80, 51750, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Minion (51750) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72130, 1.00, 51758, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Raging Rynthid Sorcerer (51758) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
-     
+     , (72130, 0.8, 51750, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Rynthid Minion (51750) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72130, 1, 51758, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Raging Rynthid Sorcerer (51758) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;


### PR DESCRIPTION
Graveyard
Lady Mhoire NPC emote now matches the emote script, turning off her reward event. 

Bloodstone Factory
Replaced reward room door with one that has a 5 min reset. 
Moved two of the chests in the reward room to flank the surface portal for a better match to retail layout.
The Master Bloodstone will now spawn in the same location as the Bloodstone Stockpile, as in retail.

Uziz Liberation
Simulacrum Shifter now has a chance to spawn Elemental Protectors instead of automatically spawning them to match retail.

Rynthid Artifact Collection
Removed buggy kill task message from Corrupted Crystal of Torments and Corrupted Crystal of Rage.