### PR TITLE
Fix Hoshino KT rewards to match PCAP data

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46678 Lieutenant Aurin.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46678 Lieutenant Aurin.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46678;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46678, 'ace46678-lieutenantaurin', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46678, 'ace46678-lieutenantaurin', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46678,   1,         16) /* ItemType - Creature */
@@ -140,7 +140,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Well done. Please, accept this reward with my thanks for your assistance.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskGolemSamuraiCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskGolemSamurai0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46678.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46678.es
@@ -1,0 +1,32 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskGolemSamuraiCompleted0812@2
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskGolemSamurai0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskGolemSamurai0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Well done. Please, accept this reward with my thanks for your assistance.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 4,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskGolemSamuraiCompleted0812
+                                    - EraseQuest: KillTaskGolemSamurai0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm Golem Samurai.
+                                    - Tell: Return to me after you have killed %tqm Golem Samurai and I will reward you.
+                        QuestFailure:
+                            - Tell: Always an honor. I am called Aurin. I have been tasked with weakening the forces here. To that end, I am rewarding those that can help destroy the golems they are producing that appear as the Isparian warriors called Samurai.
+                            - Tell: If you will do me the honor of killing %tqm of the Golem Samurai within the towns or up within the walled fortress, I will reward you for your efforts.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress above. Killing those on the edges will not assist my task, so I cannot reward you for those.
+                            - SetQuestCompletions: KillTaskGolemSamurai0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46679 Sergeant Trebuus.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46679 Sergeant Trebuus.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46679;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46679, 'ace46679-sergeanttrebuus', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46679, 'ace46679-sergeanttrebuus', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46679,   1,         16) /* ItemType - Creature */
@@ -140,10 +140,11 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Well done. Well done indeed. You do your people proud.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralArchersCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralArchers0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  6,  10 /* Tell */, 0, 1, NULL, 'I''m authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralArchersCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralArchers0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  7,  10 /* Tell */, 0, 1, NULL, 'I''m authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (46679, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'KillTaskSpectralArchersCompleted0812', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46679.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46679.es
@@ -1,0 +1,32 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralArchersCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralArchers0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralArchers0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Well done. Well done indeed. You do your people proud.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 5,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralArchersCompleted0812
+                                    - EraseQuest: KillTaskSpectralArchers0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm Spectral Archers.
+                                    - Tell: Return to me after you have killed %tqm Spectral Archers and I will reward you.
+                        QuestFailure:
+                            - Tell: Greetings to you. I have been sent here to deal with the overabundance of puny, but sharp, projectiles raining down on our forces. To that end, I'm rewarding independent agents who take it upon themselves to 'end' 15 of their Spectral Archers.
+                            - Tell: If you will do me the honor of killing 15 of the Spectral Archers within the towns or up within the walled fortress, I will reward you for your assistance.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress above. Killing those on the edges will not assist my task. They put their worst shots on the edges, so I cannot reward you for those.
+                            - SetQuestCompletions: KillTaskSpectralArchers0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46680 Lord Eorlinde.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46680 Lord Eorlinde.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46680;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46680, 'ace46680-lordeorlinde', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46680, 'ace46680-lordeorlinde', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46680,   1,         16) /* ItemType - Creature */
@@ -140,7 +140,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Your skill is remarkable. Please, accept this reward, as well as my thanks, for your assistance.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralBloodmagesCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralBloodMages0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46680.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46680.es
@@ -1,0 +1,33 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralBloodmagesCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralBloodMages0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralBloodMages0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Your skill is remarkable. Please, accept this reward, as well as my thanks, for your assistance.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 4,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralBloodmagesCompleted0812
+                                    - EraseQuest: KillTaskSpectralBloodMages0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm  Spectral Bloodmages.
+                                    - Tell: Return to me after you have killed %tqm  Spectral Bloodmages
+                        QuestFailure:
+                            - Tell: Greetings. I was wondering if you would assist me with a bit of a hunt.
+                            - Tell: In this place, there are undead spirits imbued with the terrible powers of the Dark Falatacot, called Spectral Bloodmages. There are also equally dangerous spirits known as Spectral Voidmages, which appear to be the result of Dark Falatacot magics used upon one of the Umbreans or Penumbreans
+                            - Tell: While these two types of spirits continue to exist, they pose a tremendous threat to the kingdom. If you will aid our efforts by dispatching 5 of them, I will reward you for your assistance.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress. Killing those on the edges will not assist my task, so I cannot reward you for those.
+                            - SetQuestCompletions: KillTaskSpectralBloodMages0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46681 Corporal Irashi.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46681 Corporal Irashi.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46681;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46681, 'ace46681-corporalirashi', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46681, 'ace46681-corporalirashi', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46681,   1,         16) /* ItemType - Creature */
@@ -138,7 +138,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Thank you for your assistance. Please, accept this reward for your efforts.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralBushiCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralBushi0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46681.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46681.es
@@ -1,0 +1,32 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralBushiCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralBushi0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralBushi0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Thank you for your assistance. Please, accept this reward for your efforts.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 5,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralBushiCompleted0812
+                                    - EraseQuest: KillTaskSpectralBushi0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm  Spectral Bushi.
+                                    - Tell: Return to me after you have killed %tqm  Spectral Bushi and I will reward you.
+                        QuestFailure:
+                            - Tell: It is an honor to meet you. I am known as Corporal Irashi. I have been sent to coordinate the weakening of the enemy forces here. To that end, I am rewarding those that assist me with the removal of the main force of Spectral Bushi.
+                            - Tell: If you will assist me by killing 10 of the Spectral Bushi within the towns or up within the walled fortress, I will reward you for your efforts.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress. Killing those on the edges will not assist my task, so I cannot reward you for those.
+                            - SetQuestCompletions: KillTaskSpectralBushi0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46682 Griffon.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46682 Griffon.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46682;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46682, 'ace46682-griffon', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46682, 'ace46682-griffon', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46682,   1,         16) /* ItemType - Creature */
@@ -139,7 +139,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Your skill is quite remarkable. Please, accept this reward for your aid in this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralClawsBladesCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralClawsBlades0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46682.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46682.es
@@ -1,0 +1,33 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralClawsBladesCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralClawsBlades0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralClawsBlades0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Your skill is quite remarkable. Please, accept this reward for your aid in this.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 5,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralClawsBladesCompleted0812
+                                    - EraseQuest: KillTaskSpectralClawsBlades0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm  Spectral Blade and Claws.
+                                    - Tell: Return to me after you have killed %tqm  Spectral Blade and Claws and I will reward you.
+                        QuestFailure:
+                            - Tell: Greetings. I am called Griffon. I have come here at the behest of my order to deal with those spirits here who are training in the arts of the Nanjou Shou-jen.
+                            - Tell: To that end, if you aid me in hunting 10 of the Spectral Claw Adepts, Claw Masters, Blade Adepts or Blade Masters, I'll happily reward you for your help.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress. Those you find on the outskirts are likely decoys, and I will not reward you for those.
+                            - SetQuestCompletions: KillTaskSpectralClawsBlades0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46683 Aun Kirtal.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46683 Aun Kirtal.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46683;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46683, 'ace46683-aunkirtal', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46683, 'ace46683-aunkirtal', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46683,   1,         16) /* ItemType - Creature */
@@ -128,7 +128,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Your hunt for today is complete. Accept this reward for your aid in this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralMinionsCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralMinions0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46683.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46683.es
@@ -1,0 +1,32 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralMinionsCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralMinions0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralMinions0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Your hunt for today is complete. Accept this reward for your aid in this.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 5,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralMinionsCompleted0812
+                                    - EraseQuest: KillTaskSpectralMinions0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm Spectral Minions.
+                                    - Tell: Return to me after you have killed %tqm Spectral Minions and I will reward you.
+                        QuestFailure:
+                            - Tell: Aun Kirtal tells you, "I am Aun Kirtal of the Palenqual Xuta. I have been tasked with thinning the forces here. To that end, I am rewarding those that assist me with the destruction of the Spectral Minions.
+                            - Tell: "If you will aid me by killing 15 of the Spectral Minions within the towns or up within the walled fortress, I will reward your good work.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress. Killing those on the edges will not assist my task, so I cannot reward you for those.
+                            - SetQuestCompletions: KillTaskSpectralMinions0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46684 Hanamoto Aki'ko.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46684 Hanamoto Aki'ko.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46684;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46684, 'ace46684-hanamotoakiko', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46684, 'ace46684-hanamotoakiko', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46684,   1,         16) /* ItemType - Creature */
@@ -138,8 +138,8 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Well done. Please, accept this reward with my thanks for your assistance.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 48746 /* Aged Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralNinjasCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralNinjas0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  7,  10 /* Tell */, 0, 1, NULL, 'I''m authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46684.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46684.es
@@ -1,0 +1,32 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralNinjasCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralNinjas0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralNinjas0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Well done. Please, accept this reward with my thanks for your assistance.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 4,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralNinjasCompleted0812
+                                    - EraseQuest: KillTaskSpectralNinjas0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm Spectral Nanjou Shou-jen.
+                                    - Tell: Return to me after you have killed %tqm Spectral Nanjou Shou-jen and I will reward you.
+                        QuestFailure:
+                            - Tell: It is an honor to speak with you. I am known as Hanamoto Aki'ko. I have come here to assist those who serve the Prince in dealing with a most dangerous and subtle foe.
+                            - Tell: To that end, if you will do me the honor of killing %tqm of the Spectral Nanjou Shou-jen within the towns or up within the walled fortress, I will reward you for your efforts.
+                            - Tell: Make sure you hunt those well within the towns or the walled fortress above. Killing those on the edges will not assist my task, so I cannot reward you for those.
+                            - SetQuestCompletions: KillTaskSpectralNinjas0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46686 Lieutenant Takamaki.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46686 Lieutenant Takamaki.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46686;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46686, 'ace46686-lieutenanttakamaki', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46686, 'ace46686-lieutenanttakamaki', 10, '2021-12-08 03:15:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46686,   1,         16) /* ItemType - Creature */
@@ -136,8 +136,8 @@ SET @parent_id = LAST_INSERT_ID();
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Well done. Please, accept this reward with my thanks for your assistance.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 3000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 51954 /* Durable Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'KillTaskSpectralSamuraiCompleted0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  31 /* EraseQuest */, 0, 1, NULL, 'KillTaskSpectralSamurai0812', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/46686.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/46686.es
@@ -1,0 +1,31 @@
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqIntStat: Level, 200 - 999
+        TestSuccess:
+            - InqQuest: KillTaskSpectralSamuraiCompleted0812
+                QuestSuccess:
+                    - Tell: Thank you again for your assistance. Return later, and I may have more work for you.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuestSolves: KillTaskSpectralSamurai0812@KillTaskInProgress, 1
+                        QuestSuccess:
+                            - InqQuest: KillTaskSpectralSamurai0812@KillTaskCompleted
+                                QuestSuccess:
+                                    - Tell: Well done. Please, accept this reward with my thanks for your assistance.
+                                    - AwardNoShareXP: 15,000,000
+                                    - AwardLuminance: 5,000
+                                    - Give: Trade Note (250,000) (20630), 2
+                                    - Give: 51954
+                                    - StampQuest: KillTaskSpectralSamuraiCompleted0812
+                                    - EraseQuest: KillTaskSpectralSamurai0812
+                                    - Tell: I'm authorized to send adventurers out on daily hunts, so return tomorrow if you wish to aid us again.
+                                QuestFailure:
+                                    - DirectBroadcast: You've killed %tqc out of %tqm Spectral Samurai.
+                                    - Tell: Return to me after you have killed %tqm Spectral Samurai and I will reward you.
+                        QuestFailure:
+                            - Tell: Greetings. I am rewarding those who will aid in the removal of the Spectral Samurai within the area. They're making it hard for the researchers to operate within the canyon.
+                            - Tell: If you will kill %tqm of the Spectral Samurai within the area or up on the plateaus, I will reward you for your help.
+                            - SetQuestCompletions: KillTaskSpectralSamurai0812, 0
+        TestFailure:
+            - Tell: I'm afraid the tasks I have are too difficult for you at this time, come back when you are more experienced.


### PR DESCRIPTION
Fixes Hoshino area kill task rewards to match PCAP data.
Data taken from PCAP Part 1\Callaway-01-30-2017-BurQuests\pkt_2017-1-30_1485791858_log.pcap