### PR TITLE
Update 37083 Sword of Soroku.sql

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/37083 Sword of Soroku.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/37083 Sword of Soroku.sql
@@ -42,7 +42,8 @@ VALUES (37083,   5,  -0.033) /* ManaRate */
      , (37083,  29,     1.1) /* WeaponDefense */
      , (37083,  62,     1.1) /* WeaponOffense */
      , (37083,  63,       1) /* DamageMod */
-     , (37083, 147,    0.31) /* CriticalFrequency */;
+     , (37083, 147,    0.31) /* CriticalFrequency */
+     , (37083, 156,    0.15) /* ProcSpellRate */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37083,   1, 'Sword of Soroku') /* Name */


### PR DESCRIPTION
added missing float value for procspellrate.
made proc spell rate double that of Runed weapons. with a spell that lasts 10 seconds.
only evidence of a higher rate is via the wiki.
http://acpedia.org/wiki/Sword_of_Soroku
runed weapons have a proc rate of 7.5%