### PR TITLE
Fix Seasoned Explorer Gear

### DIFF
--- a/Database/Patches/2012-08-TheRisenPrincess/9 WeenieDefaults/Caster/45958 Seasoned Explorer Baton.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/9 WeenieDefaults/Caster/45958 Seasoned Explorer Baton.sql
@@ -59,4 +59,4 @@ VALUES (45958,  2560,      2)  /* Minor Mana Conversion Prowess */
      , (45958,  1605,      2)  /* Aura of Defender Self VI */
      , (45958,  2569,      2)  /* Minor War Magic Aptitude */
      , (45958,   664,      2)  /* Mana Conversion Mastery Other VI */
-     , (45958,  2158,      2)  /* Aura of Spirit Drinker Self VI */;
+     , (45958,  3258,      2)  /* Aura of Spirit Drinker Self VI */;

--- a/Database/Patches/2012-08-TheRisenPrincess/9 WeenieDefaults/MissileWeapon/70207 Seasoned Explorer Slingshot.sql
+++ b/Database/Patches/2012-08-TheRisenPrincess/9 WeenieDefaults/MissileWeapon/70207 Seasoned Explorer Slingshot.sql
@@ -49,7 +49,7 @@ VALUES (70207,   5, -0.025000000372529) /* ManaRate */
      , (70207, 157,     1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (70207,   1, 'Amateur Explorer Slingshot') /* Name */;
+VALUES (70207,   1, 'Seasoned Explorer Slingshot') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (70207,   1,   33559694) /* Setup */


### PR DESCRIPTION
Minor fixes for seasoned explorer gear.
Change seasoned explorer baton spell from 2158 (Storm's Boon) to 3258 (Aura of Spirit Drinker Self VI).
Change seasoned explorer slingshot name to have "Seasoned" instead of "Amateur".