### PR TITLE
Fix Red Rune Spear and Atlatl Stats

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/33064 Red Rune Silveran Spear.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/33064 Red Rune Silveran Spear.sql
@@ -9,7 +9,7 @@ VALUES (33064,   1,          1) /* ItemType - MeleeWeapon */
      , (33064,   9,    1048576) /* ValidLocations - MeleeWeapon */
      , (33064,  16,          1) /* ItemUseable - No */
      , (33064,  19,      20000) /* Value */
-     , (33064,  44,         84) /* Damage */
+     , (33064,  44,         62) /* Damage */
      , (33064,  45,          2) /* DamageType - Pierce */
      , (33064,  46,          2) /* DefaultCombatStyle - OneHanded */
      , (33064,  47,          2) /* AttackType - Thrust */
@@ -37,8 +37,8 @@ VALUES (33064,   5,   -0.05) /* ManaRate */
      , (33064,  21,       0) /* WeaponLength */
      , (33064,  22,     0.5) /* DamageVariance */
      , (33064,  26,       0) /* MaximumVelocity */
-     , (33064,  29,    1.27) /* WeaponDefense */
-     , (33064,  62,    1.35) /* WeaponOffense */
+     , (33064,  29,    1.10) /* WeaponDefense */
+     , (33064,  62,    1.15) /* WeaponOffense */
      , (33064,  63,       1) /* DamageMod */
      , (33064, 136,    1.99) /* CriticalMultiplier */
      , (33064, 147,    0.33) /* CriticalFrequency */

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/33111 Red Rune Silveran Atlatl.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/33111 Red Rune Silveran Atlatl.sql
@@ -9,11 +9,11 @@ VALUES (33111,   1,        256) /* ItemType - MissileWeapon */
      , (33111,   9,    4194304) /* ValidLocations - MissileWeapon */
      , (33111,  16,          1) /* ItemUseable - No */
      , (33111,  19,      20000) /* Value */
-     , (33111,  44,         34) /* Damage */
+     , (33111,  44,         12) /* Damage */
      , (33111,  45,          0) /* DamageType - Undef */
      , (33111,  46,       1024) /* DefaultCombatStyle - Atlatl */
      , (33111,  48,         47) /* WeaponSkill - MissileWeapons */
-     , (33111,  49,          0) /* WeaponTime */
+     , (33111,  49,         50) /* WeaponTime */
      , (33111,  50,          4) /* AmmoType - Atlatl */
      , (33111,  51,          2) /* CombatUse - Missile */
      , (33111,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
@@ -36,7 +36,7 @@ VALUES (33111,   5,   -0.05) /* ManaRate */
      , (33111,  21,       0) /* WeaponLength */
      , (33111,  22,       0) /* DamageVariance */
      , (33111,  26,    24.9) /* MaximumVelocity */
-     , (33111,  29,    1.32) /* WeaponDefense */
+     , (33111,  29,    1.15) /* WeaponDefense */
      , (33111,  62,       1) /* WeaponOffense */
      , (33111,  63,    2.65) /* DamageMod */
      , (33111, 136,       2) /* CriticalMultiplier */


### PR DESCRIPTION
Fixes the base stats on the red rune spear and atlatl to match their base stats instead of their buffed stats.