### PR TITLE
Hoshino Increase Visual Awareness

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46426 Ronin Hirachi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46426 Ronin Hirachi.sql
@@ -37,7 +37,7 @@ VALUES (46426,   1,       5) /* HeartbeatInterval */
      , (46426,  17,       1) /* ArmorModVsFire */
      , (46426,  18,       1) /* ArmorModVsAcid */
      , (46426,  19,       1) /* ArmorModVsElectric */
-     , (46426,  31,      16) /* VisualAwarenessRange */
+     , (46426,  31,      25) /* VisualAwarenessRange */
      , (46426,  34,       1) /* PowerupTime */
      , (46426,  36,       1) /* ChargeSpeed */
      , (46426,  39,     1.6) /* DefaultScale */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46428 Ronin Shimakawa.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46428 Ronin Shimakawa.sql
@@ -41,7 +41,7 @@ VALUES (46428,   1,       5) /* HeartbeatInterval */
      , (46428,  17,    0.95) /* ArmorModVsFire */
      , (46428,  18,       1) /* ArmorModVsAcid */
      , (46428,  19,       1) /* ArmorModVsElectric */
-     , (46428,  31,      16) /* VisualAwarenessRange */
+     , (46428,  31,      25) /* VisualAwarenessRange */
      , (46428,  34,       1) /* PowerupTime */
      , (46428,  36,       1) /* ChargeSpeed */
      , (46428,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46430 Ronin Ginmura.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46430 Ronin Ginmura.sql
@@ -38,7 +38,7 @@ VALUES (46430,   1,       5) /* HeartbeatInterval */
      , (46430,  17,    0.95) /* ArmorModVsFire */
      , (46430,  18,       1) /* ArmorModVsAcid */
      , (46430,  19,       1) /* ArmorModVsElectric */
-     , (46430,  31,      16) /* VisualAwarenessRange */
+     , (46430,  31,      25) /* VisualAwarenessRange */
      , (46430,  34,       1) /* PowerupTime */
      , (46430,  36,       1) /* ChargeSpeed */
      , (46430,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46498 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46498 Spectral Archer.sql
@@ -38,7 +38,7 @@ VALUES (46498,   1,       5) /* HeartbeatInterval */
      , (46498,  17,       1) /* ArmorModVsFire */
      , (46498,  18,       1) /* ArmorModVsAcid */
      , (46498,  19,    0.95) /* ArmorModVsElectric */
-     , (46498,  31,      18) /* VisualAwarenessRange */
+     , (46498,  31,      35) /* VisualAwarenessRange */
      , (46498,  64,    0.45) /* ResistSlash */
      , (46498,  65,    0.35) /* ResistPierce */
      , (46498,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46499 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46499 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (46499,   1,       5) /* HeartbeatInterval */
      , (46499,  17,       1) /* ArmorModVsFire */
      , (46499,  18,       1) /* ArmorModVsAcid */
      , (46499,  19,    0.95) /* ArmorModVsElectric */
-     , (46499,  31,      18) /* VisualAwarenessRange */
+     , (46499,  31,      35) /* VisualAwarenessRange */
      , (46499,  64,    0.45) /* ResistSlash */
      , (46499,  65,    0.35) /* ResistPierce */
      , (46499,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46500 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46500 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (46500,   1,       5) /* HeartbeatInterval */
      , (46500,  17,       1) /* ArmorModVsFire */
      , (46500,  18,       1) /* ArmorModVsAcid */
      , (46500,  19,       1) /* ArmorModVsElectric */
-     , (46500,  31,      18) /* VisualAwarenessRange */
+     , (46500,  31,      35) /* VisualAwarenessRange */
      , (46500,  64,    0.45) /* ResistSlash */
      , (46500,  65,    0.35) /* ResistPierce */
      , (46500,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46501 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46501 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (46501,   1,       5) /* HeartbeatInterval */
      , (46501,  17,       1) /* ArmorModVsFire */
      , (46501,  18,       1) /* ArmorModVsAcid */
      , (46501,  19,       1) /* ArmorModVsElectric */
-     , (46501,  31,      18) /* VisualAwarenessRange */
+     , (46501,  31,      35) /* VisualAwarenessRange */
      , (46501,  64,    0.45) /* ResistSlash */
      , (46501,  65,    0.35) /* ResistPierce */
      , (46501,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46502 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46502 Spectral Archer.sql
@@ -38,7 +38,7 @@ VALUES (46502,   1,       5) /* HeartbeatInterval */
      , (46502,  17,    0.95) /* ArmorModVsFire */
      , (46502,  18,       1) /* ArmorModVsAcid */
      , (46502,  19,       1) /* ArmorModVsElectric */
-     , (46502,  31,      18) /* VisualAwarenessRange */
+     , (46502,  31,      35) /* VisualAwarenessRange */
      , (46502,  64,    0.45) /* ResistSlash */
      , (46502,  65,    0.35) /* ResistPierce */
      , (46502,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46503 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46503 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (46503,   1,       5) /* HeartbeatInterval */
      , (46503,  17,    0.95) /* ArmorModVsFire */
      , (46503,  18,       1) /* ArmorModVsAcid */
      , (46503,  19,       1) /* ArmorModVsElectric */
-     , (46503,  31,      18) /* VisualAwarenessRange */
+     , (46503,  31,      35) /* VisualAwarenessRange */
      , (46503,  64,    0.45) /* ResistSlash */
      , (46503,  65,    0.35) /* ResistPierce */
      , (46503,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46504 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46504 Spectral Archer.sql
@@ -38,7 +38,7 @@ VALUES (46504,   1,       5) /* HeartbeatInterval */
      , (46504,  17,       1) /* ArmorModVsFire */
      , (46504,  18,    0.95) /* ArmorModVsAcid */
      , (46504,  19,       1) /* ArmorModVsElectric */
-     , (46504,  31,      18) /* VisualAwarenessRange */
+     , (46504,  31,      35) /* VisualAwarenessRange */
      , (46504,  64,    0.45) /* ResistSlash */
      , (46504,  65,    0.35) /* ResistPierce */
      , (46504,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46505 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46505 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (46505,   1,       5) /* HeartbeatInterval */
      , (46505,  17,       1) /* ArmorModVsFire */
      , (46505,  18,    0.95) /* ArmorModVsAcid */
      , (46505,  19,       1) /* ArmorModVsElectric */
-     , (46505,  31,      18) /* VisualAwarenessRange */
+     , (46505,  31,      35) /* VisualAwarenessRange */
      , (46505,  64,    0.45) /* ResistSlash */
      , (46505,  65,    0.35) /* ResistPierce */
      , (46505,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46506 Spectral Blade Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46506 Spectral Blade Adept.sql
@@ -41,7 +41,7 @@ VALUES (46506,   1,       5) /* HeartbeatInterval */
      , (46506,  17,       1) /* ArmorModVsFire */
      , (46506,  18,       1) /* ArmorModVsAcid */
      , (46506,  19,       1) /* ArmorModVsElectric */
-     , (46506,  31,      16) /* VisualAwarenessRange */
+     , (46506,  31,      35) /* VisualAwarenessRange */
      , (46506,  34,       1) /* PowerupTime */
      , (46506,  36,       1) /* ChargeSpeed */
      , (46506,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46507 Spectral Blade Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46507 Spectral Blade Adept.sql
@@ -42,7 +42,7 @@ VALUES (46507,   1,       5) /* HeartbeatInterval */
      , (46507,  17,       1) /* ArmorModVsFire */
      , (46507,  18,       1) /* ArmorModVsAcid */
      , (46507,  19,       1) /* ArmorModVsElectric */
-     , (46507,  31,      16) /* VisualAwarenessRange */
+     , (46507,  31,      35) /* VisualAwarenessRange */
      , (46507,  34,       1) /* PowerupTime */
      , (46507,  36,       1) /* ChargeSpeed */
      , (46507,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46508 Spectral Blade Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46508 Spectral Blade Master.sql
@@ -43,7 +43,7 @@ VALUES (46508,   1,       5) /* HeartbeatInterval */
      , (46508,  17,       1) /* ArmorModVsFire */
      , (46508,  18,       1) /* ArmorModVsAcid */
      , (46508,  19,       1) /* ArmorModVsElectric */
-     , (46508,  31,      16) /* VisualAwarenessRange */
+     , (46508,  31,      35) /* VisualAwarenessRange */
      , (46508,  34,       1) /* PowerupTime */
      , (46508,  36,       1) /* ChargeSpeed */
      , (46508,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46509 Spectral Blade Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46509 Spectral Blade Master.sql
@@ -42,7 +42,7 @@ VALUES (46509,   1,       5) /* HeartbeatInterval */
      , (46509,  17,       1) /* ArmorModVsFire */
      , (46509,  18,       1) /* ArmorModVsAcid */
      , (46509,  19,       1) /* ArmorModVsElectric */
-     , (46509,  31,      16) /* VisualAwarenessRange */
+     , (46509,  31,      35) /* VisualAwarenessRange */
      , (46509,  34,       1) /* PowerupTime */
      , (46509,  36,       1) /* ChargeSpeed */
      , (46509,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46510 Spectral Bloodmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46510 Spectral Bloodmage.sql
@@ -42,7 +42,7 @@ VALUES (46510,   1,       5) /* HeartbeatInterval */
      , (46510,  17,       1) /* ArmorModVsFire */
      , (46510,  18,       1) /* ArmorModVsAcid */
      , (46510,  19,       1) /* ArmorModVsElectric */
-     , (46510,  31,      16) /* VisualAwarenessRange */
+     , (46510,  31,      35) /* VisualAwarenessRange */
      , (46510,  34,       1) /* PowerupTime */
      , (46510,  36,       1) /* ChargeSpeed */
      , (46510,  54,       5) /* UseRadius */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46511 Spectral Bloodmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46511 Spectral Bloodmage.sql
@@ -43,6 +43,7 @@ VALUES (46511,   1,       5) /* HeartbeatInterval */
      , (46511,  17,       1) /* ArmorModVsFire */
      , (46511,  18,       1) /* ArmorModVsAcid */
      , (46511,  19,       1) /* ArmorModVsElectric */
+     , (46511,  31,      35) /* VisualAwarenessRange */
      , (46511,  34,       1) /* PowerupTime */
      , (46511,  36,       1) /* ChargeSpeed */
      , (46511,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46512 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46512 Spectral Bushi.sql
@@ -42,7 +42,7 @@ VALUES (46512,   1,       5) /* HeartbeatInterval */
      , (46512,  17,       1) /* ArmorModVsFire */
      , (46512,  18,       1) /* ArmorModVsAcid */
      , (46512,  19,    0.95) /* ArmorModVsElectric */
-     , (46512,  31,      16) /* VisualAwarenessRange */
+     , (46512,  31,      35) /* VisualAwarenessRange */
      , (46512,  34,       1) /* PowerupTime */
      , (46512,  36,       1) /* ChargeSpeed */
      , (46512,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46513 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46513 Spectral Bushi.sql
@@ -43,7 +43,7 @@ VALUES (46513,   1,       5) /* HeartbeatInterval */
      , (46513,  17,       1) /* ArmorModVsFire */
      , (46513,  18,       1) /* ArmorModVsAcid */
      , (46513,  19,    0.95) /* ArmorModVsElectric */
-     , (46513,  31,      16) /* VisualAwarenessRange */
+     , (46513,  31,      35) /* VisualAwarenessRange */
      , (46513,  34,       1) /* PowerupTime */
      , (46513,  36,       1) /* ChargeSpeed */
      , (46513,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46514 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46514 Spectral Bushi.sql
@@ -38,7 +38,7 @@ VALUES (46514,   1,       5) /* HeartbeatInterval */
      , (46514,  17,       1) /* ArmorModVsFire */
      , (46514,  18,       1) /* ArmorModVsAcid */
      , (46514,  19,       1) /* ArmorModVsElectric */
-     , (46514,  31,      16) /* VisualAwarenessRange */
+     , (46514,  31,      35) /* VisualAwarenessRange */
      , (46514,  34,       1) /* PowerupTime */
      , (46514,  36,       1) /* ChargeSpeed */
      , (46514,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46515 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46515 Spectral Bushi.sql
@@ -43,7 +43,7 @@ VALUES (46515,   1,       5) /* HeartbeatInterval */
      , (46515,  17,       1) /* ArmorModVsFire */
      , (46515,  18,       1) /* ArmorModVsAcid */
      , (46515,  19,       1) /* ArmorModVsElectric */
-     , (46515,  31,      16) /* VisualAwarenessRange */
+     , (46515,  31,      35) /* VisualAwarenessRange */
      , (46515,  34,       1) /* PowerupTime */
      , (46515,  36,       1) /* ChargeSpeed */
      , (46515,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46516 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46516 Spectral Bushi.sql
@@ -38,7 +38,7 @@ VALUES (46516,   1,       5) /* HeartbeatInterval */
      , (46516,  17,    0.95) /* ArmorModVsFire */
      , (46516,  18,       1) /* ArmorModVsAcid */
      , (46516,  19,       1) /* ArmorModVsElectric */
-     , (46516,  31,      16) /* VisualAwarenessRange */
+     , (46516,  31,      35) /* VisualAwarenessRange */
      , (46516,  34,       1) /* PowerupTime */
      , (46516,  36,       1) /* ChargeSpeed */
      , (46516,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46517 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46517 Spectral Bushi.sql
@@ -39,7 +39,7 @@ VALUES (46517,   1,       5) /* HeartbeatInterval */
      , (46517,  17,    0.95) /* ArmorModVsFire */
      , (46517,  18,       1) /* ArmorModVsAcid */
      , (46517,  19,       1) /* ArmorModVsElectric */
-     , (46517,  31,      16) /* VisualAwarenessRange */
+     , (46517,  31,      35) /* VisualAwarenessRange */
      , (46517,  34,       1) /* PowerupTime */
      , (46517,  36,       1) /* ChargeSpeed */
      , (46517,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46518 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46518 Spectral Bushi.sql
@@ -38,7 +38,7 @@ VALUES (46518,   1,       5) /* HeartbeatInterval */
      , (46518,  17,       1) /* ArmorModVsFire */
      , (46518,  18,    0.95) /* ArmorModVsAcid */
      , (46518,  19,       1) /* ArmorModVsElectric */
-     , (46518,  31,      16) /* VisualAwarenessRange */
+     , (46518,  31,      35) /* VisualAwarenessRange */
      , (46518,  34,       1) /* PowerupTime */
      , (46518,  36,       1) /* ChargeSpeed */
      , (46518,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46519 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46519 Spectral Bushi.sql
@@ -39,7 +39,7 @@ VALUES (46519,   1,       5) /* HeartbeatInterval */
      , (46519,  17,       1) /* ArmorModVsFire */
      , (46519,  18,    0.95) /* ArmorModVsAcid */
      , (46519,  19,       1) /* ArmorModVsElectric */
-     , (46519,  31,      16) /* VisualAwarenessRange */
+     , (46519,  31,      35) /* VisualAwarenessRange */
      , (46519,  34,       1) /* PowerupTime */
      , (46519,  36,       1) /* ChargeSpeed */
      , (46519,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46520 Spectral Claw Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46520 Spectral Claw Adept.sql
@@ -41,7 +41,7 @@ VALUES (46520,   1,       5) /* HeartbeatInterval */
      , (46520,  17,       1) /* ArmorModVsFire */
      , (46520,  18,       1) /* ArmorModVsAcid */
      , (46520,  19,       1) /* ArmorModVsElectric */
-     , (46520,  31,      16) /* VisualAwarenessRange */
+     , (46520,  31,      35) /* VisualAwarenessRange */
      , (46520,  34,       1) /* PowerupTime */
      , (46520,  36,       1) /* ChargeSpeed */
      , (46520,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46521 Spectral Claw Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46521 Spectral Claw Adept.sql
@@ -42,7 +42,7 @@ VALUES (46521,   1,       5) /* HeartbeatInterval */
      , (46521,  17,       1) /* ArmorModVsFire */
      , (46521,  18,       1) /* ArmorModVsAcid */
      , (46521,  19,       1) /* ArmorModVsElectric */
-     , (46521,  31,      16) /* VisualAwarenessRange */
+     , (46521,  31,      35) /* VisualAwarenessRange */
      , (46521,  34,       1) /* PowerupTime */
      , (46521,  36,       1) /* ChargeSpeed */
      , (46521,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46522 Spectral Claw Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46522 Spectral Claw Master.sql
@@ -38,7 +38,7 @@ VALUES (46522,   1,       5) /* HeartbeatInterval */
      , (46522,  17,       1) /* ArmorModVsFire */
      , (46522,  18,       1) /* ArmorModVsAcid */
      , (46522,  19,       1) /* ArmorModVsElectric */
-     , (46522,  31,      16) /* VisualAwarenessRange */
+     , (46522,  31,      35) /* VisualAwarenessRange */
      , (46522,  34,       1) /* PowerupTime */
      , (46522,  36,       1) /* ChargeSpeed */
      , (46522,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46523 Spectral Claw Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46523 Spectral Claw Master.sql
@@ -39,7 +39,7 @@ VALUES (46523,   1,       5) /* HeartbeatInterval */
      , (46523,  17,       1) /* ArmorModVsFire */
      , (46523,  18,       1) /* ArmorModVsAcid */
      , (46523,  19,       1) /* ArmorModVsElectric */
-     , (46523,  31,      16) /* VisualAwarenessRange */
+     , (46523,  31,      35) /* VisualAwarenessRange */
      , (46523,  34,       1) /* PowerupTime */
      , (46523,  36,       1) /* ChargeSpeed */
      , (46523,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46524 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46524 Spectral Minion.sql
@@ -39,7 +39,7 @@ VALUES (46524,   1,       5) /* HeartbeatInterval */
      , (46524,  17,       1) /* ArmorModVsFire */
      , (46524,  18,       1) /* ArmorModVsAcid */
      , (46524,  19,    0.95) /* ArmorModVsElectric */
-     , (46524,  31,      16) /* VisualAwarenessRange */
+     , (46524,  31,      35) /* VisualAwarenessRange */
      , (46524,  34,       1) /* PowerupTime */
      , (46524,  36,       1) /* ChargeSpeed */
      , (46524,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46525 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46525 Spectral Minion.sql
@@ -40,7 +40,7 @@ VALUES (46525,   1,       5) /* HeartbeatInterval */
      , (46525,  17,       1) /* ArmorModVsFire */
      , (46525,  18,       1) /* ArmorModVsAcid */
      , (46525,  19,    0.95) /* ArmorModVsElectric */
-     , (46525,  31,      16) /* VisualAwarenessRange */
+     , (46525,  31,      35) /* VisualAwarenessRange */
      , (46525,  34,       1) /* PowerupTime */
      , (46525,  36,       1) /* ChargeSpeed */
      , (46525,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46526 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46526 Spectral Minion.sql
@@ -39,7 +39,7 @@ VALUES (46526,   1,       5) /* HeartbeatInterval */
      , (46526,  17,       1) /* ArmorModVsFire */
      , (46526,  18,       1) /* ArmorModVsAcid */
      , (46526,  19,       1) /* ArmorModVsElectric */
-     , (46526,  31,      16) /* VisualAwarenessRange */
+     , (46526,  31,      35) /* VisualAwarenessRange */
      , (46526,  34,       1) /* PowerupTime */
      , (46526,  36,       1) /* ChargeSpeed */
      , (46526,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46527 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46527 Spectral Minion.sql
@@ -40,7 +40,7 @@ VALUES (46527,   1,       5) /* HeartbeatInterval */
      , (46527,  17,       1) /* ArmorModVsFire */
      , (46527,  18,       1) /* ArmorModVsAcid */
      , (46527,  19,       1) /* ArmorModVsElectric */
-     , (46527,  31,      16) /* VisualAwarenessRange */
+     , (46527,  31,      35) /* VisualAwarenessRange */
      , (46527,  34,       1) /* PowerupTime */
      , (46527,  36,       1) /* ChargeSpeed */
      , (46527,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46528 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46528 Spectral Minion.sql
@@ -39,7 +39,7 @@ VALUES (46528,   1,       5) /* HeartbeatInterval */
      , (46528,  17,    0.95) /* ArmorModVsFire */
      , (46528,  18,       1) /* ArmorModVsAcid */
      , (46528,  19,       1) /* ArmorModVsElectric */
-     , (46528,  31,      16) /* VisualAwarenessRange */
+     , (46528,  31,      35) /* VisualAwarenessRange */
      , (46528,  34,       1) /* PowerupTime */
      , (46528,  36,       1) /* ChargeSpeed */
      , (46528,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46529 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46529 Spectral Minion.sql
@@ -40,7 +40,7 @@ VALUES (46529,   1,       5) /* HeartbeatInterval */
      , (46529,  17,    0.95) /* ArmorModVsFire */
      , (46529,  18,       1) /* ArmorModVsAcid */
      , (46529,  19,       1) /* ArmorModVsElectric */
-     , (46529,  31,      16) /* VisualAwarenessRange */
+     , (46529,  31,      35) /* VisualAwarenessRange */
      , (46529,  34,       1) /* PowerupTime */
      , (46529,  36,       1) /* ChargeSpeed */
      , (46529,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46530 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46530 Spectral Minion.sql
@@ -39,7 +39,7 @@ VALUES (46530,   1,       5) /* HeartbeatInterval */
      , (46530,  17,       1) /* ArmorModVsFire */
      , (46530,  18,    0.95) /* ArmorModVsAcid */
      , (46530,  19,       1) /* ArmorModVsElectric */
-     , (46530,  31,      16) /* VisualAwarenessRange */
+     , (46530,  31,      35) /* VisualAwarenessRange */
      , (46530,  34,       1) /* PowerupTime */
      , (46530,  36,       1) /* ChargeSpeed */
      , (46530,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46531 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46531 Spectral Minion.sql
@@ -40,7 +40,7 @@ VALUES (46531,   1,       5) /* HeartbeatInterval */
      , (46531,  17,       1) /* ArmorModVsFire */
      , (46531,  18,    0.95) /* ArmorModVsAcid */
      , (46531,  19,       1) /* ArmorModVsElectric */
-     , (46531,  31,      16) /* VisualAwarenessRange */
+     , (46531,  31,      35) /* VisualAwarenessRange */
      , (46531,  34,       1) /* PowerupTime */
      , (46531,  36,       1) /* ChargeSpeed */
      , (46531,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46532 Spectral Nanjou Shou-jen.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46532 Spectral Nanjou Shou-jen.sql
@@ -43,7 +43,7 @@ VALUES (46532,   1,       5) /* HeartbeatInterval */
      , (46532,  17,       1) /* ArmorModVsFire */
      , (46532,  18,       1) /* ArmorModVsAcid */
      , (46532,  19,       1) /* ArmorModVsElectric */
-     , (46532,  31,      18) /* VisualAwarenessRange */
+     , (46532,  31,      35) /* VisualAwarenessRange */
      , (46532,  39,       1) /* DefaultScale */
      , (46532,  64,    0.45) /* ResistSlash */
      , (46532,  65,    0.35) /* ResistPierce */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46533 Spectral Nanjou Shou-jen.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46533 Spectral Nanjou Shou-jen.sql
@@ -43,7 +43,7 @@ VALUES (46533,   1,       5) /* HeartbeatInterval */
      , (46533,  17,       1) /* ArmorModVsFire */
      , (46533,  18,       1) /* ArmorModVsAcid */
      , (46533,  19,       1) /* ArmorModVsElectric */
-     , (46533,  31,      18) /* VisualAwarenessRange */
+     , (46533,  31,      35) /* VisualAwarenessRange */
      , (46533,  39,       1) /* DefaultScale */
      , (46533,  64,    0.45) /* ResistSlash */
      , (46533,  65,    0.35) /* ResistPierce */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46534 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46534 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46534,   1,       5) /* HeartbeatInterval */
      , (46534,  17,       1) /* ArmorModVsFire */
      , (46534,  18,       1) /* ArmorModVsAcid */
      , (46534,  19,    0.95) /* ArmorModVsElectric */
-     , (46534,  31,      10) /* VisualAwarenessRange */
+     , (46534,  31,      35) /* VisualAwarenessRange */
      , (46534,  34,       1) /* PowerupTime */
      , (46534,  36,       1) /* ChargeSpeed */
      , (46534,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46535 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46535 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46535,   1,       5) /* HeartbeatInterval */
      , (46535,  17,       1) /* ArmorModVsFire */
      , (46535,  18,       1) /* ArmorModVsAcid */
      , (46535,  19,    0.95) /* ArmorModVsElectric */
-     , (46535,  31,      16) /* VisualAwarenessRange */
+     , (46535,  31,      35) /* VisualAwarenessRange */
      , (46535,  34,       1) /* PowerupTime */
      , (46535,  36,       1) /* ChargeSpeed */
      , (46535,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46536 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46536 Spectral Samurai.sql
@@ -42,7 +42,7 @@ VALUES (46536,   1,       5) /* HeartbeatInterval */
      , (46536,  17,       1) /* ArmorModVsFire */
      , (46536,  18,       1) /* ArmorModVsAcid */
      , (46536,  19,       1) /* ArmorModVsElectric */
-     , (46536,  31,      16) /* VisualAwarenessRange */
+     , (46536,  31,      35) /* VisualAwarenessRange */
      , (46536,  34,       1) /* PowerupTime */
      , (46536,  36,       1) /* ChargeSpeed */
      , (46536,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46537 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46537 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46537,   1,       5) /* HeartbeatInterval */
      , (46537,  17,       1) /* ArmorModVsFire */
      , (46537,  18,       1) /* ArmorModVsAcid */
      , (46537,  19,       1) /* ArmorModVsElectric */
-     , (46537,  31,      16) /* VisualAwarenessRange */
+     , (46537,  31,      35) /* VisualAwarenessRange */
      , (46537,  34,       1) /* PowerupTime */
      , (46537,  36,       1) /* ChargeSpeed */
      , (46537,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46538 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46538 Spectral Samurai.sql
@@ -42,7 +42,7 @@ VALUES (46538,   1,       5) /* HeartbeatInterval */
      , (46538,  17,    0.95) /* ArmorModVsFire */
      , (46538,  18,       1) /* ArmorModVsAcid */
      , (46538,  19,       1) /* ArmorModVsElectric */
-     , (46538,  31,      16) /* VisualAwarenessRange */
+     , (46538,  31,      35) /* VisualAwarenessRange */
      , (46538,  34,       1) /* PowerupTime */
      , (46538,  36,       1) /* ChargeSpeed */
      , (46538,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46539 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46539 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46539,   1,       5) /* HeartbeatInterval */
      , (46539,  17,    0.95) /* ArmorModVsFire */
      , (46539,  18,       1) /* ArmorModVsAcid */
      , (46539,  19,       1) /* ArmorModVsElectric */
-     , (46539,  31,      16) /* VisualAwarenessRange */
+     , (46539,  31,      35) /* VisualAwarenessRange */
      , (46539,  34,       1) /* PowerupTime */
      , (46539,  36,       1) /* ChargeSpeed */
      , (46539,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46540 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46540 Spectral Samurai.sql
@@ -42,7 +42,7 @@ VALUES (46540,   1,       5) /* HeartbeatInterval */
      , (46540,  17,       1) /* ArmorModVsFire */
      , (46540,  18,    0.95) /* ArmorModVsAcid */
      , (46540,  19,       1) /* ArmorModVsElectric */
-     , (46540,  31,      16) /* VisualAwarenessRange */
+     , (46540,  31,      35) /* VisualAwarenessRange */
      , (46540,  34,       1) /* PowerupTime */
      , (46540,  36,       1) /* ChargeSpeed */
      , (46540,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46541 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46541 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46541,   1,       5) /* HeartbeatInterval */
      , (46541,  17,       1) /* ArmorModVsFire */
      , (46541,  18,    0.95) /* ArmorModVsAcid */
      , (46541,  19,       1) /* ArmorModVsElectric */
-     , (46541,  31,      16) /* VisualAwarenessRange */
+     , (46541,  31,      35) /* VisualAwarenessRange */
      , (46541,  34,       1) /* PowerupTime */
      , (46541,  36,       1) /* ChargeSpeed */
      , (46541,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46561 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46561 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46561,   1,       5) /* HeartbeatInterval */
      , (46561,  17,       1) /* ArmorModVsFire */
      , (46561,  18,       1) /* ArmorModVsAcid */
      , (46561,  19,    0.95) /* ArmorModVsElectric */
-     , (46561,  31,      16) /* VisualAwarenessRange */
+     , (46561,  31,      35) /* VisualAwarenessRange */
      , (46561,  34,       1) /* PowerupTime */
      , (46561,  36,       1) /* ChargeSpeed */
      , (46561,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46562 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46562 Spectral Archer.sql
@@ -38,7 +38,7 @@ VALUES (46562,   1,       5) /* HeartbeatInterval */
      , (46562,  17,    0.95) /* ArmorModVsFire */
      , (46562,  18,       1) /* ArmorModVsAcid */
      , (46562,  19,       1) /* ArmorModVsElectric */
-     , (46562,  31,      18) /* VisualAwarenessRange */
+     , (46562,  31,      35) /* VisualAwarenessRange */
      , (46562,  64,    0.45) /* ResistSlash */
      , (46562,  65,    0.35) /* ResistPierce */
      , (46562,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46563 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46563 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (46563,   1,       5) /* HeartbeatInterval */
      , (46563,  17,       1) /* ArmorModVsFire */
      , (46563,  18,       1) /* ArmorModVsAcid */
      , (46563,  19,       1) /* ArmorModVsElectric */
-     , (46563,  31,      18) /* VisualAwarenessRange */
+     , (46563,  31,      35) /* VisualAwarenessRange */
      , (46563,  64,    0.45) /* ResistSlash */
      , (46563,  65,    0.35) /* ResistPierce */
      , (46563,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46564 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46564 Spectral Samurai.sql
@@ -43,7 +43,7 @@ VALUES (46564,   1,       5) /* HeartbeatInterval */
      , (46564,  17,       1) /* ArmorModVsFire */
      , (46564,  18,    0.95) /* ArmorModVsAcid */
      , (46564,  19,       1) /* ArmorModVsElectric */
-     , (46564,  31,      10) /* VisualAwarenessRange */
+     , (46564,  31,      35) /* VisualAwarenessRange */
      , (46564,  34,       1) /* PowerupTime */
      , (46564,  36,       1) /* ChargeSpeed */
      , (46564,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46565 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46565 Spectral Minion.sql
@@ -45,7 +45,7 @@ VALUES (46565,   1,       5) /* HeartbeatInterval */
      , (46565,  17,    0.95) /* ArmorModVsFire */
      , (46565,  18,       1) /* ArmorModVsAcid */
      , (46565,  19,       1) /* ArmorModVsElectric */
-     , (46565,  31,      16) /* VisualAwarenessRange */
+     , (46565,  31,      35) /* VisualAwarenessRange */
      , (46565,  34,       1) /* PowerupTime */
      , (46565,  36,       1) /* ChargeSpeed */
      , (46565,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46566 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46566 Spectral Minion.sql
@@ -44,7 +44,7 @@ VALUES (46566,   1,       5) /* HeartbeatInterval */
      , (46566,  17,       1) /* ArmorModVsFire */
      , (46566,  18,       1) /* ArmorModVsAcid */
      , (46566,  19,    0.95) /* ArmorModVsElectric */
-     , (46566,  31,      16) /* VisualAwarenessRange */
+     , (46566,  31,      35) /* VisualAwarenessRange */
      , (46566,  34,       1) /* PowerupTime */
      , (46566,  36,       1) /* ChargeSpeed */
      , (46566,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46567 Spectral Claw Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46567 Spectral Claw Adept.sql
@@ -42,7 +42,7 @@ VALUES (46567,   1,       5) /* HeartbeatInterval */
      , (46567,  17,       1) /* ArmorModVsFire */
      , (46567,  18,       1) /* ArmorModVsAcid */
      , (46567,  19,       1) /* ArmorModVsElectric */
-     , (46567,  31,      16) /* VisualAwarenessRange */
+     , (46567,  31,      35) /* VisualAwarenessRange */
      , (46567,  34,       1) /* PowerupTime */
      , (46567,  36,       1) /* ChargeSpeed */
      , (46567,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46568 Spectral Claw Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46568 Spectral Claw Master.sql
@@ -43,7 +43,7 @@ VALUES (46568,   1,       5) /* HeartbeatInterval */
      , (46568,  17,       1) /* ArmorModVsFire */
      , (46568,  18,       1) /* ArmorModVsAcid */
      , (46568,  19,       1) /* ArmorModVsElectric */
-     , (46568,  31,      16) /* VisualAwarenessRange */
+     , (46568,  31,      35) /* VisualAwarenessRange */
      , (46568,  34,       1) /* PowerupTime */
      , (46568,  36,       1) /* ChargeSpeed */
      , (46568,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46569 Spectral Blade Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46569 Spectral Blade Adept.sql
@@ -41,7 +41,7 @@ VALUES (46569,   1,       5) /* HeartbeatInterval */
      , (46569,  17,       1) /* ArmorModVsFire */
      , (46569,  18,       1) /* ArmorModVsAcid */
      , (46569,  19,       1) /* ArmorModVsElectric */
-     , (46569,  31,      16) /* VisualAwarenessRange */
+     , (46569,  31,      35) /* VisualAwarenessRange */
      , (46569,  34,       1) /* PowerupTime */
      , (46569,  36,       1) /* ChargeSpeed */
      , (46569,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46570 Spectral Blade Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46570 Spectral Blade Master.sql
@@ -41,7 +41,7 @@ VALUES (46570,   1,       5) /* HeartbeatInterval */
      , (46570,  17,       1) /* ArmorModVsFire */
      , (46570,  18,       1) /* ArmorModVsAcid */
      , (46570,  19,       1) /* ArmorModVsElectric */
-     , (46570,  31,      16) /* VisualAwarenessRange */
+     , (46570,  31,      35) /* VisualAwarenessRange */
      , (46570,  34,       1) /* PowerupTime */
      , (46570,  36,       1) /* ChargeSpeed */
      , (46570,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46571 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46571 Spectral Bushi.sql
@@ -42,7 +42,7 @@ VALUES (46571,   1,       5) /* HeartbeatInterval */
      , (46571,  17,    0.95) /* ArmorModVsFire */
      , (46571,  18,       1) /* ArmorModVsAcid */
      , (46571,  19,       1) /* ArmorModVsElectric */
-     , (46571,  31,      16) /* VisualAwarenessRange */
+     , (46571,  31,      35) /* VisualAwarenessRange */
      , (46571,  34,       1) /* PowerupTime */
      , (46571,  36,       1) /* ChargeSpeed */
      , (46571,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46572 Spectral Bloodmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46572 Spectral Bloodmage.sql
@@ -42,7 +42,7 @@ VALUES (46572,   1,       5) /* HeartbeatInterval */
      , (46572,  17,       1) /* ArmorModVsFire */
      , (46572,  18,       1) /* ArmorModVsAcid */
      , (46572,  19,       1) /* ArmorModVsElectric */
-     , (46572,  31,      16) /* VisualAwarenessRange */
+     , (46572,  31,      35) /* VisualAwarenessRange */
      , (46572,  34,       1) /* PowerupTime */
      , (46572,  36,       1) /* ChargeSpeed */
      , (46572,  54,       5) /* UseRadius */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46574 Spectral Nanjou Shou-jen.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46574 Spectral Nanjou Shou-jen.sql
@@ -43,7 +43,7 @@ VALUES (46574,   1,       5) /* HeartbeatInterval */
      , (46574,  17,       1) /* ArmorModVsFire */
      , (46574,  18,       1) /* ArmorModVsAcid */
      , (46574,  19,       1) /* ArmorModVsElectric */
-     , (46574,  31,      18) /* VisualAwarenessRange */
+     , (46574,  31,      35) /* VisualAwarenessRange */
      , (46574,  39,       1) /* DefaultScale */
      , (46574,  64,    0.45) /* ResistSlash */
      , (46574,  65,    0.35) /* ResistPierce */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46660 Samurai Gatekeeper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46660 Samurai Gatekeeper.sql
@@ -33,7 +33,7 @@ VALUES (46660,  12,   0.429) /* Shade */
      , (46660,  17,     100) /* ArmorModVsFire */
      , (46660,  18,    0.74) /* ArmorModVsAcid */
      , (46660,  19,    0.74) /* ArmorModVsElectric */
-     , (46660,  31,      16) /* VisualAwarenessRange */
+     , (46660,  31,      35) /* VisualAwarenessRange */
      , (46660,  34,       1) /* PowerupTime */
      , (46660,  36,       1) /* ChargeSpeed */
      , (46660,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46661 Claw Master Gatekeeper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46661 Claw Master Gatekeeper.sql
@@ -38,8 +38,7 @@ VALUES (46661,   1,       5) /* HeartbeatInterval */
      , (46661,  17,       1) /* ArmorModVsFire */
      , (46661,  18,       1) /* ArmorModVsAcid */
      , (46661,  19,       1) /* ArmorModVsElectric */
-     , (46661,  27,    5.01) /* RotationSpeed */
-     , (46661,  31,      25) /* VisualAwarenessRange */
+     , (46661,  31,      35) /* VisualAwarenessRange */
      , (46661,  34,       1) /* PowerupTime */
      , (46661,  36,       1) /* ChargeSpeed */
      , (46661,  55,      75) /* HomeRadius */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46662 Bushi Gatekeeper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46662 Bushi Gatekeeper.sql
@@ -43,7 +43,7 @@ VALUES (46662,   1,       5) /* HeartbeatInterval */
      , (46662,  17,       1) /* ArmorModVsFire */
      , (46662,  18,       1) /* ArmorModVsAcid */
      , (46662,  19,       1) /* ArmorModVsElectric */
-     , (46662,  31,      16) /* VisualAwarenessRange */
+     , (46662,  31,      35) /* VisualAwarenessRange */
      , (46662,  34,       1) /* PowerupTime */
      , (46662,  36,       1) /* ChargeSpeed */
      , (46662,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46687 Spectral Voidmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46687 Spectral Voidmage.sql
@@ -42,7 +42,7 @@ VALUES (46687,   1,       5) /* HeartbeatInterval */
      , (46687,  17,       1) /* ArmorModVsFire */
      , (46687,  18,       1) /* ArmorModVsAcid */
      , (46687,  19,       1) /* ArmorModVsElectric */
-     , (46687,  31,      16) /* VisualAwarenessRange */
+     , (46687,  31,      35) /* VisualAwarenessRange */
      , (46687,  34,       1) /* PowerupTime */
      , (46687,  36,       1) /* ChargeSpeed */
      , (46687,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46688 Spectral Voidmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46688 Spectral Voidmage.sql
@@ -41,7 +41,7 @@ VALUES (46688,   1,       5) /* HeartbeatInterval */
      , (46688,  17,       1) /* ArmorModVsFire */
      , (46688,  18,       1) /* ArmorModVsAcid */
      , (46688,  19,       1) /* ArmorModVsElectric */
-     , (46688,  31,      16) /* VisualAwarenessRange */
+     , (46688,  31,      35) /* VisualAwarenessRange */
      , (46688,  34,       1) /* PowerupTime */
      , (46688,  36,       1) /* ChargeSpeed */
      , (46688,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/52292 Spectral Voidmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/52292 Spectral Voidmage.sql
@@ -42,7 +42,7 @@ VALUES (52292,   1,       5) /* HeartbeatInterval */
      , (52292,  17,       1) /* ArmorModVsFire */
      , (52292,  18,       1) /* ArmorModVsAcid */
      , (52292,  19,       1) /* ArmorModVsElectric */
-     , (52292,  31,      16) /* VisualAwarenessRange */
+     , (52292,  31,      35) /* VisualAwarenessRange */
      , (52292,  34,       1) /* PowerupTime */
      , (52292,  36,       1) /* ChargeSpeed */
      , (52292,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72490 Vicar Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72490 Vicar Archer.sql
@@ -37,7 +37,7 @@ VALUES (72490,   1,       5) /* HeartbeatInterval */
      , (72490,  17,    0.95) /* ArmorModVsFire */
      , (72490,  18,       1) /* ArmorModVsAcid */
      , (72490,  19,       1) /* ArmorModVsElectric */
-     , (72490,  31,      20) /* VisualAwarenessRange */
+     , (72490,  31,      35) /* VisualAwarenessRange */
      , (72490,  34,       1) /* PowerupTime */
      , (72490,  36,       1) /* ChargeSpeed */
      , (72490,  54,      15) /* UseRadius */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72491 Vicar Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72491 Vicar Minion.sql
@@ -34,7 +34,7 @@ VALUES (72491,  13,    0.83) /* ArmorModVsSlash */
      , (72491,  17,       1) /* ArmorModVsFire */
      , (72491,  18,    0.74) /* ArmorModVsAcid */
      , (72491,  19,    0.74) /* ArmorModVsElectric */
-     , (72491,  31,      16) /* VisualAwarenessRange */
+     , (72491,  31,      35) /* VisualAwarenessRange */
      , (72491,  34,       1) /* PowerupTime */
      , (72491,  36,       1) /* ChargeSpeed */
      , (72491,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72492 Vicar Blade Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72492 Vicar Blade Master.sql
@@ -42,7 +42,7 @@ VALUES (72492,   1,       5) /* HeartbeatInterval */
      , (72492,  17,       1) /* ArmorModVsFire */
      , (72492,  18,       1) /* ArmorModVsAcid */
      , (72492,  19,       1) /* ArmorModVsElectric */
-     , (72492,  31,      16) /* VisualAwarenessRange */
+     , (72492,  31,      35) /* VisualAwarenessRange */
      , (72492,  34,       1) /* PowerupTime */
      , (72492,  36,       1) /* ChargeSpeed */
      , (72492,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72530 Spectral Samurai Daimyo.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72530 Spectral Samurai Daimyo.sql
@@ -33,7 +33,7 @@ VALUES (72530,   1,       5) /* HeartbeatInterval */
      , (72530,  17,       1) /* ArmorModVsFire */
      , (72530,  18,       1) /* ArmorModVsAcid */
      , (72530,  19,       1) /* ArmorModVsElectric */
-     , (72530,  31,      25) /* VisualAwarenessRange */
+     , (72530,  31,      35) /* VisualAwarenessRange */
      , (72530,  34,       1) /* PowerupTime */
      , (72530,  36,       1) /* ChargeSpeed */
      , (72530,  39,     1.2) /* DefaultScale */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72531 Spectral Samurai Daimyo.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72531 Spectral Samurai Daimyo.sql
@@ -33,7 +33,7 @@ VALUES (72531,   1,       5) /* HeartbeatInterval */
      , (72531,  17,    0.85) /* ArmorModVsFire */
      , (72531,  18,       1) /* ArmorModVsAcid */
      , (72531,  19,       1) /* ArmorModVsElectric */
-     , (72531,  31,      25) /* VisualAwarenessRange */
+     , (72531,  31,      35) /* VisualAwarenessRange */
      , (72531,  34,       1) /* PowerupTime */
      , (72531,  36,       1) /* ChargeSpeed */
      , (72531,  39,     1.2) /* DefaultScale */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72532 Spectral Samurai Daimyo.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72532 Spectral Samurai Daimyo.sql
@@ -33,7 +33,7 @@ VALUES (72532,   1,       5) /* HeartbeatInterval */
      , (72532,  17,       1) /* ArmorModVsFire */
      , (72532,  18,    0.85) /* ArmorModVsAcid */
      , (72532,  19,       1) /* ArmorModVsElectric */
-     , (72532,  31,      25) /* VisualAwarenessRange */
+     , (72532,  31,      35) /* VisualAwarenessRange */
      , (72532,  34,       1) /* PowerupTime */
      , (72532,  36,       1) /* ChargeSpeed */
      , (72532,  39,     1.2) /* DefaultScale */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72540 First Lieutenant.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72540 First Lieutenant.sql
@@ -41,7 +41,7 @@ VALUES (72540,   1,       5) /* HeartbeatInterval */
      , (72540,  17,       1) /* ArmorModVsFire */
      , (72540,  18,       1) /* ArmorModVsAcid */
      , (72540,  19,       1) /* ArmorModVsElectric */
-     , (72540,  31,      16) /* VisualAwarenessRange */
+     , (72540,  31,      20) /* VisualAwarenessRange */
      , (72540,  34,       1) /* PowerupTime */
      , (72540,  36,       1) /* ChargeSpeed */
      , (72540,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72553 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72553 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (72553,   1,       5) /* HeartbeatInterval */
      , (72553,  17,       1) /* ArmorModVsFire */
      , (72553,  18,       1) /* ArmorModVsAcid */
      , (72553,  19,    0.95) /* ArmorModVsElectric */
-     , (72553,  31,      18) /* VisualAwarenessRange */
+     , (72553,  31,      35) /* VisualAwarenessRange */
      , (72553,  64,    0.45) /* ResistSlash */
      , (72553,  65,    0.35) /* ResistPierce */
      , (72553,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72554 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72554 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (72554,   1,       5) /* HeartbeatInterval */
      , (72554,  17,       1) /* ArmorModVsFire */
      , (72554,  18,    0.95) /* ArmorModVsAcid */
      , (72554,  19,       1) /* ArmorModVsElectric */
-     , (72554,  31,      18) /* VisualAwarenessRange */
+     , (72554,  31,      35) /* VisualAwarenessRange */
      , (72554,  64,    0.45) /* ResistSlash */
      , (72554,  65,    0.35) /* ResistPierce */
      , (72554,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72555 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72555 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (72555,   1,       5) /* HeartbeatInterval */
      , (72555,  17,    0.95) /* ArmorModVsFire */
      , (72555,  18,       1) /* ArmorModVsAcid */
      , (72555,  19,       1) /* ArmorModVsElectric */
-     , (72555,  31,      18) /* VisualAwarenessRange */
+     , (72555,  31,      35) /* VisualAwarenessRange */
      , (72555,  64,    0.45) /* ResistSlash */
      , (72555,  65,    0.35) /* ResistPierce */
      , (72555,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72556 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72556 Spectral Archer.sql
@@ -39,7 +39,7 @@ VALUES (72556,   1,       5) /* HeartbeatInterval */
      , (72556,  17,       1) /* ArmorModVsFire */
      , (72556,  18,       1) /* ArmorModVsAcid */
      , (72556,  19,       1) /* ArmorModVsElectric */
-     , (72556,  31,      18) /* VisualAwarenessRange */
+     , (72556,  31,      35) /* VisualAwarenessRange */
      , (72556,  64,    0.45) /* ResistSlash */
      , (72556,  65,    0.35) /* ResistPierce */
      , (72556,  66,     0.6) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72557 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72557 Spectral Minion.sql
@@ -45,7 +45,7 @@ VALUES (72557,   1,       5) /* HeartbeatInterval */
      , (72557,  17,       1) /* ArmorModVsFire */
      , (72557,  18,       1) /* ArmorModVsAcid */
      , (72557,  19,    0.95) /* ArmorModVsElectric */
-     , (72557,  31,      30) /* VisualAwarenessRange */
+     , (72557,  31,      35) /* VisualAwarenessRange */
      , (72557,  34,       1) /* PowerupTime */
      , (72557,  36,       1) /* ChargeSpeed */
      , (72557,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72558 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72558 Spectral Minion.sql
@@ -41,7 +41,7 @@ VALUES (72558,   1,       5) /* HeartbeatInterval */
      , (72558,  17,       1) /* ArmorModVsFire */
      , (72558,  18,    0.95) /* ArmorModVsAcid */
      , (72558,  19,       1) /* ArmorModVsElectric */
-     , (72558,  31,      30) /* VisualAwarenessRange */
+     , (72558,  31,      35) /* VisualAwarenessRange */
      , (72558,  34,       1) /* PowerupTime */
      , (72558,  36,       1) /* ChargeSpeed */
      , (72558,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72559 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72559 Spectral Minion.sql
@@ -46,7 +46,7 @@ VALUES (72559,   1,       5) /* HeartbeatInterval */
      , (72559,  17,    0.95) /* ArmorModVsFire */
      , (72559,  18,       1) /* ArmorModVsAcid */
      , (72559,  19,       1) /* ArmorModVsElectric */
-     , (72559,  31,      30) /* VisualAwarenessRange */
+     , (72559,  31,      35) /* VisualAwarenessRange */
      , (72559,  34,       1) /* PowerupTime */
      , (72559,  36,       1) /* ChargeSpeed */
      , (72559,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72560 Spectral Minion.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72560 Spectral Minion.sql
@@ -41,7 +41,7 @@ VALUES (72560,   1,       5) /* HeartbeatInterval */
      , (72560,  17,       1) /* ArmorModVsFire */
      , (72560,  18,       1) /* ArmorModVsAcid */
      , (72560,  19,       1) /* ArmorModVsElectric */
-     , (72560,  31,      30) /* VisualAwarenessRange */
+     , (72560,  31,      35) /* VisualAwarenessRange */
      , (72560,  34,       1) /* PowerupTime */
      , (72560,  36,       1) /* ChargeSpeed */
      , (72560,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72561 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72561 Spectral Bushi.sql
@@ -44,7 +44,7 @@ VALUES (72561,   1,       5) /* HeartbeatInterval */
      , (72561,  17,       1) /* ArmorModVsFire */
      , (72561,  18,       1) /* ArmorModVsAcid */
      , (72561,  19,    0.95) /* ArmorModVsElectric */
-     , (72561,  31,      30) /* VisualAwarenessRange */
+     , (72561,  31,      35) /* VisualAwarenessRange */
      , (72561,  34,       1) /* PowerupTime */
      , (72561,  36,       1) /* ChargeSpeed */
      , (72561,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72562 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72562 Spectral Bushi.sql
@@ -40,7 +40,7 @@ VALUES (72562,   1,       5) /* HeartbeatInterval */
      , (72562,  17,       1) /* ArmorModVsFire */
      , (72562,  18,    0.95) /* ArmorModVsAcid */
      , (72562,  19,       1) /* ArmorModVsElectric */
-     , (72562,  31,      30) /* VisualAwarenessRange */
+     , (72562,  31,      35) /* VisualAwarenessRange */
      , (72562,  34,       1) /* PowerupTime */
      , (72562,  36,       1) /* ChargeSpeed */
      , (72562,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72563 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72563 Spectral Bushi.sql
@@ -44,7 +44,7 @@ VALUES (72563,   1,       5) /* HeartbeatInterval */
      , (72563,  17,    0.95) /* ArmorModVsFire */
      , (72563,  18,       1) /* ArmorModVsAcid */
      , (72563,  19,       1) /* ArmorModVsElectric */
-     , (72563,  31,      30) /* VisualAwarenessRange */
+     , (72563,  31,      35) /* VisualAwarenessRange */
      , (72563,  34,       1) /* PowerupTime */
      , (72563,  36,       1) /* ChargeSpeed */
      , (72563,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72564 Spectral Bushi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72564 Spectral Bushi.sql
@@ -40,7 +40,7 @@ VALUES (72564,   1,       5) /* HeartbeatInterval */
      , (72564,  17,       1) /* ArmorModVsFire */
      , (72564,  18,       1) /* ArmorModVsAcid */
      , (72564,  19,       1) /* ArmorModVsElectric */
-     , (72564,  31,      30) /* VisualAwarenessRange */
+     , (72564,  31,      35) /* VisualAwarenessRange */
      , (72564,  34,       1) /* PowerupTime */
      , (72564,  36,       1) /* ChargeSpeed */
      , (72564,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72565 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72565 Spectral Samurai.sql
@@ -44,7 +44,7 @@ VALUES (72565,   1,       5) /* HeartbeatInterval */
      , (72565,  17,       1) /* ArmorModVsFire */
      , (72565,  18,       1) /* ArmorModVsAcid */
      , (72565,  19,       1) /* ArmorModVsElectric */
-     , (72565,  31,      30) /* VisualAwarenessRange */
+     , (72565,  31,      35) /* VisualAwarenessRange */
      , (72565,  34,       1) /* PowerupTime */
      , (72565,  36,       1) /* ChargeSpeed */
      , (72565,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72566 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72566 Spectral Samurai.sql
@@ -44,7 +44,7 @@ VALUES (72566,   1,       5) /* HeartbeatInterval */
      , (72566,  17,    0.95) /* ArmorModVsFire */
      , (72566,  18,       1) /* ArmorModVsAcid */
      , (72566,  19,       1) /* ArmorModVsElectric */
-     , (72566,  31,      30) /* VisualAwarenessRange */
+     , (72566,  31,      35) /* VisualAwarenessRange */
      , (72566,  34,       1) /* PowerupTime */
      , (72566,  36,       1) /* ChargeSpeed */
      , (72566,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72567 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72567 Spectral Samurai.sql
@@ -44,7 +44,7 @@ VALUES (72567,   1,       5) /* HeartbeatInterval */
      , (72567,  17,       1) /* ArmorModVsFire */
      , (72567,  18,       1) /* ArmorModVsAcid */
      , (72567,  19,    0.95) /* ArmorModVsElectric */
-     , (72567,  31,      30) /* VisualAwarenessRange */
+     , (72567,  31,      35) /* VisualAwarenessRange */
      , (72567,  34,       1) /* PowerupTime */
      , (72567,  36,       1) /* ChargeSpeed */
      , (72567,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72568 Spectral Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72568 Spectral Samurai.sql
@@ -44,7 +44,7 @@ VALUES (72568,   1,       5) /* HeartbeatInterval */
      , (72568,  17,       1) /* ArmorModVsFire */
      , (72568,  18,    0.95) /* ArmorModVsAcid */
      , (72568,  19,       1) /* ArmorModVsElectric */
-     , (72568,  31,      30) /* VisualAwarenessRange */
+     , (72568,  31,      35) /* VisualAwarenessRange */
      , (72568,  34,       1) /* PowerupTime */
      , (72568,  36,       1) /* ChargeSpeed */
      , (72568,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72569 Spectral Blade Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72569 Spectral Blade Master.sql
@@ -45,7 +45,7 @@ VALUES (72569,   1,       5) /* HeartbeatInterval */
      , (72569,  17,       1) /* ArmorModVsFire */
      , (72569,  18,       1) /* ArmorModVsAcid */
      , (72569,  19,       1) /* ArmorModVsElectric */
-     , (72569,  31,      30) /* VisualAwarenessRange */
+     , (72569,  31,      35) /* VisualAwarenessRange */
      , (72569,  34,       1) /* PowerupTime */
      , (72569,  36,       1) /* ChargeSpeed */
      , (72569,  64,    0.45) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72570 Spectral Bloodmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72570 Spectral Bloodmage.sql
@@ -40,7 +40,7 @@ VALUES (72570,   1,       5) /* HeartbeatInterval */
      , (72570,  17,       1) /* ArmorModVsFire */
      , (72570,  18,       1) /* ArmorModVsAcid */
      , (72570,  19,       1) /* ArmorModVsElectric */
-     , (72570,  31,      30) /* VisualAwarenessRange */
+     , (72570,  31,      35) /* VisualAwarenessRange */
      , (72570,  34,       1) /* PowerupTime */
      , (72570,  36,       1) /* ChargeSpeed */
      , (72570,  54,       5) /* UseRadius */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/72571 Spectral Voidmage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/72571 Spectral Voidmage.sql
@@ -38,7 +38,7 @@ VALUES (72571,   1,       5) /* HeartbeatInterval */
      , (72571,  17,       1) /* ArmorModVsFire */
      , (72571,  18,       1) /* ArmorModVsAcid */
      , (72571,  19,       1) /* ArmorModVsElectric */
-     , (72571,  31,      30) /* VisualAwarenessRange */
+     , (72571,  31,      35) /* VisualAwarenessRange */
      , (72571,  34,       1) /* PowerupTime */
      , (72571,  36,       1) /* ChargeSpeed */
      , (72571,  64,     0.5) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/46603 Clay Golem Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/46603 Clay Golem Samurai.sql
@@ -36,7 +36,7 @@ VALUES (46603,   1,       5) /* HeartbeatInterval */
      , (46603,  17,       1) /* ArmorModVsFire */
      , (46603,  18,       1) /* ArmorModVsAcid */
      , (46603,  19,       1) /* ArmorModVsElectric */
-     , (46603,  31,      17) /* VisualAwarenessRange */
+     , (46603,  31,      35) /* VisualAwarenessRange */
      , (46603,  34,     2.3) /* PowerupTime */
      , (46603,  39,     1.2) /* DefaultScale */
      , (46603,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/46613 Bronze Golem Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/46613 Bronze Golem Samurai.sql
@@ -36,7 +36,7 @@ VALUES (46613,   1,       5) /* HeartbeatInterval */
      , (46613,  17,       1) /* ArmorModVsFire */
      , (46613,  18,       1) /* ArmorModVsAcid */
      , (46613,  19,     0.9) /* ArmorModVsElectric */
-     , (46613,  31,      17) /* VisualAwarenessRange */
+     , (46613,  31,      35) /* VisualAwarenessRange */
      , (46613,  34,     2.3) /* PowerupTime */
      , (46613,  39,     1.2) /* DefaultScale */
      , (46613,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/46614 Iron Golem Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/46614 Iron Golem Samurai.sql
@@ -36,7 +36,7 @@ VALUES (46614,   1,       5) /* HeartbeatInterval */
      , (46614,  17,       1) /* ArmorModVsFire */
      , (46614,  18,     0.9) /* ArmorModVsAcid */
      , (46614,  19,       1) /* ArmorModVsElectric */
-     , (46614,  31,      17) /* VisualAwarenessRange */
+     , (46614,  31,      35) /* VisualAwarenessRange */
      , (46614,  34,     2.3) /* PowerupTime */
      , (46614,  39,     1.2) /* DefaultScale */
      , (46614,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/46651 Bronze Golem Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/46651 Bronze Golem Samurai.sql
@@ -37,7 +37,7 @@ VALUES (46651,   1,       5) /* HeartbeatInterval */
      , (46651,  17,       1) /* ArmorModVsFire */
      , (46651,  18,       1) /* ArmorModVsAcid */
      , (46651,  19,     0.9) /* ArmorModVsElectric */
-     , (46651,  31,      17) /* VisualAwarenessRange */
+     , (46651,  31,      35) /* VisualAwarenessRange */
      , (46651,  34,     2.3) /* PowerupTime */
      , (46651,  39,     1.2) /* DefaultScale */
      , (46651,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/46652 Clay Golem Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/46652 Clay Golem Samurai.sql
@@ -37,7 +37,7 @@ VALUES (46652,   1,       5) /* HeartbeatInterval */
      , (46652,  17,       1) /* ArmorModVsFire */
      , (46652,  18,       1) /* ArmorModVsAcid */
      , (46652,  19,       1) /* ArmorModVsElectric */
-     , (46652,  31,      17) /* VisualAwarenessRange */
+     , (46652,  31,      35) /* VisualAwarenessRange */
      , (46652,  34,     2.3) /* PowerupTime */
      , (46652,  39,     1.2) /* DefaultScale */
      , (46652,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/46653 Iron Golem Samurai.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/46653 Iron Golem Samurai.sql
@@ -37,7 +37,7 @@ VALUES (46653,   1,       5) /* HeartbeatInterval */
      , (46653,  17,       1) /* ArmorModVsFire */
      , (46653,  18,     0.9) /* ArmorModVsAcid */
      , (46653,  19,       1) /* ArmorModVsElectric */
-     , (46653,  31,      17) /* VisualAwarenessRange */
+     , (46653,  31,      35) /* VisualAwarenessRange */
      , (46653,  34,     2.3) /* PowerupTime */
      , (46653,  39,     1.2) /* DefaultScale */
      , (46653,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/48924 Clay Golem Kachi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/48924 Clay Golem Kachi.sql
@@ -34,7 +34,7 @@ VALUES (48924,   1,       5) /* HeartbeatInterval */
      , (48924,  17,       1) /* ArmorModVsFire */
      , (48924,  18,       1) /* ArmorModVsAcid */
      , (48924,  19,       1) /* ArmorModVsElectric */
-     , (48924,  31,      17) /* VisualAwarenessRange */
+     , (48924,  31,      35) /* VisualAwarenessRange */
      , (48924,  34,     2.3) /* PowerupTime */
      , (48924,  39,     1.2) /* DefaultScale */
      , (48924,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/48925 Bronze Golem Kachi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/48925 Bronze Golem Kachi.sql
@@ -34,7 +34,7 @@ VALUES (48925,   1,       5) /* HeartbeatInterval */
      , (48925,  17,       1) /* ArmorModVsFire */
      , (48925,  18,       1) /* ArmorModVsAcid */
      , (48925,  19,     0.9) /* ArmorModVsElectric */
-     , (48925,  31,      17) /* VisualAwarenessRange */
+     , (48925,  31,      35) /* VisualAwarenessRange */
      , (48925,  34,     2.3) /* PowerupTime */
      , (48925,  39,     1.2) /* DefaultScale */
      , (48925,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/48926 Iron Golem Kachi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/48926 Iron Golem Kachi.sql
@@ -33,7 +33,7 @@ VALUES (48926,   1,       5) /* HeartbeatInterval */
      , (48926,  17,       1) /* ArmorModVsFire */
      , (48926,  18,     0.9) /* ArmorModVsAcid */
      , (48926,  19,       1) /* ArmorModVsElectric */
-     , (48926,  31,      17) /* VisualAwarenessRange */
+     , (48926,  31,      35) /* VisualAwarenessRange */
      , (48926,  34,     2.3) /* PowerupTime */
      , (48926,  39,     1.2) /* DefaultScale */
      , (48926,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/48929 Bronze Golem Sekkou.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/48929 Bronze Golem Sekkou.sql
@@ -33,7 +33,7 @@ VALUES (48929,   1,       5) /* HeartbeatInterval */
      , (48929,  17,       1) /* ArmorModVsFire */
      , (48929,  18,       1) /* ArmorModVsAcid */
      , (48929,  19,     0.9) /* ArmorModVsElectric */
-     , (48929,  31,      17) /* VisualAwarenessRange */
+     , (48929,  31,      35) /* VisualAwarenessRange */
      , (48929,  34,     2.3) /* PowerupTime */
      , (48929,  39,     1.2) /* DefaultScale */
      , (48929,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/48930 Clay Golem Sekkou.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/48930 Clay Golem Sekkou.sql
@@ -35,7 +35,7 @@ VALUES (48930,   1,       5) /* HeartbeatInterval */
      , (48930,  17,       1) /* ArmorModVsFire */
      , (48930,  18,       1) /* ArmorModVsAcid */
      , (48930,  19,       1) /* ArmorModVsElectric */
-     , (48930,  31,      17) /* VisualAwarenessRange */
+     , (48930,  31,      35) /* VisualAwarenessRange */
      , (48930,  34,     2.3) /* PowerupTime */
      , (48930,  39,     1.2) /* DefaultScale */
      , (48930,  64,     0.1) /* ResistSlash */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/48931 Iron Golem Sekkou.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/48931 Iron Golem Sekkou.sql
@@ -35,7 +35,7 @@ VALUES (48931,   1,       5) /* HeartbeatInterval */
      , (48931,  17,       1) /* ArmorModVsFire */
      , (48931,  18,     0.9) /* ArmorModVsAcid */
      , (48931,  19,       1) /* ArmorModVsElectric */
-     , (48931,  31,      17) /* VisualAwarenessRange */
+     , (48931,  31,      35) /* VisualAwarenessRange */
      , (48931,  34,     2.3) /* PowerupTime */
      , (48931,  39,     1.2) /* DefaultScale */
      , (48931,  64,     0.1) /* ResistSlash */


### PR DESCRIPTION
Increased visual awareness range of Hoshino creatures to 35, with a few exceptions for some dungeon bosses.