### PR TITLE
Update Arcane Death

### DIFF
--- a/Database/Patches/2 SpellTableExtendedData/04264 Arcane Death.sql
+++ b/Database/Patches/2 SpellTableExtendedData/04264 Arcane Death.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 4264;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (4264, 'Arcane Death', 2 /* Pierce */, 450, 450, 37159 /* Arcane Death */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2021-11-01 00:00:00');
+VALUES (4264, 'Arcane Death', 2 /* Pierce */, 2000, 500, 37159 /* Arcane Death */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2021-11-01 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/04282 Arcane Death.sql
+++ b/Database/Patches/2 SpellTableExtendedData/04282 Arcane Death.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 4282;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (4282, 'Arcane Death', 2 /* Pierce */, 250, 250, 37159 /* Arcane Death */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2021-11-01 00:00:00');
+VALUES (4282, 'Arcane Death', 2 /* Pierce */, 2000, 500, 37159 /* Arcane Death */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2021-11-01 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/04283 Arcane Death.sql
+++ b/Database/Patches/2 SpellTableExtendedData/04283 Arcane Death.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 4283;
 
 INSERT INTO `spell` (`id`, `name`, `e_Type`, `base_Intensity`, `variance`, `wcid`, `num_Projectiles`, `num_Projectiles_Variance`, `spread_Angle`, `vertical_Angle`, `default_Launch_Angle`, `non_Tracking`, `create_Offset_Origin_X`, `create_Offset_Origin_Y`, `create_Offset_Origin_Z`, `padding_Origin_X`, `padding_Origin_Y`, `padding_Origin_Z`, `dims_Origin_X`, `dims_Origin_Y`, `dims_Origin_Z`, `peturbation_Origin_X`, `peturbation_Origin_Y`, `peturbation_Origin_Z`, `imbued_Effect`, `slayer_Creature_Type`, `slayer_Damage_Bonus`, `crit_Freq`, `crit_Multiplier`, `ignore_Magic_Resist`, `elemental_Modifier`, `last_Modified`)
-VALUES (4283, 'Arcane Death', 2 /* Pierce */, 250, 250, 37376 /* Arcane Death */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2021-11-01 00:00:00');
+VALUES (4283, 'Arcane Death', 2 /* Pierce */, 2000, 500, 37376 /* Arcane Death */, 1, 0, 0, 0, 0, False, 0, 0, 0, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0 /* Undef */, 0 /* Invalid */, 1, 0, 0, 0, 1, '2021-11-01 00:00:00');

--- a/Database/Patches/6 LandBlockExtendedData/654D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/654D.sql
@@ -103,7 +103,7 @@ INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modifi
 VALUES (0x7654D034, 0x7654D06F, '2021-08-12 13:50:19') /* Lever (29592) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D03A, 72523, 0x654D02CF, 140, -140, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Hallway Caster */
+VALUES (0x7654D03A, 72523, 0x654D02CF, 140, -140, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [140.000000 -140.000000 -35.994999] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -582,49 +582,49 @@ VALUES (0x7654D0CD, 72572, 0x654D010A, 162.996, -55.7639, -65.945, 0.707107, 0, 
 /* @teleloc 0x654D010A [162.996002 -55.763901 -65.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0CE, 72582, 0x654D02CF, 140.015, -139, -35.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0CE, 72582, 0x654D02CF, 140.015, -139, -35.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [140.014999 -139.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0CF, 72578, 0x654D02CF, 141.095, -139, -35.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0CF, 72578, 0x654D02CF, 141.095, -139, -35.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [141.095001 -139.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D0, 72578, 0x654D02CF, 138.902, -139, -35.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D0, 72578, 0x654D02CF, 138.902, -139, -35.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [138.901993 -139.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D1, 72584, 0x654D02CF, 141, -139.977, -35.995, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D1, 72584, 0x654D02CF, 141, -139.977, -35.995, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [141.000000 -139.977005 -35.994999] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D2, 72580, 0x654D02CF, 141, -141.115, -35.995, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D2, 72580, 0x654D02CF, 141, -141.115, -35.995, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [141.000000 -141.115005 -35.994999] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D3, 72580, 0x654D02CF, 141, -138.988, -35.995, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D3, 72580, 0x654D02CF, 141, -138.988, -35.995, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [141.000000 -138.988007 -35.994999] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D4, 72583, 0x654D02CF, 140.001, -141, -35.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D4, 72583, 0x654D02CF, 140.001, -141, -35.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [140.001007 -141.000000 -35.994999] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D5, 72579, 0x654D02CF, 141.047, -141, -35.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D5, 72579, 0x654D02CF, 141.047, -141, -35.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [141.046997 -141.000000 -35.994999] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D6, 72579, 0x654D02CF, 138.864, -141, -35.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D6, 72579, 0x654D02CF, 138.864, -141, -35.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [138.863998 -141.000000 -35.994999] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D7, 72585, 0x654D02CF, 139, -139.965, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D7, 72585, 0x654D02CF, 139, -139.965, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [139.000000 -139.964996 -35.994999] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D8, 72581, 0x654D02CF, 139, -141.009, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D8, 72581, 0x654D02CF, 139, -141.009, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [139.000000 -141.009003 -35.994999] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7654D0D9, 72581, 0x654D02CF, 139, -138.99, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Arcane Death */
+VALUES (0x7654D0D9, 72581, 0x654D02CF, 139, -138.99, -35.995, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Hall of Agony */
 /* @teleloc 0x654D02CF [139.000000 -138.990005 -35.994999] 0.707107 0.000000 0.000000 0.707107 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72523 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72523 Hall of Agony.sql
@@ -58,7 +58,7 @@ VALUES (72523,   1,       5) /* HeartbeatInterval */
      , (72523, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72523,   1, 'Hallway Caster') /* Name */
+VALUES (72523,   1, 'Hall of Agony') /* Name */
      , (72523,   3, 'Male') /* Sex */
      , (72523,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72578 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72578 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72578,   1,       5) /* HeartbeatInterval */
      , (72578, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72578,   1, 'Arcane Death') /* Name */
+VALUES (72578,   1, 'Hall of Agony') /* Name */
      , (72578,   3, 'Male') /* Sex */
      , (72578,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72579 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72579 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72579,   1,       5) /* HeartbeatInterval */
      , (72579, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72579,   1, 'Arcane Death') /* Name */
+VALUES (72579,   1, 'Hall of Agony') /* Name */
      , (72579,   3, 'Male') /* Sex */
      , (72579,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72580 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72580 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72580,   1,       5) /* HeartbeatInterval */
      , (72580, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72580,   1, 'Arcane Death') /* Name */
+VALUES (72580,   1, 'Hall of Agony') /* Name */
      , (72580,   3, 'Male') /* Sex */
      , (72580,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72581 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72581 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72581,   1,       5) /* HeartbeatInterval */
      , (72581, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72581,   1, 'Arcane Death') /* Name */
+VALUES (72581,   1, 'Hall of Agony') /* Name */
      , (72581,   3, 'Male') /* Sex */
      , (72581,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72582 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72582 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72582,   1,       5) /* HeartbeatInterval */
      , (72582, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72582,   1, 'Arcane Death') /* Name */
+VALUES (72582,   1, 'Hall of Agony') /* Name */
      , (72582,   3, 'Male') /* Sex */
      , (72582,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72583 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72583 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72583,   1,       5) /* HeartbeatInterval */
      , (72583, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72583,   1, 'Arcane Death') /* Name */
+VALUES (72583,   1, 'Hall of Agony') /* Name */
      , (72583,   3, 'Male') /* Sex */
      , (72583,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72584 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72584 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72584,   1,       5) /* HeartbeatInterval */
      , (72584, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72584,   1, 'Arcane Death') /* Name */
+VALUES (72584,   1, 'Hall of Agony') /* Name */
      , (72584,   3, 'Male') /* Sex */
      , (72584,   4, 'Sho') /* HeritageGroup */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72585 Hall of Agony.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72585 Hall of Agony.sql
@@ -60,7 +60,7 @@ VALUES (72585,   1,       5) /* HeartbeatInterval */
      , (72585, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72585,   1, 'Arcane Death') /* Name */
+VALUES (72585,   1, 'Hall of Agony') /* Name */
      , (72585,   3, 'Male') /* Sex */
      , (72585,   4, 'Sho') /* HeritageGroup */;
 


### PR DESCRIPTION
Increased the damage on the Arcane Death spell used for traps in the Jester, Empyrean Rescue and Hoshino Must Die.

Sample damage numbers on a player with pierce pro 8, legendary pierce ward, and old school aegis equipped:

412, 455, 425, 486, 495, 474, 454, 439, 403, 427

Updated name of Hoshino Must Die traps to Hall of Agony as seen in a retail video.

Updated comments in the dungeon landblock with the traps to match.