### PR TITLE
Uber Lady Aerfalle Quest

### DIFF
--- a/Database/Patches/2 SpellTableExtendedData/05010 Entering Aerfalle's Sanctum.sql
+++ b/Database/Patches/2 SpellTableExtendedData/05010 Entering Aerfalle's Sanctum.sql
@@ -1,5 +1,5 @@
 DELETE FROM `spell` WHERE `id` = 5010;
 
 INSERT INTO `spell` (`id`, `name`, `position_Obj_Cell_ID`, `position_Origin_X`, `position_Origin_Y`, `position_Origin_Z`, `position_Angles_W`, `position_Angles_X`, `position_Angles_Y`, `position_Angles_Z`, `last_Modified`)
-VALUES (5010, 'Entering Aerfalle''s Sanctum', 0x016002A5, 80, -160, 0.005, 1, 0, 0, 0, '2021-11-01 00:00:00');
-/* @teleloc 0x016002A5 [80.000000 -160.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (5010, 'Entering Aerfalle''s Sanctum', 3052405699, 110.501999, -112.401001, -15.190000, -0.466483, 0.000000, 0.000000, -0.884530, '2019-03-18 09:00:00');
+/* @teleloc 0xB5F003C3 [110.501999 -112.401001 -15.190000] -0.466483 0.000000 0.000000 -0.884530 */

--- a/Database/Patches/6 LandBlockExtendedData/01F5.sql
+++ b/Database/Patches/6 LandBlockExtendedData/01F5.sql
@@ -1,0 +1,1323 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x01F5;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5000,  7351, 0x01F50101, 184.089, -6.97412, -41.995, 0.215654, 0, 0, -0.97647, False, '2005-02-09 10:00:00'); /* Aerfalle Gen */
+/* @teleloc 0x01F50101 [184.089005 -6.974120 -41.994999] 0.215654 0.000000 0.000000 -0.976470 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5008,  5619, 0x01F50104, 110, -50, -30, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Hot Air */
+/* @teleloc 0x01F50104 [110.000000 -50.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F500F,  4145, 0x01F50114, 150, -75.259, -35.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50114 [150.000000 -75.259003 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F500F, 0x701F5010, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5010,  2131, 0x01F50114, 150.027, -77.5728, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50114 [150.026993 -77.572800 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F501C,  2131, 0x01F5012C, 183.779, -61.1313, -36, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F5012C [183.779007 -61.131302 -36.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F501D,  2131, 0x01F5012C, 183.792, -58.8521, -36, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F5012C [183.792007 -58.852100 -36.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F501E,  7562, 0x01F5012C, 184.03, -58.7746, -34.39, 0.999912, 0, 0, -0.013266, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F5012C [184.029999 -58.774601 -34.389999] 0.999912 0.000000 0.000000 -0.013266 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F501E, 0x701F501D, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F501F,  7562, 0x01F5012C, 183.805, -61.1705, -34.4836, 0.756229, 0, 0, -0.654307, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F5012C [183.804993 -61.170502 -34.483601] 0.756229 0.000000 0.000000 -0.654307 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F501F, 0x701F501C, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5024,  5625, 0x01F50138, 70, -34.75, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50138 [70.000000 -34.750000 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5025,   285, 0x01F5013A, 74.3921, -53.2623, -28.5, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01F5013A [74.392097 -53.262299 -28.500000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5028,  5625, 0x01F5013C, 70, -45.25, -30, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5013C [70.000000 -45.250000 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F502B,  5625, 0x01F5013F, 80, -34.75, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5013F [80.000000 -34.750000 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5032,  5625, 0x01F50143, 80, -45.25, -30, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50143 [80.000000 -45.250000 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5035,  5625, 0x01F50146, 90, -34.75, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50146 [90.000000 -34.750000 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5036,  1300, 0x01F50147, 85.25, -40, -29.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50147 [85.250000 -40.000000 -29.995001] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5039,  5624, 0x01F5014B, 90, -64.755, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5014B [90.000000 -64.754997 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F503A,  5624, 0x01F5014C, 85.233, -70, -29.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5014C [85.233002 -70.000000 -29.995001] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F503D,  5624, 0x01F50151, 90, -75.245, -30, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50151 [90.000000 -75.245003 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F503E,  7506, 0x01F50152, 98.8925, -32.303, -29.995, 0.155825, 0, 0, 0.987785, False, '2005-02-09 10:00:00'); /* Statue */
+/* @teleloc 0x01F50152 [98.892502 -32.303001 -29.995001] 0.155825 0.000000 0.000000 0.987785 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F503F,  7505, 0x01F50152, 103.998, -26.5832, -29.995, -0.997254, 0, 0, -0.07405, False, '2005-02-09 10:00:00'); /* Statue */
+/* @teleloc 0x01F50152 [103.998001 -26.583200 -29.995001] -0.997254 0.000000 0.000000 -0.074050 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5040,  7504, 0x01F50152, 104.02, -33.8563, -29.995, 0.502974, 0, 0, -0.864302, False, '2005-02-09 10:00:00'); /* Statue */
+/* @teleloc 0x01F50152 [104.019997 -33.856300 -29.995001] 0.502974 0.000000 0.000000 -0.864302 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5041,  9183, 0x01F50152, 102.226, -27.772, -29.995, 0.939961, 0, 0, -0.341282, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50152 [102.225998 -27.771999 -29.995001] 0.939961 0.000000 0.000000 -0.341282 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5042,  9183, 0x01F50152, 100, -30, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50152 [100.000000 -30.000000 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5043,  9183, 0x01F50152, 102.273, -32.1951, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50152 [102.273003 -32.195099 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5044,  9183, 0x01F50152, 97.6945, -32.0575, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50152 [97.694504 -32.057499 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5045,  9183, 0x01F50152, 98.0959, -27.7548, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50152 [98.095901 -27.754801 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5046,  5625, 0x01F50154, 100, -34.75, -30, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50154 [100.000000 -34.750000 -30.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5047,  1300, 0x01F50155, 104.927, -40, -29.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50155 [104.927002 -40.000000 -29.995001] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F504A,  2131, 0x01F5015A, 100.057, -73.8168, -29.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F5015A [100.056999 -73.816803 -29.995001] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F504B,  2131, 0x01F5015C, 100.065, -76.1578, -29.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F5015C [100.065002 -76.157799 -29.995001] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F504C,  7561, 0x01F5015C, 102.404, -76.7162, -28.3231, -0.999452, 0, 0, -0.033103, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F5015C [102.403999 -76.716202 -28.323099] -0.999452 0.000000 0.000000 -0.033103 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F504C, 0x701F504B, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F504D,  7562, 0x01F5015C, 98.0364, -76.2075, -28.283, -0.999452, 0, 0, -0.033103, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F5015C [98.036400 -76.207497 -28.283001] -0.999452 0.000000 0.000000 -0.033103 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F504D, 0x701F504A, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F504F,  2131, 0x01F5015F, 110.539, -20.5263, -32.995, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F5015F [110.539001 -20.526300 -32.994999] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5051,  5625, 0x01F50163, 110, -34.75, -30, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50163 [110.000000 -34.750000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5052,  4145, 0x01F50164, 110, -25.25, -30, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50164 [110.000000 -25.250000 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5052, 0x701F504F, '2005-02-09 10:00:00') /* Pressure Plate (2131) */
+     , (0x701F5052, 0x701F5064, '2005-02-09 10:00:00') /* Lever (285) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5053,  5619, 0x01F50168, 112.754, -47.2081, -29.6071, -0.999957, 0, 0, 0.00925958, False, '2005-02-09 10:00:00'); /* Hot Air */
+/* @teleloc 0x01F50168 [112.753998 -47.208099 -29.607100] -0.999957 0.000000 0.000000 0.009260 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5054,  5619, 0x01F50168, 107.246, -47.4464, -29.6071, -0.999957, 0, 0, 0.00925958, False, '2005-02-09 10:00:00'); /* Hot Air */
+/* @teleloc 0x01F50168 [107.246002 -47.446400 -29.607100] -0.999957 0.000000 0.000000 0.009260 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5055,  5619, 0x01F50168, 107.04, -52.7659, -29.6071, -0.999957, 0, 0, 0.00925958, False, '2005-02-09 10:00:00'); /* Hot Air */
+/* @teleloc 0x01F50168 [107.040001 -52.765900 -29.607100] -0.999957 0.000000 0.000000 0.009260 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5056,  5619, 0x01F50168, 112.72, -52.9979, -29.6071, -0.999957, 0, 0, 0.00925958, False, '2005-02-09 10:00:00'); /* Hot Air */
+/* @teleloc 0x01F50168 [112.720001 -52.997898 -29.607100] -0.999957 0.000000 0.000000 0.009260 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5059,  7408, 0x01F5016C, 107, -94, -29.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Lady of Aerlinthe's Chest */
+/* @teleloc 0x01F5016C [107.000000 -94.000000 -29.995001] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F505D,  5624, 0x01F5016D, 124.754, -40, -29.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5016D [124.753998 -40.000000 -29.995001] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5060,  2131, 0x01F50171, 120.015, -73.8219, -29.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50171 [120.014999 -73.821899 -29.995001] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5061,  2131, 0x01F50173, 120.023, -76.1495, -29.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50173 [120.023003 -76.149498 -29.995001] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5062,  7562, 0x01F50173, 117.746, -76.434, -28.5371, -0.997836, 0, 0, -0.0657546, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F50173 [117.746002 -76.433998 -28.537100] -0.997836 0.000000 0.000000 -0.065755 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5062, 0x701F5060, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5063,  7561, 0x01F50173, 122.333, -76.8616, -28.2696, -0.997836, 0, 0, -0.0657546, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F50173 [122.333000 -76.861603 -28.269600] -0.997836 0.000000 0.000000 -0.065755 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5063, 0x701F5061, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5064,   285, 0x01F50174, 124.889, -93.7251, -28.5, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01F50174 [124.889000 -93.725098 -28.500000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5069,  2131, 0x01F50180, 130.003, -83.7393, -29.995, 0.931056, 0, 0, -0.364877,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50180 [130.003006 -83.739304 -29.995001] 0.931056 0.000000 0.000000 -0.364877 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F506A,  4067, 0x01F50182, 129.917, -90.5152, -28.149, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Frost Trap */
+/* @teleloc 0x01F50182 [129.917007 -90.515198 -28.149000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F506A, 0x701F5069, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F506E,  5624, 0x01F50188, 135.245, -50, -30, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50188 [135.244995 -50.000000 -30.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F506F,   143, 0x01F50189, 144.05, -62.8325, -29.9875, -0.707107, 0, 0, 0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01F50189 [144.050003 -62.832500 -29.987499] -0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5072,  5624, 0x01F5018B, 135.245, -60, -30, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5018B [135.244995 -60.000000 -30.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5076,  5624, 0x01F5018F, 135.245, -80, -30, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5018F [135.244995 -80.000000 -30.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5077,  1294, 0x01F50192, 135.245, -90, -30, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50192 [135.244995 -90.000000 -30.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F507D,   171, 0x01F501B2, 23.8765, -56.3999, -17.995, 0.132902, 0, 0, -0.991129, False, '2005-02-09 10:00:00'); /* Vat */
+/* @teleloc 0x01F501B2 [23.876499 -56.399899 -17.995001] 0.132902 0.000000 0.000000 -0.991129 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5080,   152, 0x01F501B3, 23.454, -67.4816, -18, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Font */
+/* @teleloc 0x01F501B3 [23.454000 -67.481598 -18.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5087,  5624, 0x01F501BB, 35, -70, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F501BB [35.000000 -70.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F508C,  5624, 0x01F501C5, 40, -75.25, -18, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F501C5 [40.000000 -75.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F508D,   286, 0x01F501C9, 53.3015, -71.5623, -16.844, -4.37114E-08, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01F501C9 [53.301498 -71.562302 -16.844000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F508E,  4145, 0x01F501CA, 50, -74.105, -17.995, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F501CA [50.000000 -74.105003 -17.995001] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F508E, 0x701F508D, '2005-02-09 10:00:00') /* Lever (286) */
+     , (0x701F508E, 0x701F50E3, '2005-02-09 10:00:00') /* Lever (285) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5094,  4139, 0x01F501CD, 63.23, -70, -17.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F501CD [63.230000 -70.000000 -17.995001] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5094, 0x701F5025, '2005-02-09 10:00:00') /* Lever (285) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5097,  5624, 0x01F501D2, 60, -75.25, -18, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F501D2 [60.000000 -75.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5098,  5489, 0x01F501DF, 0, -120, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501DF [0.000000 -120.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5099,  5489, 0x01F501E0, 10, -110, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E0 [10.000000 -110.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F509A,  5489, 0x01F501E1, 10, -120, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E1 [10.000000 -120.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F509B,  5489, 0x01F501E2, 10, -130, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E2 [10.000000 -130.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F509C,  5489, 0x01F501E3, 10, -140, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E3 [10.000000 -140.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F509D,  5489, 0x01F501E4, 20, -100, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E4 [20.000000 -100.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F509E,  5489, 0x01F501E5, 20, -110, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E5 [20.000000 -110.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F509F,  5489, 0x01F501E6, 20, -130, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E6 [20.000000 -130.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A0,  5489, 0x01F501E7, 20, -140, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E7 [20.000000 -140.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A1,  5489, 0x01F501E8, 30, -90, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E8 [30.000000 -90.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A2,  5489, 0x01F501E9, 30, -100, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501E9 [30.000000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A3,  5489, 0x01F501EA, 30, -130, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501EA [30.000000 -130.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A4,  5489, 0x01F501EB, 30, -140, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501EB [30.000000 -140.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A5,  5489, 0x01F501EC, 30, -150, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501EC [30.000000 -150.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A6,  5489, 0x01F501ED, 40, -90, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501ED [40.000000 -90.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A7,  5489, 0x01F501EE, 40, -100, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501EE [40.000000 -100.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A8,  5489, 0x01F501EF, 40, -130, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501EF [40.000000 -130.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50A9,  5489, 0x01F501F0, 40, -140, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F0 [40.000000 -140.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50AA,  5489, 0x01F501F1, 40, -150, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F1 [40.000000 -150.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50AB,  5489, 0x01F501F2, 40, -160, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F2 [40.000000 -160.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50AC,  5489, 0x01F501F4, 50, -160, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F4 [50.000000 -160.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50AD,  5489, 0x01F501F5, 60, -90, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F5 [60.000000 -90.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50AE,  5489, 0x01F501F6, 60, -100, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F6 [60.000000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50AF,  5489, 0x01F501F7, 60, -130, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F7 [60.000000 -130.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B0,  5489, 0x01F501F8, 60, -140, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F8 [60.000000 -140.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B1,  5489, 0x01F501F9, 60, -150, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501F9 [60.000000 -150.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B2,  5489, 0x01F501FA, 60, -160, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501FA [60.000000 -160.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B3,  5489, 0x01F501FB, 70, -90, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501FB [70.000000 -90.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B4,  5489, 0x01F501FC, 70, -100, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501FC [70.000000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B5,  5489, 0x01F501FD, 70, -130, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501FD [70.000000 -130.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B6,  5489, 0x01F501FE, 70, -140, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501FE [70.000000 -140.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B7,  5489, 0x01F501FF, 70, -150, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F501FF [70.000000 -150.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B8,  5489, 0x01F50200, 80, -100, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50200 [80.000000 -100.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50B9,  5489, 0x01F50201, 80, -110, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50201 [80.000000 -110.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50BA,  5489, 0x01F50202, 80, -130, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50202 [80.000000 -130.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50BB,  5489, 0x01F50203, 80, -140, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50203 [80.000000 -140.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50BC,  5489, 0x01F50204, 90, -110, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50204 [90.000000 -110.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50BD,  5489, 0x01F50205, 90, -120, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50205 [90.000000 -120.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50BE,  5489, 0x01F50206, 90, -130, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50206 [90.000000 -130.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50BF,  5489, 0x01F50207, 90, -140, -6, -4.37114E-08, 0, 0, -1, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x01F50207 [90.000000 -140.000000 -6.000000] -0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50C1,  5624, 0x01F5021B, 44.782, -110, 0.005, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5021B [44.782001 -110.000000 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50C2,   568, 0x01F5021C, 40, -105.135, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5021C [40.000000 -105.135002 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50C6,  7480, 0x01F50223, 50, -120, 0.120375, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Firestorm Ambush Gen! */
+/* @teleloc 0x01F50223 [50.000000 -120.000000 0.120375] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50C7,  1301, 0x01F50225, 50, -144.75, 0, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50225 [50.000000 -144.750000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50C8,  1302, 0x01F50225, 50, -135.25, 0, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50225 [50.000000 -135.250000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50C9,  7562, 0x01F50225, 50.0252, -142.449, 1.67687, 0.999753, 0, 0, 0.022233, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F50225 [50.025200 -142.449005 1.676870] 0.999753 0.000000 0.000000 0.022233 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F50C9, 0x701F50CB, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50CA,  7561, 0x01F50225, 50.0735, -138.223, 1.85075, -0.998494, 0, 0, -0.054868, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x01F50225 [50.073502 -138.223007 1.850750] -0.998494 0.000000 0.000000 -0.054868 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F50CA, 0x701F50CC, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50CB,  2131, 0x01F50225, 50.0195, -141.366, 0.005, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50225 [50.019501 -141.365997 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50CC,  2131, 0x01F50225, 50.0352, -139.026, 0.005, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50225 [50.035198 -139.026001 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50CD,  7443, 0x01F50226, 50, -145.696, 0.908, -0.999988, 0, 0, -0.00489531, False, '2005-02-09 10:00:00'); /* Flame Barrier Trap */
+/* @teleloc 0x01F50226 [50.000000 -145.695999 0.908000] -0.999988 0.000000 0.000000 -0.004895 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F50CD, 0x701F50D3, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50D2,  7923, 0x01F50228, 46.7304, -169.162, 0, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x01F50228 [46.730400 -169.162003 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F50D2, 0x701F5122, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5123, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5124, '2005-02-09 10:00:00') /* Firestorm (7092) */
+     , (0x701F50D2, 0x701F5125, '2005-02-09 10:00:00') /* Firestorm (7092) */
+     , (0x701F50D2, 0x701F5126, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F50D2, 0x701F5127, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F50D2, 0x701F5128, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F50D2, 0x701F5129, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F512A, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F512B, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F512C, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F512D, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F50D2, 0x701F512E, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F50D2, 0x701F512F, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5130, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5131, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5132, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5133, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5159, '2005-02-09 10:00:00') /* Firestorm (7092) */
+     , (0x701F50D2, 0x701F515A, '2005-02-09 10:00:00') /* Hellfire (7093) */
+     , (0x701F50D2, 0x701F515B, '2005-02-09 10:00:00') /* Hellfire (7093) */
+     , (0x701F50D2, 0x701F515C, '2005-02-09 10:00:00') /* Firestorm (7092) */
+     , (0x701F50D2, 0x701F515D, '2005-02-09 10:00:00') /* Hellfire (7093) */
+     , (0x701F50D2, 0x701F515E, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F515F, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5160, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5161, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5162, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5163, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F50D2, 0x701F5164, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5165, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F50D2, 0x701F5166, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5167, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5168, '2005-02-09 10:00:00') /* Dark Revenant (4217) */
+     , (0x701F50D2, 0x701F5169, '2005-02-09 10:00:00') /* Dark Revenant (4217) */
+     , (0x701F50D2, 0x701F516A, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F516B, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F516C, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F516D, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F516E, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F516F, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5170, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5171, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5172, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5173, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F517A, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F517B, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F517C, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F517D, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F517E, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F50D2, 0x701F517F, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5180, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F50D2, 0x701F5181, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5182, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F50D2, 0x701F5183, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F50D2, 0x701F5184, '2005-02-09 10:00:00') /* Diamond Golem (4216) */
+     , (0x701F50D2, 0x701F5185, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F50D2, 0x701F5186, '2005-02-09 10:00:00') /* Relic Bones (7179) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50D3,  2131, 0x01F50228, 50.0344, -166.136, 0, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01F50228 [50.034401 -166.136002 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50D5,   153, 0x01F5022C, 60, -110, 0, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Fountain */
+/* @teleloc 0x01F5022C [60.000000 -110.000000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50D6,  5624, 0x01F5022E, 55.2629, -110, 0.005, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5022E [55.262901 -110.000000 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50D7,   568, 0x01F50230, 60, -105.25, 0, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50230 [60.000000 -105.250000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50DC,   568, 0x01F5024D, 15.25, -120, 6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5024D [15.250000 -120.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50DD,  5624, 0x01F5024E, 24.75, -120, 6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5024E [24.750000 -120.000000 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50DE,   568, 0x01F50255, 25.1218, -110, 0.144187, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50255 [25.121799 -110.000000 0.144187] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E1,   568, 0x01F50259, 30, -124.75, 6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50259 [30.000000 -124.750000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E2,  5624, 0x01F5025C, 30, -115.25, 6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5025C [30.000000 -115.250000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E3,   285, 0x01F50262, 43.4861, -115.607, 7.3315, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01F50262 [43.486099 -115.607002 7.331500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E4,   285, 0x01F50262, 42.2422, -115.609, 7.3315, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01F50262 [42.242199 -115.609001 7.331500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E6,  1300, 0x01F50265, 44.75, -120, 6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50265 [44.750000 -120.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E7,  9182, 0x01F5026B, 53, -120, 6.005, -0.678365, 0, 0, -0.734725, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F5026B [53.000000 -120.000000 6.005000] -0.678365 0.000000 0.000000 -0.734725 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50E8,  9182, 0x01F5026B, 47, -120, 6.005, 0.731907, 0, 0, -0.681405, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F5026B [47.000000 -120.000000 6.005000] 0.731907 0.000000 0.000000 -0.681405 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50EA,  7627, 0x01F50273, 60, -120, 6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01F50273 [60.000000 -120.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50EB,  9182, 0x01F50273, 62.2436, -122.082, 6.005, -0.859153, 0, 0, -0.511718, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50273 [62.243599 -122.082001 6.005000] -0.859153 0.000000 0.000000 -0.511718 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50EC,  9182, 0x01F50273, 62.242, -118.362, 6.005, -0.859153, 0, 0, -0.511718, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50273 [62.242001 -118.362000 6.005000] -0.859153 0.000000 0.000000 -0.511718 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50ED,  9182, 0x01F50273, 58.102, -117.639, 6.005, -0.695082, 0, 0, -0.71893, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50273 [58.102001 -117.639000 6.005000] -0.695082 0.000000 0.000000 -0.718930 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50EE,  9182, 0x01F50273, 58.1111, -122.27, 6.005, -0.695082, 0, 0, -0.71893, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50273 [58.111099 -122.269997 6.005000] -0.695082 0.000000 0.000000 -0.718930 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50EF,  1300, 0x01F50276, 55.25, -120, 6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50276 [55.250000 -120.000000 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F0,   568, 0x01F5027E, 74.755, -110, 0.392, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5027E [74.754997 -110.000000 0.392000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F2,   286, 0x01F50281, 74.3984, -117.904, 7.5, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01F50281 [74.398399 -117.903999 7.500000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F3,  9182, 0x01F50281, 70, -120, 6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50281 [70.000000 -120.000000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F4,  9182, 0x01F50281, 67.737, -117.925, 6.005, 0.961706, 0, 0, 0.274082, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50281 [67.737000 -117.925003 6.005000] 0.961706 0.000000 0.000000 0.274082 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F5,  9182, 0x01F50281, 67.9384, -122.243, 6.005, 0.961706, 0, 0, 0.274082, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50281 [67.938400 -122.242996 6.005000] 0.961706 0.000000 0.000000 0.274082 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F6,  9182, 0x01F50281, 72.3596, -122.096, 6.005, -0.39948, 0, 0, 0.916742, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50281 [72.359596 -122.096001 6.005000] -0.399480 0.000000 0.000000 0.916742 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F7,  9182, 0x01F50281, 71.9462, -117.701, 6.005, -0.929001, 0, 0, 0.370077, False, '2005-02-09 10:00:00'); /* Aerfalle Keep Mana Field */
+/* @teleloc 0x01F50281 [71.946198 -117.700996 6.005000] -0.929001 0.000000 0.000000 0.370077 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F8,   568, 0x01F50283, 70, -124.75, 6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50283 [70.000000 -124.750000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50F9,  4139, 0x01F50286, 70, -115.25, 6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F50286 [70.000000 -115.250000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F50F9, 0x701F50E4, '2005-02-09 10:00:00') /* Lever (285) */
+     , (0x701F50F9, 0x701F50F2, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50FC,   568, 0x01F5028E, 84.75, -120, 6, -0.707107, 0, 0, 0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5028E [84.750000 -120.000000 6.000000] -0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50FD,  5624, 0x01F5028F, 75.25, -120, 6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01F5028F [75.250000 -120.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50FE, 28281, 0x01F50101, 183.093, -5.66716, -41.995, 0.548166, 0, 0, 0.83637, False, '2005-02-09 10:00:00'); /* Aerfalle Uber Gen */
+/* @teleloc 0x01F50101 [183.093002 -5.667160 -41.994999] 0.548166 0.000000 0.000000 0.836370 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F50FF, 24320, 0x01F50101, 182.354, -14.0242, -41.9917, -0.007128, 0, 0, 0.999975,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F50101 [182.354004 -14.024200 -41.991699] -0.007128 0.000000 0.000000 0.999975 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5100,  7178, 0x01F50101, 182.316, -11.3541, -41.995, -0.007128, 0, 0, 0.999975,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50101 [182.315994 -11.354100 -41.994999] -0.007128 0.000000 0.000000 0.999975 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5101,  7178, 0x01F50103, 188.124, -10.8571, -41.995, 0.120261, 0, 0, 0.992742,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50103 [188.123993 -10.857100 -41.994999] 0.120261 0.000000 0.000000 0.992742 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5102,  7107, 0x01F5010A, 128.77, -19.3396, -35.945, -0.700354, 0, 0, -0.713795,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F5010A [128.770004 -19.339600 -35.945000] -0.700354 0.000000 0.000000 -0.713795 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5103,  7107, 0x01F5010A, 128.806, -21.2352, -35.945, -0.700354, 0, 0, -0.713795,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F5010A [128.806000 -21.235201 -35.945000] -0.700354 0.000000 0.000000 -0.713795 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5104,  7126, 0x01F5010C, 132.161, -28.2962, -35.995, -0.82882, 0, 0, -0.559515,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F5010C [132.160995 -28.296200 -35.994999] -0.828820 0.000000 0.000000 -0.559515 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5105,  7126, 0x01F5010D, 138.042, -21.3521, -35.995, -0.7359, 0, 0, -0.67709,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F5010D [138.042007 -21.352100 -35.994999] -0.735900 0.000000 0.000000 -0.677090 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5106,  7126, 0x01F5010E, 141.398, -28.6611, -35.995, -0.880616, 0, 0, -0.473831,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F5010E [141.397995 -28.661100 -35.994999] -0.880616 0.000000 0.000000 -0.473831 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5107,  7107, 0x01F5010E, 135.103, -28.1593, -35.945, 0.584373, 0, 0, -0.811485,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F5010E [135.102997 -28.159300 -35.945000] 0.584373 0.000000 0.000000 -0.811485 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5108,  7107, 0x01F5010E, 139.097, -25.3636, -35.945, 0.995376, 0, 0, 0.096052,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F5010E [139.097000 -25.363600 -35.945000] 0.995376 0.000000 0.000000 0.096052 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5109,  7126, 0x01F5010F, 148.614, -32.1568, -35.995, -0.925289, 0, 0, -0.379263,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F5010F [148.613998 -32.156799 -35.994999] -0.925289 0.000000 0.000000 -0.379263 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F510A,  7107, 0x01F5010F, 149.969, -34.3287, -35.9082, 0.987525, 0, 0, 0.157463,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F5010F [149.968994 -34.328701 -35.908199] 0.987525 0.000000 0.000000 0.157463 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F510B,  7126, 0x01F50110, 151.988, -38.9699, -35.995, -0.93437, 0, 0, -0.356303,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F50110 [151.988007 -38.969898 -35.994999] -0.934370 0.000000 0.000000 -0.356303 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F510C,  7126, 0x01F50116, 159.144, -40.889, -35.995, -0.99944, 0, 0, 0.0334709,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F50116 [159.143997 -40.889000 -35.994999] -0.999440 0.000000 0.000000 0.033471 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F510D,  7107, 0x01F50116, 159.441, -43.3888, -35.988, 0.949976, 0, 0, 0.312323,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F50116 [159.440994 -43.388802 -35.987999] 0.949976 0.000000 0.000000 0.312323 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F510E,  7126, 0x01F50117, 164.177, -52.6133, -35.995, -0.93831, 0, 0, -0.345796,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F50117 [164.177002 -52.613300 -35.994999] -0.938310 0.000000 0.000000 -0.345796 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F510F,  7107, 0x01F50117, 160.756, -48.1129, -35.988, -0.475509, 0, 0, 0.879711,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F50117 [160.755997 -48.112900 -35.987999] -0.475509 0.000000 0.000000 0.879711 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5110,  7126, 0x01F50119, 160.589, -59.1384, -35.995, -0.983544, 0, 0, 0.180667,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F50119 [160.589005 -59.138401 -35.994999] -0.983544 0.000000 0.000000 0.180667 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5111,  7107, 0x01F5011E, 159.98, -67.4502, -35.988, -1, 0, 0, -0.000195,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F5011E [159.979996 -67.450203 -35.987999] -1.000000 0.000000 0.000000 -0.000195 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5112,  7126, 0x01F50121, 169.303, -50.6747, -35.995, -0.863194, 0, 0, -0.504872,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F50121 [169.302994 -50.674702 -35.994999] -0.863194 0.000000 0.000000 -0.504872 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5113,  7107, 0x01F50122, 170.216, -59.4841, -35.988, -0.999097, 0, 0, 0.042491,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F50122 [170.216003 -59.484100 -35.987999] -0.999097 0.000000 0.000000 0.042491 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5114,  7126, 0x01F50123, 167.973, -59.0023, -35.995, -0.940309, 0, 0, -0.340321,  True, '2005-02-09 10:00:00'); /* Cursed Wisp */
+/* @teleloc 0x01F50123 [167.973007 -59.002300 -35.994999] -0.940309 0.000000 0.000000 -0.340321 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5115,  7107, 0x01F50123, 165.283, -58.4388, -35.945, -0.909697, 0, 0, -0.415272,  True, '2005-02-09 10:00:00'); /* Wasteland Rat */
+/* @teleloc 0x01F50123 [165.283005 -58.438801 -35.945000] -0.909697 0.000000 0.000000 -0.415272 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5116, 22933, 0x01F50125, 181.866, -20.451, -38.628, -0.094664, 0, 0, 0.995509,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F50125 [181.865997 -20.451000 -38.627998] -0.094664 0.000000 0.000000 0.995509 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5117,  7179, 0x01F50127, 180.609, -26.2938, -35.995, 0.080217, 0, 0, 0.996777,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50127 [180.608994 -26.293800 -35.994999] 0.080217 0.000000 0.000000 0.996777 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5118, 22933, 0x01F50129, 180.371, -47.764, -35.99, 0.52344, 0, 0, -0.852063,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F50129 [180.371002 -47.764000 -35.990002] 0.523440 0.000000 0.000000 -0.852063 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5119, 22933, 0x01F5012A, 184.361, -51.0303, -35.99, 0.66969, 0, 0, -0.742641,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F5012A [184.360992 -51.030300 -35.990002] 0.669690 0.000000 0.000000 -0.742641 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F511A, 22933, 0x01F5012C, 175.601, -59.9389, -35.99, 0.72954, 0, 0, 0.683938,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F5012C [175.600998 -59.938900 -35.990002] 0.729540 0.000000 0.000000 0.683938 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F511B, 22933, 0x01F5012C, 181.502, -60.32, -35.99, 0.72954, 0, 0, 0.683938,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F5012C [181.501999 -60.320000 -35.990002] 0.729540 0.000000 0.000000 0.683938 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F511C,  7179, 0x01F5012E, 187.441, -17.8148, -40.2256, -0.0493541, 0, 0, -0.998781,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5012E [187.440994 -17.814800 -40.225601] -0.049354 0.000000 0.000000 -0.998781 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F511D,  7179, 0x01F5012F, 188.461, -25.9075, -35.995, 0.609493, 0, 0, 0.792791,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5012F [188.460999 -25.907499 -35.994999] 0.609493 0.000000 0.000000 0.792791 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F511E, 24320, 0x01F5012F, 187.597, -29.5711, -35.9917, 0.882156, 0, 0, 0.470957,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F5012F [187.597000 -29.571100 -35.991699] 0.882156 0.000000 0.000000 0.470957 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F511F, 23082, 0x01F5012F, 187.701, -27.516, -35.99, -0.808048, 0, 0, -0.589116,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F5012F [187.701004 -27.516001 -35.990002] -0.808048 0.000000 0.000000 -0.589116 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5120, 23082, 0x01F50132, 189.716, -53.3535, -35.945, 0.042636, 0, 0, 0.999091,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F50132 [189.716003 -53.353500 -35.945000] 0.042636 0.000000 0.000000 0.999091 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5121, 23082, 0x01F50133, 189.154, -59.3344, -35.99, 0.72954, 0, 0, 0.683938,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F50133 [189.154007 -59.334400 -35.990002] 0.729540 0.000000 0.000000 0.683938 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5122,  4216, 0x01F50136, 73.0645, -26.8283, -29.99, 0.02126, 0, 0, -0.999774,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50136 [73.064499 -26.828300 -29.990000] 0.021260 0.000000 0.000000 -0.999774 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5123,  4216, 0x01F50136, 67.2581, -27.8237, -29.99, 0.132731, 0, 0, -0.991152,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50136 [67.258102 -27.823700 -29.990000] 0.132731 0.000000 0.000000 -0.991152 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5124,  7092, 0x01F50139, 66.9271, -37.3082, -29.9915, -0.0442847, 0, 0, -0.999019,  True, '2005-02-09 10:00:00'); /* Firestorm */
+/* @teleloc 0x01F50139 [66.927101 -37.308201 -29.991501] -0.044285 0.000000 0.000000 -0.999019 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5125,  7092, 0x01F50139, 67.2254, -43.3288, -29.9915, 0.999392, 0, 0, -0.0348688,  True, '2005-02-09 10:00:00'); /* Firestorm */
+/* @teleloc 0x01F50139 [67.225403 -43.328800 -29.991501] 0.999392 0.000000 0.000000 -0.034869 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5126, 23082, 0x01F5013A, 72.6527, -50, -29.99, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F5013A [72.652702 -50.000000 -29.990000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5127, 23082, 0x01F5013A, 67.5028, -49.9455, -29.99, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F5013A [67.502800 -49.945499 -29.990000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5128, 23082, 0x01F5013A, 70, -52.8465, -29.99, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F5013A [70.000000 -52.846500 -29.990000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5129,  7178, 0x01F5013D, 83.4054, -31.8878, -29.995, -0.310368, 0, 0, -0.950616,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5013D [83.405403 -31.887800 -29.995001] -0.310368 0.000000 0.000000 -0.950616 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F512A,  7178, 0x01F5013D, 77.108, -32.2969, -29.995, 0.230177, 0, 0, -0.973149,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5013D [77.108002 -32.296902 -29.995001] 0.230177 0.000000 0.000000 -0.973149 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F512B,  7178, 0x01F5013D, 80.483, -28.4886, -29.995, -0.042728, 0, 0, -0.999087,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5013D [80.483002 -28.488600 -29.995001] -0.042728 0.000000 0.000000 -0.999087 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F512C,  7179, 0x01F5013D, 76.7494, -26.9325, -29.995, -0.211066, 0, 0, 0.977472,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5013D [76.749397 -26.932501 -29.995001] -0.211066 0.000000 0.000000 0.977472 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F512D, 22933, 0x01F50140, 83.1432, -36.6909, -29.99, 0.497186, 0, 0, 0.867644,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F50140 [83.143204 -36.690899 -29.990000] 0.497186 0.000000 0.000000 0.867644 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F512E, 23082, 0x01F50140, 82.868, -42.9097, -29.99, -0.940439, 0, 0, -0.339961,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F50140 [82.867996 -42.909698 -29.990000] -0.940439 0.000000 0.000000 -0.339961 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F512F,  4216, 0x01F50140, 83.1807, -40.1391, -29.99, 0.706242, 0, 0, 0.70797,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50140 [83.180702 -40.139099 -29.990000] 0.706242 0.000000 0.000000 0.707970 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5130,  7178, 0x01F50141, 77.8659, -52.2849, -29.995, -0.971748, 0, 0, 0.236019,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50141 [77.865898 -52.284901 -29.995001] -0.971748 0.000000 0.000000 0.236019 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5131,  7178, 0x01F50141, 82.4594, -47.3339, -29.995, -0.930778, 0, 0, -0.365584,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50141 [82.459396 -47.333900 -29.995001] -0.930778 0.000000 0.000000 -0.365584 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5132,  7179, 0x01F50141, 82.1822, -53.1546, -29.995, -0.978854, 0, 0, -0.204562,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50141 [82.182198 -53.154598 -29.995001] -0.978854 0.000000 0.000000 -0.204562 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5133,  7179, 0x01F50141, 76.9239, -47.7179, -29.995, -0.743005, 0, 0, 0.669285,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50141 [76.923897 -47.717899 -29.995001] -0.743005 0.000000 0.000000 0.669285 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5134,  4254, 0x01F50144, 92.5006, -27.4022, -29.995, -0.112746, 0, 0, -0.993624,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50144 [92.500603 -27.402201 -29.995001] -0.112746 0.000000 0.000000 -0.993624 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5135,  4254, 0x01F50144, 87.3395, -26.999, -29.995, 0.129483, 0, 0, -0.991582,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50144 [87.339500 -26.999001 -29.995001] 0.129483 0.000000 0.000000 -0.991582 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5136,  4254, 0x01F50144, 87.1889, -33.0745, -29.995, 0.902132, 0, 0, -0.431459,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50144 [87.188904 -33.074501 -29.995001] 0.902132 0.000000 0.000000 -0.431459 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5137,  4254, 0x01F50144, 92.8229, -33.0167, -29.995, -0.918156, 0, 0, -0.396219,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50144 [92.822899 -33.016701 -29.995001] -0.918156 0.000000 0.000000 -0.396219 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5138,  4254, 0x01F50152, 102.657, -27.4087, -29.995, 0.350355, 0, 0, 0.936617,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50152 [102.656998 -27.408701 -29.995001] 0.350355 0.000000 0.000000 0.936617 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5139,  4254, 0x01F50152, 97.4578, -27.8622, -29.995, -0.21766, 0, 0, 0.976025,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50152 [97.457802 -27.862200 -29.995001] -0.217660 0.000000 0.000000 0.976025 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F513A,  4254, 0x01F50152, 97.0357, -32.5359, -29.995, -0.846354, 0, 0, 0.53262,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50152 [97.035698 -32.535900 -29.995001] -0.846354 0.000000 0.000000 0.532620 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F513B,  4254, 0x01F50152, 103.129, -33.1399, -29.995, -0.934126, 0, 0, -0.356943,  True, '2005-02-09 10:00:00'); /* Umbris Shadow */
+/* @teleloc 0x01F50152 [103.128998 -33.139900 -29.995001] -0.934126 0.000000 0.000000 -0.356943 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F513C, 24320, 0x01F50157, 96.8624, -46.8612, -29.9918, -0.623047, 0, 0, 0.782184,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F50157 [96.862396 -46.861198 -29.991800] -0.623047 0.000000 0.000000 0.782184 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F513D,  7487, 0x01F5015D, 97.1391, -88.9165, -29.9915, 0.949949, 0, 0, -0.312405,  True, '2005-02-09 10:00:00'); /* Inferno */
+/* @teleloc 0x01F5015D [97.139099 -88.916496 -29.991501] 0.949949 0.000000 0.000000 -0.312405 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F513E,  7487, 0x01F5015D, 103.136, -90.2071, -29.9915, 0.998685, 0, 0, -0.0512667,  True, '2005-02-09 10:00:00'); /* Inferno */
+/* @teleloc 0x01F5015D [103.136002 -90.207100 -29.991501] 0.998685 0.000000 0.000000 -0.051267 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F513F,  7179, 0x01F50161, 113.481, -26.6718, -29.995, -0.27834, 0, 0, -0.960483,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50161 [113.481003 -26.671801 -29.995001] -0.278340 0.000000 0.000000 -0.960483 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5140,  7179, 0x01F50161, 107.475, -28.1515, -29.995, 0.245001, 0, 0, -0.969523,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50161 [107.474998 -28.151501 -29.995001] 0.245001 0.000000 0.000000 -0.969523 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5141,  7178, 0x01F50165, 107.095, -39.1219, -29.995, -0.714299, 0, 0, -0.699841,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50165 [107.095001 -39.121899 -29.995001] -0.714299 0.000000 0.000000 -0.699841 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5142,  7178, 0x01F50165, 107.056, -41.0175, -29.995, -0.714299, 0, 0, -0.699841,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50165 [107.056000 -41.017502 -29.995001] -0.714299 0.000000 0.000000 -0.699841 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5143,  7179, 0x01F50166, 110.012, -43.5204, -29.995, -0.999999, 0, 0, 0.001461,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50166 [110.012001 -43.520401 -29.995001] -0.999999 0.000000 0.000000 0.001461 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5144, 24320, 0x01F50169, 106.748, -56.7941, -29.9918, 0.990325, 0, 0, -0.138766,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F50169 [106.748001 -56.794102 -29.991800] 0.990325 0.000000 0.000000 -0.138766 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5145, 24320, 0x01F50169, 113.297, -56.6683, -29.9918, 0.975484, 0, 0, 0.220071,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F50169 [113.296997 -56.668301 -29.991800] 0.975484 0.000000 0.000000 0.220071 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5146, 24320, 0x01F50169, 109.922, -62.6722, -29.9918, 0.999999, 0, 0, 0.0010656,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F50169 [109.921997 -62.672199 -29.991800] 0.999999 0.000000 0.000000 0.001066 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5147, 28047, 0x01F5016C, 113, -94, -29.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Lady of Aerlinthe's Ornate Chest */
+/* @teleloc 0x01F5016C [113.000000 -94.000000 -29.995001] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5148,  7179, 0x01F5016D, 118.874, -39.0289, -29.995, 0.725572, 0, 0, 0.688146,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5016D [118.874001 -39.028900 -29.995001] 0.725572 0.000000 0.000000 0.688146 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5149,  7179, 0x01F5016D, 118.776, -40.5798, -29.995, 0.725572, 0, 0, 0.688146,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5016D [118.776001 -40.579800 -29.995001] 0.725572 0.000000 0.000000 0.688146 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F514A, 24320, 0x01F5016E, 122.289, -52.0048, -29.9918, 0.202889, 0, 0, 0.979202,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F5016E [122.289001 -52.004799 -29.991800] 0.202889 0.000000 0.000000 0.979202 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F514B,  7178, 0x01F5016F, 121.793, -62.3341, -29.995, -0.85967, 0, 0, -0.51085,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5016F [121.792999 -62.334099 -29.995001] -0.859670 0.000000 0.000000 -0.510850 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F514C,  7178, 0x01F5016F, 122.8, -58.2491, -29.995, -0.85967, 0, 0, -0.51085,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5016F [122.800003 -58.249100 -29.995001] -0.859670 0.000000 0.000000 -0.510850 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F514D,  7487, 0x01F50174, 122.522, -90.0616, -29.9915, -0.985116, 0, 0, -0.171893,  True, '2005-02-09 10:00:00'); /* Inferno */
+/* @teleloc 0x01F50174 [122.522003 -90.061600 -29.991501] -0.985116 0.000000 0.000000 -0.171893 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F514E,  7487, 0x01F50174, 117.507, -90.9321, -29.9915, -0.992476, 0, 0, -0.122443,  True, '2005-02-09 10:00:00'); /* Inferno */
+/* @teleloc 0x01F50174 [117.507004 -90.932098 -29.991501] -0.992476 0.000000 0.000000 -0.122443 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F514F,  7179, 0x01F50186, 142.793, -53.0393, -29.995, 0.928176, 0, 0, 0.372141,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50186 [142.792999 -53.039299 -29.995001] 0.928176 0.000000 0.000000 0.372141 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5150,  7179, 0x01F50186, 142.868, -49.1243, -29.995, 0.647779, 0, 0, 0.761828,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50186 [142.867996 -49.124298 -29.995001] 0.647779 0.000000 0.000000 0.761828 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5151,  7179, 0x01F50186, 137.405, -48.1749, -29.995, 0.207491, 0, 0, 0.978237,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50186 [137.404999 -48.174900 -29.995001] 0.207491 0.000000 0.000000 0.978237 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5152,  7178, 0x01F50189, 141.303, -62.1381, -29.995, -0.941485, 0, 0, -0.337055,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50189 [141.302994 -62.138100 -29.995001] -0.941485 0.000000 0.000000 -0.337055 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5153,  7178, 0x01F50189, 141.024, -58.179, -29.995, -0.33706, 0, 0, -0.941483,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50189 [141.024002 -58.179001 -29.995001] -0.337060 0.000000 0.000000 -0.941483 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5154,  7178, 0x01F50189, 137.781, -60.6212, -29.995, -0.783528, 0, 0, -0.621357,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50189 [137.781006 -60.621201 -29.995001] -0.783528 0.000000 0.000000 -0.621357 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5155,  4217, 0x01F5018D, 143.194, -82.5939, -29.9918, -0.906867, 0, 0, -0.421418,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F5018D [143.194000 -82.593903 -29.991800] -0.906867 0.000000 0.000000 -0.421418 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5156,  4217, 0x01F5018D, 140.753, -77.5558, -29.9918, -0.170611, 0, 0, -0.985338,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F5018D [140.753006 -77.555801 -29.991800] -0.170611 0.000000 0.000000 -0.985338 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5157,  4217, 0x01F5018D, 137.016, -81.6433, -29.9918, -0.979458, 0, 0, -0.201649,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F5018D [137.016006 -81.643303 -29.991800] -0.979458 0.000000 0.000000 -0.201649 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5158, 24962, 0x01F50190, 142.843, -92.5394, -29.9945, 0.901143, 0, 0, 0.433521,  True, '2005-02-09 10:00:00'); /* Olthoi Noble Grub */
+/* @teleloc 0x01F50190 [142.843002 -92.539398 -29.994499] 0.901143 0.000000 0.000000 0.433521 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5159,  7092, 0x01F501B0, 17.6103, -37.6794, -17.9915, 0.221097, 0, 0, -0.975252,  True, '2005-02-09 10:00:00'); /* Firestorm */
+/* @teleloc 0x01F501B0 [17.610300 -37.679401 -17.991501] 0.221097 0.000000 0.000000 -0.975252 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F515A,  7093, 0x01F501B1, 17.6826, -49.8968, -17.9915, -0.704532, 0, 0, 0.709672,  True, '2005-02-09 10:00:00'); /* Hellfire */
+/* @teleloc 0x01F501B1 [17.682600 -49.896801 -17.991501] -0.704532 0.000000 0.000000 0.709672 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F515B,  7093, 0x01F501B2, 17.9642, -60.1321, -17.9915, -0.710629, 0, 0, 0.703567,  True, '2005-02-09 10:00:00'); /* Hellfire */
+/* @teleloc 0x01F501B2 [17.964199 -60.132099 -17.991501] -0.710629 0.000000 0.000000 0.703567 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F515C,  7092, 0x01F501B3, 20.0126, -71.2797, -17.9915, 0.999739, 0, 0, -0.022855,  True, '2005-02-09 10:00:00'); /* Firestorm */
+/* @teleloc 0x01F501B3 [20.012600 -71.279701 -17.991501] 0.999739 0.000000 0.000000 -0.022855 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F515D,  7093, 0x01F501B3, 17.8973, -68.1858, -17.9915, -0.703396, 0, 0, 0.710798,  True, '2005-02-09 10:00:00'); /* Hellfire */
+/* @teleloc 0x01F501B3 [17.897301 -68.185799 -17.991501] -0.703396 0.000000 0.000000 0.710798 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F515E,  7178, 0x01F501B4, 29.3346, -39.7928, -17.995, 0.316998, 0, 0, -0.948426,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F501B4 [29.334600 -39.792801 -17.995001] 0.316998 0.000000 0.000000 -0.948426 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F515F,  7178, 0x01F501BC, 43.7938, -40.0695, -17.995, -0.726964, 0, 0, -0.686676,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F501BC [43.793800 -40.069500 -17.995001] -0.726964 0.000000 0.000000 -0.686676 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5160,  4216, 0x01F501BE, 37.0061, -47.8828, -17.99, -0.197212, 0, 0, 0.980361,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F501BE [37.006100 -47.882801 -17.990000] -0.197212 0.000000 0.000000 0.980361 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5161,  4216, 0x01F501C3, 40.212, -80.3459, -17.99, -0.999497, 0, 0, -0.031717,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F501C3 [40.212002 -80.345901 -17.990000] -0.999497 0.000000 0.000000 -0.031717 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5162,  7179, 0x01F501C7, 52.8843, -50.9147, -17.995, -0.0141337, 0, 0, -0.9999,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F501C7 [52.884300 -50.914700 -17.995001] -0.014134 0.000000 0.000000 -0.999900 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5163, 24320, 0x01F501C7, 47.0829, -50.5171, -17.9918, 0.0092058, 0, 0, 0.999958,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F501C7 [47.082901 -50.517101 -17.991800] 0.009206 0.000000 0.000000 0.999958 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5164,  7179, 0x01F501C8, 53.1719, -55.1778, -17.995, -0.999832, 0, 0, 0.0183367,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F501C8 [53.171902 -55.177799 -17.995001] -0.999832 0.000000 0.000000 0.018337 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5165, 24320, 0x01F501C8, 47.1171, -55.241, -17.945, -0.99998, 0, 0, 0.00625223,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01F501C8 [47.117100 -55.241001 -17.945000] -0.999980 0.000000 0.000000 0.006252 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5166,  7178, 0x01F501C8, 48.1598, -62.1619, -17.995, -0.999757, 0, 0, 0.0220306,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F501C8 [48.159801 -62.161900 -17.995001] -0.999757 0.000000 0.000000 0.022031 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5167,  7178, 0x01F501C8, 46.6244, -57.7991, -17.995, -0.0175037, 0, 0, -0.999847,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F501C8 [46.624401 -57.799099 -17.995001] -0.017504 0.000000 0.000000 -0.999847 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5168,  4217, 0x01F501C8, 52.4498, -62.5375, -17.9918, 0.999931, 0, 0, -0.0117266,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F501C8 [52.449799 -62.537498 -17.991800] 0.999931 0.000000 0.000000 -0.011727 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5169,  4217, 0x01F501C8, 52.0905, -57.4299, -17.9918, -0.00579119, 0, 0, -0.999983,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F501C8 [52.090500 -57.429901 -17.991800] -0.005791 0.000000 0.000000 -0.999983 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F516A,  7179, 0x01F501C9, 49.8277, -70.0917, -17.995, 0.00752695, 0, 0, -0.999972,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F501C9 [49.827702 -70.091698 -17.995001] 0.007527 0.000000 0.000000 -0.999972 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F516B,  4216, 0x01F501CB, 61.8229, -48.0899, -17.99, 0.0243004, 0, 0, 0.999705,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F501CB [61.822899 -48.089901 -17.990000] 0.024300 0.000000 0.000000 0.999705 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F516C,  4216, 0x01F501D0, 60.0706, -80.4584, -17.99, 0.999809, 0, 0, 0.019547,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F501D0 [60.070599 -80.458397 -17.990000] 0.999809 0.000000 0.000000 0.019547 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F516D,  7179, 0x01F501D3, 73.0276, -70.1227, -22.731, -0.707104, 0, 0, -0.70711,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F501D3 [73.027603 -70.122704 -22.731001] -0.707104 0.000000 0.000000 -0.707110 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F516E,  7179, 0x01F50218, 42.266, -110.078, 0.005, -0.709281, 0, 0, 0.704926,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50218 [42.265999 -110.078003 0.005000] -0.709281 0.000000 0.000000 0.704926 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F516F,  7179, 0x01F50222, 49.7559, -106.311, 0.005, -0.005722, 0, 0, 0.999984,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50222 [49.755901 -106.310997 0.005000] -0.005722 0.000000 0.000000 0.999984 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5170,  7178, 0x01F50222, 52.9336, -107.636, 0.005, 0.136584, 0, 0, 0.990628,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50222 [52.933601 -107.636002 0.005000] 0.136584 0.000000 0.000000 0.990628 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5171,  7178, 0x01F50222, 46.777, -109.864, 0.005, -0.236514, 0, 0, 0.971628,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50222 [46.777000 -109.863998 0.005000] -0.236514 0.000000 0.000000 0.971628 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5172,  7178, 0x01F50224, 47.0913, -131.492, 0.005, -0.191637, 0, 0, 0.981466,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50224 [47.091301 -131.492004 0.005000] -0.191637 0.000000 0.000000 0.981466 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5173,  7178, 0x01F50224, 53.4005, -130.983, 0.005, 0.237486, 0, 0, 0.971391,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50224 [53.400501 -130.983002 0.005000] 0.237486 0.000000 0.000000 0.971391 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5174,  7421, 0x01F50226, 47.1941, -153.115, 0.01, 0.00740836, 0, 0, -0.999973,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50226 [47.194099 -153.115005 0.010000] 0.007408 0.000000 0.000000 -0.999973 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5175,  7421, 0x01F50226, 53.0621, -153.272, 0.01, -0.0175907, 0, 0, -0.999845,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50226 [53.062099 -153.272003 0.010000] -0.017591 0.000000 0.000000 -0.999845 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5176,  7422, 0x01F50226, 46.3867, -147.09, 0.00825, -0.134171, 0, 0, 0.990958,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F50226 [46.386700 -147.089996 0.008250] -0.134171 0.000000 0.000000 0.990958 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5177,  7422, 0x01F50226, 53.6482, -146.35, 0.00825, 0.0648544, 0, 0, 0.997895,  True, '2005-02-09 10:00:00'); /* Dark Revenant */
+/* @teleloc 0x01F50226 [53.648201 -146.350006 0.008250] 0.064854 0.000000 0.000000 0.997895 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5178,  7925, 0x01F50228, 46.792, -170.353, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 10 Min.) */
+/* @teleloc 0x01F50228 [46.792000 -170.352997 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5178, 0x701F5134, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F5135, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F5136, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F5137, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F5138, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F5139, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F513A, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F513B, '2005-02-09 10:00:00') /* Umbris Shadow (4254) */
+     , (0x701F5178, 0x701F513D, '2005-02-09 10:00:00') /* Inferno (7487) */
+     , (0x701F5178, 0x701F513E, '2005-02-09 10:00:00') /* Inferno (7487) */
+     , (0x701F5178, 0x701F514D, '2005-02-09 10:00:00') /* Inferno (7487) */
+     , (0x701F5178, 0x701F514E, '2005-02-09 10:00:00') /* Inferno (7487) */
+     , (0x701F5178, 0x701F5174, '2005-02-09 10:00:00') /* Diamond Golem (7421) */
+     , (0x701F5178, 0x701F5175, '2005-02-09 10:00:00') /* Diamond Golem (7421) */
+     , (0x701F5178, 0x701F5176, '2005-02-09 10:00:00') /* Dark Revenant (7422) */
+     , (0x701F5178, 0x701F5177, '2005-02-09 10:00:00') /* Dark Revenant (7422) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5179,  7923, 0x01F50228, 46.752, -167.963, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x01F50228 [46.751999 -167.962997 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5179, 0x701F50FF, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F5100, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5101, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5102, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5103, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5104, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F5105, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F5106, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F5107, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5108, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5109, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F510A, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F510B, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F510C, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F510D, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F510E, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F510F, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5110, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F5111, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5112, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F5113, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5114, '2005-02-09 10:00:00') /* Cursed Wisp (7126) */
+     , (0x701F5179, 0x701F5115, '2005-02-09 10:00:00') /* Wasteland Rat (7107) */
+     , (0x701F5179, 0x701F5116, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F5179, 0x701F5117, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5118, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F5179, 0x701F5119, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F5179, 0x701F511A, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F5179, 0x701F511B, '2005-02-09 10:00:00') /* Mist Golem (22933) */
+     , (0x701F5179, 0x701F511C, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F511D, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F511E, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F511F, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F5179, 0x701F5120, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F5179, 0x701F5121, '2005-02-09 10:00:00') /* Nubilous Golem (23082) */
+     , (0x701F5179, 0x701F513C, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F513F, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5140, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5141, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5142, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5143, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5144, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F5145, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F5146, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F5148, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5149, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F514A, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x701F5179, 0x701F514B, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F514C, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F514F, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5150, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5151, '2005-02-09 10:00:00') /* Relic Bones (7179) */
+     , (0x701F5179, 0x701F5152, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5153, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5154, '2005-02-09 10:00:00') /* Cursed Bones (7178) */
+     , (0x701F5179, 0x701F5155, '2005-02-09 10:00:00') /* Dark Revenant (4217) */
+     , (0x701F5179, 0x701F5156, '2005-02-09 10:00:00') /* Dark Revenant (4217) */
+     , (0x701F5179, 0x701F5157, '2005-02-09 10:00:00') /* Dark Revenant (4217) */
+     , (0x701F5179, 0x701F5158, '2005-02-09 10:00:00') /* Olthoi Noble Grub (24962) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F517A,  7179, 0x01F5022C, 57.6073, -110.064, 0.005, 0.720669, 0, 0, 0.69328,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5022C [57.607300 -110.064003 0.005000] 0.720669 0.000000 0.000000 0.693280 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F517B,  7178, 0x01F5022C, 62.7221, -112.304, 0.005, -0.853211, 0, 0, -0.521566,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5022C [62.722099 -112.304001 0.005000] -0.853211 0.000000 0.000000 -0.521566 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F517C,  7178, 0x01F5024B, 17.9388, -117.481, 6.005, 0.0707304, 0, 0, -0.997495,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F5024B [17.938801 -117.481003 6.005000] 0.070730 0.000000 0.000000 -0.997495 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F517D,  7179, 0x01F5024B, 22.4867, -122.089, 6.005, 0.925736, 0, 0, 0.378171,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5024B [22.486700 -122.088997 6.005000] 0.925736 0.000000 0.000000 0.378171 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F517E, 23082, 0x01F50256, 30.4318, -109.664, 3.01, 0.685705, 0, 0, -0.727879,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F50256 [30.431801 -109.664001 3.010000] 0.685705 0.000000 0.000000 -0.727879 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F517F,  7179, 0x01F50257, 27.3444, -122.743, 6.005, 0.93531, 0, 0, -0.353828,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F50257 [27.344400 -122.742996 6.005000] 0.935310 0.000000 0.000000 -0.353828 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5180, 22933, 0x01F50257, 26.696, -117.055, 6.01, 0.412839, 0, 0, -0.910804,  True, '2005-02-09 10:00:00'); /* Mist Golem */
+/* @teleloc 0x01F50257 [26.695999 -117.055000 6.010000] 0.412839 0.000000 0.000000 -0.910804 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5181,  4216, 0x01F50262, 42.2719, -117.374, 6.01, 0.525241, 0, 0, 0.850954,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50262 [42.271900 -117.374001 6.010000] 0.525241 0.000000 0.000000 0.850954 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5182,  7178, 0x01F50262, 42.6247, -123.249, 6.005, 0.889627, 0, 0, 0.456687,  True, '2005-02-09 10:00:00'); /* Cursed Bones */
+/* @teleloc 0x01F50262 [42.624699 -123.249001 6.005000] 0.889627 0.000000 0.000000 0.456687 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5183, 23082, 0x01F50280, 69.5363, -110.126, 3.01, 0.713411, 0, 0, 0.700746,  True, '2005-02-09 10:00:00'); /* Nubilous Golem */
+/* @teleloc 0x01F50280 [69.536301 -110.125999 3.010000] 0.713411 0.000000 0.000000 0.700746 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5184,  4216, 0x01F50281, 70.3902, -119.578, 6.01, -0.999993, 0, 0, -0.003793,  True, '2005-02-09 10:00:00'); /* Diamond Golem */
+/* @teleloc 0x01F50281 [70.390198 -119.578003 6.010000] -0.999993 0.000000 0.000000 -0.003793 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5185,  7179, 0x01F5028C, 82.7541, -122.308, 6.005, 0.887052, 0, 0, 0.461669,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5028C [82.754097 -122.307999 6.005000] 0.887052 0.000000 0.000000 0.461669 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5186,  7179, 0x01F5028C, 76.7348, -117.252, 6.005, -0.403374, 0, 0, 0.915035,  True, '2005-02-09 10:00:00'); /* Relic Bones */
+/* @teleloc 0x01F5028C [76.734802 -117.251999 6.005000] -0.403374 0.000000 0.000000 0.915035 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5187,  5085, 0x01F50222, 48.2895, -107.131, 0.055, 0.874507, 0, 0, -0.485014, False, '2021-06-08 11:39:06'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x01F50222 [48.289501 -107.130997 0.055000] 0.874507 0.000000 0.000000 -0.485014 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701F5187, 0x701F5188, '2021-06-08 11:48:39') /* Nexus-keyed Mana Shard (40911) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5188, 40911, 0x01F5015D, 96.6093, -93.4713, -28.9798, 0.373374, 0, 0, 0.927681,  True, '2021-06-08 11:48:39'); /* Nexus-keyed Mana Shard */
+/* @teleloc 0x01F5015D [96.609299 -93.471298 -28.979799] 0.373374 0.000000 0.000000 0.927681 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701F5189, 72378, 0x01F50102, 189.863, -1.158, -41.945, 1, 0, 0, 0, False, '2021-06-08 11:54:42'); /* Aerfalle's Sanctum Gen */
+/* @teleloc 0x01F50102 [189.863007 -1.158000 -41.945000] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/6 LandBlockExtendedData/B5F0.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B5F0.sql
@@ -1,13 +1,631 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0xB5F0;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B5F0199, 87235, 0xB5F003D9, 98.1669, 35.4613, 2.805, -0.958845, 0, 0, -0.283931, False, '2021-11-01 00:00:00'); /* Gift Box Generator */
+VALUES (0x7B5F0000, 30764, 0xB5F00102, 112.738, -74.3598, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00102 [112.737999 -74.359802 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0001, 30764, 0xB5F00103, 120.991, -68.7119, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00103 [120.990997 -68.711899 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0002, 30764, 0xB5F00104, 129.243, -63.064, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00104 [129.242996 -63.063999 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0003, 30764, 0xB5F00105, 107.091, -66.1074, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00105 [107.091003 -66.107399 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0004, 30764, 0xB5F00106, 123.595, -54.8117, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00106 [123.595001 -54.811699 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0005, 30764, 0xB5F00107, 101.443, -57.855, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00107 [101.443001 -57.855000 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0006, 30764, 0xB5F00108, 117.947, -46.5593, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00108 [117.946999 -46.559299 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0007, 30764, 0xB5F00109, 95.7949, -49.6027, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00109 [95.794899 -49.602699 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0008, 30764, 0xB5F0010A, 112.3, -38.3069, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F0010A [112.300003 -38.306900 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0009, 30764, 0xB5F0010B, 90.147, -41.3503, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F0010B [90.147003 -41.350300 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F000A, 30764, 0xB5F0010C, 98.3994, -35.7024, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F0010C [98.399399 -35.702400 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F000B, 30764, 0xB5F0010D, 106.652, -30.0546, -87.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F0010D [106.652000 -30.054600 -87.199997] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F000C, 28062, 0xB5F0010E, 129.682, -99.1169, -81.263, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* Eastern Aerlinthe Island */
+/* @teleloc 0xB5F0010E [129.682007 -99.116898 -81.263000] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F000F, 40930, 0xB5F00111, 140.129, -96.675, -81.2, -0.295604, 0, 0, 0.955311, False, '2019-02-10 00:00:00'); /* Lady of Aerlinthe's Embossed Chest */
+/* @teleloc 0xB5F00111 [140.128998 -96.675003 -81.199997] -0.295604 0.000000 0.000000 0.955311 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0010,   568, 0xB5F00115, 135.252, -89.5491, -81.2, -0.955311, 0, 0, -0.295604, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F00115 [135.251999 -89.549103 -81.199997] -0.955311 0.000000 0.000000 -0.295604 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0011, 28064, 0xB5F00116, 146.187, -87.8211, -81.263, -0.88453, 0, 0, 0.466483, False, '2019-02-10 00:00:00'); /* Western Aerlinthe Island */
+/* @teleloc 0xB5F00116 [146.186996 -87.821098 -81.263000] -0.884530 0.000000 0.000000 0.466483 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0012,   568, 0xB5F0011A, 123.971, -72.9702, -81.2, -0.955311, 0, 0, -0.295604, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F0011A [123.971001 -72.970200 -81.199997] -0.955311 0.000000 0.000000 -0.295604 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0031, 30764, 0xB5F00252, 161.814, -4.41974, -41.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00252 [161.813995 -4.419740 -41.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0032, 30764, 0xB5F00253, 170.066, 1.22811, -41.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00253 [170.065994 1.228110 -41.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0034, 30764, 0xB5F00254, 156.166, 3.83263, -41.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00254 [156.166000 3.832630 -41.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0036, 30764, 0xB5F00255, 164.418, 9.48047, -41.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00255 [164.417999 9.480470 -41.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0038, 30764, 0xB5F00262, 193.096, -67.8342, -39.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00262 [193.095993 -67.834198 -39.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F003B, 30764, 0xB5F00267, 167.462, -12.6721, -41.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00267 [167.462006 -12.672100 -41.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F003C, 30764, 0xB5F00268, 175.714, -7.02426, -41.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0xB5F00268 [175.714005 -7.024260 -41.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F003E,   568, 0xB5F0027F, 107.89, -120.393, -33.2, -0.955311, 0, 0, -0.295604, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F0027F [107.889999 -120.392998 -33.200001] -0.955311 0.000000 0.000000 -0.295604 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F004D,   568, 0xB5F0029B, 136.619, -82.2515, -33.2, -0.466483, 0, 0, -0.88453, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F0029B [136.619003 -82.251503 -33.200001] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F004E,  4453, 0xB5F0029C, 184.483, -55.2493, -33.2, -0.955311, 0, 0, -0.295604, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F0029C [184.483002 -55.249298 -33.200001] -0.955311 0.000000 0.000000 -0.295604 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F005A,   568, 0xB5F002AF, 85.2986, -87.3835, -33.2, -0.955311, 0, 0, -0.295604, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F002AF [85.298599 -87.383499 -33.200001] -0.955311 0.000000 0.000000 -0.295604 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F005B,   568, 0xB5F002AF, 90.6641, -95.2232, -33.2, -0.295604, 0, 0, 0.955311, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F002AF [90.664101 -95.223198 -33.200001] -0.295604 0.000000 0.000000 0.955311 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0069,   568, 0xB5F002C2, 114.028, -49.242, -33.2, 0.466483, 0, 0, 0.88453, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0xB5F002C2 [114.028000 -49.242001 -33.200001] 0.466483 0.000000 0.000000 0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F006A,  7924, 0xB5F0000A, 37.5459, 27.8719, 22.8107, 0.92388, 0, 0, -0.382683, False, '2019-02-10 00:00:00'); /* Linkable Monster Generator */
+/* @teleloc 0xB5F0000A [37.545898 27.871901 22.810699] 0.923880 0.000000 0.000000 -0.382683 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7B5F006A, 0x7B5F006D, '2019-02-10 00:00:00') /* Lich Oppressor (22905) */
+     , (0x7B5F006A, 0x7B5F006E, '2019-02-10 00:00:00') /* Dark Guardian (22904) */
+     , (0x7B5F006A, 0x7B5F006F, '2019-02-10 00:00:00') /* Lich Oppressor (22905) */
+     , (0x7B5F006A, 0x7B5F0070, '2019-02-10 00:00:00') /* Dark Guardian (22904) */
+     , (0x7B5F006A, 0x7B5F0072, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F0073, '2019-02-10 00:00:00') /* Plasma Golem (7098) */
+     , (0x7B5F006A, 0x7B5F0074, '2019-02-10 00:00:00') /* Plasma Golem (7098) */
+     , (0x7B5F006A, 0x7B5F0075, '2019-02-10 00:00:00') /* Incendiary Knight (31827) */
+     , (0x7B5F006A, 0x7B5F0076, '2019-02-10 00:00:00') /* Incendiary Knight (31827) */
+     , (0x7B5F006A, 0x7B5F0077, '2019-02-10 00:00:00') /* Incendiary Knight (31827) */
+     , (0x7B5F006A, 0x7B5F0078, '2019-02-10 00:00:00') /* Ashen Bones (7780) */
+     , (0x7B5F006A, 0x7B5F0079, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F007A, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F007B, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F007C, '2019-02-10 00:00:00') /* Ashen Bones (7780) */
+     , (0x7B5F006A, 0x7B5F007D, '2019-02-10 00:00:00') /* Ashen Bones (7780) */
+     , (0x7B5F006A, 0x7B5F007E, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F007F, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F0080, '2019-02-10 00:00:00') /* Ashen Bones (7780) */
+     , (0x7B5F006A, 0x7B5F0081, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F0082, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F0083, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F0084, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F0085, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F0086, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F0087, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F0088, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F0089, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F008A, '2019-02-10 00:00:00') /* Pyre Skeleton (37459) */
+     , (0x7B5F006A, 0x7B5F008B, '2019-02-10 00:00:00') /* Pyre Skeleton (37459) */
+     , (0x7B5F006A, 0x7B5F008C, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F008D, '2019-02-10 00:00:00') /* Corrupted Maiden (37453) */
+     , (0x7B5F006A, 0x7B5F008E, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F008F, '2019-02-10 00:00:00') /* Pyre Skeleton (37459) */
+     , (0x7B5F006A, 0x7B5F0090, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F0091, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F0092, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F0093, '2019-02-10 00:00:00') /* Pyre Champion (37457) */
+     , (0x7B5F006A, 0x7B5F0094, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F0095, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F0096, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F0097, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F0098, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F0099, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F009A, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F009B, '2019-02-10 00:00:00') /* Wight Captain (37460) */
+     , (0x7B5F006A, 0x7B5F009C, '2019-02-10 00:00:00') /* Wight Captain (37460) */
+     , (0x7B5F006A, 0x7B5F009D, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F009E, '2019-02-10 00:00:00') /* Wight Blade Sorcerer (37461) */
+     , (0x7B5F006A, 0x7B5F009F, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F00A0, '2019-02-10 00:00:00') /* Wight Blade Sorcerer (37461) */
+     , (0x7B5F006A, 0x7B5F00A1, '2019-02-10 00:00:00') /* Corrupted Dread (37452) */
+     , (0x7B5F006A, 0x7B5F00A2, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F00A3, '2019-02-10 00:00:00') /* Wight Blade Sorcerer (37461) */
+     , (0x7B5F006A, 0x7B5F00A4, '2019-02-10 00:00:00') /* Wight Blade Sorcerer (37461) */
+     , (0x7B5F006A, 0x7B5F00A5, '2019-02-10 00:00:00') /* Corrupted Dread (37452) */
+     , (0x7B5F006A, 0x7B5F00A6, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F00A7, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F00A8, '2019-02-10 00:00:00') /* Corrupted Maiden (37453) */
+     , (0x7B5F006A, 0x7B5F00A9, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F00AA, '2019-02-10 00:00:00') /* Pyre Champion (37457) */
+     , (0x7B5F006A, 0x7B5F00AB, '2019-02-10 00:00:00') /* Pyre Skeleton (37459) */
+     , (0x7B5F006A, 0x7B5F00AC, '2019-02-10 00:00:00') /* Dark Guardian (22904) */
+     , (0x7B5F006A, 0x7B5F00AD, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F00B1, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F00B2, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F00B4, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F00C0, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00C1, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00CB, '2019-02-10 00:00:00') /* Lich Oppressor (22905) */
+     , (0x7B5F006A, 0x7B5F00CC, '2019-02-10 00:00:00') /* Dark Guardian (22904) */
+     , (0x7B5F006A, 0x7B5F00CD, '2019-02-10 00:00:00') /* Lich Oppressor (22905) */
+     , (0x7B5F006A, 0x7B5F00CE, '2019-02-10 00:00:00') /* Dark Guardian (22904) */
+     , (0x7B5F006A, 0x7B5F00CF, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F00D0, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F00D1, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F00D2, '2019-02-10 00:00:00') /* Pyre Minion (37458) */
+     , (0x7B5F006A, 0x7B5F00D3, '2019-02-10 00:00:00') /* Corrupted Maiden (37453) */
+     , (0x7B5F006A, 0x7B5F00D4, '2019-02-10 00:00:00') /* Corrupted Dread (37452) */
+     , (0x7B5F006A, 0x7B5F00D5, '2019-02-10 00:00:00') /* Wight (37462) */
+     , (0x7B5F006A, 0x7B5F00D6, '2019-02-10 00:00:00') /* Dark Guardian (22904) */
+     , (0x7B5F006A, 0x7B5F00D7, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00D8, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00D9, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F00DA, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00DB, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00DC, '2019-02-10 00:00:00') /* Bound Pyre Champion (40924) */
+     , (0x7B5F006A, 0x7B5F00DD, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00DE, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00DF, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F00E0, '2019-02-10 00:00:00') /* Bound Light Falatacot (40925) */
+     , (0x7B5F006A, 0x7B5F00E1, '2019-02-10 00:00:00') /* Revenant Lord (40927) */
+     , (0x7B5F006A, 0x7B5F00F6, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F00F7, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F00F8, '2019-02-10 00:00:00') /* Pyre Skeleton (40926) */
+     , (0x7B5F006A, 0x7B5F0202, '2021-06-11 08:06:10') /* Pyre Skeleton (40926) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F006D, 22905, 0xB5F003AC, 99.2771, -107.808, -21.1925, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Lich Oppressor */
+/* @teleloc 0xB5F003AC [99.277100 -107.807999 -21.192499] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F006E, 22904, 0xB5F003B0, 102.812, -94.4571, -21.1917, -0.317047, 0, 0, 0.94841,  True, '2019-02-10 00:00:00'); /* Dark Guardian */
+/* @teleloc 0xB5F003B0 [102.811996 -94.457100 -21.191700] -0.317047 0.000000 0.000000 0.948410 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F006F, 22905, 0xB5F003B4, 109.423, -88.847, -21.1925, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Lich Oppressor */
+/* @teleloc 0xB5F003B4 [109.422997 -88.847000 -21.192499] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0070, 22904, 0xB5F003B5, 118.188, -82.3216, -21.1917, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Dark Guardian */
+/* @teleloc 0xB5F003B5 [118.188004 -82.321602 -21.191700] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0072, 40926, 0xB5F00288, 189.949, -64.0894, -33.1975, -0.327099, 0, 0, 0.94499,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F00288 [189.949005 -64.089401 -33.197498] -0.327099 0.000000 0.000000 0.944990 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0073,  7098, 0xB5F00264, 171.739, -17.3546, -39.19, -0.526953, 0, 0, 0.849895,  True, '2019-02-10 00:00:00'); /* Plasma Golem */
+/* @teleloc 0xB5F00264 [171.738998 -17.354601 -39.189999] -0.526953 0.000000 0.000000 0.849895 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0074,  7098, 0xB5F00265, 179.074, -12.6963, -39.19, -0.0804103, 0, 0, 0.996762,  True, '2019-02-10 00:00:00'); /* Plasma Golem */
+/* @teleloc 0xB5F00265 [179.074005 -12.696300 -39.189999] -0.080410 0.000000 0.000000 0.996762 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0075, 31827, 0xB5F00253, 165.105, -0.143451, -41.1968, 0.293277, 0, 0, -0.956028,  True, '2019-02-10 00:00:00'); /* Incendiary Knight */
+/* @teleloc 0xB5F00253 [165.104996 -0.143451 -41.196800] 0.293277 0.000000 0.000000 -0.956028 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0076, 31827, 0xB5F00254, 157.471, 3.23299, -41.1968, 0.46829, 0, 0, -0.883575,  True, '2019-02-10 00:00:00'); /* Incendiary Knight */
+/* @teleloc 0xB5F00254 [157.470993 3.232990 -41.196800] 0.468290 0.000000 0.000000 -0.883575 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0077, 31827, 0xB5F00255, 164.795, 7.13337, -41.1968, 0.257016, 0, 0, -0.966407,  True, '2019-02-10 00:00:00'); /* Incendiary Knight */
+/* @teleloc 0xB5F00255 [164.794998 7.133370 -41.196800] 0.257016 0.000000 0.000000 -0.966407 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0078,  7780, 0xB5F00354, 132.189, -73.1657, -27.1975, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Ashen Bones */
+/* @teleloc 0xB5F00354 [132.188995 -73.165703 -27.197500] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0079, 40925, 0xB5F002A2, 132.484, -72.9638, -33.194, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F002A2 [132.483994 -72.963799 -33.194000] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F007A, 40924, 0xB5F002B0, 115.364, -72.5228, -33.1973, -0.882561, 0, 0, 0.470198,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F002B0 [115.363998 -72.522797 -33.197300] -0.882561 0.000000 0.000000 0.470198 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F007B, 40924, 0xB5F002B2, 126.772, -64.7551, -33.1973, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F002B2 [126.772003 -64.755096 -33.197300] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F007C,  7780, 0xB5F0036A, 109.348, -64.5624, -27.1975, -0.875781, 0, 0, 0.482708,  True, '2019-02-10 00:00:00'); /* Ashen Bones */
+/* @teleloc 0xB5F0036A [109.348000 -64.562401 -27.197500] -0.875781 0.000000 0.000000 0.482708 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F007D,  7780, 0xB5F0036C, 120.958, -56.6167, -27.1975, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Ashen Bones */
+/* @teleloc 0xB5F0036C [120.958000 -56.616699 -27.197500] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F007E, 40925, 0xB5F002BA, 121.191, -56.4575, -33.194, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F002BA [121.191002 -56.457500 -33.194000] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F007F, 40926, 0xB5F002C0, 103.877, -56.0947, -33.1975, -0.89404, 0, 0, 0.447988,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F002C0 [103.876999 -56.094700 -33.197498] -0.894040 0.000000 0.000000 0.447988 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0080,  7780, 0xB5F00352, 121.289, -80.6258, -27.1975, -0.875781, 0, 0, 0.482709,  True, '2019-02-10 00:00:00'); /* Ashen Bones */
+/* @teleloc 0xB5F00352 [121.289001 -80.625801 -27.197500] -0.875781 0.000000 0.000000 0.482709 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0081, 40925, 0xB5F002A0, 120.896, -80.8945, -33.194, -0.89404, 0, 0, 0.447988,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F002A0 [120.896004 -80.894501 -33.194000] -0.894040 0.000000 0.000000 0.447988 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0082, 40925, 0xB5F002B8, 109.741, -64.2531, -33.194, -0.89404, 0, 0, 0.447988,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F002B8 [109.740997 -64.253098 -33.194000] -0.894040 0.000000 0.000000 0.447988 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0083, 40925, 0xB5F00391, 101.443, -57.855, -27.194, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F00391 [101.443001 -57.855000 -27.194000] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0084, 40927, 0xB5F00308, 75.8079, -2.69298, -33.1917, 0.309521, 0, 0, -0.950893,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F00308 [75.807899 -2.692980 -33.191700] 0.309521 0.000000 0.000000 -0.950893 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0085, 40925, 0xB5F00277, 140.978, -115.622, -33.194, -0.881355, 0, 0, 0.472455,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F00277 [140.977997 -115.622002 -33.194000] -0.881355 0.000000 0.000000 0.472455 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0086, 40926, 0xB5F00298, 126.472, -89.156, -33.1975, -0.882561, 0, 0, 0.470198,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F00298 [126.472000 -89.155998 -33.197498] -0.882561 0.000000 0.000000 0.470198 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0087, 40925, 0xB5F0033D, 124.034, -90.8645, -27.194, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F0033D [124.033997 -90.864502 -27.194000] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0088, 37458, 0xB5F002B6, 79.8557, -80.2556, -33.1975, 0.458107, 0, 0, -0.888897,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002B6 [79.855698 -80.255600 -33.197498] 0.458107 0.000000 0.000000 -0.888897 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0089, 37458, 0xB5F002B5, 72.8079, -89.4075, -33.1975, 0.87525, 0, 0, 0.483671,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002B5 [72.807899 -89.407501 -33.197498] 0.875250 0.000000 0.000000 0.483671 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F008A, 37459, 0xB5F002B5, 76.5028, -83.7403, -33.1975, -0.658814, 0, 0, -0.752306,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F002B5 [76.502800 -83.740303 -33.197498] -0.658814 0.000000 0.000000 -0.752306 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F008B, 37459, 0xB5F002BE, 76.5642, -71.8927, -33.1975, -0.797204, 0, 0, 0.60371,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F002BE [76.564201 -71.892700 -33.197498] -0.797204 0.000000 0.000000 0.603710 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F008C, 37458, 0xB5F002BD, 67.1982, -80.6054, -33.1975, 0.975239, 0, 0, -0.221152,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002BD [67.198196 -80.605400 -33.197498] 0.975239 0.000000 0.000000 -0.221152 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F008D, 37453, 0xB5F002BD, 69.8307, -75.606, -33.195, -0.00358377, 0, 0, -0.999994,  True, '2019-02-10 00:00:00'); /* Corrupted Maiden */
+/* @teleloc 0xB5F002BD [69.830704 -75.606003 -33.195000] -0.003584 0.000000 0.000000 -0.999994 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F008E, 37458, 0xB5F002C7, 73.0805, -70.4044, -33.1975, 1, 0, 0, 0,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002C7 [73.080498 -70.404404 -33.197498] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F008F, 37459, 0xB5F002C7, 74.6953, -67.7491, -33.1975, 0.725896, 0, 0, -0.687805,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F002C7 [74.695297 -67.749100 -33.197498] 0.725896 0.000000 0.000000 -0.687805 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0090, 40927, 0xB5F002DC, 106.652, -30.0546, -33.1917, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F002DC [106.652000 -30.054600 -33.191700] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0091, 40927, 0xB5F002D8, 89.8831, -41.5309, -33.1917, 0.886483, 0, 0, -0.46276,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F002D8 [89.883102 -41.530899 -33.191700] 0.886483 0.000000 0.000000 -0.462760 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0092, 37458, 0xB5F002C6, 67.0711, -73.1638, -33.1975, 0.785688, 0, 0, 0.618623,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002C6 [67.071098 -73.163803 -33.197498] 0.785688 0.000000 0.000000 0.618623 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0093, 37457, 0xB5F002C6, 64.1619, -72.8545, -33.1973, -0.415183, 0, 0, 0.909738,  True, '2019-02-10 00:00:00'); /* Pyre Champion */
+/* @teleloc 0xB5F002C6 [64.161903 -72.854500 -33.197300] -0.415183 0.000000 0.000000 0.909738 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0094, 40927, 0xB5F002FE, 95.356, -13.5498, -33.1917, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F002FE [95.356003 -13.549800 -33.191700] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0095, 40927, 0xB5F002FA, 78.8513, -24.8456, -33.1917, -0.892142, 0, 0, 0.451755,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F002FA [78.851303 -24.845600 -33.191700] -0.892142 0.000000 0.000000 0.451755 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0096, 37462, 0xB5F00297, 105.878, -102.265, -33.1917, -0.674225, 0, 0, 0.738526,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F00297 [105.877998 -102.264999 -33.191700] -0.674225 0.000000 0.000000 0.738526 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0097, 37462, 0xB5F0028B, 104.401, -116.598, -33.1917, -0.341883, 0, 0, 0.939743,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F0028B [104.401001 -116.598000 -33.191700] -0.341883 0.000000 0.000000 0.939743 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0098, 37462, 0xB5F00296, 102.874, -108.109, -33.1917, 0.453309, 0, 0, 0.891353,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F00296 [102.874001 -108.109001 -33.191700] 0.453309 0.000000 0.000000 0.891353 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0099, 37462, 0xB5F00296, 97.2191, -107.131, -33.1917, 0.412766, 0, 0, -0.910837,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F00296 [97.219101 -107.130997 -33.191700] 0.412766 0.000000 0.000000 -0.910837 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F009A, 37462, 0xB5F0029E, 93.3287, -100.158, -33.1917, -0.707922, 0, 0, 0.706291,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F0029E [93.328697 -100.157997 -33.191700] -0.707922 0.000000 0.000000 0.706291 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F009B, 37460, 0xB5F0029E, 96.7353, -98.6708, -33.1917, 0.027315, 0, 0, 0.999627,  True, '2019-02-10 00:00:00'); /* Wight Captain */
+/* @teleloc 0xB5F0029E [96.735298 -98.670799 -33.191700] 0.027315 0.000000 0.000000 0.999627 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F009C, 37460, 0xB5F00295, 93.6357, -113.739, -33.1917, 0.940223, 0, 0, -0.340559,  True, '2019-02-10 00:00:00'); /* Wight Captain */
+/* @teleloc 0xB5F00295 [93.635696 -113.738998 -33.191700] 0.940223 0.000000 0.000000 -0.340559 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F009D, 37462, 0xB5F0028A, 97.8392, -117.786, -33.1917, -0.867961, 0, 0, -0.496633,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F0028A [97.839203 -117.786003 -33.191700] -0.867961 0.000000 0.000000 -0.496633 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F009E, 37461, 0xB5F0028A, 96.1001, -125.828, -33.1917, -0.99228, 0, 0, 0.124021,  True, '2019-02-10 00:00:00'); /* Wight Blade Sorcerer */
+/* @teleloc 0xB5F0028A [96.100098 -125.828003 -33.191700] -0.992280 0.000000 0.000000 0.124021 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F009F, 37462, 0xB5F0029D, 91.1961, -106.203, -33.1917, -0.796568, 0, 0, -0.604549,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F0029D [91.196098 -106.203003 -33.191700] -0.796568 0.000000 0.000000 -0.604549 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A0, 37461, 0xB5F0029D, 80.9174, -104.3, -33.1917, 0.655383, 0, 0, -0.755296,  True, '2019-02-10 00:00:00'); /* Wight Blade Sorcerer */
+/* @teleloc 0xB5F0029D [80.917397 -104.300003 -33.191700] 0.655383 0.000000 0.000000 -0.755296 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A1, 37452, 0xB5F0029D, 86.4193, -105.461, -33.1768, -0.648355, 0, 0, 0.761338,  True, '2019-02-10 00:00:00'); /* Corrupted Dread */
+/* @teleloc 0xB5F0029D [86.419296 -105.460999 -33.176800] -0.648355 0.000000 0.000000 0.761338 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A2, 37462, 0xB5F0028C, 108.97, -110.227, -33.1917, 0.73751, 0, 0, -0.675337,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F0028C [108.970001 -110.226997 -33.191700] 0.737510 0.000000 0.000000 -0.675337 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A3, 37461, 0xB5F0028C, 117.487, -110.869, -33.1917, -0.804784, 0, 0, -0.593568,  True, '2019-02-10 00:00:00'); /* Wight Blade Sorcerer */
+/* @teleloc 0xB5F0028C [117.487000 -110.869003 -33.191700] -0.804784 0.000000 0.000000 -0.593568 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A4, 37461, 0xB5F0029F, 102.77, -89.2916, -33.1917, -0.0852074, 0, 0, -0.996363,  True, '2019-02-10 00:00:00'); /* Wight Blade Sorcerer */
+/* @teleloc 0xB5F0029F [102.769997 -89.291603 -33.191700] -0.085207 0.000000 0.000000 -0.996363 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A5, 37452, 0xB5F0029F, 102.141, -93.4371, -33.1768, -0.0491614, 0, 0, 0.998791,  True, '2019-02-10 00:00:00'); /* Corrupted Dread */
+/* @teleloc 0xB5F0029F [102.140999 -93.437103 -33.176800] -0.049161 0.000000 0.000000 0.998791 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A6, 40924, 0xB5F0027F, 109.978, -124.745, -33.1973, 0.309521, 0, 0, -0.950893,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F0027F [109.977997 -124.745003 -33.197300] 0.309521 0.000000 0.000000 -0.950893 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A7, 37458, 0xB5F002B7, 91.1488, -78.6223, -33.1975, 0.909388, 0, 0, 0.415948,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002B7 [91.148804 -78.622299 -33.197498] 0.909388 0.000000 0.000000 0.415948 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A8, 37453, 0xB5F002B7, 86.9161, -75.8674, -33.195, -0.330368, 0, 0, -0.943852,  True, '2019-02-10 00:00:00'); /* Corrupted Maiden */
+/* @teleloc 0xB5F002B7 [86.916100 -75.867401 -33.195000] -0.330368 0.000000 0.000000 -0.943852 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00A9, 37458, 0xB5F002C8, 77.3115, -62.3718, -33.1975, 0.769293, 0, 0, -0.638896,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002C8 [77.311501 -62.371799 -33.197498] 0.769293 0.000000 0.000000 -0.638896 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00AA, 37457, 0xB5F002C8, 79.2722, -58.7032, -33.1973, -0.765097, 0, 0, 0.643915,  True, '2019-02-10 00:00:00'); /* Pyre Champion */
+/* @teleloc 0xB5F002C8 [79.272202 -58.703201 -33.197300] -0.765097 0.000000 0.000000 0.643915 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00AB, 37459, 0xB5F002C8, 81.0666, -59.0925, -33.1975, -0.974706, 0, 0, -0.223493,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F002C8 [81.066597 -59.092499 -33.197498] -0.974706 0.000000 0.000000 -0.223493 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00AC, 22904, 0xB5F0024B, 67.664, 3.87776, -51.1917, -0.904958, 0, 0, 0.4255,  True, '2019-02-10 00:00:00'); /* Dark Guardian */
+/* @teleloc 0xB5F0024B [67.664001 3.877760 -51.191700] -0.904958 0.000000 0.000000 0.425500 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00AD, 40924, 0xB5F00241, 51.0508, -19.6366, -51.1973, -0.959525, 0, 0, -0.281624,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F00241 [51.050800 -19.636600 -51.197300] -0.959525 0.000000 0.000000 -0.281624 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00B1, 40925, 0xB5F00177, 84.3996, -33.0728, -51.194, 0.616333, 0, 0, -0.787485,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F00177 [84.399597 -33.072800 -51.194000] 0.616333 0.000000 0.000000 -0.787485 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00B2, 40924, 0xB5F001DD, 71.0366, -30.7445, -51.1973, 0.634767, 0, 0, -0.772704,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F001DD [71.036598 -30.744499 -51.197300] 0.634767 0.000000 0.000000 -0.772704 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00B4, 40925, 0xB5F00157, 59.742, -50.0415, -51.194, -0.88681, 0, 0, 0.462135,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F00157 [59.742001 -50.041500 -51.194000] -0.886810 0.000000 0.000000 0.462135 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00C0, 40927, 0xB5F00111, 141.596, -95.1991, -81.1917, 0.330163, 0, 0, -0.943924,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F00111 [141.595993 -95.199097 -81.191704] 0.330163 0.000000 0.000000 -0.943924 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00C1, 40927, 0xB5F00111, 138.684, -97.3305, -81.1917, 0.18084, 0, 0, -0.983513,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F00111 [138.684006 -97.330498 -81.191704] 0.180840 0.000000 0.000000 -0.983513 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00CB, 22905, 0xB5F003BB, 101.235, -82.7696, -21.1925, 0.350955, 0, 0, 0.936392,  True, '2019-02-10 00:00:00'); /* Lich Oppressor */
+/* @teleloc 0xB5F003BB [101.235001 -82.769600 -21.192499] 0.350955 0.000000 0.000000 0.936392 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00CC, 22904, 0xB5F00358, 150.625, -58.9862, -27.1917, -0.539497, 0, 0, -0.841987,  True, '2019-02-10 00:00:00'); /* Dark Guardian */
+/* @teleloc 0xB5F00358 [150.625000 -58.986198 -27.191700] -0.539497 0.000000 0.000000 -0.841987 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00CD, 22905, 0xB5F00358, 151.522, -60.9354, -27.1925, -0.539497, 0, 0, -0.841987,  True, '2019-02-10 00:00:00'); /* Lich Oppressor */
+/* @teleloc 0xB5F00358 [151.522003 -60.935398 -27.192499] -0.539497 0.000000 0.000000 -0.841987 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00CE, 22904, 0xB5F003C0, 120.991, -68.7119, -21.1917, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Dark Guardian */
+/* @teleloc 0xB5F003C0 [120.990997 -68.711899 -21.191700] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00CF, 40926, 0xB5F0029C, 184.454, -52.7092, -33.1975, -0.944251, 0, 0, -0.329228,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F0029C [184.453995 -52.709202 -33.197498] -0.944251 0.000000 0.000000 -0.329228 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D0, 40926, 0xB5F0029C, 182.428, -54.7959, -33.1975, -0.944251, 0, 0, -0.329228,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F0029C [182.427994 -54.795898 -33.197498] -0.944251 0.000000 0.000000 -0.329228 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D1, 40926, 0xB5F00285, 167.243, -86.3084, -33.1975, -0.89404, 0, 0, 0.447988,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F00285 [167.242996 -86.308403 -33.197498] -0.894040 0.000000 0.000000 0.447988 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D2, 37458, 0xB5F002C7, 71.025, -68.0591, -33.1975, 0.500733, 0, 0, -0.865602,  True, '2019-02-10 00:00:00'); /* Pyre Minion */
+/* @teleloc 0xB5F002C7 [71.025002 -68.059097 -33.197498] 0.500733 0.000000 0.000000 -0.865602 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D3, 37453, 0xB5F002B6, 83.6733, -76.824, -33.195, -0.74416, 0, 0, -0.668001,  True, '2019-02-10 00:00:00'); /* Corrupted Maiden */
+/* @teleloc 0xB5F002B6 [83.673302 -76.823997 -33.195000] -0.744160 0.000000 0.000000 -0.668001 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D4, 37452, 0xB5F0029F, 103.756, -88.6435, -33.1768, 0.897502, 0, 0, -0.44101,  True, '2019-02-10 00:00:00'); /* Corrupted Dread */
+/* @teleloc 0xB5F0029F [103.755997 -88.643501 -33.176800] 0.897502 0.000000 0.000000 -0.441010 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D5, 37462, 0xB5F0028C, 108.997, -107.452, -33.1917, 1, 0, 0, 0,  True, '2019-02-10 00:00:00'); /* Wight */
+/* @teleloc 0xB5F0028C [108.997002 -107.452003 -33.191700] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D6, 22904, 0xB5F0024A, 72.6644, 7.27334, -51.1917, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Dark Guardian */
+/* @teleloc 0xB5F0024A [72.664398 7.273340 -51.191700] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D7, 40927, 0xB5F00249, 68.6278, 7.42263, -51.1917, -0.960175, 0, 0, -0.279399,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F00249 [68.627800 7.422630 -51.191700] -0.960175 0.000000 0.000000 -0.279399 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D8, 40927, 0xB5F00249, 71.5538, 3.4984, -51.1917, 0.309521, 0, 0, -0.950893,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F00249 [71.553802 3.498400 -51.191700] 0.309521 0.000000 0.000000 -0.950893 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00D9, 40924, 0xB5F00244, 100.565, 14.2506, -51.1973, -0.959525, 0, 0, -0.281624,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F00244 [100.565002 14.250600 -51.197300] -0.959525 0.000000 0.000000 -0.281624 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00DA, 40927, 0xB5F001AE, 117.509, -10.5065, -51.1917, -0.952185, 0, 0, -0.305521,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F001AE [117.509003 -10.506500 -51.191700] -0.952185 0.000000 0.000000 -0.305521 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00DB, 40927, 0xB5F0015F, 67.9944, -44.3937, -51.1917, -0.952185, 0, 0, -0.305521,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F0015F [67.994400 -44.393700 -51.191700] -0.952185 0.000000 0.000000 -0.305521 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00DC, 40924, 0xB5F0020D, 103.608, -7.90198, -51.1973, -0.875781, 0, 0, 0.482709,  True, '2019-02-10 00:00:00'); /* Bound Pyre Champion */
+/* @teleloc 0xB5F0020D [103.608002 -7.901980 -51.197300] -0.875781 0.000000 0.000000 0.482709 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00DD, 40927, 0xB5F0022C, 120.113, 3.39376, -51.1917, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F0022C [120.112999 3.393760 -51.191700] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00DE, 40927, 0xB5F001F5, 87.1036, -19.1977, -51.1917, 0.285655, 0, 0, -0.958332,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F001F5 [87.103600 -19.197701 -51.191700] 0.285655 0.000000 0.000000 -0.958332 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00DF, 40925, 0xB5F001BA, 125.761, -4.85861, -51.194, -0.466483, 0, 0, -0.88453,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F001BA [125.761002 -4.858610 -51.194000] -0.466483 0.000000 0.000000 -0.884530 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00E0, 40925, 0xB5F00196, 101.004, -21.8022, -51.194, -0.999895, 0, 0, 0.0145136,  True, '2019-02-10 00:00:00'); /* Bound Light Falatacot */
+/* @teleloc 0xB5F00196 [101.003998 -21.802200 -51.194000] -0.999895 0.000000 0.000000 0.014514 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00E1, 40927, 0xB5F001C2, 54.0942, -41.7892, -51.1917, -0.88681, 0, 0, 0.462134,  True, '2019-02-10 00:00:00'); /* Revenant Lord */
+/* @teleloc 0xB5F001C2 [54.094200 -41.789200 -51.191700] -0.886810 0.000000 0.000000 0.462134 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00F6, 40926, 0xB5F003D9, 97.5216, 36.4032, 2.8025, 0.285655, 0, 0, -0.958333,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F003D9 [97.521599 36.403198 2.802500] 0.285655 0.000000 0.000000 -0.958333 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00F7, 40926, 0xB5F003CC, 98.3666, 24.7183, 2.8025, 0.886691, 0, 0, -0.462363,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F003CC [98.366600 24.718300 2.802500] 0.886691 0.000000 0.000000 -0.462363 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F00F8, 40926, 0xB5F003D3, 108.929, 32.3047, 2.8025, -0.440003, 0, 0, -0.897996,  True, '2019-02-10 00:00:00'); /* Pyre Skeleton */
+/* @teleloc 0xB5F003D3 [108.929001 32.304699 2.802500] -0.440003 0.000000 0.000000 -0.897996 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0199, 87235, 0xB5F003D9, 98.1669, 35.4613, 2.805, -0.958845, 0, 0, -0.283931, False, '2021-06-08 12:16:26'); /* Gift Box Generator */
 /* @teleloc 0xB5F003D9 [98.166901 35.461300 2.805000] -0.958845 0.000000 0.000000 -0.283931 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B5F0200, 80215, 0xB5F00121, 115.431, -60.4282, -81.195, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Menhir Ring Sixteen */
+VALUES (0x7B5F0200, 80215, 0xB5F00121, 115.431, -60.4282, -81.195, 1, 0, 0, 0, False, '2021-01-18 09:00:00'); /* Menhir Ring Sixteen */
 /* @teleloc 0xB5F00121 [115.431000 -60.428200 -81.195000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B5F0201,  8127, 0xB5F00121, 115.431, -60.4282, -81.195, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Menhir Mana Field */
+VALUES (0x7B5F0201,  8127, 0xB5F00121, 115.431, -60.4282, -81.195, 1, 0, 0, 0, False, '2021-01-18 09:00:00'); /* Menhir Mana Field */
 /* @teleloc 0xB5F00121 [115.431000 -60.428200 -81.195000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0202, 40926, 0xB5F00285, 166.498, -85.2382, -33.1975, 0.876015, 0, 0, -0.482284,  True, '2021-06-11 08:06:10'); /* Pyre Skeleton */
+/* @teleloc 0xB5F00285 [166.498001 -85.238197 -33.197498] 0.876015 0.000000 0.000000 -0.482284 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0203, 72379, 0xB5F00124, 111.039, -54.0976, -81.145, -0.960748, 0, 0, -0.277424, False, '2021-06-11 12:20:59'); /* Aerfalle Extreme Gen */
+/* @teleloc 0xB5F00124 [111.039001 -54.097599 -81.144997] -0.960748 0.000000 0.000000 -0.277424 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0204, 72380, 0xB5F00124, 111.663, -51.3954, -81.145, 0.951938, 0, 0, 0.306291, False, '2021-06-11 12:34:00');
+/* @teleloc 0xB5F00124 [111.663002 -51.395401 -81.144997] 0.951938 0.000000 0.000000 0.306291 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B5F0205, 72381, 0xB5F00111, 138.154, -93.6048, -81.1385, -0.959525, 0, 0, -0.281624, False, '2021-06-11 13:10:56');
+/* @teleloc 0xB5F00111 [138.154007 -93.604797 -81.138496] -0.959525 0.000000 0.000000 -0.281624 */

--- a/Database/Patches/8 QuestDefDB/AerfalleCharmPickup.sql
+++ b/Database/Patches/8 QuestDefDB/AerfalleCharmPickup.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'AerfalleCharmPickup';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AerfalleCharmPickup', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/AerfalleEmbossedTokenPickup.sql
+++ b/Database/Patches/8 QuestDefDB/AerfalleEmbossedTokenPickup.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'AerfalleEmbossedTokenPickup';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AerfalleEmbossedTokenPickup', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/AerfalleOrnateTokenPickup.sql
+++ b/Database/Patches/8 QuestDefDB/AerfalleOrnateTokenPickup.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'AerfalleOrnateTokenPickup';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AerfalleOrnateTokenPickup', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/AerfalleRewardGiverInProgress.sql
+++ b/Database/Patches/8 QuestDefDB/AerfalleRewardGiverInProgress.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'AerfalleRewardGiverInProgress';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AerfalleRewardGiverInProgress', 300, -1, 'Ghost of Galaeral Spawned', '2021-02-07 06:51:50');

--- a/Database/Patches/8 QuestDefDB/AerfalleTokenPickup.sql
+++ b/Database/Patches/8 QuestDefDB/AerfalleTokenPickup.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'AerfalleTokenPickup';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AerfalleTokenPickup', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/AshbaneExtremeTurnedIn.sql
+++ b/Database/Patches/8 QuestDefDB/AshbaneExtremeTurnedIn.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'AshbaneExtremeTurnedIn';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('AshbaneExtremeTurnedIn', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/EmbossedAshenKeyPickup.sql
+++ b/Database/Patches/8 QuestDefDB/EmbossedAshenKeyPickup.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'EmbossedAshenKeyPickup';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('EmbossedAshenKeyPickup', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/ExtremeAerfalleStaffObtained.sql
+++ b/Database/Patches/8 QuestDefDB/ExtremeAerfalleStaffObtained.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'ExtremeAerfalleStaffObtained';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('ExtremeAerfalleStaffObtained', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/28058 Staff of Aerfalle.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/28058 Staff of Aerfalle.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28058;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28058, 'ace28058-staffaerfallenew', 35, '2005-02-09 10:00:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28058,   1,      32768) /* ItemType - Caster */
+     , (28058,   3,         20) /* PaletteTemplate - Silver */
+     , (28058,   5,        250) /* EncumbranceVal */
+     , (28058,   8,         25) /* Mass */
+     , (28058,   9,   16777216) /* ValidLocations - Held */
+     , (28058,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (28058,  18,          1) /* UiEffects - Magical */
+     , (28058,  19,      10150) /* Value */
+     , (28058,  33,          1) /* Bonded - Bonded */
+     , (28058,  46,        512) /* DefaultCombatStyle - Magic */
+     , (28058,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (28058,  94,         16) /* TargetType - Creature */
+     , (28058, 106,        300) /* ItemSpellcraft */
+     , (28058, 107,       1500) /* ItemCurMana */
+     , (28058, 108,       3000) /* ItemMaxMana */
+     , (28058, 109,        100) /* ItemDifficulty */
+     , (28058, 114,          1) /* Attuned - Attuned */
+     , (28058, 115,        275) /* ItemSkillLevelLimit */
+     , (28058, 117,        250) /* ItemManaCost */
+     , (28058, 150,        103) /* HookPlacement - Hook */
+     , (28058, 151,          2) /* HookType - Wall */
+     , (28058, 353,         12) /* WeaponType - Magic */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28058,  15, True ) /* LightsStatus */
+     , (28058,  22, True ) /* Inscribable */
+     , (28058,  23, True ) /* DestroyOnSell */
+     , (28058,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28058,   5,  -0.083) /* ManaRate */
+     , (28058,  29,    1.04) /* WeaponDefense */
+     , (28058, 144,    0.06) /* ManaConversionMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28058,   1, 'Staff of Aerfalle') /* Name */
+     , (28058,   7, 'Made with the help of Rytheran and, in beneficence, His Eternal Splendor.') /* Inscription */
+     , (28058,   8, 'Lady Aerfalle') /* ScribeName */
+     , (28058,  16, 'A staff made from the petrified wood of Aerlinthe, taken from the Dark Magus of that island. This artifact is several centuries old.') /* LongDesc */
+     , (28058,  33, 'AerfalleStaffObtained') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28058,   1,   33556630) /* Setup */
+     , (28058,   3,  536870932) /* SoundTable */
+     , (28058,   6,   67111919) /* PaletteBase */
+     , (28058,   7,  268436016) /* ClothingBase */
+     , (28058,   8,  100670752) /* Icon */
+     , (28058,  22,  872415275) /* PhysicsEffectTable */
+     , (28058,  27, 1073742049) /* UseUserAnimation - UseMagicWand */
+     , (28058,  28,        130) /* Spell - Acid Volley VI */
+     , (28058,  36,  234881046) /* MutateFilter */
+     , (28058,  37,         34) /* ItemSkillLimit - WarMagic */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (28058,   616,      2)  /* Life Magic Mastery Other VI */
+     , (28058,   640,      2)  /* War Magic Mastery Other VI */
+     , (28058,   909,      2)  /* Leadership Mastery Other VI */;

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/28059 War Staff of Aerfalle.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/28059 War Staff of Aerfalle.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28059;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28059, 'ace28059-staffaerfallenewuber', 35, '2005-02-09 10:00:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28059,   1,      32768) /* ItemType - Caster */
+     , (28059,   3,         20) /* PaletteTemplate - Silver */
+     , (28059,   5,        250) /* EncumbranceVal */
+     , (28059,   8,         25) /* Mass */
+     , (28059,   9,   16777216) /* ValidLocations - Held */
+     , (28059,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (28059,  18,          1) /* UiEffects - Magical */
+     , (28059,  19,      12150) /* Value */
+     , (28059,  33,          1) /* Bonded - Bonded */
+     , (28059,  46,        512) /* DefaultCombatStyle - Magic */
+     , (28059,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (28059,  94,         16) /* TargetType - Creature */
+     , (28059, 106,        325) /* ItemSpellcraft */
+     , (28059, 107,       2000) /* ItemCurMana */
+     , (28059, 108,       3500) /* ItemMaxMana */
+     , (28059, 109,        120) /* ItemDifficulty */
+     , (28059, 114,          1) /* Attuned - Attuned */
+     , (28059, 115,        325) /* ItemSkillLevelLimit */
+     , (28059, 117,        250) /* ItemManaCost */
+     , (28059, 150,        103) /* HookPlacement - Hook */
+     , (28059, 151,          2) /* HookType - Wall */
+     , (28059, 353,         12) /* WeaponType - Magic */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28059,  15, True ) /* LightsStatus */
+     , (28059,  22, True ) /* Inscribable */
+     , (28059,  23, True ) /* DestroyOnSell */
+     , (28059,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28059,   5,  -0.083) /* ManaRate */
+     , (28059,  29,    1.06) /* WeaponDefense */
+     , (28059, 144,     0.1) /* ManaConversionMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28059,   1, 'War Staff of Aerfalle') /* Name */
+     , (28059,   7, 'Made with the help of Rytheran and, in beneficence, His Eternal Splendor.') /* Inscription */
+     , (28059,   8, 'Lady Aerfalle') /* ScribeName */
+     , (28059,  16, 'A staff made from the petrified wood of Aerlinthe, taken from the Dark Magus of that island. This artifact is several centuries old.') /* LongDesc */
+     , (28059,  33, 'UberAerfalleStaffObtained') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28059,   1,   33556630) /* Setup */
+     , (28059,   3,  536870932) /* SoundTable */
+     , (28059,   6,   67111919) /* PaletteBase */
+     , (28059,   7,  268436016) /* ClothingBase */
+     , (28059,   8,  100670752) /* Icon */
+     , (28059,  22,  872415275) /* PhysicsEffectTable */
+     , (28059,  27, 1073742049) /* UseUserAnimation - UseMagicWand */
+     , (28059,  28,       2123) /* Spell - Celdiseth's Searing */
+     , (28059,  36,  234881046) /* MutateFilter */
+     , (28059,  37,         34) /* ItemSkillLimit - WarMagic */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (28059,   616,      2)  /* Life Magic Mastery Other VI */
+     , (28059,   909,      2)  /* Leadership Mastery Other VI */
+     , (28059,  2322,      2)  /* Hieromancer's Boon */;

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/40909 Mana-infused Acid War Staff of Aerfalle.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/40909 Mana-infused Acid War Staff of Aerfalle.sql
@@ -1,0 +1,67 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40909;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40909, 'ace40909-manainfusedacidwarstaffofaerfalle', 35, '2019-02-10 00:00:00') /* Caster */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40909,   1,      32768) /* ItemType - Caster */
+     , (40909,   3,         20) /* PaletteTemplate - Silver */
+     , (40909,   5,        250) /* EncumbranceVal */
+     , (40909,   8,         25) /* Mass */
+     , (40909,   9,   16777216) /* ValidLocations - Held */
+     , (40909,  16,    6291460) /* ItemUseable - SourceWieldedTargetRemoteNeverWalk */
+     , (40909,  18,          1) /* UiEffects - Magical */
+     , (40909,  19,      15000) /* Value */
+     , (40909,  33,          1) /* Bonded - Bonded */
+     , (40909,  45,         32) /* DamageType - Acid */
+     , (40909,  46,        512) /* DefaultCombatStyle - Magic */
+     , (40909,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (40909,  94,         16) /* TargetType - Creature */
+     , (40909, 106,        450) /* ItemSpellcraft */
+     , (40909, 107,       2500) /* ItemCurMana */
+     , (40909, 108,       5000) /* ItemMaxMana */
+     , (40909, 114,          1) /* Attuned - Attuned */
+     , (40909, 151,          2) /* HookType - Wall */
+     , (40909, 158,          7) /* WieldRequirements - Level */
+     , (40909, 159,          1) /* WieldSkillType - Axe */
+     , (40909, 160,        150) /* WieldDifficulty */
+     , (40909, 270,          1) /* WieldRequirements2 - Skill */
+     , (40909, 271,         34) /* WieldSkillType2 - WarMagic */
+     , (40909, 272,        355) /* WieldDifficulty2 */
+     , (40909, 353,         12) /* WeaponType - Magic */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40909,  22, True ) /* Inscribable */
+     , (40909,  23, True ) /* DestroyOnSell */
+     , (40909,  69, False) /* IsSellable */
+     , (40909,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40909,   5,  -0.083) /* ManaRate */
+     , (40909,  29,    1.12) /* WeaponDefense */
+     , (40909, 144,    0.15) /* ManaConversionMod */
+     , (40909, 152,    1.12) /* ElementalDamageMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40909,   1, 'Mana-infused Acid War Staff of Aerfalle') /* Name */
+     , (40909,   7, 'Made with the help of Rytheran and, in beneficence, His Eternal Splendor.') /* Inscription */
+     , (40909,   8, 'Lady Aerfalle') /* ScribeName */
+     , (40909,  16, 'A heavily enchanted staff made from the petrified wood of Aerlinthe, taken from the Dark Magus of that island. This artifact is several centuries old.') /* LongDesc */
+     , (40909,  33, 'ExtremeAerfalleStaffObtained') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40909,   1,   33556630) /* Setup */
+     , (40909,   3,  536870932) /* SoundTable */
+     , (40909,   6,   67111919) /* PaletteBase */
+     , (40909,   7,  268436016) /* ClothingBase */
+     , (40909,   8,  100670752) /* Icon */
+     , (40909,  22,  872415275) /* PhysicsEffectTable */
+     , (40909,  28,       4434) /* Spell - AcidVolley8 */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40909,  2262,      2)  /* LeadershipMasteryOther7 */
+     , (40909,  2266,      2)  /* LifeMagicMasteryOther7 */
+     , (40909,  2519,      2)  /* Major Leadership */
+     , (40909,  2520,      2)  /* Major Life Magic Aptitude */
+     , (40909,  4637,      2)  /* WarMagicMasteryOther8 */
+     , (40909,  4715,      2)  /* Epic War Magic Aptitude */;

--- a/Database/Patches/9 WeenieDefaults/Chest/Container/07408 Lady of Aerlinthe's Chest.sql
+++ b/Database/Patches/9 WeenieDefaults/Chest/Container/07408 Lady of Aerlinthe's Chest.sql
@@ -1,0 +1,58 @@
+DELETE FROM `weenie` WHERE `class_Id` = 7408;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (7408, 'chestaerfalle', 20, '2005-02-09 10:00:00') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (7408,   1,        512) /* ItemType - Container */
+     , (7408,   5,       9000) /* EncumbranceVal */
+     , (7408,   6,         -1) /* ItemsCapacity */
+     , (7408,   7,         -1) /* ContainersCapacity */
+     , (7408,   8,       3000) /* Mass */
+     , (7408,  16,         48) /* ItemUseable - ViewedRemote */
+     , (7408,  19,       2500) /* Value */
+     , (7408,  37,        240) /* ResistItemAppraisal */
+     , (7408,  38,       5000) /* ResistLockpick */
+     , (7408,  81,          6) /* MaxGeneratedObjects */
+     , (7408,  82,          6) /* InitGeneratedObjects */
+     , (7408,  83,          2) /* ActivationResponse - Use */
+     , (7408,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (7408,  96,        500) /* EncumbranceCapacity */
+     , (7408, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (7408,   1, True ) /* Stuck */
+     , (7408,   2, False) /* Open */
+     , (7408,   3, True ) /* Locked */
+     , (7408,  12, True ) /* ReportCollisions */
+     , (7408,  13, False) /* Ethereal */
+     , (7408,  33, False) /* ResetMessagePending */
+     , (7408,  34, False) /* DefaultOpen */
+     , (7408,  35, True ) /* DefaultLocked */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (7408,  11,      30) /* ResetInterval */
+     , (7408,  41,      30) /* RegenerationInterval */
+     , (7408,  43,       1) /* GeneratorRadius */
+     , (7408,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (7408,   1, 'Lady of Aerlinthe''s Chest') /* Name */
+     , (7408,  12, 'keyaerfalle') /* LockCode */
+     , (7408,  14, 'Use this item to open it and see its contents.') /* Use */
+     , (7408,  16, 'A rusty old chest, inscribed with Dericostian runes. There is a suspicious glow near the lock.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (7408,   1,   33554556) /* Setup */
+     , (7408,   2,  150994948) /* MotionTable */
+     , (7408,   3,  536870945) /* SoundTable */
+     , (7408,   8,  100667424) /* Icon */
+     , (7408,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (7408, -1, 9010, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Unreadable Scroll (9010) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (7408, -1, 28058, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Staff of Aerfalle (28058) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (7408, -1, 28045, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Aerfalle's Pallium (28045) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (7408, -1, 28066, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Ashbane (28066) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (7408, -1, 40913, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Aerfalle's Token (40913) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (7408, -1, 317, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 5 from Death Treasure Table id: 317 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Chest/Container/28047 Lady of Aerlinthe's Ornate Chest.sql
+++ b/Database/Patches/9 WeenieDefaults/Chest/Container/28047 Lady of Aerlinthe's Ornate Chest.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28047;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28047, 'chestaerfalleuber', 20, '2021-11-01 00:00:00') /* Chest */;
+VALUES (28047, 'chestaerfalleuber', 20, '2019-04-08 04:44:07') /* Chest */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28047,   1,        512) /* ItemType - Container */
@@ -14,8 +14,8 @@ VALUES (28047,   1,        512) /* ItemType - Container */
      , (28047,  19,       2500) /* Value */
      , (28047,  37,        240) /* ResistItemAppraisal */
      , (28047,  38,       5000) /* ResistLockpick */
-     , (28047,  81,          5) /* MaxGeneratedObjects */
-     , (28047,  82,          5) /* InitGeneratedObjects */
+     , (28047,  81,          6) /* MaxGeneratedObjects */
+     , (28047,  82,          6) /* InitGeneratedObjects */
      , (28047,  83,          2) /* ActivationResponse - Use */
      , (28047,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
      , (28047,  96,        500) /* EncumbranceCapacity */
@@ -44,17 +44,18 @@ VALUES (28047,   1, 'Lady of Aerlinthe''s Ornate Chest') /* Name */
      , (28047,  16, 'A beautifully detailed chest made of ebony wood and polished gold, inscribed with Dericostian runes. There is a suspicious glow near the lock.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (28047,   1, 0x02000F7A) /* Setup */
-     , (28047,   2, 0x09000004) /* MotionTable */
-     , (28047,   3, 0x20000021) /* SoundTable */
-     , (28047,   6, 0x040015A4) /* PaletteBase */
-     , (28047,   7, 0x10000567) /* ClothingBase */
-     , (28047,   8, 0x0600344A) /* Icon */
-     , (28047,  22, 0x3400002B) /* PhysicsEffectTable */;
+VALUES (28047,   1,   33558394) /* Setup */
+     , (28047,   2,  150994948) /* MotionTable */
+     , (28047,   3,  536870945) /* SoundTable */
+     , (28047,   6,   67114404) /* PaletteBase */
+     , (28047,   7,  268436839) /* ClothingBase */
+     , (28047,   8,  100676682) /* Icon */
+     , (28047,  22,  872415275) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (28047, -1, 9010, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Unreadable Scroll (9010) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
      , (28047, -1, 28059, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate War Staff of Aerfalle (28059) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
      , (28047, -1, 28046, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Aerfalle's Supreme Pallium (28046) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
      , (28047, -1, 28067, 0, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Superior Ashbane (28067) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (28047, -1, 40914, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Aerfalle's Ornate Token (40914) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
      , (28047, -1, 317, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 5 from Death Treasure Table id: 317 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Chest/Container/40930 Lady of Aerlinthe's Embossed Chest.sql
+++ b/Database/Patches/9 WeenieDefaults/Chest/Container/40930 Lady of Aerlinthe's Embossed Chest.sql
@@ -1,0 +1,60 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40930;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40930, 'ace40930-chestaerfalleextreme', 20, '2019-02-10 00:00:00') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40930,   1,        512) /* ItemType - Container */
+     , (40930,   5,       9000) /* EncumbranceVal */
+     , (40930,   6,         -1) /* ItemsCapacity */
+     , (40930,   7,         -1) /* ContainersCapacity */
+     , (40930,  16,         48) /* ItemUseable - ViewedRemote */
+     , (40930,  19,       2500) /* Value */
+     , (40930,  38,       5000) /* ResistLockpick */
+     , (40930,  81,          7) /* MaxGeneratedObjects */
+     , (40930,  82,          7) /* InitGeneratedObjects */
+     , (40930,  83,          2) /* ActivationResponse - Use */
+     , (40930,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (40930, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40930,   1, True ) /* Stuck */
+     , (40930,   2, False) /* Open */
+     , (40930,   3, True ) /* Locked */
+     , (40930,  33, False) /* ResetMessagePending */
+     , (40930,  34, False) /* DefaultOpen */
+     , (40930,  35, True ) /* DefaultLocked */
+     , (40930,  86, True ) /* ChestRegenOnClose */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40930,  11,      30) /* ResetInterval */
+     , (40930,  41,      30) /* RegenerationInterval */
+     , (40930,  43,       1) /* GeneratorRadius */
+     , (40930,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40930,   1, 'Lady of Aerlinthe''s Embossed Chest') /* Name */
+     , (40930,  12, 'EmbossedAshenKey') /* LockCode */
+     , (40930,  14, 'Use this item to open it and see its contents.') /* Use */
+     , (40930,  16, 'A beautifully detailed chest made of ebony wood and polished, embossed gold. The entirety of the chest is inscribed with Dericostian runes. There is a suspicious glow near the lock.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40930,   1,   33558394) /* Setup */
+     , (40930,   2,  150994948) /* MotionTable */
+     , (40930,   3,  536870945) /* SoundTable */
+     , (40930,   7,  268436839) /* ClothingBase */
+     , (40930,   8,  100676682) /* Icon */
+     , (40930,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40930, 8040, 3052405009, 140.129, -96.675, -81.2, -0.2956039, 0, 0, 0.9553106) /* PCAPRecordedLocation */
+/* @teleloc 0xB5F00111 [140.129000 -96.675000 -81.200000] -0.295604 0.000000 0.000000 0.955311 */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40930, -1, 9010, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Unreadable Scroll (9010) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (40930, -1, 40909, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mana-infused Acid War Staff of Aerfalle (40909) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (40930, -1, 40907, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Aerfalle's Mana-infused Pallium (40907) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (40930, -1, 40908, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Reforged Ashbane (40908) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (40930, -1, 40912, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Aerfalle's Embossed Token (40912) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (40930, -1, 46035, 0, 1, 1, 2, 8, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enhanced Black Fire Atlan Stone (46035) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (40930, -1,  2001, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 8 from Death Treasure Table id: 2001 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Clothing/40907 Aerfalle's Mana-infused Pallium.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Clothing/40907 Aerfalle's Mana-infused Pallium.sql
@@ -1,0 +1,65 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40907;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40907, 'ace40907-aerfallesmanainfusedpallium', 2, '2019-02-10 00:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40907,   1,          4) /* ItemType - Clothing */
+     , (40907,   3,         39) /* PaletteTemplate - Black */
+     , (40907,   4,      81664) /* ClothingPriority - OuterwearUpperLegs, OuterwearLowerLegs, OuterwearChest, OuterwearAbdomen, OuterwearUpperArms, OuterwearLowerArms, Feet */
+     , (40907,   5,        200) /* EncumbranceVal */
+     , (40907,   9,      32512) /* ValidLocations - Armor */
+     , (40907,  16,          1) /* ItemUseable - No */
+     , (40907,  18,          1) /* UiEffects - Magical */
+     , (40907,  19,      15000) /* Value */
+     , (40907,  28,        220) /* ArmorLevel */
+     , (40907,  33,          1) /* Bonded - Bonded */
+     , (40907,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40907, 106,        400) /* ItemSpellcraft */
+     , (40907, 107,       3000) /* ItemCurMana */
+     , (40907, 108,       3000) /* ItemMaxMana */
+     , (40907, 109,        325) /* ItemDifficulty */
+     , (40907, 114,          1) /* Attuned - Attuned */
+     , (40907, 151,          2) /* HookType - Wall */
+     , (40907, 158,          7) /* WieldRequirements - Level */
+     , (40907, 159,          1) /* WieldSkillType - Axe */
+     , (40907, 160,        150) /* WieldDifficulty */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40907,  22, True ) /* Inscribable */
+     , (40907,  23, True ) /* DestroyOnSell */
+     , (40907,  69, False) /* IsSellable */
+     , (40907,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40907,   5,   -0.05) /* ManaRate */
+     , (40907,  12,  0.0986) /* Shade */
+     , (40907,  13,     0.8) /* ArmorModVsSlash */
+     , (40907,  14,     0.8) /* ArmorModVsPierce */
+     , (40907,  15,       1) /* ArmorModVsBludgeon */
+     , (40907,  16,     0.8) /* ArmorModVsCold */
+     , (40907,  17,     0.8) /* ArmorModVsFire */
+     , (40907,  18,     0.8) /* ArmorModVsAcid */
+     , (40907,  19,     0.8) /* ArmorModVsElectric */
+     , (40907, 165,       1) /* ArmorModVsNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40907,   1, 'Aerfalle''s Mana-infused Pallium') /* Name */
+     , (40907,  16, 'A heavily enchanted black robe obtained from the Lady of Aerlinthe''s personal treasure chest.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40907,   1,   33554854) /* Setup */
+     , (40907,   3,  536870932) /* SoundTable */
+     , (40907,   6,   67108990) /* PaletteBase */
+     , (40907,   7,  268435853) /* ClothingBase */
+     , (40907,   8,  100672444) /* Icon */
+     , (40907,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40907,  3964,      2)  /* Epic Focus */
+     , (40907,  4227,      2)  /* Epic Willpower */
+     , (40907,  4304,      2)  /* FocusOther8 */
+     , (40907,  4328,      2)  /* WillpowerOther8 */
+     , (40907,  4601,      2)  /* ManaMasteryOther8 */
+     , (40907,  4705,      2)  /* Epic Mana Conversion */
+     , (40907,  5009,      2)  /* AerfallesWardGreater */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/28060 Ghost of Galaeral.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/28060 Ghost of Galaeral.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28060;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28060, 'ghostgalaeralnpc', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (28060, 'ghostgalaeralnpc', 10, '2021-06-13 11:30:01') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (28060,   1,         16) /* ItemType - Creature */
@@ -20,12 +20,7 @@ VALUES (28060,   1,         16) /* ItemType - Creature */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (28060,   1, True ) /* Stuck */
-     , (28060,   8, True ) /* AllowGive */
-     , (28060,  12, True ) /* ReportCollisions */
-     , (28060,  13, False) /* Ethereal */
-     , (28060,  19, False) /* Attackable */
-     , (28060,  41, True ) /* ReportCollisionsAsEnvironment */
-     , (28060,  52, True ) /* AiImmobile */;
+     , (28060,  19, False) /* Attackable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (28060,   1,       5) /* HeartbeatInterval */
@@ -33,6 +28,7 @@ VALUES (28060,   1,       5) /* HeartbeatInterval */
      , (28060,   3,     0.6) /* HealthRate */
      , (28060,   4,     0.5) /* StaminaRate */
      , (28060,   5,       2) /* ManaRate */
+     , (28060,  12,     0.5) /* Shade */
      , (28060,  13,     0.8) /* ArmorModVsSlash */
      , (28060,  14,    0.47) /* ArmorModVsPierce */
      , (28060,  15,    0.65) /* ArmorModVsBludgeon */
@@ -63,12 +59,22 @@ INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (28060,   1, 'Ghost of Galaeral') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (28060,   1, 0x020016E7) /* Setup */
-     , (28060,   2, 0x090001CB) /* MotionTable */
-     , (28060,   3, 0x200000B6) /* SoundTable */
-     , (28060,   4, 0x3000003D) /* CombatTable */
-     , (28060,   8, 0x06003447) /* Icon */
-     , (28060,  22, 0x340000AB) /* PhysicsEffectTable */;
+VALUES (28060,   1,   33560295) /* Setup */
+     , (28060,   2,  150995403) /* MotionTable */
+     , (28060,   3,  536871094) /* SoundTable */
+     , (28060,   8,  100676679) /* Icon */
+     , (28060,  22,  872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (28060,  0,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (28060,  1,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (28060,  2,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (28060,  3,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (28060,  4,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (28060,  5,  4,  2, 0.75,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (28060,  6,  4,  0,    0,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (28060,  7,  4,  0,    0,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (28060,  8,  4,  3, 0.75,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (28060,   1, 140, 0, 0) /* Strength */
@@ -79,86 +85,110 @@ VALUES (28060,   1, 140, 0, 0) /* Strength */
      , (28060,   6, 290, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (28060,   1,   100, 0, 0, 200) /* MaxHealth */
-     , (28060,   3,   150, 0, 0, 350) /* MaxStamina */
-     , (28060,   5,   150, 0, 0, 440) /* MaxMana */;
+VALUES (28060,   1,   100, 0, 0,  200) /* MaxHealth */
+     , (28060,   3,   150, 0, 0,  350) /* MaxStamina */
+     , (28060,   5,   150, 0, 0,  440) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (28060,  1, 0, 3, 0, 125, 0, 1984.09299414236) /* Axe                 Specialized */
-     , (28060,  2, 0, 2, 0, 110, 0, 1984.09299414236) /* Bow                 Trained */
-     , (28060,  3, 0, 2, 0, 110, 0, 1984.09299414236) /* Crossbow            Trained */
-     , (28060,  4, 0, 3, 0, 120, 0, 1984.09299414236) /* Dagger              Specialized */
-     , (28060,  5, 0, 3, 0, 120, 0, 1984.09299414236) /* Mace                Specialized */
-     , (28060,  6, 0, 2, 0, 130, 0, 1984.09299414236) /* MeleeDefense        Trained */
-     , (28060,  7, 0, 2, 0, 120, 0, 1984.09299414236) /* MissileDefense      Trained */
-     , (28060,  9, 0, 2, 0, 100, 0, 1984.09299414236) /* Spear               Trained */
-     , (28060, 10, 0, 2, 0, 100, 0, 1984.09299414236) /* Staff               Trained */
-     , (28060, 11, 0, 3, 0, 120, 0, 1984.09299414236) /* Sword               Specialized */
-     , (28060, 13, 0, 2, 0, 200, 0, 1984.09299414236) /* UnarmedCombat       Trained */
-     , (28060, 14, 0, 2, 0, 230, 0, 1984.09299414236) /* ArcaneLore          Trained */
-     , (28060, 15, 0, 2, 0, 182, 0, 1984.09299414236) /* MagicDefense        Trained */
-     , (28060, 20, 0, 2, 0,  90, 0, 1984.09299414236) /* Deception           Trained */
-     , (28060, 31, 0, 2, 0, 230, 0, 1984.09299414236) /* CreatureEnchantment Trained */
-     , (28060, 32, 0, 2, 0, 200, 0, 1984.09299414236) /* ItemEnchantment     Trained */
-     , (28060, 33, 0, 2, 0, 230, 0, 1984.09299414236) /* LifeMagic           Trained */
-     , (28060, 34, 0, 2, 0, 230, 0, 1984.09299414236) /* WarMagic            Trained */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (28060,  0,  4,  0,    0,  150,  120,   71,   98,    5,   75,   98,  108,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (28060,  1,  4,  0,    0,  150,  120,   71,   98,    5,   75,   98,  108,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (28060,  2,  4,  0,    0,  150,  120,   71,   98,    5,   75,   98,  108,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (28060,  3,  4,  0,    0,  150,  120,   71,   98,    5,   75,   98,  108,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (28060,  4,  4,  0,    0,  150,  120,   71,   98,    5,   75,   98,  108,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (28060,  5,  4,  2, 0.75,  150,  120,   71,   98,    5,   75,   98,  108,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (28060,  6,  4,  0,    0,  160,  128,   75,  104,    5,   80,  104,  115,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (28060,  7,  4,  0,    0,  160,  128,   75,  104,    5,   80,  104,  115,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (28060,  8,  4,  3, 0.75,  160,  128,   75,  104,    5,   80,  104,  115,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (28060,  1, 0, 3, 0, 125, 0,1984.09299414236) /* Axe                 Specialized */
+     , (28060,  2, 0, 2, 0, 110, 0,1984.09299414236) /* Bow                 Trained */
+     , (28060,  3, 0, 2, 0, 110, 0,1984.09299414236) /* Crossbow            Trained */
+     , (28060,  4, 0, 3, 0, 120, 0,1984.09299414236) /* Dagger              Specialized */
+     , (28060,  5, 0, 3, 0, 120, 0,1984.09299414236) /* Mace                Specialized */
+     , (28060,  6, 0, 2, 0, 130, 0,1984.09299414236) /* MeleeDefense        Trained */
+     , (28060,  7, 0, 2, 0, 120, 0,1984.09299414236) /* MissileDefense      Trained */
+     , (28060,  9, 0, 2, 0, 100, 0,1984.09299414236) /* Spear               Trained */
+     , (28060, 10, 0, 2, 0, 100, 0,1984.09299414236) /* Staff               Trained */
+     , (28060, 11, 0, 3, 0, 120, 0,1984.09299414236) /* Sword               Specialized */
+     , (28060, 13, 0, 2, 0, 200, 0,1984.09299414236) /* UnarmedCombat       Trained */
+     , (28060, 14, 0, 2, 0, 230, 0,1984.09299414236) /* ArcaneLore          Trained */
+     , (28060, 15, 0, 2, 0, 182, 0,1984.09299414236) /* MagicDefense        Trained */
+     , (28060, 20, 0, 2, 0,  90, 0,1984.09299414236) /* Deception           Trained */
+     , (28060, 31, 0, 2, 0, 230, 0,1984.09299414236) /* CreatureEnchantment Trained */
+     , (28060, 32, 0, 2, 0, 200, 0,1984.09299414236) /* ItemEnchantment     Trained */
+     , (28060, 33, 0, 2, 0, 230, 0,1984.09299414236) /* LifeMagic           Trained */
+     , (28060, 34, 0, 2, 0, 230, 0,1984.09299414236) /* WarMagic            Trained */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28060,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (28060, 5 /* HeartBeat */, 0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28060,  6 /* Give */,      1, 7447 /* Sacrificial Dagger */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (28060, 1 /* Refuse */, 1, 40911, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  17 /* LocalBroadcast */, 1, 0, NULL, 'A haunting voice echoes in the halls of the Keep. "Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years, the suffering and the agony of those she has destroyed. Blessings of Ithaenc go with you."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  23 /* StartEvent */, 1, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,   5 /* Motion */, 1, 1, 0x40000011 /* Dead */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  24 /* StopEvent */, 1, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 67 /* Goto */, 0, 1, NULL, 'CheckFellowship', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28060,  6 /* Give */,      1, 28065 /* Sacrificial Dagger */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (28060, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'CheckFellowship', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  17 /* LocalBroadcast */, 1, 0, NULL, 'A haunting voice echoes in the halls of the Keep. "Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years, the suffering and the agony of those she has destroyed. Blessings of Ithaenc go with you."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  23 /* StartEvent */, 1, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,   5 /* Motion */, 1, 1, 0x40000011 /* Dead */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  24 /* StopEvent */, 1, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 58 /* InqFellowQuest */, 0, 1, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28060,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (28060, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  10 /* Tell */, 1, 1, NULL, 'The songs of my sisters echo across eternity and I am left to rot; bound through the arts of ill-wind taught by sisters who had fallen to the call of the twisted dark. Thousands of years bound against my will to a tether not of my making, bereft of power and ability to purchase a final release, I have waited and watched within the walls of this prison.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'The skein of her life now draws taut as she is stirred to action, re-exerting her command over these halls and drawing on the lives of those she once imprisoned. Through the countless years, most that were bound here against their will have become lost and slipped into madness, the echo of their lives now scattered dust and formless agony. Not I.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  10 /* Tell */, 1, 1, NULL, 'I recall the device, the tool used to pull the blood of my heart into a vessel that held my precious vitae long enough to rip free my soul and lock it within the walls of this keep, evermore a servant to her will. But my years of servitude draw near an end, and through the voices of elder sisters who sang to the deep and refused to sell our secrets to the Dericost, I am given a moment of clarity to find my freedom. Yet the walls ever remain my prison.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  10 /* Tell */, 1, 1, NULL, 'Aerfalle has changed. She has grown her flesh anew and taken the glamour of her youth. But all this imagery is false. She risks more power at the cost of those bound in these halls. My fallen sisters seek not redemption, but through their folly they will give me mine. Aerfalle''s strength lies in tunnels long crushed by the weight of time, halls within this keep that you cannot traverse, halls which I can still travel.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  6,  10 /* Tell */, 1, 1, NULL, 'But I cannot lessen her strength without an instrument of sacrifice. The blade that drew my heart''s blood must be used to stab at her crusted heart and weaken her strength.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  7,  10 /* Tell */, 1, 1, NULL, 'Bring me the dagger and I shall take my revenge and aid you in her destruction.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 61 /* StampFellowQuest */, 0, 1, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'StartExtreme', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (28060, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'StartExtreme', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (28060, 30 /* QuestNoFellow */, 1, NULL, NULL, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'You must create a Fellowship before I can open the way.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (28060, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'StartExtreme', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 40911, -1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 64 /* TellFellow */, 1, 1, NULL, 'Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years, the suffering and the agony of those she has destroyed.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 64 /* TellFellow */, 1, 1, NULL, 'Blessings of Ithaenc go with you. You will find your gateway in the place where she once created her greater works, where now her shell of an apprentice resides.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 65 /* FellowBroadcast */, 1, 1, NULL, 'The Ghost of Galaeral chants a few words, binding your fellowship together and settling a protective enchantment over you all.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 64 /* TellFellow */, 1, 1, NULL, 'Your Fellowship is now bound together for a time, and will be protected from the dangers of the tear for the next ninety minutes. Hunt well.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 23 /* StartEvent */, 1, 1, NULL, 'AerfalleExtremeGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 66 /* LockFellow */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 5 /* Motion */, 1, 1, 0x100000A0 /* EnterPortal */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 24 /* StopEvent */, 1, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (28060, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 1, 1, NULL, 'The songs of my sisters echo across eternity and I am left to rot: bound through the arts of ill-wind taught by sisters who had fallen to the call of the twisted dark. Thousands of years bound against my will to a tether not of my making, bereft of power and ability to purchase a final release, I have waited and watched within the walls of this prison.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'The skein of her life now draws taut as she is stirred to action, re-exerting her command over these halls and drawing on the lives of those she once imprisoned. Through the countless years, most that were bound here against their will have become lost and slipped into madness, the echo of their lives now scattered dust and formless agony. Not I. Nor the sister wakened from her slumber.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'She is given over to shattering the charlatan now standing in the stead of the Lady of Aerlinthe. My task remains unfinished, but my resolve renewed. Aerfalle''s homunculus shows renewed strength and understanding, but is magic weaker than the strength of my order. My servitude is no more, I am free as is the Lady who once called these halls her home. Yet the walls ever remain my prison. She sheds them as she sheds her place within, but still, I feel her.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1, 1, NULL, 'Aerfalle''s changes continue. Her flesh, the flush of youth and beauty once lost, regained. Far beneath the crusted land and molten fires of Aerlinthe, she returns to perfect her arts and shun, ever more, the curses of undeath. Drawing power still from those bound in these halls she leaves one vestige of herself here to follow.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 1, 1, NULL, 'Magic threads weave together on the head of pin and from that point tendrils latch onto the walls of Aerfalle''s former home. They course through the aged and crumbling walls as veins siphoning lifeblood from the walls and all that trespass here. But, her mastery fails her, for her signature lay upon this single point of magic.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 1, 1, NULL, 'A signature that still lay within this keep, and with that source, I will tear wide the fabric of this space and hers and grant you access to Aerfalle to exact vengeance upon her for all the terror she wrought upon my order and my sisters.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 1, 1, NULL, 'Bring me this shard of magic, and I will open the way, but be warned, I will need to protect you from the dangers of such a tear, and to ensure that protection, I will need to temporarily bind you and your companions together for a time. You will need to be bound in Fellowship in order to hunt Aerfalle in her Sanctum. Thus is the nature of what I can do to gain you access to her.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/28060.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/28060.es
@@ -1,0 +1,39 @@
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.075
+    - Motion: Twitch1
+    
+Refuse: 40911
+    - Motion: Ready
+    - TurnToTarget
+    - Goto: CheckFellowship
+
+GotoSet: CheckFellowship
+    - InqFellowQuest: ExtremeAerfalleAccess
+        QuestFailure:
+            - StampFellowQuest: ExtremeAerfalleAccess
+            - Goto: StartExtreme
+        QuestSuccess:
+            - Goto: StartExtreme
+        QuestNoFellow:
+            - Tell: You must create a Fellowship before I can open the way.
+
+GotoSet: StartExtreme
+    - TakeItems: 40911, -1
+    - Delay: 1, TellFellow: Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years, the suffering and the agony of those she has destroyed. 
+    - Delay: 1, TellFellow: Blessings of Ithaenc go with you. You will find your gateway in the place where she once created her greater works, where now her shell of an apprentice resides.
+    - Delay: 1, FellowBroadcast: The Ghost of Galaeral chants a few words, binding your fellowship together and settling a protective enchantment over you all.
+    - Delay: 1, TellFellow: Your Fellowship is now bound together for a time, and will be protected from the dangers of the tear for the next ninety minutes. Hunt well.
+    - Delay: 1, StartEvent: AerfalleExtremeGen
+    - Delay: 1, LockFellow
+    - Delay: 1, Motion: EnterPortal
+    - Delay: 1, StopEvent: AerfalleUberGen
+
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - Delay: 1, Tell: The songs of my sisters echo across eternity and I am left to rot: bound through the arts of ill-wind taught by sisters who had fallen to the call of the twisted dark. Thousands of years bound against my will to a tether not of my making, bereft of power and ability to purchase a final release, I have waited and watched within the walls of this prison.
+    - Delay: 1, Tell: The skein of her life now draws taut as she is stirred to action, re-exerting her command over these halls and drawing on the lives of those she once imprisoned. Through the countless years, most that were bound here against their will have become lost and slipped into madness, the echo of their lives now scattered dust and formless agony. Not I. Nor the sister wakened from her slumber.
+    - Delay: 1, Tell: She is given over to shattering the charlatan now standing in the stead of the Lady of Aerlinthe. My task remains unfinished, but my resolve renewed. Aerfalle's homunculus shows renewed strength and understanding, but is magic weaker than the strength of my order. My servitude is no more, I am free as is the Lady who once called these halls her home. Yet the walls ever remain my prison. She sheds them as she sheds her place within, but still, I feel her.
+    - Delay: 1, Tell: Aerfalle's changes continue. Her flesh, the flush of youth and beauty once lost, regained. Far beneath the crusted land and molten fires of Aerlinthe, she returns to perfect her arts and shun, ever more, the curses of undeath. Drawing power still from those bound in these halls she leaves one vestige of herself here to follow.
+    - Delay: 1, Tell: Magic threads weave together on the head of pin and from that point tendrils latch onto the walls of Aerfalle's former home. They course through the aged and crumbling walls as veins siphoning lifeblood from the walls and all that trespass here. But, her mastery fails her, for her signature lay upon this single point of magic.
+    - Delay: 1, Tell: A signature that still lay within this keep, and with that source, I will tear wide the fabric of this space and hers and grant you access to Aerfalle to exact vengeance upon her for all the terror she wrought upon my order and my sisters.
+    - Delay: 1, Tell: Bring me this shard of magic, and I will open the way, but be warned, I will need to protect you from the dangers of such a tear, and to ensure that protection, I will need to temporarily bind you and your companions together for a time. You will need to be bound in Fellowship in order to hunt Aerfalle in her Sanctum. Thus is the nature of what I can do to gain you access to her.

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/40923 Bound Spectral Handmaiden.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/40923 Bound Spectral Handmaiden.sql
@@ -1,0 +1,124 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40923;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40923, 'ace40923-boundspectralhandmaiden', 10, '2020-07-23 03:33:44') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40923,   1,      16) /* ItemType - Creature */
+     , (40923,   2,      77) /* CreatureType - Ghost */
+     , (40923,   3,       8) /* PaletteTemplate - Green */
+     , (40923,   6,      -1) /* ItemsCapacity */
+     , (40923,   7,      -1) /* ContainersCapacity */
+     , (40923,  16,       1) /* ItemUseable - No */
+     , (40923,  25,     215) /* Level */
+     , (40923,  27,       0) /* ArmorType - None */
+     , (40923,  40,       2) /* CombatMode - Melee */
+     , (40923,  68,       3) /* TargetingTactic - Random, Focused */
+     , (40923,  93,    1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (40923, 133,       2) /* ShowableOnRadar - ShowMovement */
+     , (40923, 140,       1) /* AiOptions - CanOpenDoors */
+     , (40923, 146, 1300000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40923,   1, True ) /* Stuck */
+     , (40923,   6, False) /* AiUsesMana */
+     , (40923,  11, False) /* IgnoreCollisions */
+     , (40923,  12, True ) /* ReportCollisions */
+     , (40923,  13, False) /* Ethereal */
+     , (40923,  14, True ) /* GravityStatus */
+     , (40923,  19, True ) /* Attackable */
+     , (40923,  29, True ) /* NoCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40923,   1,       5) /* HeartbeatInterval */
+     , (40923,   2,       0) /* HeartbeatTimestamp */
+     , (40923,   3,     0.6) /* HealthRate */
+     , (40923,   4,     0.5) /* StaminaRate */
+     , (40923,   5,       2) /* ManaRate */
+     , (40923,  12,       0) /* Shade */
+     , (40923,  13,    0.64) /* ArmorModVsSlash */
+     , (40923,  14,    0.96) /* ArmorModVsPierce */
+     , (40923,  15,    0.96) /* ArmorModVsBludgeon */
+     , (40923,  16,       1) /* ArmorModVsCold */
+     , (40923,  17,    0.64) /* ArmorModVsFire */
+     , (40923,  18,    0.97) /* ArmorModVsAcid */
+     , (40923,  19,    0.75) /* ArmorModVsElectric */
+     , (40923,  31,      18) /* VisualAwarenessRange */
+     , (40923,  34,       1) /* PowerupTime */
+     , (40923,  36,       1) /* ChargeSpeed */
+     , (40923,  39,     0.8) /* DefaultScale */
+     , (40923,  64,     0.8) /* ResistSlash */
+     , (40923,  65,     0.8) /* ResistPierce */
+     , (40923,  66,    0.79) /* ResistBludgeon */
+     , (40923,  67,    0.89) /* ResistFire */
+     , (40923,  68,    0.34) /* ResistCold */
+     , (40923,  69,    0.49) /* ResistAcid */
+     , (40923,  70,    0.84) /* ResistElectric */
+     , (40923,  71,       1) /* ResistHealthBoost */
+     , (40923,  72,       1) /* ResistStaminaDrain */
+     , (40923,  73,       1) /* ResistStaminaBoost */
+     , (40923,  74,       1) /* ResistManaDrain */
+     , (40923,  75,       1) /* ResistManaBoost */
+     , (40923,  76,     0.8) /* Translucency */
+     , (40923, 104,      10) /* ObviousRadarRange */
+     , (40923, 122,       2) /* AiAcquireHealth */
+     , (40923, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40923,   1, 'Bound Spectral Handmaiden') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40923,  1,  33558816) /* Setup */
+     , (40923,  2, 150995302) /* MotionTable */
+     , (40923,  3, 536871094) /* SoundTable */
+     , (40923,  4, 805306368) /* CombatTable */
+     , (40923,  6,  67115251) /* PaletteBase */
+     , (40923,  7, 268436835) /* ClothingBase */
+     , (40923,  8, 100676679) /* Icon */
+     , (40923, 22, 872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40923, 8040, 3052405035, 97.84459, -36.18274, -81.3868, 0.9959748, 0, 0, -0.08963408) /* PCAPRecordedLocation */
+/* @teleloc 0xB5F0012B [97.844590 -36.182740 -81.386800] 0.995975 0.000000 0.000000 -0.089634 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40923,   1, 350, 0, 0) /* Strength */
+     , (40923,   2, 200, 0, 0) /* Endurance */
+     , (40923,   3, 300, 0, 0) /* Quickness */
+     , (40923,   4, 380, 0, 0) /* Coordination */
+     , (40923,   5, 340, 0, 0) /* Focus */
+     , (40923,   6, 340, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40923,   1,   390, 0, 0,  490) /* MaxHealth */
+     , (40923,   3,     0, 0, 0,  200) /* MaxStamina */
+     , (40923,   5,   350, 0, 0,  690) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40923,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
+     , (40923,  7, 0, 3, 0, 520, 0, 0) /* MissileDefense      Specialized */
+     , (40923, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
+     , (40923, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
+     , (40923, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (40923, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
+     , (40923, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
+     , (40923, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
+     , (40923, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
+     , (40923, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40923,  0,  1,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40923,  1,  1,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40923,  2,  1,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen */
+     , (40923,  3,  1,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40923,  4,  1,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm */
+     , (40923,  5,  8, 800, 0.75,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40923, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'The Spectral Handmaiden shatters into deadly ice shards!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1787 /* Halo of Frost */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/40925 Bound Light Falatacot.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/40925 Bound Light Falatacot.sql
@@ -1,0 +1,127 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40925;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40925, 'ace40925-boundlightfalatacot', 10, '2021-06-12 08:43:56') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40925,   1,         16) /* ItemType - Creature */
+     , (40925,   2,         77) /* CreatureType - Ghost */
+     , (40925,   6,         -1) /* ItemsCapacity */
+     , (40925,   7,         -1) /* ContainersCapacity */
+     , (40925,  16,          1) /* ItemUseable - No */
+     , (40925,  25,        220) /* Level */
+     , (40925,  27,          0) /* ArmorType - None */
+     , (40925,  40,          2) /* CombatMode - Melee */
+     , (40925,  68,          3) /* TargetingTactic - Random, Focused */
+     , (40925,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (40925, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (40925, 140,          1) /* AiOptions - CanOpenDoors */
+     , (40925, 146,    1400000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40925,   1, True ) /* Stuck */
+     , (40925,   6, True ) /* AiUsesMana */
+     , (40925,  11, False) /* IgnoreCollisions */
+     , (40925,  12, True ) /* ReportCollisions */
+     , (40925,  13, False) /* Ethereal */
+     , (40925,  14, True ) /* GravityStatus */
+     , (40925,  19, True ) /* Attackable */
+     , (40925, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40925,   1,       5) /* HeartbeatInterval */
+     , (40925,   2,       0) /* HeartbeatTimestamp */
+     , (40925,   3,     0.6) /* HealthRate */
+     , (40925,   4,     0.5) /* StaminaRate */
+     , (40925,   5,       2) /* ManaRate */
+     , (40925,  13,    0.85) /* ArmorModVsSlash */
+     , (40925,  14,     0.7) /* ArmorModVsPierce */
+     , (40925,  15,    0.95) /* ArmorModVsBludgeon */
+     , (40925,  16,       1) /* ArmorModVsCold */
+     , (40925,  17,    0.75) /* ArmorModVsFire */
+     , (40925,  18,    0.95) /* ArmorModVsAcid */
+     , (40925,  19,    0.75) /* ArmorModVsElectric */
+     , (40925,  31,      18) /* VisualAwarenessRange */
+     , (40925,  34,       1) /* PowerupTime */
+     , (40925,  36,       1) /* ChargeSpeed */
+     , (40925,  39,     1.2) /* DefaultScale */
+     , (40925,  41,      20) /* RegenerationInterval */
+     , (40925,  64,     0.8) /* ResistSlash */
+     , (40925,  65,     0.8) /* ResistPierce */
+     , (40925,  66,    0.79) /* ResistBludgeon */
+     , (40925,  67,    0.89) /* ResistFire */
+     , (40925,  68,    0.34) /* ResistCold */
+     , (40925,  69,    0.49) /* ResistAcid */
+     , (40925,  70,    0.84) /* ResistElectric */
+     , (40925,  71,       1) /* ResistHealthBoost */
+     , (40925,  72,       1) /* ResistStaminaDrain */
+     , (40925,  73,       1) /* ResistStaminaBoost */
+     , (40925,  74,       1) /* ResistManaDrain */
+     , (40925,  75,       1) /* ResistManaBoost */
+     , (40925,  76,     0.5) /* Translucency */
+     , (40925,  80,       3) /* AiUseMagicDelay */
+     , (40925, 104,      10) /* ObviousRadarRange */
+     , (40925, 122,       2) /* AiAcquireHealth */
+     , (40925, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40925,   1, 'Bound Light Falatacot') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40925,   1,   33560295) /* Setup */
+     , (40925,   2,  150995403) /* MotionTable */
+     , (40925,   3,  536871094) /* SoundTable */
+     , (40925,   4,  805306368) /* CombatTable */
+     , (40925,   8,  100676679) /* Icon */
+     , (40925,  22,  872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40925,  0,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40925,  1,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40925,  2,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40925,  3,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40925,  4,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40925,  5,  8,600, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40925,  6,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40925,  7,  8,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40925,  8,  8,600, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40925,   1, 490, 0, 0) /* Strength */
+     , (40925,   2, 420, 0, 0) /* Endurance */
+     , (40925,   3, 300, 0, 0) /* Quickness */
+     , (40925,   4, 420, 0, 0) /* Coordination */
+     , (40925,   5, 420, 0, 0) /* Focus */
+     , (40925,   6, 420, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40925,   1, 14960, 0, 0,15210) /* MaxHealth */
+     , (40925,   3,  3000, 0, 0, 3420) /* MaxStamina */
+     , (40925,   5,     0, 0, 0,  420) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40925, 31, 0, 2, 0, 300, 0, 0) /* CreatureMagic */
+     , (40925, 33, 0, 2, 0, 300, 0, 0) /* LifeMagic */
+     , (40925, 45, 0, 2, 0, 530, 0, 0) /* LightWeapons */
+     , (40925, 15, 0, 2, 0, 350, 0, 0) /* MagicDefense */
+     , (40925, 16, 0, 2, 0, 400, 0, 0) /* ManaConversion */
+     , (40925,  6, 0, 2, 0, 530, 0, 0) /* MeleeDefense */
+     , (40925,  7, 0, 2, 0, 550, 0, 0) /* MissileDefense */
+     , (40925, 43, 0, 2, 0, 300, 0, 0) /* VoidMagic */
+     , (40925, 34, 0, 2, 0, 300, 0, 0) /* WarMagic */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40925,  1785,   2.05) /* Cassius' Ring of Fire */
+     , (40925,  2070,   2.05) /* Heart Rend */
+     , (40925,  2127,   2.05) /* Silencia's Scorn */
+     , (40925,  2130,   2.05) /* Infernae */
+     , (40925,  2170,   2.05) /* Inferno's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40925, 3 /* Death */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'You hear a fading voice in your mind, "Thank you for freeing me..."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/40925.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/40925.es
@@ -1,0 +1,2 @@
+Death: Probability: 0.2
+    - LocalBroadcast: You hear a fading voice in your mind, "Thank you for freeing me..."

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/40932 Ghost of Dylaeral.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/40932 Ghost of Dylaeral.sql
@@ -1,0 +1,160 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40932;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40932, 'ace40932-ghostofdylaeral', 10, '2021-06-13 11:33:41') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40932,   1,         16) /* ItemType - Creature */
+     , (40932,   2,         77) /* CreatureType - Ghost */
+     , (40932,   6,         -1) /* ItemsCapacity */
+     , (40932,   7,         -1) /* ContainersCapacity */
+     , (40932,  16,         32) /* ItemUseable - Remote */
+     , (40932,  25,         74) /* Level */
+     , (40932,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (40932,  95,          8) /* RadarBlipColor - Yellow */
+     , (40932, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (40932, 134,         16) /* PlayerKillerStatus - RubberGlue */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40932,   1, True ) /* Stuck */
+     , (40932,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40932,   1,       5) /* HeartbeatInterval */
+     , (40932,   2,       0) /* HeartbeatTimestamp */
+     , (40932,   3,     0.6) /* HealthRate */
+     , (40932,   4,     0.5) /* StaminaRate */
+     , (40932,   5,       2) /* ManaRate */
+     , (40932,  12,     0.5) /* Shade */
+     , (40932,  13,     0.8) /* ArmorModVsSlash */
+     , (40932,  14,    0.47) /* ArmorModVsPierce */
+     , (40932,  15,    0.65) /* ArmorModVsBludgeon */
+     , (40932,  16,    0.03) /* ArmorModVsCold */
+     , (40932,  17,     0.5) /* ArmorModVsFire */
+     , (40932,  18,    0.65) /* ArmorModVsAcid */
+     , (40932,  19,    0.72) /* ArmorModVsElectric */
+     , (40932,  34,       1) /* PowerupTime */
+     , (40932,  36,       1) /* ChargeSpeed */
+     , (40932,  39,     1.3) /* DefaultScale */
+     , (40932,  64,       1) /* ResistSlash */
+     , (40932,  65,    0.52) /* ResistPierce */
+     , (40932,  66,    0.75) /* ResistBludgeon */
+     , (40932,  67,       1) /* ResistFire */
+     , (40932,  68,     0.1) /* ResistCold */
+     , (40932,  69,    0.75) /* ResistAcid */
+     , (40932,  70,    0.86) /* ResistElectric */
+     , (40932,  71,       1) /* ResistHealthBoost */
+     , (40932,  72,       1) /* ResistStaminaDrain */
+     , (40932,  73,       1) /* ResistStaminaBoost */
+     , (40932,  74,       1) /* ResistManaDrain */
+     , (40932,  75,       1) /* ResistManaBoost */
+     , (40932,  76,     0.5) /* Translucency */
+     , (40932, 104,      10) /* ObviousRadarRange */
+     , (40932, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40932,   1, 'Ghost of Dylaeral') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40932,   1,   33560295) /* Setup */
+     , (40932,   2,  150995403) /* MotionTable */
+     , (40932,   3,  536871094) /* SoundTable */
+     , (40932,   8,  100676679) /* Icon */
+     , (40932,  22,  872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40932,  0, 0, 0, 0, 0, 0, 0, 0, 0) /**/
+/* @teleloc 0x0 [0.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 0.000000 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40932,  0,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40932,  1,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40932,  2,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40932,  3,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40932,  4,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40932,  5,  4,  2, 0.75,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40932,  6,  4,  0,    0,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40932,  7,  4,  0,    0,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40932,  8,  4,  3, 0.75,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40932,   1, 140, 0, 0) /* Strength */
+     , (40932,   2, 200, 0, 0) /* Endurance */
+     , (40932,   3, 160, 0, 0) /* Quickness */
+     , (40932,   4, 160, 0, 0) /* Coordination */
+     , (40932,   5, 290, 0, 0) /* Focus */
+     , (40932,   6, 290, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40932,   1,   100, 0, 0,  200) /* MaxHealth */
+     , (40932,   3,   150, 0, 0,  350) /* MaxStamina */
+     , (40932,   5,   150, 0, 0,  440) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40932,  1, 0, 3, 0, 125, 0,1984.09299414236) /* Axe                 Specialized */
+     , (40932,  2, 0, 2, 0, 110, 0,1984.09299414236) /* Bow                 Trained */
+     , (40932,  3, 0, 2, 0, 110, 0,1984.09299414236) /* Crossbow            Trained */
+     , (40932,  4, 0, 3, 0, 120, 0,1984.09299414236) /* Dagger              Specialized */
+     , (40932,  5, 0, 3, 0, 120, 0,1984.09299414236) /* Mace                Specialized */
+     , (40932,  6, 0, 2, 0, 130, 0,1984.09299414236) /* MeleeDefense        Trained */
+     , (40932,  7, 0, 2, 0, 120, 0,1984.09299414236) /* MissileDefense      Trained */
+     , (40932,  9, 0, 2, 0, 100, 0,1984.09299414236) /* Spear               Trained */
+     , (40932, 10, 0, 2, 0, 100, 0,1984.09299414236) /* Staff               Trained */
+     , (40932, 11, 0, 3, 0, 120, 0,1984.09299414236) /* Sword               Specialized */
+     , (40932, 13, 0, 2, 0, 200, 0,1984.09299414236) /* UnarmedCombat       Trained */
+     , (40932, 14, 0, 2, 0, 230, 0,1984.09299414236) /* ArcaneLore          Trained */
+     , (40932, 15, 0, 2, 0, 182, 0,1984.09299414236) /* MagicDefense        Trained */
+     , (40932, 20, 0, 2, 0,  90, 0,1984.09299414236) /* Deception           Trained */
+     , (40932, 31, 0, 2, 0, 230, 0,1984.09299414236) /* CreatureEnchantment Trained */
+     , (40932, 32, 0, 2, 0, 200, 0,1984.09299414236) /* ItemEnchantment     Trained */
+     , (40932, 33, 0, 2, 0, 230, 0,1984.09299414236) /* LifeMagic           Trained */
+     , (40932, 34, 0, 2, 0, 230, 0,1984.09299414236) /* WarMagic            Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40932, 5 /* HeartBeat */, 0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40932, 6 /* Give */, 1, 7447 /* Sacrificial Dagger */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 1, 1, NULL, 'Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years upon this ''appprentice'' of our tormentor, for the suffering and the agony of those she has destroyed.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 23 /* StartEvent */, 1, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 5 /* Motion */, 1, 1, 0x100000A0 /* EnterPortal */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 24 /* StopEvent */, 1, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40932, 6 /* Give */, 1, 28065 /* Sacrificial Dagger */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 1, 1, NULL, 'Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years upon this ''appprentice'' of our tormentor, for the suffering and the agony of those she has destroyed.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 23 /* StartEvent */, 1, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 5 /* Motion */, 1, 1, 0x100000A0 /* EnterPortal */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 24 /* StopEvent */, 1, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40932, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 1, 1, NULL, 'A whisper began in the darkness and wove, within mine ears, a mystery that woke my shattered mind. Discord gave way to logic as the hum of the soft sound set fire to the long dormant desire within a hollow and aged frame. I stirred, at last, reaching through the mist of ages and found an anchor there. A sister''s song sung in perfect concert with the pound of a long dead heart aching still with the remembrance of life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'Thus I rose and traveled these stone hallways, decrepit and crumbling from the weight of time and neglect wrought upon them by the cruel mistress who once kept them pristine and polished as a mirror. So vain was she once that her reflection must shine upon her everywhere and so the stone shone brightly in her time of breath.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'Now, as I return to be at sister''s side, she leaves the halls she kept in such perfect union to a flawed and lesser vessel: a guardian, student and imposter. A creation of dust, alteration and magics drawn from the annals of the Dericost. Strengthened further by Aerfalle''s own understanding and communion with forces she has yet to fully see, understand and embrace, this straw child proves to be a thing easily weakened. A simple token, one of great potency before the mistress of these halls transcended the curse of undeath - in her manner - and poured herself and all her weakness into the fragile frame which now stands in her stead.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1, 1, NULL, 'Galaeral, my sister in blood, redeemer and rescuer of my once lost soul seeks still to revisit vengeance on Aerfalle and seeks entrance to her true sanctum. Her voice freed me from madness and showed me that this prison is far from the worst fate for the Falatacot. For this, I take her place to seek vengeance on the imposter with the same instruments that have long split the glamour from the shell of Aerfalle.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 1, 1, NULL, 'The dagger, which drew forth our Vitae, tore free our souls and placed upon us this curse must be given over to shatter the glamorous visage that shrouds the vessel left by Aerfalle. Bring me this and I will shatter the vessels strength and leave it in ruin as these halls.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/40932.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/40932.es
@@ -1,0 +1,27 @@
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.075
+    - Motion: Twitch1
+
+Give: Sacrificial Dagger (7447)
+    - Motion: Ready
+    - TurnToTarget
+    - Delay: 1, Tell: Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years upon this 'appprentice' of our tormentor, for the suffering and the agony of those she has destroyed.
+    - Delay: 1, StartEvent: AerfalleGen
+    - Delay: 1, Motion: EnterPortal
+    - Delay: 1, StopEvent: AerfalleUberGen
+
+Give: Sacrificial Dagger (28065)
+    - Motion: Ready
+    - TurnToTarget
+    - Delay: 1, Tell: Light is not lost on this world yet. I shall enact my part of this bargain, outlander. Seek vengeance for the countless years upon this 'appprentice' of our tormentor, for the suffering and the agony of those she has destroyed.
+    - Delay: 1, StartEvent: AerfalleGen
+    - Delay: 1, Motion: EnterPortal
+    - Delay: 1, StopEvent: AerfalleUberGen
+
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - Delay: 1, Tell: A whisper began in the darkness and wove, within mine ears, a mystery that woke my shattered mind. Discord gave way to logic as the hum of the soft sound set fire to the long dormant desire within a hollow and aged frame. I stirred, at last, reaching through the mist of ages and found an anchor there. A sister's song sung in perfect concert with the pound of a long dead heart aching still with the remembrance of life.
+    - Delay: 1, Tell: Thus I rose and traveled these stone hallways, decrepit and crumbling from the weight of time and neglect wrought upon them by the cruel mistress who once kept them pristine and polished as a mirror. So vain was she once that her reflection must shine upon her everywhere and so the stone shone brightly in her time of breath.
+    - Delay: 1, Tell: Now, as I return to be at sister's side, she leaves the halls she kept in such perfect union to a flawed and lesser vessel: a guardian, student and imposter. A creation of dust, alteration and magics drawn from the annals of the Dericost. Strengthened further by Aerfalle's own understanding and communion with forces she has yet to fully see, understand and embrace, this straw child proves to be a thing easily weakened. A simple token, one of great potency before the mistress of these halls transcended the curse of undeath - in her manner - and poured herself and all her weakness into the fragile frame which now stands in her stead.
+    - Delay: 1, Tell: Galaeral, my sister in blood, redeemer and rescuer of my once lost soul seeks still to revisit vengeance on Aerfalle and seeks entrance to her true sanctum. Her voice freed me from madness and showed me that this prison is far from the worst fate for the Falatacot. For this, I take her place to seek vengeance on the imposter with the same instruments that have long split the glamour from the shell of Aerfalle.
+    - Delay: 1, Tell: The dagger, which drew forth our Vitae, tore free our souls and placed upon us this curse must be given over to shatter the glamorous visage that shrouds the vessel left by Aerfalle. Bring me this and I will shatter the vessels strength and leave it in ruin as these halls.

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/43746 Ghost of Galaeral.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/43746 Ghost of Galaeral.sql
@@ -1,0 +1,156 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43746;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43746, 'ace43746-ghostgalaeralnpc', 10, '2021-06-11 01:54:50') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43746,   1,         16) /* ItemType - Creature */
+     , (43746,   2,         77) /* CreatureType - Ghost */
+     , (43746,   6,         -1) /* ItemsCapacity */
+     , (43746,   7,         -1) /* ContainersCapacity */
+     , (43746,  16,         32) /* ItemUseable - Remote */
+     , (43746,  25,         74) /* Level */
+     , (43746,  27,          0) /* ArmorType - None */
+     , (43746,  40,          1) /* CombatMode - NonCombat */
+     , (43746,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (43746,  95,          8) /* RadarBlipColor - Yellow */
+     , (43746, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (43746, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (43746, 146,       5222) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43746,   1, True ) /* Stuck */
+     , (43746,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43746,   1,       5) /* HeartbeatInterval */
+     , (43746,   2,       0) /* HeartbeatTimestamp */
+     , (43746,   3,     0.6) /* HealthRate */
+     , (43746,   4,     0.5) /* StaminaRate */
+     , (43746,   5,       2) /* ManaRate */
+     , (43746,  12,     0.5) /* Shade */
+     , (43746,  13,     0.8) /* ArmorModVsSlash */
+     , (43746,  14,    0.47) /* ArmorModVsPierce */
+     , (43746,  15,    0.65) /* ArmorModVsBludgeon */
+     , (43746,  16,    0.03) /* ArmorModVsCold */
+     , (43746,  17,     0.5) /* ArmorModVsFire */
+     , (43746,  18,    0.65) /* ArmorModVsAcid */
+     , (43746,  19,    0.72) /* ArmorModVsElectric */
+     , (43746,  34,       1) /* PowerupTime */
+     , (43746,  36,       1) /* ChargeSpeed */
+     , (43746,  39,     1.3) /* DefaultScale */
+     , (43746,  64,       1) /* ResistSlash */
+     , (43746,  65,    0.52) /* ResistPierce */
+     , (43746,  66,    0.75) /* ResistBludgeon */
+     , (43746,  67,       1) /* ResistFire */
+     , (43746,  68,     0.1) /* ResistCold */
+     , (43746,  69,    0.75) /* ResistAcid */
+     , (43746,  70,    0.86) /* ResistElectric */
+     , (43746,  71,       1) /* ResistHealthBoost */
+     , (43746,  72,       1) /* ResistStaminaDrain */
+     , (43746,  73,       1) /* ResistStaminaBoost */
+     , (43746,  74,       1) /* ResistManaDrain */
+     , (43746,  75,       1) /* ResistManaBoost */
+     , (43746,  76,     0.5) /* Translucency */
+     , (43746, 104,      10) /* ObviousRadarRange */
+     , (43746, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43746,   1, 'Ghost of Galaeral') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43746,   1,   33560295) /* Setup */
+     , (43746,   2,  150995403) /* MotionTable */
+     , (43746,   3,  536871094) /* SoundTable */
+     , (43746,   8,  100676679) /* Icon */
+     , (43746,  22,  872415403) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (43746,  0,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (43746,  1,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (43746,  2,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (43746,  3,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (43746,  4,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (43746,  5,  4,  2, 0.75,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (43746,  6,  4,  0,    0,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (43746,  7,  4,  0,    0,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (43746,  8,  4,  3, 0.75,  160,   80,   80,   80,   80,   80,   80,   80,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (43746,   1, 140, 0, 0) /* Strength */
+     , (43746,   2, 200, 0, 0) /* Endurance */
+     , (43746,   3, 160, 0, 0) /* Quickness */
+     , (43746,   4, 160, 0, 0) /* Coordination */
+     , (43746,   5, 290, 0, 0) /* Focus */
+     , (43746,   6, 290, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (43746,   1,   100, 0, 0,  200) /* MaxHealth */
+     , (43746,   3,   150, 0, 0,  350) /* MaxStamina */
+     , (43746,   5,   150, 0, 0,  440) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (43746,  1, 0, 3, 0, 125, 0,1984.09299414236) /* Axe                 Specialized */
+     , (43746,  2, 0, 2, 0, 110, 0,1984.09299414236) /* Bow                 Trained */
+     , (43746,  3, 0, 2, 0, 110, 0,1984.09299414236) /* Crossbow            Trained */
+     , (43746,  4, 0, 3, 0, 120, 0,1984.09299414236) /* Dagger              Specialized */
+     , (43746,  5, 0, 3, 0, 120, 0,1984.09299414236) /* Mace                Specialized */
+     , (43746,  6, 0, 2, 0, 130, 0,1984.09299414236) /* MeleeDefense        Trained */
+     , (43746,  7, 0, 2, 0, 120, 0,1984.09299414236) /* MissileDefense      Trained */
+     , (43746,  9, 0, 2, 0, 100, 0,1984.09299414236) /* Spear               Trained */
+     , (43746, 10, 0, 2, 0, 100, 0,1984.09299414236) /* Staff               Trained */
+     , (43746, 11, 0, 3, 0, 120, 0,1984.09299414236) /* Sword               Specialized */
+     , (43746, 13, 0, 2, 0, 200, 0,1984.09299414236) /* UnarmedCombat       Trained */
+     , (43746, 14, 0, 2, 0, 230, 0,1984.09299414236) /* ArcaneLore          Trained */
+     , (43746, 15, 0, 2, 0, 182, 0,1984.09299414236) /* MagicDefense        Trained */
+     , (43746, 20, 0, 2, 0,  90, 0,1984.09299414236) /* Deception           Trained */
+     , (43746, 31, 0, 2, 0, 230, 0,1984.09299414236) /* CreatureEnchantment Trained */
+     , (43746, 32, 0, 2, 0, 200, 0,1984.09299414236) /* ItemEnchantment     Trained */
+     , (43746, 33, 0, 2, 0, 230, 0,1984.09299414236) /* LifeMagic           Trained */
+     , (43746, 34, 0, 2, 0, 230, 0,1984.09299414236) /* WarMagic            Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (43746, 9 /* Generation */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 81 /* StampMyQuest */, 0, 1, NULL, 'AerfalleRewardGiverInProgress', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (43746, 5 /* HeartBeat */, 1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'AerfalleRewardGiverInProgress@Countdown', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (43746, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AerfalleRewardGiverInProgress@Countdown', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 8 /* Say */, 0, 20, NULL, 'I must go now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleExtremeRewards', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (43746, 6 /* Give */, 1, 43529, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'I see you have defeated the cruel Lady and thus achieved retribution for those she has destroyed. A deed of such high measure must be rewarded.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (43746, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'I see the cruel Lady has been defeated. Hand me proof of your deed.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/43746.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/43746.es
@@ -1,0 +1,18 @@
+Generation:
+    - StampMyQuest: AerfalleRewardGiverInProgress
+
+HeartBeat: Style: NonCombat, Substyle: Ready
+    - InqMyQuest: AerfalleRewardGiverInProgress@Countdown
+        QuestFailure:
+            - Say: I must go now., Extent: 20
+            - StopEvent: AerfalleExtremeRewards
+            - DeleteSelf
+
+Give: 43529
+    - TurnToTarget
+    - Tell: I see you have defeated the cruel Lady and thus achieved retribution for those she has destroyed. A deed of such high measure must be rewarded.
+    - AwardLuminance: 15,000
+
+Use:
+    - TurnToTarget
+    - Tell: I see the cruel Lady has been defeated. Hand me proof of your deed.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/09275 Aerfalle's Keep Stopgap!.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/09275 Aerfalle's Keep Stopgap!.sql
@@ -1,0 +1,117 @@
+DELETE FROM `weenie` WHERE `class_Id` = 9275;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (9275, 'ace9275-aerfallekeepnpcstopgap', 10, '2005-02-09 10:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (9275,   1,         16) /* ItemType - Creature */
+     , (9275,   2,         31) /* CreatureType - Human */
+     , (9275,   6,         -1) /* ItemsCapacity */
+     , (9275,   7,         -1) /* ContainersCapacity */
+     , (9275,   8,        120) /* Mass */
+     , (9275,  16,         32) /* ItemUseable - Remote */
+     , (9275,  25,         15) /* Level */
+     , (9275,  27,          0) /* ArmorType - None */
+     , (9275,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (9275,  95,          8) /* RadarBlipColor - Yellow */
+     , (9275, 133,          0) /* ShowableOnRadar - Undefined */
+     , (9275, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (9275, 146,        307) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (9275,   1, True ) /* Stuck */
+     , (9275,   8, True ) /* AllowGive */
+     , (9275,  12, True ) /* ReportCollisions */
+     , (9275,  13, True ) /* Ethereal */
+     , (9275,  18, True ) /* Visibility */
+     , (9275,  19, False) /* Attackable */
+     , (9275,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (9275,  42, True ) /* AllowEdgeSlide */
+     , (9275,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (9275,   1,       5) /* HeartbeatInterval */
+     , (9275,   2,       0) /* HeartbeatTimestamp */
+     , (9275,   3,    0.16) /* HealthRate */
+     , (9275,   4,       5) /* StaminaRate */
+     , (9275,   5,       1) /* ManaRate */
+     , (9275,  13,     0.9) /* ArmorModVsSlash */
+     , (9275,  14,       1) /* ArmorModVsPierce */
+     , (9275,  15,     1.1) /* ArmorModVsBludgeon */
+     , (9275,  16,     0.4) /* ArmorModVsCold */
+     , (9275,  17,     0.4) /* ArmorModVsFire */
+     , (9275,  18,       1) /* ArmorModVsAcid */
+     , (9275,  19,     0.6) /* ArmorModVsElectric */
+     , (9275,  54,       3) /* UseRadius */
+     , (9275,  64,       1) /* ResistSlash */
+     , (9275,  65,       1) /* ResistPierce */
+     , (9275,  66,       1) /* ResistBludgeon */
+     , (9275,  67,       1) /* ResistFire */
+     , (9275,  68,       1) /* ResistCold */
+     , (9275,  69,       1) /* ResistAcid */
+     , (9275,  70,       1) /* ResistElectric */
+     , (9275,  71,       1) /* ResistHealthBoost */
+     , (9275,  72,       1) /* ResistStaminaDrain */
+     , (9275,  73,       1) /* ResistStaminaBoost */
+     , (9275,  74,       1) /* ResistManaDrain */
+     , (9275,  75,       1) /* ResistManaBoost */
+     , (9275, 104,      10) /* ObviousRadarRange */
+     , (9275, 125,       1) /* ResistHealthDrain */
+     , (9275, 131,       1) /* EmotePriority */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (9275,   1, 'Aerfalle''s Keep Stopgap!') /* Name */
+     , (9275,   3, 'Male') /* Sex */
+     , (9275,   4, 'Sho') /* HeritageGroup */
+     , (9275,   5, 'Stopgap') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (9275,   1,   33554433) /* Setup */
+     , (9275,   2,  150994945) /* MotionTable */
+     , (9275,   3,  536870913) /* SoundTable */
+     , (9275,   4,  805306368) /* CombatTable */
+     , (9275,   8,  100667446) /* Icon */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (9275,   1,  90, 0, 0) /* Strength */
+     , (9275,   2, 100, 0, 0) /* Endurance */
+     , (9275,   3,  75, 0, 0) /* Quickness */
+     , (9275,   4, 120, 0, 0) /* Coordination */
+     , (9275,   5, 140, 0, 0) /* Focus */
+     , (9275,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (9275,   1,    10, 0, 0, 60) /* MaxHealth */
+     , (9275,   3,    10, 0, 0, 110) /* MaxStamina */
+     , (9275,   5,    10, 0, 0, 140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (9275,  6, 0, 2, 0,   1, 0, 633.380416853002) /* MeleeDefense        Trained */
+     , (9275,  7, 0, 2, 0,   1, 0, 633.380416853002) /* MissileDefense      Trained */
+     , (9275, 13, 0, 2, 0,   1, 0, 633.380416853002) /* UnarmedCombat       Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (9275,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (9275,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (9275,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (9275,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (9275,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (9275,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (9275,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (9275,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (9275,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (9275,  5 /* HeartBeat */,      1, NULL, 2147483709 /* NonCombat */, 1090519043 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 2, 1, 318767239 /* Wave */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  24 /* StopEvent */, 5400, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   5 /* Motion */, 2, 1, 318767229 /* BowDeep */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  24 /* StopEvent */, 2, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,   5 /* Motion */, 2, 1, 318767236 /* Point */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  24 /* StopEvent */, 2, 1, NULL, 'AerfalleExtremeGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  6,   5 /* Motion */, 2, 1, 318767236 /* Point */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  7,  24 /* StopEvent */, 10, 1, NULL, 'AerfalleKeepStopgapGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Skeleton/40924 Bound Pyre Champion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Skeleton/40924 Bound Pyre Champion.sql
@@ -1,0 +1,126 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40924;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40924, 'ace40924-boundpyrechampion', 10, '2020-07-23 03:33:44') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40924,   1,         16) /* ItemType - Creature */
+     , (40924,   2,         30) /* CreatureType - Skeleton */
+     , (40924,   3,         39) /* PaletteTemplate - Black */
+     , (40924,   6,         -1) /* ItemsCapacity */
+     , (40924,   7,         -1) /* ContainersCapacity */
+     , (40924,  16,          1) /* ItemUseable - No */
+     , (40924,  25,        265) /* Level */
+     , (40924,  27,          0) /* ArmorType - None */
+     , (40924,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (40924,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (40924, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (40924, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (40924, 140,          1) /* AiOptions - CanOpenDoors */
+     , (40924, 146,    2500000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40924,   1, True ) /* Stuck */
+     , (40924,   6, True ) /* AiUsesMana */
+     , (40924,  11, False) /* IgnoreCollisions */
+     , (40924,  12, True ) /* ReportCollisions */
+     , (40924,  13, False) /* Ethereal */
+     , (40924,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40924,   1,       5) /* HeartbeatInterval */
+     , (40924,   2,       0) /* HeartbeatTimestamp */
+     , (40924,   3,     0.2) /* HealthRate */
+     , (40924,   4,     0.5) /* StaminaRate */
+     , (40924,   5,       2) /* ManaRate */
+     , (40924,  12,       0) /* Shade */
+     , (40924,  13,    0.69) /* ArmorModVsSlash */
+     , (40924,  14,    0.69) /* ArmorModVsPierce */
+     , (40924,  15,    0.65) /* ArmorModVsBludgeon */
+     , (40924,  16,    0.85) /* ArmorModVsCold */
+     , (40924,  17,    0.85) /* ArmorModVsFire */
+     , (40924,  18,    0.75) /* ArmorModVsAcid */
+     , (40924,  19,    0.75) /* ArmorModVsElectric */
+     , (40924,  31,      25) /* VisualAwarenessRange */
+     , (40924,  34,       1) /* PowerupTime */
+     , (40924,  36,       1) /* ChargeSpeed */
+     , (40924,  39,     1.1) /* DefaultScale */
+     , (40924,  64,    0.58) /* ResistSlash */
+     , (40924,  65,    0.58) /* ResistPierce */
+     , (40924,  66,    0.66) /* ResistBludgeon */
+     , (40924,  67,     0.3) /* ResistFire */
+     , (40924,  68,     0.3) /* ResistCold */
+     , (40924,  69,    0.42) /* ResistAcid */
+     , (40924,  70,     0.4) /* ResistElectric */
+     , (40924,  71,       1) /* ResistHealthBoost */
+     , (40924,  72,       1) /* ResistStaminaDrain */
+     , (40924,  73,       1) /* ResistStaminaBoost */
+     , (40924,  74,       1) /* ResistManaDrain */
+     , (40924,  75,       1) /* ResistManaBoost */
+     , (40924,  80,       1) /* AiUseMagicDelay */
+     , (40924, 104,      10) /* ObviousRadarRange */
+     , (40924, 122,       2) /* AiAcquireHealth */
+     , (40924, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40924,   1, 'Bound Pyre Champion') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40924,  1,  33560229) /* Setup */
+     , (40924,  2, 150994981) /* MotionTable */
+     , (40924,  3, 536870942) /* SoundTable */
+     , (40924,  4, 805306368) /* CombatTable */
+     , (40924,  6,  67116522) /* PaletteBase */
+     , (40924,  7, 268437008) /* ClothingBase */
+     , (40924,  8, 100669124) /* Icon */
+     , (40924, 22, 872415269) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40924, 8040, 3052405424, 115.364, -72.5228, -33.19725, -0.882561, 0, 0, 0.470198) /* PCAPRecordedLocation */
+/* @teleloc 0xB5F002B0 [115.364000 -72.522800 -33.197250] -0.882561 0.000000 0.000000 0.470198 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40924,   1, 500, 0, 0) /* Strength */
+     , (40924,   2, 500, 0, 0) /* Endurance */
+     , (40924,   3, 300, 0, 0) /* Quickness */
+     , (40924,   4, 300, 0, 0) /* Coordination */
+     , (40924,   5, 400, 0, 0) /* Focus */
+     , (40924,   6, 400, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40924,   1,  6581, 0, 0, 6831) /* MaxHealth */
+     , (40924,   3,  4200, 0, 0, 4700) /* MaxStamina */
+     , (40924,   5,  3500, 0, 0, 3900) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40924,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
+     , (40924,  7, 0, 3, 0, 397, 0, 0) /* MissileDefense      Specialized */
+     , (40924, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
+     , (40924, 20, 0, 3, 0, 120, 0, 0) /* Deception           Specialized */
+     , (40924, 33, 0, 3, 0, 280, 0, 0) /* LifeMagic           Specialized */
+     , (40924, 34, 0, 3, 0, 280, 0, 0) /* WarMagic            Specialized */
+     , (40924, 44, 0, 3, 0, 565, 0, 0) /* HeavyWeapons        Specialized */
+     , (40924, 45, 0, 3, 0, 565, 0, 0) /* LightWeapons        Specialized */
+     , (40924, 46, 0, 3, 0, 565, 0, 0) /* FinesseWeapons      Specialized */
+     , (40924, 47, 0, 3, 0, 565, 0, 0) /* MissileWeapons      Specialized */
+     , (40924, 48, 0, 3, 0, 200, 0, 0) /* Shield              Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40924,  0,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40924,  1,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40924,  2,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40924,  3,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40924,  4,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40924,  5,  4, 275, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40924,  6,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40924,  7,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40924,  8,  4, 275, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40924,  1785,   2.05)  /* Cassius' Ring of Fire */
+     , (40924,  2127,   2.05)  /* Silencia's Scorn */
+     , (40924,  2170,   2.05)  /* Inferno's Gift */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (40924, 2, 35096,  1, 0, 0, False) /* Create Pyre Blade (35096) for Wield */
+     , (40924, 2, 38852,  1, 0, 0, False) /* Create  (38852) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Skeleton/40926 Pyre Skeleton.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Skeleton/40926 Pyre Skeleton.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 40926;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (40926, 'ace40926-pyreskeleton', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (40926, 'ace40926-pyreskeleton', 10, '2019-08-22 00:00:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (40926,   1,         16) /* ItemType - Creature */
@@ -64,18 +64,17 @@ VALUES (40926,   1,       5) /* HeartbeatInterval */
      , (40926, 166,    0.82) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (40926,   1, 'Pyre Skeleton') /* Name */
-     , (40926,  45, 'KilltaskGraveyardSkeleton_1309') /* KillQuest */;
+VALUES (40926,   1, 'Pyre Skeleton') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (40926,   1, 0x02000F7C) /* Setup */
-     , (40926,   2, 0x09000025) /* MotionTable */
-     , (40926,   3, 0x2000001E) /* SoundTable */
-     , (40926,   4, 0x30000000) /* CombatTable */
-     , (40926,   6, 0x04001DEA) /* PaletteBase */
-     , (40926,   7, 0x10000612) /* ClothingBase */
-     , (40926,   8, 0x060016C4) /* Icon */
-     , (40926,  22, 0x34000025) /* PhysicsEffectTable */
+VALUES (40926,   1,   33558396) /* Setup */
+     , (40926,   2,  150994981) /* MotionTable */
+     , (40926,   3,  536870942) /* SoundTable */
+     , (40926,   4,  805306368) /* CombatTable */
+     , (40926,   6,   67116522) /* PaletteBase */
+     , (40926,   7,  268437010) /* ClothingBase */
+     , (40926,   8,  100669124) /* Icon */
+     , (40926,  22,  872415269) /* PhysicsEffectTable */
      , (40926,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -98,10 +97,10 @@ VALUES (40926,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
      , (40926, 20, 0, 3, 0, 120, 0, 0) /* Deception           Specialized */
      , (40926, 33, 0, 3, 0, 260, 0, 0) /* LifeMagic           Specialized */
      , (40926, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
-     , (40926, 44, 0, 3, 0, 545, 0, 0) /* HeavyWeapons        Specialized */
-     , (40926, 45, 0, 3, 0, 545, 0, 0) /* LightWeapons        Specialized */
-     , (40926, 46, 0, 3, 0, 545, 0, 0) /* FinesseWeapons      Specialized */
-     , (40926, 47, 0, 3, 0, 545, 0, 0) /* MissileWeapons      Specialized */;
+     , (40926, 44, 0, 3, 0, 545, 0, 0) /* Heavy Weapons       Specialized */
+     , (40926, 45, 0, 3, 0, 545, 0, 0) /* Light Weapons       Specialized */
+     , (40926, 46, 0, 3, 0, 545, 0, 0) /* Finesse Weapons     Specialized */
+     , (40926, 47, 0, 3, 0, 545, 0, 0) /* Missile Weapons     Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40926,  0,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -115,48 +114,9 @@ VALUES (40926,  0,  4,  0,    0,  450,  450,  450,  450,  450,  450,  450,  450,
      , (40926,  8,  4, 275, 0.75,  450,  450,  450,  450,  450,  450,  450,  450,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40926,  2170,   2.05)  /* Inferno's Gift */
-     , (40926,  2745,   2.05)  /* Flame Arc VII */
-     , (40926,  2130,   2.05)  /* Infernae */;
+VALUES (40926,  2170,    2.05)  /* Inferno's Gift */
+     , (40926,  2745,    2.05)  /* Flame Arc VII */
+     , (40926,  2130,    2.05)  /* Infernae */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (40926, 2, 35095,  1, 0, 0, False) /* Create Pyre Claw (35095) for Wield */
-     , (40926, 9, 38714,  0, 0, 0.75, False) /* Create Pyre Skeleton Jaw (38714) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.25, False) /* Create nothing for ContainTreasure */
-     , (40926, 9, 35105,  1, 0, 0.5, False) /* Create Pyre Shroud (35105) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.5, False) /* Create nothing for ContainTreasure */
-     , (40926, 9, 48908,  0, 0, 0.06, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
-     , (40926, 9, 35383,  0, 0, 0.02, False) /* Create Ancient Mhoire Coin (35383) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
-     , (40926, 9, 35504,  0, 0, 0.01, False) /* Create Ornate Bone Key (35504) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */
-     , (40926, 9, 37290,  1, 0, 0.06, False) /* Create Jester's Token (37290) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
-     , (40926, 9, 37247,  0, 0, 0.003, False) /* Create Ace of Eyes (37247) for ContainTreasure */
-     , (40926, 9, 37248,  0, 0, 0.003, False) /* Create Two of Eyes (37248) for ContainTreasure */
-     , (40926, 9, 37249,  0, 0, 0.003, False) /* Create Three of Eyes (37249) for ContainTreasure */
-     , (40926, 9, 37250,  0, 0, 0.003, False) /* Create Four of Eyes (37250) for ContainTreasure */
-     , (40926, 9, 37251,  0, 0, 0.003, False) /* Create Five of Eyes (37251) for ContainTreasure */
-     , (40926, 9, 37252,  0, 0, 0.003, False) /* Create Six of Eyes (37252) for ContainTreasure */
-     , (40926, 9, 37253,  0, 0, 0.003, False) /* Create Seven of Eyes (37253) for ContainTreasure */
-     , (40926, 9, 37254,  0, 0, 0.003, False) /* Create Eight of Eyes (37254) for ContainTreasure */
-     , (40926, 9, 37255,  0, 0, 0.003, False) /* Create Nine of Eyes (37255) for ContainTreasure */
-     , (40926, 9, 37256,  0, 0, 0.003, False) /* Create Ten of Eyes (37256) for ContainTreasure */
-     , (40926, 9, 37257,  0, 0, 0.003, False) /* Create Jack of Eyes (37257) for ContainTreasure */
-     , (40926, 9, 37258,  0, 0, 0.003, False) /* Create Queen of Eyes (37258) for ContainTreasure */
-     , (40926, 9, 37259,  0, 0, 0.003, False) /* Create King of Eyes (37259) for ContainTreasure */
-     , (40926, 9, 37234,  0, 0, 0.003, False) /* Create Ace of Hands (37234) for ContainTreasure */
-     , (40926, 9, 37235,  0, 0, 0.003, False) /* Create Two of Hands (37235) for ContainTreasure */
-     , (40926, 9, 37236,  0, 0, 0.003, False) /* Create Three of Hands (37236) for ContainTreasure */
-     , (40926, 9, 37237,  0, 0, 0.003, False) /* Create Four of Hands (37237) for ContainTreasure */
-     , (40926, 9, 37238,  0, 0, 0.003, False) /* Create Five of Hands (37238) for ContainTreasure */
-     , (40926, 9, 37239,  0, 0, 0.003, False) /* Create Six of Hands (37239) for ContainTreasure */
-     , (40926, 9, 37240,  0, 0, 0.003, False) /* Create Seven of Hands (37240) for ContainTreasure */
-     , (40926, 9, 37241,  0, 0, 0.003, False) /* Create Eight of Hands (37241) for ContainTreasure */
-     , (40926, 9, 37242,  0, 0, 0.003, False) /* Create Nine of Hands (37242) for ContainTreasure */
-     , (40926, 9, 37243,  0, 0, 0.003, False) /* Create Ten of Hands (37243) for ContainTreasure */
-     , (40926, 9, 37244,  0, 0, 0.003, False) /* Create Jack of Hands (37244) for ContainTreasure */
-     , (40926, 9, 37245,  0, 0, 0.003, False) /* Create Queen of Hands (37245) for ContainTreasure */
-     , (40926, 9, 37246,  0, 0, 0.003, False) /* Create King of Hands (37246) for ContainTreasure */
-     , (40926, 9,     0,  0, 0, 0.922, False) /* Create nothing for ContainTreasure */;
+VALUES (40926, 2, 35096,  1, 0, 0, False) /* Create Pyre Blade (35096) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/06771 Leikotha.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/06771 Leikotha.sql
@@ -1,0 +1,482 @@
+DELETE FROM `weenie` WHERE `class_Id` = 6771;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (6771, 'mumiyahgreatercrimsonhaft', 10, '2021-06-11 03:49:40') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (6771,   1,         16) /* ItemType - Creature */
+     , (6771,   2,         14) /* CreatureType - Undead */
+     , (6771,   3,         44) /* PaletteTemplate - Tanred */
+     , (6771,   6,         -1) /* ItemsCapacity */
+     , (6771,   7,         -1) /* ContainersCapacity */
+     , (6771,  16,         32) /* ItemUseable - Remote */
+     , (6771,  25,         72) /* Level */
+     , (6771,  27,          0) /* ArmorType - None */
+     , (6771,  40,          1) /* CombatMode - NonCombat */
+     , (6771,  72,         14) /* FriendType - Undead */
+     , (6771,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (6771,  95,          8) /* RadarBlipColor - Yellow */
+     , (6771, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (6771, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (6771, 146,        862) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (6771,   1, True ) /* Stuck */
+     , (6771,   7, True ) /* AiUseHumanMagicAnimations */
+     , (6771,   8, True ) /* AllowGive */
+     , (6771,  12, True ) /* ReportCollisions */
+     , (6771,  13, False) /* Ethereal */
+     , (6771,  19, False) /* Attackable */
+     , (6771,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (6771,  50, True ) /* NeverFailCasting */
+     , (6771,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (6771,   1,       5) /* HeartbeatInterval */
+     , (6771,   2,       0) /* HeartbeatTimestamp */
+     , (6771,   3,    0.35) /* HealthRate */
+     , (6771,   4,     0.5) /* StaminaRate */
+     , (6771,   5,       2) /* ManaRate */
+     , (6771,  12,     0.5) /* Shade */
+     , (6771,  13,    0.53) /* ArmorModVsSlash */
+     , (6771,  14,    0.33) /* ArmorModVsPierce */
+     , (6771,  15,    0.53) /* ArmorModVsBludgeon */
+     , (6771,  16,    0.26) /* ArmorModVsCold */
+     , (6771,  17,     0.4) /* ArmorModVsFire */
+     , (6771,  18,       1) /* ArmorModVsAcid */
+     , (6771,  19,    0.17) /* ArmorModVsElectric */
+     , (6771,  34,       1) /* PowerupTime */
+     , (6771,  36,       1) /* ChargeSpeed */
+     , (6771,  39,     1.1) /* DefaultScale */
+     , (6771,  64,    0.75) /* ResistSlash */
+     , (6771,  65,    0.58) /* ResistPierce */
+     , (6771,  66,    0.75) /* ResistBludgeon */
+     , (6771,  67,       1) /* ResistFire */
+     , (6771,  68,     0.4) /* ResistCold */
+     , (6771,  69,       1) /* ResistAcid */
+     , (6771,  70,    0.46) /* ResistElectric */
+     , (6771,  71,       1) /* ResistHealthBoost */
+     , (6771,  72,       1) /* ResistStaminaDrain */
+     , (6771,  73,       1) /* ResistStaminaBoost */
+     , (6771,  74,       1) /* ResistManaDrain */
+     , (6771,  75,       1) /* ResistManaBoost */
+     , (6771, 104,      10) /* ObviousRadarRange */
+     , (6771, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (6771,   1, 'Leikotha') /* Name */
+     , (6771,   3, 'Female') /* Sex */
+     , (6771,   4, 'Haebrous') /* HeritageGroup */
+     , (6771,   5, 'Blademaster') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (6771,   1,   33554433) /* Setup */
+     , (6771,   2,  150994981) /* MotionTable */
+     , (6771,   3,  536870942) /* SoundTable */
+     , (6771,   4,  805306368) /* CombatTable */
+     , (6771,   6,   67108990) /* PaletteBase */
+     , (6771,   7,  268435645) /* ClothingBase */
+     , (6771,   8,  100669122) /* Icon */
+     , (6771,  22,  872415272) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (6771,  0,  4,  0,    0,   70,   35,   35,   35,   35,   35,   35,   35,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (6771,  1,  4,  0,    0,   65,   32,   32,   32,   32,   32,   32,   32,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (6771,  2,  4,  0,    0,   70,   35,   35,   35,   35,   35,   35,   35,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (6771,  3,  4,  0,    0,   70,   35,   35,   35,   35,   35,   35,   35,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (6771,  4,  4,  0,    0,   65,   32,   32,   32,   32,   32,   32,   32,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (6771,  5,  4, 15, 0.75,   70,   35,   35,   35,   35,   35,   35,   35,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (6771,  6,  4,  0,    0,   70,   35,   35,   35,   35,   35,   35,   35,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (6771,  7,  4,  0,    0,   75,   37,   37,   37,   37,   37,   37,   37,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (6771,  8,  4, 20, 0.75,   80,   40,   40,   40,   40,   40,   40,   40,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (6771,   1, 145, 0, 0) /* Strength */
+     , (6771,   2,  80, 0, 0) /* Endurance */
+     , (6771,   3,  80, 0, 0) /* Quickness */
+     , (6771,   4,  80, 0, 0) /* Coordination */
+     , (6771,   5,  75, 0, 0) /* Focus */
+     , (6771,   6,  75, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (6771,   1,    40, 0, 0,   80) /* MaxHealth */
+     , (6771,   3,   200, 0, 0,  280) /* MaxStamina */
+     , (6771,   5,     0, 0, 0,   75) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (6771,  1, 0, 3, 0, 110, 0,494.64494915801) /* Axe                 Specialized */
+     , (6771,  4, 0, 3, 0, 110, 0,494.64494915801) /* Dagger              Specialized */
+     , (6771,  5, 0, 2, 0, 110, 0,494.64494915801) /* Mace                Trained */
+     , (6771,  6, 0, 2, 0, 100, 0,494.64494915801) /* MeleeDefense        Trained */
+     , (6771,  7, 0, 2, 0,  50, 0,494.64494915801) /* MissileDefense      Trained */
+     , (6771,  9, 0, 2, 0, 110, 0,494.64494915801) /* Spear               Trained */
+     , (6771, 10, 0, 2, 0, 110, 0,494.64494915801) /* Staff               Trained */
+     , (6771, 11, 0, 3, 0, 110, 0,494.64494915801) /* Sword               Specialized */
+     , (6771, 13, 0, 2, 0, 110, 0,494.64494915801) /* UnarmedCombat       Trained */
+     , (6771, 14, 0, 2, 0, 250, 0,494.64494915801) /* ArcaneLore          Trained */
+     , (6771, 15, 0, 2, 0, 100, 0,494.64494915801) /* MagicDefense        Trained */
+     , (6771, 20, 0, 2, 0,  90, 0,494.64494915801) /* Deception           Trained */
+     , (6771, 31, 0, 2, 0, 250, 0,494.64494915801) /* CreatureEnchantment Trained */
+     , (6771, 33, 0, 2, 0, 250, 0,494.64494915801) /* LifeMagic           Trained */
+     , (6771, 34, 0, 2, 0, 250, 0,494.64494915801) /* WarMagic            Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 5 /* HeartBeat */, 0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'In your mind, a soft voice sighs, "Please leave me be... I wish thee no harm."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'In your mind, a soft voice sighs, "So many turns of the world have passed. When shall my torment end?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 5 /* HeartBeat */, 0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'In your mind, a soft voice sighs, "Disturb me not... Travel past this hole in the earth."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 6778 /* Repaired Haft */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha inspects the haft.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0, 1, NULL, 'It is almost as I remember it when he carried it in his hand. Not quite though. Some harm cannot be undone.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha sighs.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'Ai, Wari. One like thee, a child of another sun. He carried this haft, a great blade resting within it, and sought to release me. He failed... and now has been cursed as I have.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 18 /* DirectBroadcast */, 1, 1, NULL, 'A single tear rolls down Leikotha''s cheek. She raises a hand to her face and the dry wrappings absorb the tear instantly.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0, 1, NULL, 'As I have said, I shall reward you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 10000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 1, 1, NULL, 'If thou returns with the gems that once graced this haft, I will reward thee again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 31 /* EraseQuest */, 0, 1, NULL, 'CrimsonBrokenHaft2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 6660 /* The Ruby Al-Shajar */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Mine thanks. This gem was but the first one that graced the axe Wari once wielded. Thy people had begun to establish holdings here on Ireth Lassel when Wari came across this ancient tomb. This place of mourning that I have haunted for millennia.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha looks to the ceiling above her, and then returns her attention to you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 0, 1, NULL, 'After defeating those that surround me, Wari approached me. The long days had gone by so slowly, and this diminutive creature, one so much like mine own people, intrigued me. For a moment, this curiosity lifted the burden of my torment off my soul.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'I hailed this creature, asked him his name and what he sought. A moment he stood silent, considering me. Then he told me his name, what had passed on the land above, and that he now looked for a cause to lend his blade to.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0, 1, NULL, 'A spark of hope entered my heart, if I could still be said to have one. So long had I sought to undo Nerash''s binding, the curse that forever keeps me from passing. Perhaps this curious creature could finally undo it. Ai, I was wrong, so very wrong.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 1, 1, NULL, 'Ai, I see I have tarried thee long enough. I will reward thee for thy efforts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 25000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 1, 1, NULL, 'If thou brings me another of the gems, perhaps I will tell thee more.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 6661 /* The Ruby Al-Khur */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'The fifth gem. I see thou have seen Wari. Fate has not been kind to a soul so noble. Some once said the same of me. However, thou does deserve a reward for giving Wari a moment of peace.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 25000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'Now you know what I found when I entered Sylsfear. Wari had sought out the undead lords, those who, in their life, had maintained the facility and studied the mana and structure of this world. These undead lords and their minions had overpowered Wari, had discovered why he sought them out, and thought of an appropriate punishment.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'His mighty blade was shattered and spread about the undead minions as trophies. He was left with but one piece; the gem thou have brought to me. The lords also cursed Wari in a manner similar to me. Yet Wari''s curse had been imperfect and his mind was now as shattered his axe had been.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1, 1, NULL, 'I wept bitter tears when I returned to this tomb, seeing what had become of this noble child of distant sun. Ai, the tears were for me as well, for now I knew my torment would not end.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0, 1, NULL, 'Thou does know the tale now, and I have but a few final words to offer thee: Do not fear the fate that awaits all creatures that draw breath, for fates much worse than that can be meted out.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 1, 1, NULL, 'Now please leave me be.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 6662 /* The Ruby Mahwan */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Wari''s fourth gem. Thank thee.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 25000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'I had stood here, impassive, watching the days begin and end, ceaselessly. As the millennia had passed, I thought I had but one feeling left to me: sorrow. Yet Wari had shown I had another: hope. Now this fleshless fool, the one who told me of Wari''s death, had brought out yet another: fury.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'I struck down the fool, although not before I found out where Wari had fallen. Wari had sought the answer to unbinding me in the dungeon Sylsfear.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1, 1, NULL, 'I left this tomb, something I had not done for untold ages, and sought out those who had done this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha sighs.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 1, 1, NULL, 'Ai, if only I had not. If only.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 6663 /* The Ruby Yujazik */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'The second gem from Wari''s axe. Allow me to reward thee.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 25000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'Since thou has shown an interest in Wari''s tale, I will continue to tell it to thee.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'I had told Wari of Nerash''s poison arrow and my fall at the Plateau of Gelid. Of how Nerash, a foul undead minion of Dericost, had sought to keep me at his side for all eternity. Of how I had been tortured and twisted by his dark rites and doomed to never know the peace of oblivion. Of my daughter, Alysse, who only knew her mother as a loathsome monster, who had been forced to flee the light.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1, 1, NULL, 'Wari''s noble heart was moved, he swore to find a means to undo Nerash''s binding. I told him of the undead lords who roamed the sands of this land. The secrets of blood were known to them, perhaps they could aid him in releasing the binding.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0, 1, NULL, 'Wari set off to find these lords. Never again did I see him.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 6664 /* The Ruby Sulmada */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Ai, thou have found the third gem from Wari''s axe. You shall be rewarded.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 2 /* AwardXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 25000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'Many days passed after Wari left this tomb. Days that had been very much the others before Wari had come, yet the spark of hope remained.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'Then one of these creatures, these minor undead who derive a sick pleasure from seeing mine torment, told me that Wari had fallen. It cackled, the teeth in its fleshless skull rattling together with pleasure.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0, 1, NULL, 'The spark of hope died. Ai, if I could but join it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 8134 /* Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AshbaneTurnedIn@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AshbaneTurnedIn@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Leave me be, I have nothing to offer thee right now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8134 /* Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AshbaneTurnedIn@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha releases a dry, rasping gasp.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0, 1, NULL, 'Ashbane... mine own sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha examines her sword, feeling the weight of the blade in her hands.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0, 1, NULL, 'Spinning lies in my mind...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0, 1, NULL, 'What I did...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 18 /* DirectBroadcast */, 1, 1, NULL, 'A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 0, 1, NULL, 'Why... why...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha stares silently at the blade of the sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 0, 1, NULL, 'How... where... ai, thy mind tells me that thou has found in one of Aerfalle''s caches. Foul magus that she is. I shall reward thee for thy efforts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 500000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 22 /* StampQuest */, 0, 1, NULL, 'AshbaneTurnedIn', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 13, 10 /* Tell */, 1, 1, NULL, 'Now leave me. Leave me with my bitter memories...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 14, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2942 /* Free Ride to the Abandoned Mine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 28066 /* Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AshbaneTurnedIn@01', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AshbaneTurnedIn@01', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Leave me be, I have nothing to offer thee right now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 28066 /* Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AshbaneTurnedIn@01', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha releases a dry, rasping gasp.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0, 1, NULL, 'Ashbane... mine own sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha examines her sword, feeling the weight of the blade in her hands.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0, 1, NULL, 'Spinning lies in my mind...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0, 1, NULL, 'What I did...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 18 /* DirectBroadcast */, 1, 1, NULL, 'A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 0, 1, NULL, 'Why... why...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha stares silently at the blade of the sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 0, 1, NULL, 'How... where... ai, thy mind tells me that thou has found in one of Aerfalle''s caches. Foul magus that she is. I shall reward thee for thy efforts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 13765337, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.19999999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 22 /* StampQuest */, 0, 1, NULL, 'AshbaneTurnedIn', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 13, 10 /* Tell */, 1, 1, NULL, 'Now leave me. Leave me with my bitter memories...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 14, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2942 /* Free Ride to the Abandoned Mine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 28067 /* Superior Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AshbaneUberTurnedIn@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AshbaneUberTurnedIn@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Leave me be, I have nothing to offer thee right now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 28067 /* Superior Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AshbaneUberTurnedIn@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 36 /* InqIntStat */, 0, 1, NULL, 'Level_80-9999_2', NULL, 80, 9999, NULL, NULL, NULL, NULL, 25 /* Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'Level_80-9999_2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha releases a dry, rasping gasp.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Ashbane... mine own sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha examines her sword, feeling the weight of the blade in her hands.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 0, 1, NULL, 'I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'Spinning lies in my mind...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0, 1, NULL, 'What I did...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 18 /* DirectBroadcast */, 1, 1, NULL, 'A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 0, 1, NULL, 'Why... why...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha stares silently at the blade of the sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 10 /* Tell */, 0, 1, NULL, 'How... where... ai, thy mind tells me that thou has found in one of Aerfalle''s caches. Foul magus that she is. I shall reward thee for thy efforts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 13765337, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.19999999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 22 /* StampQuest */, 0, 1, NULL, 'AshbaneUberTurnedIn', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 10 /* Tell */, 1, 1, NULL, 'Now leave me. Leave me with my bitter memories...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 13, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2942 /* Free Ride to the Abandoned Mine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'Level_80-9999_2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha tilts her head from side to side, as if judging you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'I have no time for a child''s pestering. Be gone, lest my rage return and I strike thee down.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 28067 /* Superior Ashbane */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 2, 1, NULL, 'Be glad that mine ire is held in check.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2942 /* Free Ride to the Abandoned Mine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 6 /* Give */, 1, 40908, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'AshbaneExtremeTurnedIn@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'AshbaneExtremeTurnedIn@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Leave me be, I have nothing to offer thee right now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 40908, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'AshbaneExtremeTurnedIn@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 36 /* InqIntStat */, 0, 1, NULL, 'Level_150-9999_2', NULL, 150, 9999, NULL, NULL, NULL, NULL, 25 /* Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'Level_150-9999_2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha releases a dry, rasping gasp.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Ashbane... mine own sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha examines her sword, feeling the weight of the blade in her hands.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 0, 1, NULL, 'I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0, 1, NULL, 'Spinning lies in my mind...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0, 1, NULL, 'What I did...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 18 /* DirectBroadcast */, 1, 1, NULL, 'A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 0, 1, NULL, 'Why... why...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 18 /* DirectBroadcast */, 1, 1, NULL, 'Leikotha stares silently at the blade of the sword.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 10 /* Tell */, 0, 1, NULL, 'How... where... ai, thy mind tells me that thou has found in one of Aerfalle''s caches. Foul magus that she is. I shall reward thee for thy efforts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 50000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 22 /* StampQuest */, 0, 1, NULL, 'AshbaneExtremeTurnedIn', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 10 /* Tell */, 1, 1, NULL, 'Now leave me. Leave me with my bitter memories...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 13, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2942 /* Free Ride to the Abandoned Mine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'Level_150-9999_2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Leikotha tilts her head from side to side, as if judging you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'I have no time for a child''s pestering. Be gone, lest my rage return and I strike thee down.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 40908, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 2, 1, NULL, 'Be glad that mine ire is held in check.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2942 /* Free Ride to the Abandoned Mine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 20 /* UpdateQuest */, 0, 1, NULL, 'CrimsonBrokenHaft@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'CrimsonBrokenHaft@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Ai, another comes, breaking mine wretched musings. Why have you come to this sandy tomb, filled with unnatural beasts? Is your heart filled with greed, seeking what treasures may lay within? Or is your heart of a more noble nature, perhaps seeking to release me from this torment? It matters not, for I have but one thing to offer you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6777 /* Broken Haft */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 0, 1, NULL, 'Like so many things found on this unhappy world, it is broken. Once though it belonged to a friend. One like thee. One who hoped to release me. Ai, he failed... he failed.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'Take the haft, I would see it used again in his name than have it stay with me and crumble to dust. If thou have no use for the Haft, I would still see it as it once was. Return the haft to me, repaired, and I will reward thee. Those that surround me speak of one of thy kind who may know how to set it to order once more. Look for her at 1.7 S, 36.6 E.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'CrimsonBrokenHaft@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'CrimsonBrokenHaft2@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'CrimsonBrokenHaft2@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Thy mind tells that the haft has been repaired. Give it to me, and I shall reward thee.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (6771, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'CrimsonBrokenHaft2@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'I have given you all I have to offer. Take the haft, seek the one at 1.7 S, 36.6 E.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/06771.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/06771.es
@@ -1,0 +1,194 @@
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.05
+    - LocalBroadcast: In your mind, a soft voice sighs, "Please leave me be... I wish thee no harm."
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.1
+    - LocalBroadcast: In your mind, a soft voice sighs, "So many turns of the world have passed. When shall my torment end?"
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.15
+    - LocalBroadcast: In your mind, a soft voice sighs, "Disturb me not... Travel past this hole in the earth."
+
+Give: Repaired Haft (6778)
+    - TurnToTarget
+    - DirectBroadcast: Leikotha inspects the haft.
+    - Tell: It is almost as I remember it when he carried it in his hand. Not quite though. Some harm cannot be undone.
+    - Delay: 1, DirectBroadcast: Leikotha sighs.
+    - Tell: Ai, Wari. One like thee, a child of another sun. He carried this haft, a great blade resting within it, and sought to release me. He failed... and now has been cursed as I have.
+    - Delay: 1, DirectBroadcast: A single tear rolls down Leikotha's cheek. She raises a hand to her face and the dry wrappings absorb the tear instantly.
+    - Tell: As I have said, I shall reward you.
+    - AwardXP: 10,000
+    - Delay: 1, Tell: If thou returns with the gems that once graced this haft, I will reward thee again.
+    - EraseQuest: CrimsonBrokenHaft2
+
+Give: The Ruby Al-Shajar (6660)
+    - TurnToTarget
+    - Tell: Mine thanks. This gem was but the first one that graced the axe Wari once wielded. Thy people had begun to establish holdings here on Ireth Lassel when Wari came across this ancient tomb. This place of mourning that I have haunted for millennia.
+    - Delay: 1, DirectBroadcast: Leikotha looks to the ceiling above her, and then returns her attention to you.
+    - Tell: After defeating those that surround me, Wari approached me. The long days had gone by so slowly, and this diminutive creature, one so much like mine own people, intrigued me. For a moment, this curiosity lifted the burden of my torment off my soul.
+    - Delay: 1, Tell: I hailed this creature, asked him his name and what he sought. A moment he stood silent, considering me. Then he told me his name, what had passed on the land above, and that he now looked for a cause to lend his blade to.
+    - Tell: A spark of hope entered my heart, if I could still be said to have one. So long had I sought to undo Nerash's binding, the curse that forever keeps me from passing. Perhaps this curious creature could finally undo it. Ai, I was wrong, so very wrong.
+    - Delay: 1, Tell: Ai, I see I have tarried thee long enough. I will reward thee for thy efforts.
+    - AwardXP: 25,000
+    - Delay: 1, Tell: If thou brings me another of the gems, perhaps I will tell thee more.
+
+Give: The Ruby Al-Khur (6661)
+    - TurnToTarget
+    - Tell: The fifth gem. I see thou have seen Wari. Fate has not been kind to a soul so noble. Some once said the same of me. However, thou does deserve a reward for giving Wari a moment of peace.
+    - AwardXP: 25,000
+    - Delay: 1, Tell: Now you know what I found when I entered Sylsfear. Wari had sought out the undead lords, those who, in their life, had maintained the facility and studied the mana and structure of this world. These undead lords and their minions had overpowered Wari, had discovered why he sought them out, and thought of an appropriate punishment.
+    - Tell: His mighty blade was shattered and spread about the undead minions as trophies. He was left with but one piece; the gem thou have brought to me. The lords also cursed Wari in a manner similar to me. Yet Wari's curse had been imperfect and his mind was now as shattered his axe had been.
+    - Delay: 1, Tell: I wept bitter tears when I returned to this tomb, seeing what had become of this noble child of distant sun. Ai, the tears were for me as well, for now I knew my torment would not end.
+    - Tell: Thou does know the tale now, and I have but a few final words to offer thee: Do not fear the fate that awaits all creatures that draw breath, for fates much worse than that can be meted out.
+    - Delay: 1, Tell: Now please leave me be.
+
+Give: The Ruby Mahwan (6662)
+    - TurnToTarget
+    - Tell: Wari's fourth gem. Thank thee.
+    - AwardXP: 25,000
+    - Delay: 1, Tell: I had stood here, impassive, watching the days begin and end, ceaselessly. As the millennia had passed, I thought I had but one feeling left to me: sorrow. Yet Wari had shown I had another: hope. Now this fleshless fool, the one who told me of Wari's death, had brought out yet another: fury.
+    - Tell: I struck down the fool, although not before I found out where Wari had fallen. Wari had sought the answer to unbinding me in the dungeon Sylsfear.
+    - Delay: 1, Tell: I left this tomb, something I had not done for untold ages, and sought out those who had done this.
+    - DirectBroadcast: Leikotha sighs.
+    - Delay: 1, Tell: Ai, if only I had not. If only.
+
+Give: The Ruby Yujazik (6663)
+    - TurnToTarget
+    - Tell: The second gem from Wari's axe. Allow me to reward thee.
+    - AwardXP: 25,000
+    - Delay: 1, Tell: Since thou has shown an interest in Wari's tale, I will continue to tell it to thee.
+    - Tell: I had told Wari of Nerash's poison arrow and my fall at the Plateau of Gelid. Of how Nerash, a foul undead minion of Dericost, had sought to keep me at his side for all eternity. Of how I had been tortured and twisted by his dark rites and doomed to never know the peace of oblivion. Of my daughter, Alysse, who only knew her mother as a loathsome monster, who had been forced to flee the light.
+    - Delay: 1, Tell: Wari's noble heart was moved, he swore to find a means to undo Nerash's binding. I told him of the undead lords who roamed the sands of this land. The secrets of blood were known to them, perhaps they could aid him in releasing the binding.
+    - Tell: Wari set off to find these lords. Never again did I see him.
+
+Give: The Ruby Sulmada (6664)
+    - TurnToTarget
+    - Tell: Ai, thou have found the third gem from Wari's axe. You shall be rewarded.
+    - AwardXP: 25,000
+    - Delay: 1, Tell: Many days passed after Wari left this tomb. Days that had been very much the others before Wari had come, yet the spark of hope remained.
+    - Delay: 1, Tell: Then one of these creatures, these minor undead who derive a sick pleasure from seeing mine torment, told me that Wari had fallen. It cackled, the teeth in its fleshless skull rattling together with pleasure.
+    - Tell: The spark of hope died. Ai, if I could but join it.
+
+Give: Ashbane (8134)
+    - InqQuest: AshbaneTurnedIn
+        QuestSuccess:
+            - TurnToTarget
+            - Tell: Leave me be, I have nothing to offer thee right now.
+            - Give: Ashbane (8134)
+        QuestFailure:
+            - TurnToTarget
+            - DirectBroadcast: Leikotha releases a dry, rasping gasp.
+            - Tell: Ashbane... mine own sword.
+            - Delay: 1, DirectBroadcast: Leikotha examines her sword, feeling the weight of the blade in her hands.
+            - Tell: I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...
+            - Tell: Spinning lies in my mind...
+            - Tell: What I did...
+            - Delay: 1, DirectBroadcast: A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.
+            - Tell: Why... why...
+            - Delay: 1, DirectBroadcast: Leikotha stares silently at the blade of the sword.
+            - Tell: How... where... ai, thy mind tells me that thou has found in one of Aerfalle's caches. Foul magus that she is. I shall reward thee for thy efforts.
+            - AwardNoShareXP: 500,000
+            - StampQuest: AshbaneTurnedIn
+            - Delay: 1, Tell: Now leave me. Leave me with my bitter memories...
+            - CastSpellInstant: 2942 - Free Ride to the Abandoned Mine
+
+Give: Ashbane (28066)
+    - InqQuest: AshbaneTurnedIn@01
+        QuestSuccess:
+            - TurnToTarget
+            - Tell: Leave me be, I have nothing to offer thee right now.
+            - Give: Ashbane (28066)
+        QuestFailure:
+            - TurnToTarget
+            - DirectBroadcast: Leikotha releases a dry, rasping gasp.
+            - Tell: Ashbane... mine own sword.
+            - Delay: 1, DirectBroadcast: Leikotha examines her sword, feeling the weight of the blade in her hands.
+            - Tell: I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...
+            - Tell: Spinning lies in my mind...
+            - Tell: What I did...
+            - Delay: 1, DirectBroadcast: A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.
+            - Tell: Why... why...
+            - Delay: 1, DirectBroadcast: Leikotha stares silently at the blade of the sword.
+            - Tell: How... where... ai, thy mind tells me that thou has found in one of Aerfalle's caches. Foul magus that she is. I shall reward thee for thy efforts.
+            - AwardLevelProportionalXP: 20%, 0 - 13,765,337
+            - StampQuest: AshbaneTurnedIn
+            - Delay: 1, Tell: Now leave me. Leave me with my bitter memories...
+            - CastSpellInstant: 2942 - Free Ride to the Abandoned Mine
+
+Give: Superior Ashbane (28067)
+    - InqQuest: AshbaneUberTurnedIn
+        QuestSuccess:
+            - TurnToTarget
+            - Tell: Leave me be, I have nothing to offer thee right now.
+            - Give: Superior Ashbane (28067)
+        QuestFailure:
+            - TurnToTarget
+            - InqIntStat: Level, 80 - 9,999
+                TestSuccess:
+                    - DirectBroadcast: Leikotha releases a dry, rasping gasp.
+                    - Tell: Ashbane... mine own sword.
+                    - Delay: 1, DirectBroadcast: Leikotha examines her sword, feeling the weight of the blade in her hands.
+                    - Tell: I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...
+                    - Tell: Spinning lies in my mind...
+                    - Tell: What I did...
+                    - Delay: 1, DirectBroadcast: A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.
+                    - Tell: Why... why...
+                    - Delay: 1, DirectBroadcast: Leikotha stares silently at the blade of the sword.
+                    - Tell: How... where... ai, thy mind tells me that thou has found in one of Aerfalle's caches. Foul magus that she is. I shall reward thee for thy efforts.
+                    - AwardLevelProportionalXP: 20%, 0 - 13,765,337
+                    - StampQuest: AshbaneUberTurnedIn
+                    - Delay: 1, Tell: Now leave me. Leave me with my bitter memories...
+                    - CastSpellInstant: 2942 - Free Ride to the Abandoned Mine
+                TestFailure:
+                    - DirectBroadcast: Leikotha tilts her head from side to side, as if judging you.
+                    - Tell: I have no time for a child's pestering. Be gone, lest my rage return and I strike thee down.
+                    - Give: Superior Ashbane (28067)
+                    - Delay: 2, Tell: Be glad that mine ire is held in check.
+                    - CastSpellInstant: 2942 - Free Ride to the Abandoned Mine
+
+Give: 40908
+    - InqQuest: AshbaneExtremeTurnedIn
+        QuestSuccess:
+            - TurnToTarget
+            - Tell: Leave me be, I have nothing to offer thee right now.
+            - Give: 40908
+        QuestFailure:
+            - TurnToTarget
+            - InqIntStat: Level, 150 - 9,999
+                TestSuccess:
+                    - DirectBroadcast: Leikotha releases a dry, rasping gasp.
+                    - Tell: Ashbane... mine own sword.
+                    - Delay: 1, DirectBroadcast: Leikotha examines her sword, feeling the weight of the blade in her hands.
+                    - Tell: I had dropped this on the hill of Ayn Tayan... My rage had so blinded me. Ferah, had played me for the fool...
+                    - Tell: Spinning lies in my mind...
+                    - Tell: What I did...
+                    - Delay: 1, DirectBroadcast: A sound slowly builds within Leikotha, until finally an unearthly scream emanates from her. You feel the din about to deafen you when the scream stops.
+                    - Tell: Why... why...
+                    - Delay: 1, DirectBroadcast: Leikotha stares silently at the blade of the sword.
+                    - Tell: How... where... ai, thy mind tells me that thou has found in one of Aerfalle's caches. Foul magus that she is. I shall reward thee for thy efforts.
+                    - AwardNoShareXP: 50,000,000
+                    - StampQuest: AshbaneExtremeTurnedIn
+                    - Delay: 1, Tell: Now leave me. Leave me with my bitter memories...
+                    - CastSpellInstant: 2942 - Free Ride to the Abandoned Mine
+                TestFailure:
+                    - DirectBroadcast: Leikotha tilts her head from side to side, as if judging you.
+                    - Tell: I have no time for a child's pestering. Be gone, lest my rage return and I strike thee down.
+                    - Give: 40908
+                    - Delay: 2, Tell: Be glad that mine ire is held in check.
+                    - CastSpellInstant: 2942 - Free Ride to the Abandoned Mine
+
+Use:
+    - UpdateQuest: CrimsonBrokenHaft
+        QuestSuccess:
+            - TurnToTarget
+            - Tell: Ai, another comes, breaking mine wretched musings. Why have you come to this sandy tomb, filled with unnatural beasts? Is your heart filled with greed, seeking what treasures may lay within? Or is your heart of a more noble nature, perhaps seeking to release me from this torment? It matters not, for I have but one thing to offer you.
+            - Delay: 1, Give: Broken Haft (6777)
+            - Tell: Like so many things found on this unhappy world, it is broken. Once though it belonged to a friend. One like thee. One who hoped to release me. Ai, he failed... he failed.
+            - Delay: 1, Tell: Take the haft, I would see it used again in his name than have it stay with me and crumble to dust. If thou have no use for the Haft, I would still see it as it once was. Return the haft to me, repaired, and I will reward thee. Those that surround me speak of one of thy kind who may know how to set it to order once more. Look for her at 1.7 S, 36.6 E.
+        QuestFailure:
+            - InqQuest: CrimsonBrokenHaft2
+                QuestSuccess:
+                    - TurnToTarget
+                    - Tell: Thy mind tells that the haft has been repaired. Give it to me, and I shall reward thee.
+                QuestFailure:
+                    - TurnToTarget
+                    - Tell: I have given you all I have to offer. Take the haft, seek the one at 1.7 S, 36.6 E.
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/07369 Aerfalle's Weakened Apprentice.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/07369 Aerfalle's Weakened Apprentice.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 7369;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (7369, 'darkmagusaerfalle', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (7369, 'darkmagusaerfalle', 10, '2021-06-12 06:44:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (7369,   1,         16) /* ItemType - Creature */
@@ -69,15 +69,26 @@ INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (7369,   1, 'Aerfalle''s Weakened Apprentice') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (7369,   1, 0x02000197) /* Setup */
-     , (7369,   2, 0x09000017) /* MotionTable */
-     , (7369,   3, 0x20000016) /* SoundTable */
-     , (7369,   4, 0x30000000) /* CombatTable */
-     , (7369,   6, 0x0400007E) /* PaletteBase */
-     , (7369,   7, 0x10000232) /* ClothingBase */
-     , (7369,   8, 0x06001226) /* Icon */
-     , (7369,  22, 0x34000028) /* PhysicsEffectTable */
+VALUES (7369,   1,   33554839) /* Setup */
+     , (7369,   2,  150994967) /* MotionTable */
+     , (7369,   3,  536870934) /* SoundTable */
+     , (7369,   4,  805306368) /* CombatTable */
+     , (7369,   6,   67108990) /* PaletteBase */
+     , (7369,   7,  268436018) /* ClothingBase */
+     , (7369,   8,  100667942) /* Icon */
+     , (7369,  22,  872415272) /* PhysicsEffectTable */
      , (7369,  35,         25) /* DeathTreasureType - Loot Tier: 4 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (7369,  0,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (7369,  1,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (7369,  2,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (7369,  3,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (7369,  4,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (7369,  5,  4,160, 0.75,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (7369,  6,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (7369,  7,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (7369,  8,  4,160, 0.75,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (7369,   1, 220, 0, 0) /* Strength */
@@ -88,13 +99,18 @@ VALUES (7369,   1, 220, 0, 0) /* Strength */
      , (7369,   6, 300, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (7369,   1,   350, 0, 0, 500) /* MaxHealth */
-     , (7369,   3,   150, 0, 0, 450) /* MaxStamina */
-     , (7369,   5,   300, 0, 0, 600) /* MaxMana */;
+VALUES (7369,   1,   350, 0, 0,  500) /* MaxHealth */
+     , (7369,   3,   150, 0, 0,  450) /* MaxStamina */
+     , (7369,   5,   300, 0, 0,  600) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (7369,  6, 0, 3, 0, 283, 0, 0) /* MeleeDefense        Specialized */
+VALUES (7369, 45, 0, 3, 0, 313, 0, 0) /* LightWeapons        Specialized */
+     , (7369, 47, 0, 3, 0, 120, 0, 0) /* MissileWeapons      Specialized */
+     , (7369, 46, 0, 3, 0, 120, 0, 0) /* FinesseWeapons      Specialized */
+     , (7369,  6, 0, 3, 0, 283, 0, 0) /* MeleeDefense        Specialized */
      , (7369,  7, 0, 3, 0, 382, 0, 0) /* MissileDefense      Specialized */
+     , (7369, 44, 0, 3, 0, 313, 0, 0) /* HeavyWeapons        Specialized */
+     , (7369, 48, 0, 3, 0, 313, 0, 0) /* Shield              Specialized */
      , (7369, 14, 0, 3, 0, 230, 0, 0) /* ArcaneLore          Specialized */
      , (7369, 15, 0, 3, 0, 199, 0, 0) /* MagicDefense        Specialized */
      , (7369, 16, 0, 3, 0, 200, 0, 0) /* ManaConversion      Specialized */
@@ -102,255 +118,239 @@ VALUES (7369,  6, 0, 3, 0, 283, 0, 0) /* MeleeDefense        Specialized */
      , (7369, 31, 0, 3, 0, 150, 0, 0) /* CreatureEnchantment Specialized */
      , (7369, 32, 0, 3, 0, 150, 0, 0) /* ItemEnchantment     Specialized */
      , (7369, 33, 0, 3, 0, 150, 0, 0) /* LifeMagic           Specialized */
-     , (7369, 34, 0, 3, 0, 150, 0, 0) /* WarMagic            Specialized */
-     , (7369, 44, 0, 3, 0, 313, 0, 0) /* HeavyWeapons        Specialized */
-     , (7369, 45, 0, 3, 0, 313, 0, 0) /* LightWeapons        Specialized */
-     , (7369, 46, 0, 3, 0, 120, 0, 0) /* FinesseWeapons      Specialized */
-     , (7369, 47, 0, 3, 0, 120, 0, 0) /* MissileWeapons      Specialized */
-     , (7369, 48, 0, 3, 0, 313, 0, 0) /* Shield              Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (7369,  0,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (7369,  1,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (7369,  2,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (7369,  3,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (7369,  4,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (7369,  5,  4, 160, 0.75,  250,  375,  375,  375,  375,  225,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (7369,  6,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (7369,  7,  4,  0,    0,  250,  375,  375,  375,  375,  225,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (7369,  8,  4, 160, 0.75,  250,  375,  375,  375,  375,  225,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (7369, 34, 0, 3, 0, 150, 0, 0) /* WarMagic            Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (7369,    62,   2.04)  /* Acid Stream V */
-     , (7369,    68,   2.04)  /* Shock Wave V */
-     , (7369,    84,   2.04)  /* Flame Bolt V */
-     , (7369,    90,   2.04)  /* Force Bolt V */
-     , (7369,    96,   2.04)  /* Whirling Blade V */
-     , (7369,   279,      2)  /* Magic Resistance Self VI */
-     , (7369,   677,   2.01)  /* Mana Conversion Ineptitude Other VI */
-     , (7369,   897,   2.01)  /* Healing Ineptitude Other VI */
-     , (7369,  1094,      2)  /* Fire Protection Self VI */
-     , (7369,  1114,      2)  /* Blade Protection Self VI */
-     , (7369,  1242,   2.02)  /* Drain Health Other VI */
-     , (7369,  1265,   2.02)  /* Drain Mana Other VI */
-     , (7369,  1312,      2)  /* Armor Self VI */
-     , (7369,  1372,   2.01)  /* Frailty Other VI */
-     , (7369,  1396,   2.01)  /* Clumsiness Other VI */
-     , (7369,  1420,   2.01)  /* Slowness Other VI */
-     , (7369,  1468,   2.01)  /* Feeblemind Other VI */
-     , (7369,  1795,   2.04)  /* Acid Streak VI */
-     , (7369,  1801,   2.04)  /* Flame Streak VI */
-     , (7369,  1807,   2.04)  /* Force Streak VI */
-     , (7369,  1825,   2.04)  /* Shock Wave Streak VI */
-     , (7369,  1831,   2.03)  /* Whirling Blade Streak VI */
-     , (7369,  1882,      2)  /* Nullify All Magic Self */
-     , (7369,  2029,   2.01)  /* Stamina Blight */
-     , (7369,  2043,   2.03)  /* Weight of Eternity */
-     , (7369,  2369,   2.03)  /* Expulsion */
-     , (7369,  2372,   2.03)  /* Price of Immortality */
-     , (7369,  2373,   2.03)  /* Enervation of the Heart */
-     , (7369,  2374,   2.03)  /* Enervation of the Limb */
-     , (7369,  2375,   2.03)  /* Enervation of the Mind */
-     , (7369,  2715,   2.04)  /* Acid Arc V */
-     , (7369,  2722,   2.04)  /* Force Arc V */
-     , (7369,  2743,   2.04)  /* Flame Arc V */
-     , (7369,  2750,   2.04)  /* Shock Arc V */
-     , (7369,  2757,   2.04)  /* Blade Arc V */
-     , (7369,  3080,   2.03)  /* Bruised Flesh */
-     , (7369,  3081,   2.03)  /* Flesh of Cloth */
-     , (7369,  3082,   2.03)  /* Exposed Flesh */
-     , (7369,  3083,   2.03)  /* Flesh of Flint */
-     , (7369,  3084,   2.03)  /* Weaken Flesh */;
+VALUES (7369,    62,   2.04) /* Acid Stream V */
+     , (7369,    68,   2.04) /* Shock Wave V */
+     , (7369,    84,   2.04) /* Flame Bolt V */
+     , (7369,    90,   2.04) /* Force Bolt V */
+     , (7369,    96,   2.04) /* Whirling Blade V */
+     , (7369,   279,      2) /* Magic Resistance Self VI */
+     , (7369,   677,   2.01) /* Mana Conversion Ineptitude Other VI */
+     , (7369,   897,   2.01) /* Healing Ineptitude Other VI */
+     , (7369,  1094,      2) /* Fire Protection Self VI */
+     , (7369,  1114,      2) /* Blade Protection Self VI */
+     , (7369,  1242,   2.02) /* Drain Health Other VI */
+     , (7369,  1265,   2.02) /* Drain Mana Other VI */
+     , (7369,  1312,      2) /* Armor Self VI */
+     , (7369,  1372,   2.01) /* Frailty Other VI */
+     , (7369,  1396,   2.01) /* Clumsiness Other VI */
+     , (7369,  1420,   2.01) /* Slowness Other VI */
+     , (7369,  1468,   2.01) /* Feeblemind Other VI */
+     , (7369,  1795,   2.04) /* Acid Streak VI */
+     , (7369,  1801,   2.04) /* Flame Streak VI */
+     , (7369,  1807,   2.04) /* Force Streak VI */
+     , (7369,  1825,   2.04) /* Shock Wave Streak VI */
+     , (7369,  1831,   2.03) /* Whirling Blade Streak VI */
+     , (7369,  1882,      2) /* Nullify All Magic Self */
+     , (7369,  2029,   2.01) /* Stamina Blight */
+     , (7369,  2043,   2.03) /* Weight of Eternity */
+     , (7369,  2369,   2.03) /* Expulsion */
+     , (7369,  2372,   2.03) /* Price of Immortality */
+     , (7369,  2373,   2.03) /* Enervation of the Heart */
+     , (7369,  2374,   2.03) /* Enervation of the Limb */
+     , (7369,  2375,   2.03) /* Enervation of the Mind */
+     , (7369,  2715,   2.04) /* Acid Arc V */
+     , (7369,  2722,   2.04) /* Force Arc V */
+     , (7369,  2743,   2.04) /* Flame Arc V */
+     , (7369,  2750,   2.04) /* Shock Arc V */
+     , (7369,  2757,   2.04) /* Blade Arc V */
+     , (7369,  3080,   2.03) /* Bruised Flesh */
+     , (7369,  3081,   2.03) /* Flesh of Cloth */
+     , (7369,  3082,   2.03) /* Exposed Flesh */
+     , (7369,  3083,   2.03) /* Flesh of Flint */
+     , (7369,  3084,   2.03) /* Weaken Flesh */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  16 /* WorldBroadcast */, 0, 1, NULL, 'On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven her back into her hidden crypts, and the ground stills... until she next awakens.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  17 /* LocalBroadcast */, 0, 0, NULL, 'The withered corpse of Aerfalle hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this insignificant victory, child. For I have walked this world for over ten millennia, and I shall walk it long hence your little race has returned to the dust that birthed thee!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  24 /* StopEvent */, 0, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  24 /* StopEvent */, 0, 1, NULL, 'AerfalleKeepStopgapGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 16 /* WorldBroadcast */, 0, 1, NULL, 'On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven back the apprentice she left to guard her home... for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 17 /* LocalBroadcast */, 0, 1, NULL, 'The withered corpse of Aerfalle''s Apprentice hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this small victory, child. For my mistress will yet have her vengeance upon thee!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleKeepStopgapGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 14 /* Taunt */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 14 /* Taunt */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Did that hurt thee, %s?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Did that hurt thee, %s?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 14 /* Taunt */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 14 /* Taunt */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Perhaps I play too roughly with you fragile outlanders..."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Perhaps I play too roughly with you fragile outlanders..."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 15 /* WoundedTaunt */,   0.19, NULL, NULL, NULL, NULL, NULL, 0.19, 0.21);
+VALUES (7369, 15 /* WoundedTaunt */, 0.19, NULL, NULL, NULL, NULL, NULL, 0.19, 0.21);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "I am one of the primogen of Dericost. I am not like mine countrymen you have fought. If you strike me down, I shall rise again!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "I am one of the primogen of Dericost. I am not like mine countrymen you have fought. If you strike me down, I shall rise again!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 15 /* WoundedTaunt */,   0.49, NULL, NULL, NULL, NULL, NULL, 0.49, 0.51);
+VALUES (7369, 15 /* WoundedTaunt */, 0.49, NULL, NULL, NULL, NULL, NULL, 0.49, 0.51);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "I shall not be defeated!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "I shall not be defeated!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 15 /* WoundedTaunt */,   0.79, NULL, NULL, NULL, NULL, NULL, 0.79, 0.81);
+VALUES (7369, 15 /* WoundedTaunt */, 0.79, NULL, NULL, NULL, NULL, NULL, 0.79, 0.81);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Is that the best you can do, my poor child?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Is that the best you can do, my poor child?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 16 /* KillTaunt */,    0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 16 /* KillTaunt */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Tell your little gods who sent you to them, %s!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Tell your little gods who sent you to them, %s!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 16 /* KillTaunt */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 16 /* KillTaunt */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "That head will make a fine trophy. Which of you will next decorate my keep?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "That head will make a fine trophy. Which of you will next decorate my keep?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 17 /* NewEnemy */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 17 /* NewEnemy */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Vermin!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Vermin!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 17 /* NewEnemy */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 17 /* NewEnemy */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Don''t you have anything better to do than bother me?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Don''t you have anything better to do than bother me?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 17 /* NewEnemy */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 17 /* NewEnemy */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Disturb not your betters, child!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Disturb not your betters, child!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 18 /* Scream */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Guards! To me!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Guards! To me!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 18 /* Scream */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "A little help here, please."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "A little help here, please."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 18 /* Scream */,    0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 18 /* Scream */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Gentlemen, could I trouble you to perform thy task?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Gentlemen, could I trouble you to perform thy task?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 19 /* Homesick */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 19 /* Homesick */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Bah. There are Dark Spawn and Walkers yet in the world. You are not worthy of my attention."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Bah. There are Dark Spawn and Walkers yet in the world. You are not worthy of my attention."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 19 /* Homesick */,    0.4, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 19 /* Homesick */, 0.4, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Guards! Clean up the mess in here. I have more important things to attend to."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Guards! Clean up the mess in here. I have more important things to attend to."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 20 /* ReceiveCritical */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 20 /* ReceiveCritical */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "A skillful attack, %s."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "A skillful attack, %s."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 20 /* ReceiveCritical */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 20 /* ReceiveCritical */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Impressive, child. Your people do sometimes surprise me."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Impressive, child. Your people do sometimes surprise me."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 21 /* ResistSpell */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 21 /* ResistSpell */, 0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Your so-called magics are no match for those of old Dericost!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Your so-called magics are no match for those of old Dericost!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 21 /* ResistSpell */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 21 /* ResistSpell */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Your spellcraft is feeble, %s! Are you sure your calling is that of a mage?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Your spellcraft is feeble, %s! Are you sure your calling is that of a mage?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (7369, 21 /* ResistSpell */,   0.45, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (7369, 21 /* ResistSpell */, 0.45, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'A coolly amused voice seeps across your mind, "Is that the extent of thy powers, child? I shall show thee true power!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Is that the extent of thy powers, child? I shall show thee true power!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7409,  1, 0, 1, False) /* Create Ashen Key (7409) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */
-     , (7369, 9,  7380,  0, 0, 1, False) /* Create Sheets of Paper (7380) for ContainTreasure */
-     , (7369, 9,     0,  0, 0, 0, False) /* Create nothing for ContainTreasure */;
+VALUES (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7409,  1, 0,    1, False) /* Create Ashen Key (7409) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (7369, 9,  7380,  0, 0,    1, False) /* Create Sheets of Paper (7380) for ContainTreasure */
+     , (7369, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/07369.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/07369.es
@@ -1,0 +1,65 @@
+Death:
+    - WorldBroadcast: On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven back the apprentice she left to guard her home... for now.
+    - LocalBroadcast: The withered corpse of Aerfalle's Apprentice hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this small victory, child. For my mistress will yet have her vengeance upon thee!"
+    - StopEvent: AerfalleGen
+    - StopEvent: AerfalleKeepStopgapGen
+
+Taunt: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Did that hurt thee, %s?"
+
+Taunt: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Perhaps I play too roughly with you fragile outlanders..."
+
+WoundedTaunt: Probability: 0.19, MinHealth: 0.19, MaxHealth: 0.21
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I am one of the primogen of Dericost. I am not like mine countrymen you have fought. If you strike me down, I shall rise again!"
+
+WoundedTaunt: Probability: 0.49, MinHealth: 0.49, MaxHealth: 0.51
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I shall not be defeated!"
+
+WoundedTaunt: Probability: 0.79, MinHealth: 0.79, MaxHealth: 0.81
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Is that the best you can do, my poor child?"
+
+KillTaunt: Probability: 0.5
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Tell your little gods who sent you to them, %s!"
+
+KillTaunt:
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "That head will make a fine trophy. Which of you will next decorate my keep?"
+
+NewEnemy: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Vermin!"
+
+NewEnemy: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Don't you have anything better to do than bother me?"
+
+NewEnemy: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Disturb not your betters, child!"
+
+Scream: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Guards! To me!"
+
+Scream: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "A little help here, please."
+
+Scream: Probability: 0.5
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Gentlemen, could I trouble you to perform thy task?"
+
+Homesick: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Bah. There are Dark Spawn and Walkers yet in the world. You are not worthy of my attention."
+
+Homesick: Probability: 0.4
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Guards! Clean up the mess in here. I have more important things to attend to."
+
+ReceiveCritical: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "A skillful attack, %s."
+
+ReceiveCritical: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Impressive, child. Your people do sometimes surprise me."
+
+ResistSpell: Probability: 0.15
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Your so-called magics are no match for those of old Dericost!"
+
+ResistSpell: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Your spellcraft is feeble, %s! Are you sure your calling is that of a mage?"
+
+ResistSpell: Probability: 0.45
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Is that the extent of thy powers, child? I shall show thee true power!"

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/28054.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/28054.es
@@ -1,0 +1,66 @@
+Death:
+    - WorldBroadcast: On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven back the apprentice she left to guard her home... for now.
+    - LocalBroadcast: The withered corpse of Aerfalle's Apprentice hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this small victory, child. For my mistress will yet have her vengeance upon thee!"
+    - StopEvent: AerfalleUberGen
+    - StopEvent: AerfalleKeepStopgapGen
+
+Taunt: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Did that hurt thee, %s?"
+
+Taunt: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Perhaps I play too roughly with you fragile outlanders..."
+
+WoundedTaunt: Probability: 0.19, MinHealth: 0.19, MaxHealth: 0.21
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I am one of the primogen of Dericost. I am not like mine countrymen you have fought. If you strike me down, I shall rise again!"
+
+WoundedTaunt: Probability: 0.49, MinHealth: 0.49, MaxHealth: 0.51
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I shall not be defeated!"
+
+WoundedTaunt: Probability: 0.79, MinHealth: 0.79, MaxHealth: 0.81
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Is that the best you can do, my poor child?"
+
+KillTaunt: Probability: 0.5
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Tell your little gods who sent you to them, %s!"
+
+KillTaunt:
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "That head will make a fine trophy. Which of you will next decorate my keep?"
+
+NewEnemy: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Vermin!"
+
+NewEnemy: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Don't you have anything better to do than bother me?"
+
+NewEnemy: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Disturb not your betters, child!"
+
+Scream: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Guards! To me!"
+
+Scream: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "A little help here, please."
+
+Scream: Probability: 0.5
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Gentlemen, could I trouble you to perform thy task?"
+
+Homesick: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Bah. There are Dark Spawn and Walkers yet in the world. You are not worthy of my attention."
+
+Homesick: Probability: 0.4
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Guards! Clean up the mess in here. I have more important things to attend to."
+
+ReceiveCritical: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "A skillful attack, %s."
+
+ReceiveCritical: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Impressive, child. Your people do sometimes surprise me."
+
+ResistSpell: Probability: 0.15
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Your so-called magics are no match for those of old Dericost!"
+
+ResistSpell: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Your spellcraft is feeble, %s! Are you sure your calling is that of a mage?"
+
+ResistSpell: Probability: 0.45
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Is that the extent of thy powers, child? I shall show thee true power!"
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/40927 Revenant Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/40927 Revenant Lord.sql
@@ -1,0 +1,124 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40927;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40927, 'ace40927-revenantlord', 10, '2021-06-12 08:36:46') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40927,   1,         16) /* ItemType - Creature */
+     , (40927,   2,         14) /* CreatureType - Undead */
+     , (40927,   3,         68) /* PaletteTemplate - BlueSlime */
+     , (40927,   6,         -1) /* ItemsCapacity */
+     , (40927,   7,         -1) /* ContainersCapacity */
+     , (40927,  16,          1) /* ItemUseable - No */
+     , (40927,  25,        200) /* Level */
+     , (40927,  27,          0) /* ArmorType - None */
+     , (40927,  40,          1) /* CombatMode - NonCombat */
+     , (40927,  68,          3) /* TargetingTactic - Random, Focused */
+     , (40927,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (40927, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (40927, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (40927, 140,          1) /* AiOptions - CanOpenDoors */
+     , (40927, 146,    1100000) /* XpOverride */
+     , (40927, 307,          5) /* DamageRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40927,   1, True ) /* Stuck */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40927,   1,       5) /* HeartbeatInterval */
+     , (40927,   2,       0) /* HeartbeatTimestamp */
+     , (40927,   3,     0.6) /* HealthRate */
+     , (40927,   4,     0.5) /* StaminaRate */
+     , (40927,   5,       2) /* ManaRate */
+     , (40927,  12,       0) /* Shade */
+     , (40927,  13,     0.9) /* ArmorModVsSlash */
+     , (40927,  14,       1) /* ArmorModVsPierce */
+     , (40927,  15,       1) /* ArmorModVsBludgeon */
+     , (40927,  16,       1) /* ArmorModVsCold */
+     , (40927,  17,     0.9) /* ArmorModVsFire */
+     , (40927,  18,     0.9) /* ArmorModVsAcid */
+     , (40927,  19,       1) /* ArmorModVsElectric */
+     , (40927,  31,      18) /* VisualAwarenessRange */
+     , (40927,  34,       1) /* PowerupTime */
+     , (40927,  36,       1) /* ChargeSpeed */
+     , (40927,  39,     1.1) /* DefaultScale */
+     , (40927,  64,     0.6) /* ResistSlash */
+     , (40927,  65,     0.5) /* ResistPierce */
+     , (40927,  66,     0.5) /* ResistBludgeon */
+     , (40927,  67,     0.6) /* ResistFire */
+     , (40927,  68,     0.1) /* ResistCold */
+     , (40927,  69,     0.6) /* ResistAcid */
+     , (40927,  70,     0.5) /* ResistElectric */
+     , (40927,  71,       1) /* ResistHealthBoost */
+     , (40927,  72,       1) /* ResistStaminaDrain */
+     , (40927,  73,       1) /* ResistStaminaBoost */
+     , (40927,  74,       1) /* ResistManaDrain */
+     , (40927,  75,       1) /* ResistManaBoost */
+     , (40927,  80,       3) /* AiUseMagicDelay */
+     , (40927, 104,      10) /* ObviousRadarRange */
+     , (40927, 122,       2) /* AiAcquireHealth */
+     , (40927, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40927,   1, 'Revenant Lord') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40927,   1,   33558541) /* Setup */
+     , (40927,   2,  150994967) /* MotionTable */
+     , (40927,   3,  536870934) /* SoundTable */
+     , (40927,   4,  805306368) /* CombatTable */
+     , (40927,   6,   67114692) /* PaletteBase */
+     , (40927,   7,  268436726) /* ClothingBase */
+     , (40927,   8,  100667942) /* Icon */
+     , (40927,  22,  872415272) /* PhysicsEffectTable */
+     , (40927,  35,        449) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40927,  0,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40927,  1,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40927,  2,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40927,  3,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40927,  4,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40927,  5,  4, 90, 0.75,  450,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40927,  6,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40927,  7,  4,  0,    0,  450,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40927,  8,  4, 90, 0.75,  450,  225,  225,  225,  225,  225,  225,  225,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40927,   1, 180, 0, 0) /* Strength */
+     , (40927,   2, 190, 0, 0) /* Endurance */
+     , (40927,   3, 160, 0, 0) /* Quickness */
+     , (40927,   4, 220, 0, 0) /* Coordination */
+     , (40927,   5, 255, 0, 0) /* Focus */
+     , (40927,   6, 245, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40927,   1,  3000, 0, 0, 3095) /* MaxHealth */
+     , (40927,   3,  4000, 0, 0, 4190) /* MaxStamina */
+     , (40927,   5,  2000, 0, 0, 2245) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40927, 31, 0, 2, 0, 350, 0, 0) /* CreatureMagic */
+     , (40927, 46, 0, 2, 0, 500, 0, 0) /* FinesseWeapons */
+     , (40927, 44, 0, 2, 0, 500, 0, 0) /* HeavyWeapons */
+     , (40927, 33, 0, 2, 0, 350, 0, 0) /* LifeMagic */
+     , (40927, 45, 0, 2, 0, 500, 0, 0) /* LightWeapons */
+     , (40927, 15, 0, 2, 0, 350, 0, 0) /* MagicDefense */
+     , (40927, 16, 0, 2, 0, 300, 0, 0) /* ManaConversion */
+     , (40927,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense */
+     , (40927,  7, 0, 2, 0, 550, 0, 0) /* MissileDefense */
+     , (40927, 41, 0, 2, 0, 500, 0, 0) /* TwoHanded */
+     , (40927, 43, 0, 2, 0, 350, 0, 0) /* VoidMagic */
+     , (40927, 34, 0, 2, 0, 350, 0, 0) /* WarMagic */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40927,  2162,   2.05) /* Olthoi's Gift */
+     , (40927,  2717,   2.05) /* Acid Arc VII */
+     , (40927,  2122,   2.05) /* Disintegration */
+     , (40927,  2074,   2.05) /* Gossamer Flesh */
+     , (40927,  2123,   2.05) /* Celdiseth's Searing */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (40927, 2, 40910,  1, 0,    0, False) /* Create Dericost Blade (40910) for Wield */
+     , (40927, 9,  7045,  0, 0, 0.03, False) /* Create Dark Revenant Thighbone (7045) for ContainTreasure */
+     , (40927, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/40928 Lady Aerfalle.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/40928 Lady Aerfalle.sql
@@ -1,177 +1,173 @@
-DELETE FROM `weenie` WHERE `class_Id` = 28054;
+DELETE FROM `weenie` WHERE `class_Id` = 40928;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28054, 'darkmagusaerfalleuber', 10, '2021-06-12 06:41:08') /* Creature */;
+VALUES (40928, 'ace40928-ladyaerfalle', 10, '2021-06-11 01:18:25') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (28054,   1,         16) /* ItemType - Creature */
-     , (28054,   2,         14) /* CreatureType - Undead */
-     , (28054,   3,         39) /* PaletteTemplate - Black */
-     , (28054,   6,         -1) /* ItemsCapacity */
-     , (28054,   7,         -1) /* ContainersCapacity */
-     , (28054,  16,          1) /* ItemUseable - No */
-     , (28054,  25,        135) /* Level */
-     , (28054,  27,          0) /* ArmorType - None */
-     , (28054,  40,          1) /* CombatMode - NonCombat */
-     , (28054,  68,          3) /* TargetingTactic - Random, Focused */
-     , (28054,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
-     , (28054, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
-     , (28054, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (28054, 140,          1) /* AiOptions - CanOpenDoors */
-     , (28054, 146,     500000) /* XpOverride */;
+VALUES (40928,   1,         16) /* ItemType - Creature */
+     , (40928,   2,         14) /* CreatureType - Undead */
+     , (40928,   3,         39) /* PaletteTemplate - Black */
+     , (40928,   6,         -1) /* ItemsCapacity */
+     , (40928,   7,         -1) /* ContainersCapacity */
+     , (40928,  16,          1) /* ItemUseable - No */
+     , (40928,  25,        730) /* Level */
+     , (40928,  27,          0) /* ArmorType - None */
+     , (40928,  40,          1) /* CombatMode - NonCombat */
+     , (40928,  68,          3) /* TargetingTactic - Random, Focused */
+     , (40928,  81,          2) /* MaxGeneratedObjects */
+     , (40928,  82,          0) /* InitGeneratedObjects */
+     , (40928,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (40928, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (40928, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (40928, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (40928, 140,          1) /* AiOptions - CanOpenDoors */
+     , (40928, 145,          2) /* GeneratorEndDestructionType - Destroy */
+     , (40928, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (28054,   1, True ) /* Stuck */
-     , (28054,  11, False) /* IgnoreCollisions */
-     , (28054,  12, True ) /* ReportCollisions */
-     , (28054,  13, False) /* Ethereal */
-     , (28054,  50, True ) /* NeverFailCasting */;
+VALUES (40928,   1, True ) /* Stuck */
+     , (40928,  11, False) /* IgnoreCollisions */
+     , (40928,  12, True ) /* ReportCollisions */
+     , (40928,  13, False) /* Ethereal */
+     , (40928,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (28054,   1,       5) /* HeartbeatInterval */
-     , (28054,   2,       0) /* HeartbeatTimestamp */
-     , (28054,   3,      50) /* HealthRate */
-     , (28054,   4,      10) /* StaminaRate */
-     , (28054,   5,       2) /* ManaRate */
-     , (28054,  12,     0.1) /* Shade */
-     , (28054,  13,       1) /* ArmorModVsSlash */
-     , (28054,  14,       1) /* ArmorModVsPierce */
-     , (28054,  15,       1) /* ArmorModVsBludgeon */
-     , (28054,  16,       1) /* ArmorModVsCold */
-     , (28054,  17,     1.1) /* ArmorModVsFire */
-     , (28054,  18,     1.1) /* ArmorModVsAcid */
-     , (28054,  19,       1) /* ArmorModVsElectric */
-     , (28054,  31,      18) /* VisualAwarenessRange */
-     , (28054,  34,       1) /* PowerupTime */
-     , (28054,  36,       1) /* ChargeSpeed */
-     , (28054,  39,     1.1) /* DefaultScale */
-     , (28054,  64,     0.4) /* ResistSlash */
-     , (28054,  65,     0.4) /* ResistPierce */
-     , (28054,  66,     0.4) /* ResistBludgeon */
-     , (28054,  67,     0.6) /* ResistFire */
-     , (28054,  68,     0.1) /* ResistCold */
-     , (28054,  69,     0.6) /* ResistAcid */
-     , (28054,  70,    0.55) /* ResistElectric */
-     , (28054,  71,       1) /* ResistHealthBoost */
-     , (28054,  72,       0) /* ResistStaminaDrain */
-     , (28054,  73,       1) /* ResistStaminaBoost */
-     , (28054,  74,       0) /* ResistManaDrain */
-     , (28054,  75,       1) /* ResistManaBoost */
-     , (28054,  80,       2) /* AiUseMagicDelay */
-     , (28054, 104,      10) /* ObviousRadarRange */
-     , (28054, 122,       2) /* AiAcquireHealth */
-     , (28054, 125,       0) /* ResistHealthDrain */
-     , (28054, 127,       2) /* AiCounteractEnchantment */
-     , (28054, 128,       1) /* AiDispelEnchantment */;
+VALUES (40928,   1,       5) /* HeartbeatInterval */
+     , (40928,   2,       0) /* HeartbeatTimestamp */
+     , (40928,   3,      50) /* HealthRate */
+     , (40928,   4,      10) /* StaminaRate */
+     , (40928,   5,       2) /* ManaRate */
+     , (40928,  12,       0) /* Shade */
+     , (40928,  13,       1) /* ArmorModVsSlash */
+     , (40928,  14,       1) /* ArmorModVsPierce */
+     , (40928,  15,       1) /* ArmorModVsBludgeon */
+     , (40928,  16,       1) /* ArmorModVsCold */
+     , (40928,  17,     1.1) /* ArmorModVsFire */
+     , (40928,  18,     1.1) /* ArmorModVsAcid */
+     , (40928,  19,       1) /* ArmorModVsElectric */
+     , (40928,  31,      18) /* VisualAwarenessRange */
+     , (40928,  34,       1) /* PowerupTime */
+     , (40928,  36,       1) /* ChargeSpeed */
+     , (40928,  39,    1.25) /* DefaultScale */
+     , (40928,  43,      10) /* GeneratorRadius */
+     , (40928,  64,     0.4) /* ResistSlash */
+     , (40928,  65,     0.4) /* ResistPierce */
+     , (40928,  66,     0.4) /* ResistBludgeon */
+     , (40928,  67,     0.6) /* ResistFire */
+     , (40928,  68,     0.1) /* ResistCold */
+     , (40928,  69,     0.6) /* ResistAcid */
+     , (40928,  70,    0.55) /* ResistElectric */
+     , (40928,  71,       1) /* ResistHealthBoost */
+     , (40928,  72,       0) /* ResistStaminaDrain */
+     , (40928,  73,       1) /* ResistStaminaBoost */
+     , (40928,  74,       0) /* ResistManaDrain */
+     , (40928,  75,       1) /* ResistManaBoost */
+     , (40928,  80,       2) /* AiUseMagicDelay */
+     , (40928, 104,      10) /* ObviousRadarRange */
+     , (40928, 122,       2) /* AiAcquireHealth */
+     , (40928, 125,       0) /* ResistHealthDrain */
+     , (40928, 127,       2) /* AiCounteractEnchantment */
+     , (40928, 128,       1) /* AiDispelEnchantment */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (28054,   1, 'Aerfalle''s Apprentice') /* Name */;
+VALUES (40928,   1, 'Lady Aerfalle') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (28054,   1,   33554839) /* Setup */
-     , (28054,   2,  150994945) /* MotionTable */
-     , (28054,   3,  536870914) /* SoundTable */
-     , (28054,   4,  805306368) /* CombatTable */
-     , (28054,   6,   67108990) /* PaletteBase */
-     , (28054,   7,  268436018) /* ClothingBase */
-     , (28054,   8,  100667942) /* Icon */
-     , (28054,  22,  872415272) /* PhysicsEffectTable */
-     , (28054,  35,         29) /* DeathTreasureType - Loot Tier: 5 */;
+VALUES (40928,   1,   33558819) /* Setup */
+     , (40928,   2,  150994945) /* MotionTable */
+     , (40928,   3,  536870914) /* SoundTable */
+     , (40928,   4,  805306368) /* CombatTable */
+     , (40928,   6,   67115272) /* PaletteBase */
+     , (40928,   7,  268436837) /* ClothingBase */
+     , (40928,   8,  100667942) /* Icon */
+     , (40928,  22,  872415272) /* PhysicsEffectTable */
+     , (40928,  35,       2000) /* DeathTreasureType - Loot Tier: 8 */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (28054,  0,  4,  0,    0,  440,  220,  220,  220,  220,  220,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (28054,  1,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (28054,  2,  4,  0,    0,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (28054,  3,  4,  0,    0,  440,  220,  220,  220,  220,  220,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (28054,  4,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (28054,  5,  4,200,  0.4,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (28054,  6,  4,  0,    0,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (28054,  7,  4,  0,    0,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (28054,  8,  4,200,  0.4,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40928,  0,  4,  0,    0,  440,  220,  220,  220,  220,  220,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40928,  1,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40928,  2,  4,  0,    0,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40928,  3,  4,  0,    0,  440,  220,  220,  220,  220,  220,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40928,  4,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40928,  5,  4,600,  0.4,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40928,  6,  4,  0,    0,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40928,  7,  4,  0,    0,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40928,  8,  4,600,  0.4,  480,  240,  240,  240,  240,  240,  240,  240,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (28054,   1, 220, 0, 0) /* Strength */
-     , (28054,   2, 300, 0, 0) /* Endurance */
-     , (28054,   3, 220, 0, 0) /* Quickness */
-     , (28054,   4, 220, 0, 0) /* Coordination */
-     , (28054,   5, 300, 0, 0) /* Focus */
-     , (28054,   6, 300, 0, 0) /* Self */;
+VALUES (40928,   1, 400, 0, 0) /* Strength */
+     , (40928,   2, 300, 0, 0) /* Endurance */
+     , (40928,   3, 400, 0, 0) /* Quickness */
+     , (40928,   4, 400, 0, 0) /* Coordination */
+     , (40928,   5, 450, 0, 0) /* Focus */
+     , (40928,   6, 450, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (28054,   1,  4850, 0, 0, 5000) /* MaxHealth */
-     , (28054,   3,  1700, 0, 0, 2000) /* MaxStamina */
-     , (28054,   5,  1700, 0, 0, 2000) /* MaxMana */;
+VALUES (40928,   1,200100, 0, 0,200250) /* MaxHealth */
+     , (40928,   3,  4700, 0, 0, 5000) /* MaxStamina */
+     , (40928,   5,  4700, 0, 0, 5000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (28054,  1, 0, 3, 0, 363, 0,1983.21355336759) /* Axe                 Specialized */
-     , (28054,  2, 0, 3, 0, 120, 0,1983.21355336759) /* Bow                 Specialized */
-     , (28054,  3, 0, 3, 0, 120, 0,1983.21355336759) /* Crossbow            Specialized */
-     , (28054,  4, 0, 3, 0, 363, 0,1983.21355336759) /* Dagger              Specialized */
-     , (28054,  5, 0, 3, 0, 363, 0,1983.21355336759) /* Mace                Specialized */
-     , (28054,  6, 0, 3, 0, 371, 0,1983.21355336759) /* MeleeDefense        Specialized */
-     , (28054,  7, 0, 3, 0, 441, 0,1983.21355336759) /* MissileDefense      Specialized */
-     , (28054,  9, 0, 3, 0, 363, 0,1983.21355336759) /* Spear               Specialized */
-     , (28054, 10, 0, 3, 0, 363, 0,1983.21355336759) /* Staff               Specialized */
-     , (28054, 11, 0, 3, 0, 363, 0,1983.21355336759) /* Sword               Specialized */
-     , (28054, 13, 0, 3, 0, 363, 0,1983.21355336759) /* UnarmedCombat       Specialized */
-     , (28054, 14, 0, 3, 0, 230, 0,1983.21355336759) /* ArcaneLore          Specialized */
-     , (28054, 15, 0, 3, 0, 288, 0,1983.21355336759) /* MagicDefense        Specialized */
-     , (28054, 16, 0, 3, 0, 300, 0,1983.21355336759) /* ManaConversion      Specialized */
-     , (28054, 20, 0, 3, 0, 300, 0,1983.21355336759) /* Deception           Specialized */
-     , (28054, 31, 0, 3, 0, 300, 0,1983.21355336759) /* CreatureEnchantment Specialized */
-     , (28054, 32, 0, 3, 0, 300, 0,1983.21355336759) /* ItemEnchantment     Specialized */
-     , (28054, 33, 0, 3, 0, 300, 0,1983.21355336759) /* LifeMagic           Specialized */
-     , (28054, 34, 0, 3, 0, 300, 0,1983.21355336759) /* WarMagic            Specialized */;
+VALUES (40928, 31, 0, 2, 0, 350, 0, 0) /* CreatureMagic */
+     , (40928, 33, 0, 2, 0, 350, 0, 0) /* LifeMagic */
+     , (40928, 45, 0, 2, 0, 500, 0, 0) /* LightWeapons */
+     , (40928, 15, 0, 2, 0, 350, 0, 0) /* MagicDefense */
+     , (40928, 16, 0, 2, 0, 450, 0, 0) /* ManaConversion */
+     , (40928,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense */
+     , (40928,  7, 0, 2, 0, 550, 0, 0) /* MissileDefense */
+     , (40928, 43, 0, 2, 0, 350, 0, 0) /* VoidMagic */
+     , (40928, 34, 0, 2, 0, 350, 0, 0) /* WarMagic */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (28054,  2053,      2) /* Executor's Blessing */
-     , (28054,  2121,   2.08) /* Corrosive Flash */
-     , (28054,  2122,   2.08) /* Disintegration */
-     , (28054,  2128,   2.08) /* Ilservian's Flame */
-     , (28054,  2129,   2.08) /* Sizzling Fury */
-     , (28054,  2149,      2) /* Caustic Blessing */
-     , (28054,  2151,      2) /* Blessing of the Blade Turner */
-     , (28054,  2153,      2) /* Blessing of the Mace Turner */
-     , (28054,  2155,      2) /* Icy Blessing */
-     , (28054,  2157,      2) /* Fiery Blessing */
-     , (28054,  2159,      2) /* Storm's Blessing */
-     , (28054,  2161,      2) /* Blessing of the Arrow Turner */
-     , (28054,  2281,      2) /* Aura of Resistance */
-     , (28054,  2328,   2.01) /* Vitality Siphon */
-     , (28054,  2329,   2.01) /* Essence Void */
-     , (28054,  2370,   2.02) /* Gift of Rotting Flesh */
-     , (28054,  2371,   2.02) /* Curse of Mortal Flesh */
-     , (28054,  2372,   2.02) /* Price of Immortality */
-     , (28054,  2697,   2.02) /* Aerfalle's Touch */
-     , (28054,  2698,   2.02) /* Aerfalle's Embrace */
-     , (28054,  2705,   2.02) /* Aerfalle's Enforcement */
-     , (28054,  2706,   2.02) /* Aerfalle's Gaze */
-     , (28054,  2717,   2.08) /* Acid Arc VII */
-     , (28054,  2745,   2.08) /* Flame Arc VII */
-     , (28054,  3043,   2.02) /* Kiss of the Grave */
-     , (28054,  3056,   2.02) /* Death's Vice */
-     , (28054,  3059,   2.02) /* Enervation */
-     , (28054,  3060,   2.02) /* Poison Blood */
-     , (28054,  3061,   2.02) /* Taint Mana */
-     , (28054,  3067,   2.02) /* Matron's Curse */
-     , (28054,  3091,   2.02) /* Thin Skin */
-     , (28054,  3109,   2.05) /* Liquefy Flesh */
-     , (28054,  3110,   2.05) /* Sear Flesh */
-     , (28054,  3180,      2) /* Eradicate All Magic Self */;
+VALUES (40928,  2053,      2) /* Executor's Blessing */
+     , (40928,  2121,   2.08) /* Corrosive Flash */
+     , (40928,  2149,      2) /* Caustic Blessing */
+     , (40928,  2151,      2) /* Blessing of the Blade Turner */
+     , (40928,  2153,      2) /* Blessing of the Mace Turner */
+     , (40928,  2155,      2) /* Icy Blessing */
+     , (40928,  2157,      2) /* Fiery Blessing */
+     , (40928,  2159,      2) /* Storm's Blessing */
+     , (40928,  2161,      2) /* Blessing of the Arrow Turner */
+     , (40928,  2281,      2) /* Aura of Resistance */
+     , (40928,  2329,   2.01) /* Essence Void */
+     , (40928,  2370,   2.02) /* Gift of Rotting Flesh */
+     , (40928,  2371,   2.02) /* Curse of Mortal Flesh */
+     , (40928,  2372,   2.02) /* Price of Immortality */
+     , (40928,  2697,   2.02) /* Aerfalle's Touch */
+     , (40928,  2698,   2.02) /* Aerfalle's Embrace */
+     , (40928,  2705,   2.02) /* Aerfalle's Enforcement */
+     , (40928,  2706,   2.02) /* Aerfalle's Gaze */
+     , (40928,  3043,   2.02) /* Kiss of the Grave */
+     , (40928,  3056,   2.02) /* Death's Vice */
+     , (40928,  3059,   2.02) /* Enervation */
+     , (40928,  3060,   2.02) /* Poison Blood */
+     , (40928,  3061,   2.02) /* Taint Mana */
+     , (40928,  3067,   2.02) /* Matron's Curse */
+     , (40928,  3091,   2.02) /* Thin Skin */
+     , (40928,  3109,   2.05) /* Liquefy Flesh */
+     , (40928,  3110,   2.05) /* Sear Flesh */
+     , (40928,  3180,      2) /* Eradicate All Magic Self */
+     , (40928,  4421,   2.08) /* Acid Arc VII */
+     , (40928,  4423,   2.08) /* Flame Arc VII */
+     , (40928,  4433,   2.08) /* Disintegration */
+     , (40928,  4439,   2.08) /* Ilservian's Flame */
+     , (40928,  4440,   2.08) /* Sizzling Fury */
+     , (40928,  4643,   2.01) /* Vitality Siphon */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 16 /* WorldBroadcast */, 0, 1, NULL, 'On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven back the apprentice she left to guard her home... for now.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 17 /* LocalBroadcast */, 0, 1, NULL, 'The withered corpse of Aerfalle''s Apprentice hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this small victory, child. For my mistress will yet have her vengeance upon thee!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 2, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleUberGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 3, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleKeepStopgapGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 16 /* WorldBroadcast */, 0, 1, NULL, 'On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven her back into her hidden crypts, and the ground stills... until she next awakens.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 17 /* LocalBroadcast */, 0, 1, NULL, 'The withered corpse of Aerfalle hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this insignificant victory, child. For I have walked this world for over ten millennia, and I shall walk it long hence your little race has returned to the dust that birthed thee!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleExtremeGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 24 /* StopEvent */, 0, 1, NULL, 'AerfalleKeepStopgapGen', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 23 /* StartEvent */, 0, 1, NULL, 'AerfalleExtremeRewards', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 14 /* Taunt */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 14 /* Taunt */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -179,7 +175,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Did that hurt thee, %s?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 14 /* Taunt */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 14 /* Taunt */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -187,7 +183,16 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Perhaps I play too roughly with you fragile outlanders..."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 15 /* WoundedTaunt */, 0.19, NULL, NULL, NULL, NULL, NULL, 0.19, 0.21);
+VALUES (40928, 14 /* Taunt */, 0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "I call thee forth, bound servants of another! Let us see thy power against these small interlopers!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40928, 15 /* WoundedTaunt */, 0.19, NULL, NULL, NULL, NULL, NULL, 0.19, 0.21);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -195,7 +200,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "I am one of the primogen of Dericost. I am not like mine countrymen you have fought. If you strike me down, I shall rise again!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 15 /* WoundedTaunt */, 0.49, NULL, NULL, NULL, NULL, NULL, 0.49, 0.51);
+VALUES (40928, 15 /* WoundedTaunt */, 0.49, NULL, NULL, NULL, NULL, NULL, 0.49, 0.51);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -203,7 +208,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "I shall not be defeated!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 15 /* WoundedTaunt */, 0.79, NULL, NULL, NULL, NULL, NULL, 0.79, 0.81);
+VALUES (40928, 15 /* WoundedTaunt */, 0.79, NULL, NULL, NULL, NULL, NULL, 0.79, 0.81);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -211,7 +216,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Is that the best you can do, my poor child?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 16 /* KillTaunt */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 16 /* KillTaunt */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -219,7 +224,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Tell your little gods who sent you to them, %s!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 16 /* KillTaunt */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 16 /* KillTaunt */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -227,7 +232,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "That head will make a fine trophy. Which of you will next decorate my keep?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 17 /* NewEnemy */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 17 /* NewEnemy */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -235,7 +240,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Vermin!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 17 /* NewEnemy */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 17 /* NewEnemy */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -243,7 +248,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Don''t you have anything better to do than bother me?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 17 /* NewEnemy */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 17 /* NewEnemy */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -251,7 +256,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Disturb not your betters, child!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 18 /* Scream */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 18 /* Scream */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -259,7 +264,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Guards! To me!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 18 /* Scream */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 18 /* Scream */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -267,7 +272,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "A little help here, please."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 18 /* Scream */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 18 /* Scream */, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -275,7 +280,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Gentlemen, could I trouble you to perform thy task?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 19 /* Homesick */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 19 /* Homesick */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -283,7 +288,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Bah. There are Dark Spawn and Walkers yet in the world. You are not worthy of my attention."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 19 /* Homesick */, 0.4, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 19 /* Homesick */, 0.4, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -291,7 +296,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Guards! Clean up the mess in here. I have more important things to attend to."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 20 /* ReceiveCritical */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 20 /* ReceiveCritical */, 0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -299,7 +304,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "A skillful attack, %s."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 20 /* ReceiveCritical */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 20 /* ReceiveCritical */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -307,7 +312,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Impressive, child. Your people do sometimes surprise me."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 21 /* ResistSpell */, 0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 21 /* ResistSpell */, 0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -315,7 +320,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Your so-called magics are no match for those of old Dericost!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 21 /* ResistSpell */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 21 /* ResistSpell */, 0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -323,7 +328,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Your spellcraft is feeble, %s! Are you sure your calling is that of a mage?"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (28054, 21 /* ResistSpell */, 0.45, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (40928, 21 /* ResistSpell */, 0.45, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -331,23 +336,45 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 17 /* LocalBroadcast */, 0, 1, NULL, 'A coolly amused voice seeps across your mind, "Is that the extent of thy powers, child? I shall show thee true power!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9, 28057,  1, 0,    1, False) /* Create Ornate Ashen Key (28057) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
-     , (28054, 9,  7380,  0, 0,    1, False) /* Create Sheets of Paper (7380) for ContainTreasure */
-     , (28054, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */;
+VALUES (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 43529,  1, 0,    1, False) /* Create Lady Aerfalle's Charm (43529) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9,  7380,  0, 0,    1, False) /* Create Sheets of Paper (7380) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */
+     , (40928, 9, 40929,  1, 0,    1, False) /* Create Embossed Ashen Key (40929) for ContainTreasure */
+     , (40928, 9,     0,  0, 0,    0, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40928, 0.5, 40923, 10, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Handmaiden (40923) (x0 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (40928,   1, 40924, 10, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bound Pyre Champion(40924) (x0 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/40928.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/40928.es
@@ -1,0 +1,71 @@
+Death:
+    - WorldBroadcast: On far Aerlinthe Island, an intrepid band has found the lair of the Dark Lady Aerfalle, at whose whim the earth itself does shake. But the bold %s has driven her back into her hidden crypts, and the ground stills... until she next awakens.
+    - LocalBroadcast: The withered corpse of Aerfalle hisses in rage as it is hewn in twain... "I shall not be sent to a final rest by primitives like thee, %s!" her severed head says from the stones. "Enjoy this insignificant victory, child. For I have walked this world for over ten millennia, and I shall walk it long hence your little race has returned to the dust that birthed thee!"
+    - StopEvent: AerfalleExtremeGen
+    - StopEvent: AerfalleKeepStopgapGen
+    - StartEvent: AerfalleExtremeRewards
+
+Taunt: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Did that hurt thee, %s?"
+
+Taunt: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Perhaps I play too roughly with you fragile outlanders..."
+
+Taunt: Probability: 0.05
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I call thee forth, bound servants of another! Let us see thy power against these small interlopers!"
+    - Generate
+
+WoundedTaunt: Probability: 0.19, MinHealth: 0.19, MaxHealth: 0.21
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I am one of the primogen of Dericost. I am not like mine countrymen you have fought. If you strike me down, I shall rise again!"
+
+WoundedTaunt: Probability: 0.49, MinHealth: 0.49, MaxHealth: 0.51
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "I shall not be defeated!"
+
+WoundedTaunt: Probability: 0.79, MinHealth: 0.79, MaxHealth: 0.81
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Is that the best you can do, my poor child?"
+
+KillTaunt: Probability: 0.5
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Tell your little gods who sent you to them, %s!"
+
+KillTaunt:
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "That head will make a fine trophy. Which of you will next decorate my keep?"
+
+NewEnemy: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Vermin!"
+
+NewEnemy: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Don't you have anything better to do than bother me?"
+
+NewEnemy: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Disturb not your betters, child!"
+
+Scream: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Guards! To me!"
+
+Scream: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "A little help here, please."
+
+Scream: Probability: 0.5
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Gentlemen, could I trouble you to perform thy task?"
+
+Homesick: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Bah. There are Dark Spawn and Walkers yet in the world. You are not worthy of my attention."
+
+Homesick: Probability: 0.4
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Guards! Clean up the mess in here. I have more important things to attend to."
+
+ReceiveCritical: Probability: 0.1
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "A skillful attack, %s."
+
+ReceiveCritical: Probability: 0.2
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Impressive, child. Your people do sometimes surprise me."
+
+ResistSpell: Probability: 0.15
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Your so-called magics are no match for those of old Dericost!"
+
+ResistSpell: Probability: 0.3
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Your spellcraft is feeble, %s! Are you sure your calling is that of a mage?"
+
+ResistSpell: Probability: 0.45
+    - LocalBroadcast: A coolly amused voice seeps across your mind, "Is that the extent of thy powers, child? I shall show thee true power!"
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/40931 Aerfalle's Sanctum.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/40931 Aerfalle's Sanctum.sql
@@ -1,0 +1,89 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40931;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40931, 'ace40931-aerfallessanctum', 10, '2021-06-11 06:59:13') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40931,   1,         16) /* ItemType - Creature */
+     , (40931,   6,         -1) /* ItemsCapacity */
+     , (40931,   7,         -1) /* ContainersCapacity */
+     , (40931,  16,         32) /* ItemUseable - Remote */
+     , (40931,  93,    6294552) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, LightingOn, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (40931,  95,          4) /* RadarBlipColor - Purple */
+     , (40931, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40931,   1, True ) /* Stuck */
+     , (40931,  11, True ) /* IgnoreCollisions */
+     , (40931,  12, True ) /* ReportCollisions */
+     , (40931,  13, True ) /* Ethereal */
+     , (40931,  14, True ) /* GravityStatus */
+     , (40931,  15, True ) /* LightsStatus */
+     , (40931,  19, False) /* Attackable */
+     , (40931,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (40931,  42, True ) /* AllowEdgeSlide */
+     , (40931,  52, True ) /* AiImmobile */
+     , (40931,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (40931,  83, True ) /* NpcLooksLikeObject */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40931,  54,     0.1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40931,   1, 'Aerfalle''s Sanctum') /* Name */
+     , (40931,  16, 'A highly unstable-looking Falatacot Portal, looking more like a violent tear into Portalspace than a created thing.  Only those properly protected from its fluxuations may enter.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40931,   1,   33560216) /* Setup */
+     , (40931,   2,  150995314) /* MotionTable */
+     , (40931,   3,  536870932) /* SoundTable */
+     , (40931,   8,  100667499) /* Icon */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40931, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 36 /* InqIntStat */, 0, 1, NULL, 'Level_150-999', NULL, 150, 999, NULL, NULL, NULL, NULL, 25 /* Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40931, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'Level_150-999', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 58 /* InqFellowQuest */, 0, 1, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40931, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Your Fellowship is not properly protected to use this portal.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40931, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You can feel the violent energies swirl around you, but are kept safe by the Ghost of Galaeral''s enchantment upon your Fellowship.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5010 /* Entering Aerfalle's Sanctum */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40931, 30 /* QuestNoFellow */, 1, NULL, NULL, NULL, 'ExtremeAerfalleAccess', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You must be in a Fellowship to use this portal.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40931, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'Level_150-999', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You are not powerful enough to use this portal.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/40931.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/40931.es
@@ -1,0 +1,13 @@
+Use:
+    - InqIntStat: Level, 150 - 999
+        TestSuccess:
+            - InqFellowQuest: ExtremeAerfalleAccess
+                QuestFailure:
+                    - DirectBroadcast: Your Fellowship is not properly protected to use this portal.
+                QuestSuccess:
+                    - DirectBroadcast: You can feel the violent energies swirl around you, but are kept safe by the Ghost of Galaeral's enchantment upon your Fellowship.
+                    - CastSpellInstant: 5010
+                QuestNoFellow:
+                    - DirectBroadcast: You must be in a Fellowship to use this portal.
+        TestFailure:
+            - DirectBroadcast: You are not powerful enough to use this portal.

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/40911 Nexus-keyed Mana Shard.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/40911 Nexus-keyed Mana Shard.sql
@@ -1,0 +1,38 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40911;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40911, 'ace40911-nexuskeyedmanashard', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40911,   1,        128) /* ItemType - Misc */
+     , (40911,   5,         10) /* EncumbranceVal */
+     , (40911,  16,          1) /* ItemUseable - No */
+     , (40911,  18,         64) /* UiEffects - Lightning */
+     , (40911,  19,          0) /* Value */
+     , (40911,  33,          1) /* Bonded - Bonded */
+     , (40911,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40911, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40911,  22, True ) /* Inscribable */
+     , (40911,  23, True ) /* DestroyOnSell */
+     , (40911,  69, False) /* IsSellable */
+     , (40911,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40911,  39,     1.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40911,   1, 'Nexus-keyed Mana Shard') /* Name */
+     , (40911,  14, 'Bring this to the Ghost of Galaeral to gain access to the Lady Aerfalle, who presently resides in her deepest Sanctum.  **Be Warned: Only those of great skill (Level 150+) may enter the deepest sanctums and challenge Lady Aerfalle directly.  Also, you will need to be in a Fellowship to gain access to the Sanctum.') /* Use */
+     , (40911,  16, 'A shard of pure mana, attuned to the Nexus that lies deep under Aerlinthe Isle.  With the proper power, this could likely be used to create a portal to the nexus it is tied to.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40911,   1,   33560777) /* Setup */
+     , (40911,   3,  536870932) /* SoundTable */
+     , (40911,   8,  100690180) /* Icon */
+     , (40911,  22,  872415275) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (40911, 8040, 32833885, 96.6093, -93.4713, -28.9798, 0.373374, 0, 0, 0.9276809) /* PCAPRecordedLocation */
+/* @teleloc 0x01F5015D [96.609300 -93.471300 -28.979800] 0.373374 0.000000 0.000000 0.927681 */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/40912 Aerfalle's Embossed Token.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/40912 Aerfalle's Embossed Token.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40912;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40912, 'ace40912-aerfallesembossedtoken', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40912,   1,        128) /* ItemType - Misc */
+     , (40912,   5,         20) /* EncumbranceVal */
+     , (40912,  16,          1) /* ItemUseable - No */
+     , (40912,  19,          0) /* Value */
+     , (40912,  33,          1) /* Bonded - Bonded */
+     , (40912,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40912, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40912,  22, True ) /* Inscribable */
+     , (40912,  23, True ) /* DestroyOnSell */
+     , (40912,  69, False) /* IsSellable */
+     , (40912,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40912,  1, 'Aerfalle''s Embossed Token') /* Name */
+     , (40912, 14, 'Bring this token to Kuyiza bint Zayi the Translator, in Zaikhal, for a reward.') /* Use */
+     , (40912, 16, 'An elegant, embossed, ancient token, carved in the artistic fashion of the Dericost Nobility.  The edge of the token is inscribed with tiny Dericost runes.') /* LongDesc */
+     , (40912, 33, 'AerfalleEmbossedTokenPickup') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40912,   1,   33554689) /* Setup */
+     , (40912,   3,  536870932) /* SoundTable */
+     , (40912,   6,   67111919) /* PaletteBase */
+     , (40912,   8,  100670319) /* Icon */
+     , (40912,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/40913 Aerfalle's Token.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/40913 Aerfalle's Token.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40913;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40913, 'ace40913-aerfallestoken', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40913,   1,        128) /* ItemType - Misc */
+     , (40913,   5,         20) /* EncumbranceVal */
+     , (40913,  16,          1) /* ItemUseable - No */
+     , (40913,  19,          0) /* Value */
+     , (40913,  33,          1) /* Bonded - Bonded */
+     , (40913,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40913, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40913,  22, True ) /* Inscribable */
+     , (40913,  23, True ) /* DestroyOnSell */
+     , (40913,  69, False) /* IsSellable */
+     , (40913,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40913,   1, 'Aerfalle''s Token') /* Name */
+     , (40913,  14, 'Bring this token to Kuyiza bint Zayi the Translator, in Zaikhal, for a reward.') /* Use */
+     , (40913,  16, 'An ancient token, carved in the artistic fashion of the Dericost Nobility.  The edge of the token is inscribed with tiny Dericost runes.') /* LongDesc */
+     , (40913,  33, 'AerfalleTokenPickup') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40913,   1,   33554689) /* Setup */
+     , (40913,   3,  536870932) /* SoundTable */
+     , (40913,   6,   67111919) /* PaletteBase */
+     , (40913,   8,  100670319) /* Icon */
+     , (40913,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/40914 Aerfalle's Ornate Token.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/40914 Aerfalle's Ornate Token.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40914;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40914, 'ace40914-aerfallesornatetoken', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40914,   1,        128) /* ItemType - Misc */
+     , (40914,   5,         20) /* EncumbranceVal */
+     , (40914,  16,          1) /* ItemUseable - No */
+     , (40914,  19,          0) /* Value */
+     , (40914,  33,          1) /* Bonded - Bonded */
+     , (40914,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40914, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40914,  22, True ) /* Inscribable */
+     , (40914,  23, True ) /* DestroyOnSell */
+     , (40914,  69, False) /* IsSellable */
+     , (40914,  99, False) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40914,   1, 'Aerfalle''s Ornate Token') /* Name */
+     , (40914,  14, 'Bring this token to Kuyiza bint Zayi the Translator, in Zaikhal, for a reward.') /* Use */
+     , (40914,  16, 'An ornate, ancient token, carved in the artistic fashion of the Dericost Nobility.  The edge of the token is inscribed with tiny Dericost runes.') /* LongDesc */
+     , (40914,  33, 'AerfalleOrnateTokenPickup') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40914,   1,   33554689) /* Setup */
+     , (40914,   3,  536870932) /* SoundTable */
+     , (40914,   6,   67111919) /* PaletteBase */
+     , (40914,   8,  100670319) /* Icon */
+     , (40914,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/43529 Lady Aerfalle's Charm.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/43529 Lady Aerfalle's Charm.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43529;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43529, 'ace43529-ladyaerfallescharm', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43529,   1,        128) /* ItemType - Misc */
+     , (43529,   5,         20) /* EncumbranceVal */
+     , (43529,  16,          1) /* ItemUseable - No */
+     , (43529,  19,          0) /* Value */
+     , (43529,  33,          1) /* Bonded - Bonded */
+     , (43529,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (43529, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43529,  22, True ) /* Inscribable */
+     , (43529,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (43529,  39,    0.37) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43529,  1, 'Lady Aerfalle''s Charm') /* Name */
+     , (43529, 16, 'Bring this to the Ghost of Galaeral.') /* LongDesc */
+     , (43529, 33, 'AerfalleCharmPickup') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43529,   1,   33554683) /* Setup */
+     , (43529,   3,  536870932) /* SoundTable */
+     , (43529,   8,  100690503) /* Icon */
+     , (43529,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/28281 Aerfalle Uber Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/28281 Aerfalle Uber Gen.sql
@@ -1,11 +1,11 @@
 DELETE FROM `weenie` WHERE `class_Id` = 28281;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (28281, 'aerfalleubergen', 1, '2021-11-01 00:00:00') /* Generic */;
+VALUES (28281, 'aerfalleubergen', 1, '2019-03-26 20:02:53') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (28281,  81,          7) /* MaxGeneratedObjects */
-     , (28281,  82,          7) /* InitGeneratedObjects */
+VALUES (28281,  81,          8) /* MaxGeneratedObjects */
+     , (28281,  82,          8) /* InitGeneratedObjects */
      , (28281,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (28281, 142,          3) /* GeneratorTimeType - Event */
      , (28281, 145,          2) /* GeneratorEndDestructionType - Destroy */;
@@ -25,8 +25,8 @@ VALUES (28281,   1, 'Aerfalle Uber Gen') /* Name */
      , (28281,  34, 'AerfalleUberGen') /* GeneratorEvent */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (28281,   1, 0x0200026B) /* Setup */
-     , (28281,   8, 0x06001066) /* Icon */;
+VALUES (28281,   1,   33555051) /* Setup */
+     , (28281,   8,  100667494) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (28281, -1, 22904, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dark Guardian (22904) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
@@ -34,5 +34,6 @@ VALUES (28281, -1, 22904, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* 
      , (28281, -1, 22905, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Lich Oppressor (22905) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
      , (28281, -1, 22905, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Lich Oppressor (22905) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
      , (28281, -1, 25807, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Chimera (25807) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (28281, -1, 28054, 300, 1, 1, 1, 4, -1, 0, 0, 0x01F50101, 183.953, -7.06978, -41.995, 0.081992, 0, 0, 0.996633) /* Generate Aerfalle's Apprentice (28054) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (28281, -1, 28060, 120, 1, 1, 1, 4, -1, 0, 0, 0x01F5028C, 82.696, -117.687, 6.005, -0.437319, 0, 0, -0.899306) /* Generate Ghost of Galaeral (28060) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+     , (28281, -1, 28054, 300, 1, 1, 1, 4, -1, 0, 0, 32833793, 183.9528, -7.069776, -41.995, 0.081992, 0, 0, 0.996633) /* Generate Aerfalle's Apprentice (28054) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (28281, -1, 28060, 120, 1, 1, 1, 4, -1, 0, 0, 32834188, 82.696, -117.687, 6.005, -0.4373195, 0, 0, -0.8993062) /* Generate Ghost of Galaeral (28060) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (28281, -1, 40932, 120, 1, 1, 1, 4, -1, 0, 0, 32834188, 77.78695, -122.5468, 6.0065, 0.9238795, 0, 0, -0.3826835) /* Generate Ghost of Dylaeral (40932) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72378 Aerfalle Sanctum Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72378 Aerfalle Sanctum Gen.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72378;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72378, 'ace72378-aerfallesanctumgen', 1, '2019-03-26 20:02:53') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72378,  81,          1) /* MaxGeneratedObjects */
+     , (72378,  82,          1) /* InitGeneratedObjects */
+     , (72378,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72378, 142,          3) /* GeneratorTimeType - Event */
+     , (72378, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72378,   1, True ) /* Stuck */
+     , (72378,  11, True ) /* IgnoreCollisions */
+     , (72378,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72378,  41,      60) /* RegenerationInterval */
+     , (72378,  43,       5) /* GeneratorRadius */
+     , (72378, 121,       1) /* GeneratorInitialDelay */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72378,   1, 'Aerfalle Sanctum Gen') /* Name */
+     , (72378,  34, 'AerfalleExtremeGen') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72378,   1,   33555051) /* Setup */
+     , (72378,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72378, -1, 40931, 120, 1, 1, 1, 4, -1, 0, 0, 0x01F50102, 189.863, -1.158, -42.20983, 1, 0, 0, 0) /* Generate Aerfalle's Sanctum (40931) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72379 Aerfalle Extreme Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72379 Aerfalle Extreme Gen.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72379;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72379, 'ace72379-aerfalleextremegen', 1, '2019-03-26 20:02:53') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72379,  81,          1) /* MaxGeneratedObjects */
+     , (72379,  82,          1) /* InitGeneratedObjects */
+     , (72379,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72379, 142,          3) /* GeneratorTimeType - Event */
+     , (72379, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72379,   1, True ) /* Stuck */
+     , (72379,  11, True ) /* IgnoreCollisions */
+     , (72379,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72379,  41,      60) /* RegenerationInterval */
+     , (72379,  43,       5) /* GeneratorRadius */
+     , (72379, 121,       1) /* GeneratorInitialDelay */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72379,   1, 'Aerfalle Extreme Gen') /* Name */
+     , (72379,  34, 'AerfalleExtremeGen') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72379,   1,   33555051) /* Setup */
+     , (72379,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72379, -1, 40928, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Generate Lady Aerfalle (40928) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72380 Aerfalle Extreme Guards Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72380 Aerfalle Extreme Guards Gen.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72380;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72380, 'ace72380-aerfalleextremeguardsgen', 1, '2019-03-26 20:02:53') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72380,  81,          5) /* MaxGeneratedObjects */
+     , (72380,  82,          5) /* InitGeneratedObjects */
+     , (72380,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72380, 142,          3) /* GeneratorTimeType - Event */
+     , (72380, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72380,   1, True ) /* Stuck */
+     , (72380,  11, True ) /* IgnoreCollisions */
+     , (72380,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72380,  41,      60) /* RegenerationInterval */
+     , (72380,  43,       5) /* GeneratorRadius */
+     , (72380, 121,       1) /* GeneratorInitialDelay */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72380,   1, 'Aerfalle Extreme Guards Gen') /* Name */
+     , (72380,  34, 'AerfalleExtremeGen') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72380,   1,   33555051) /* Setup */
+     , (72380,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72380, -1, 40926, 180, 1, 1, 1, 4, 0, 0, 0, 0xB5F00127, 105.185, -37.8642, -81.1975, 0.0121231, 0, 0, -0.999927) /* Generate Pyre Skeleton (40926) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (72380, -1, 40926, 180, 1, 1, 1, 4, 0, 0, 0, 0xB5F00127, 98.0059, -42.8923, -81.1975, 0.468086, 0, 0, -0.883683) /* Generate Pyre Skeleton (40926) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (72380, -1, 40927, 180, 1, 1, 1, 4, 0, 0, 0, 0xB5F00121, 110.271, -58.7184, -81.1917, -0.96096, 0, 0, -0.276686) /* Generate Revenant Lord (40927) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (72380, -1, 40927, 180, 1, 1, 1, 4, 0, 0, 0, 0xB5F00121, 115.507, -55.1406, -81.1917, 0.978344, 0, 0, 0.206984) /* Generate Revenant Lord (40927) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (72380, -1, 40924, 180, 1, 1, 1, 4, 0, 0, 0, 0xB5F00153, 100.31071, -38.5135, -51.19725, 0.9563096, 0, 0, 0.29235584) /* Generate Bound Pyre Champion (40924) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72381 Aerfalle Extreme Reward Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72381 Aerfalle Extreme Reward Gen.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72381;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72381, 'ace72381-aerfalleextremerewardgen', 1, '2019-03-26 20:02:53') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72381,  81,          1) /* MaxGeneratedObjects */
+     , (72381,  82,          1) /* InitGeneratedObjects */
+     , (72381,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72381, 142,          3) /* GeneratorTimeType - Event */
+     , (72381, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72381,   1, True ) /* Stuck */
+     , (72381,  11, True ) /* IgnoreCollisions */
+     , (72381,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72381,  41,      60) /* RegenerationInterval */
+     , (72381,  43,       5) /* GeneratorRadius */
+     , (72381, 121,       1) /* GeneratorInitialDelay */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72381,   1, 'Aerfalle Extreme Reward Gen') /* Name */
+     , (72381,  34, 'AerfalleExtremeRewards') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72381,   1,   33555051) /* Setup */
+     , (72381,   8,  100667494) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72381, -1, 43746, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Generate Ghost of Galaeral (43746) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+

--- a/Database/Patches/9 WeenieDefaults/Key/Key/40929 Embossed Ashen Key.sql
+++ b/Database/Patches/9 WeenieDefaults/Key/Key/40929 Embossed Ashen Key.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40929;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40929, 'ace40929-embossedashenkey', 22, '2019-02-10 00:00:00') /* Key */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40929,   1,      16384) /* ItemType - Key */
+     , (40929,   5,         20) /* EncumbranceVal */
+     , (40929,  16,    2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (40929,  19,          3) /* Value */
+     , (40929,  33,          1) /* Bonded - Bonded */
+     , (40929,  91,          1) /* MaxStructure */
+     , (40929,  92,          1) /* Structure */
+     , (40929,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40929,  94,        640) /* TargetType - LockableMagicTarget */
+     , (40929, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40929,  22, True ) /* Inscribable */
+     , (40929,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40929,  1, 'Embossed Ashen Key') /* Name */
+     , (40929, 13, 'EmbossedAshenKey') /* KeyCode */
+     , (40929, 14, 'Use this item on a locked chest to unlock it.') /* Use */
+     , (40929, 16, 'An ornate, embossed key found in Aerfalle''s Keep, smudged with ash.') /* LongDesc */
+     , (40929, 33, 'EmbossedAshenKeyPickup') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40929,   1,   33554784) /* Setup */
+     , (40929,   3,  536870932) /* SoundTable */
+     , (40929,   8,  100676683) /* Icon */
+     , (40929,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/28065 Sacrificial Dagger.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/28065 Sacrificial Dagger.sql
@@ -1,0 +1,56 @@
+DELETE FROM `weenie` WHERE `class_Id` = 28065;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (28065, 'ace28065-daggergalaeralnew', 6, '2005-02-09 10:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (28065,   1,          1) /* ItemType - MeleeWeapon */
+     , (28065,   5,        120) /* EncumbranceVal */
+     , (28065,   8,         80) /* Mass */
+     , (28065,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (28065,  16,          1) /* ItemUseable - No */
+     , (28065,  19,       2500) /* Value */
+     , (28065,  33,          1) /* Bonded - Bonded */
+     , (28065,  36,       9999) /* ResistMagic */
+     , (28065,  44,         26) /* Damage */
+     , (28065,  45,          3) /* DamageType - Slash, Pierce */
+     , (28065,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (28065,  47,          6) /* AttackType - Thrust, Slash */
+     , (28065,  48,         46) /* WeaponSkill - FinesseWeapons */
+     , (28065,  49,         15) /* WeaponTime */
+     , (28065,  51,          1) /* CombatUse - Melee */
+     , (28065,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (28065, 114,          1) /* Attuned - Attuned */
+     , (28065, 150,        103) /* HookPlacement - Hook */
+     , (28065, 151,          2) /* HookType - Wall */
+     , (28065, 159,         46) /* WieldSkillType - FinesseWeapons */
+     , (28065, 160,        300) /* WieldDifficulty */
+     , (28065, 353,          6) /* WeaponType - Dagger */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (28065,  22, True ) /* Inscribable */
+     , (28065,  23, True ) /* DestroyOnSell */
+     , (28065,  65, True ) /* IgnoreMagicResist */
+     , (28065,  66, True ) /* IgnoreMagicArmor */
+     , (28065,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (28065,  21,    0.35) /* WeaponLength */
+     , (28065,  22,     0.6) /* DamageVariance */
+     , (28065,  29,       1) /* WeaponDefense */
+     , (28065,  39,    1.25) /* DefaultScale */
+     , (28065,  62,       1) /* WeaponOffense */
+     , (28065, 136,     2.5) /* CriticalMultiplier */
+     , (28065, 147,    0.25) /* CriticalFrequency */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (28065,   1, 'Sacrificial Dagger') /* Name */
+     , (28065,  16, 'A vicious looking dagger of Dericostian design, with a cruel serrated edge. There is old, dark blood on its blade. Found in the reservoir on Aerlinthe Island. This weapon is unenchantable and ignores modified armor and protection values.') /* LongDesc */
+     , (28065,  33, 'GalaeralDagger') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (28065,   1,   33558822) /* Setup */
+     , (28065,   3,  536870932) /* SoundTable */
+     , (28065,   8,  100676681) /* Icon */
+     , (28065,  22,  872415275) /* PhysicsEffectTable */
+     , (28065,  36,  234881044) /* MutateFilter */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/40908 Reforged Ashbane.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/40908 Reforged Ashbane.sql
@@ -1,0 +1,56 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40908;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40908, 'ace40908-reforgedashbane', 6, '2019-02-10 00:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40908,   1,          1) /* ItemType - MeleeWeapon */
+     , (40908,   5,        450) /* EncumbranceVal */
+     , (40908,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (40908,  16,          1) /* ItemUseable - No */
+     , (40908,  18,         32) /* UiEffects - Fire */
+     , (40908,  19,      15000) /* Value */
+     , (40908,  33,          1) /* Bonded - Bonded */
+     , (40908,  36,       9999) /* ResistMagic */
+     , (40908,  44,         90) /* Damage */
+     , (40908,  45,         16) /* DamageType - Fire */
+     , (40908,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (40908,  47,          6) /* AttackType - Thrust, Slash */
+     , (40908,  48,         45) /* WeaponSkill - LightWeapons */
+     , (40908,  49,         20) /* WeaponTime */
+     , (40908,  51,          1) /* CombatUse - Melee */
+     , (40908,  53,        101) /* PlacementPosition */
+     , (40908,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40908, 114,          1) /* Attuned - Attuned */
+     , (40908, 151,          2) /* HookType - Wall */
+     , (40908, 158,          2) /* WieldRequirements - RawSkill */
+     , (40908, 159,         45) /* WieldSkillType - LightWeapons */
+     , (40908, 160,        400) /* WieldDifficulty */
+     , (40908, 353,          2) /* WeaponType - Sword */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40908,  22, True ) /* Inscribable */
+     , (40908,  23, True ) /* DestroyOnSell */
+     , (40908,  69, False) /* IsSellable */
+     , (40908,  99, True ) /* Ivoryable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40908,  21,    0.95) /* WeaponLength */
+     , (40908,  22,    0.45) /* DamageVariance */
+     , (40908,  26,       0) /* MaximumVelocity */
+     , (40908,  29,       1) /* WeaponDefense */
+     , (40908,  39,     1.2) /* DefaultScale */
+     , (40908,  62,     1.3) /* WeaponOffense */
+     , (40908,  63,       1) /* DamageMod */
+     , (40908, 136,     2.5) /* CriticalMultiplier */
+     , (40908, 155,       1) /* IgnoreArmor */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40908,   1, 'Reforged Ashbane') /* Name */
+     , (40908,  16, 'A heavily enchanted flaming sword, wrought from magically-reinforced silver.  The magics are so elegantly inlaid into the weapon that there is no visible enchantment on the blade.  Its ivory haft is inscribed ''Ashbane,'' and bears the name of Leikotha Arenir.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40908,   1,   33558823) /* Setup */
+     , (40908,   3,  536870932) /* SoundTable */
+     , (40908,   8,  100671001) /* Icon */
+     , (40908,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/40910 Dericost Blade.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/40910 Dericost Blade.sql
@@ -1,0 +1,53 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40910;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40910, 'ace40910-dericostblade', 6, '2019-02-10 00:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40910,   1,          1) /* ItemType - MeleeWeapon */
+     , (40910,   5,        375) /* EncumbranceVal */
+     , (40910,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (40910,  16,          1) /* ItemUseable - No */
+     , (40910,  18,          1) /* UiEffects - Magical */
+     , (40910,  19,        340) /* Value */
+     , (40910,  33,         -2) /* Bonded - Destroy */
+     , (40910,  37,       9999) /* ResistItemAppraisal */
+     , (40910,  44,        200) /* Damage */
+     , (40910,  45,          3) /* DamageType - Slash, Pierce */
+     , (40910,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (40910,  47,          6) /* AttackType - Thrust, Slash */
+     , (40910,  48,         45) /* WeaponSkill - LightWeapons */
+     , (40910,  49,         30) /* WeaponTime */
+     , (40910,  51,          1) /* CombatUse - Melee */
+     , (40910,  53,        101) /* PlacementPosition - Resting */
+     , (40910,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (40910, 151,          2) /* HookType - Wall */
+     , (40910, 353,          2) /* WeaponType - Sword */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40910,  11, True ) /* IgnoreCollisions */
+     , (40910,  13, True ) /* Ethereal */
+     , (40910,  14, True ) /* GravityStatus */
+     , (40910,  19, True ) /* Attackable */
+     , (40910,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40910,  21,       0) /* WeaponLength */
+     , (40910,  22,     0.5) /* DamageVariance */
+     , (40910,  26,       0) /* MaximumVelocity */
+     , (40910,  29,       1) /* WeaponDefense */
+     , (40910,  39,    0.75) /* DefaultScale */
+     , (40910,  62,       1) /* WeaponOffense */
+     , (40910,  63,       1) /* DamageMod */
+     , (40910, 149,       1) /* WeaponMissileDefense */
+     , (40910, 150,       1) /* WeaponMagicDefense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40910,   1, 'Dericost Blade') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40910,   1,   33559637) /* Setup */
+     , (40910,   3,  536870932) /* SoundTable */
+     , (40910,   7,  268437033) /* ClothingBase */
+     , (40910,   8,  100688006) /* Icon */
+     , (40910,  22,  872415275) /* PhysicsEffectTable */;

--- a/Database/Patches/B GameEventDefDB/AerfalleExtremeGen.sql
+++ b/Database/Patches/B GameEventDefDB/AerfalleExtremeGen.sql
@@ -1,0 +1,3 @@
+DELETE FROM `event` WHERE `name` = 'AerfalleExtremeGen';
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('AerfalleExtremeGen', -1, -1, 3, '2020-01-24 19:57:17');

--- a/Database/Patches/B GameEventDefDB/AerfalleExtremeRewards.sql
+++ b/Database/Patches/B GameEventDefDB/AerfalleExtremeRewards.sql
@@ -1,0 +1,3 @@
+DELETE FROM `event` WHERE `name` = 'AerfalleExtremeRewards';
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('AerfalleExtremeRewards', -1, -1, 3, '2020-01-24 19:57:17');


### PR DESCRIPTION
Flat version of the PR, with corrected crushing blow property on Reforged Ashbane.

The update to Kuziya bint Zayi the Translator is now in a separate PR 1164 and is required for Aerfalle's token rewards.

Added the uber version of Lady Aerfalle.
Added XP tokens to normal and hard version chests.
Updated normal and hard version global to refer to Aerfalle's Apprentice instead of Aerfalle.
Updated 06771 Leikotha rewards for Ashbane to end of retail, and added Reforged Ashbane.
Added int 353 WeaponType Magic to old versions of Staff of Aerfalle.
Updated Sacrificial Dagger to end of retail stats.
Added 40932 Ghost of Dylaeral to handle easy version since 28060 Ghost of Galaeral now handles the uber version.

Note: The enhanced versions of Atlan and Isparian Weapons are NOT included in this PR.