### PR TITLE
singularity weapon slayer bonus adjustments

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/27836 Singularity Scepter of Life Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/27836 Singularity Scepter of Life Magic.sql
@@ -37,7 +37,7 @@ VALUES (27836,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (27836,   5,  -0.033) /* ManaRate */
      , (27836,  29,    1.07) /* WeaponDefense */
-     , (27836, 138,     1.4) /* SlayerDamageBonus */
+     , (27836, 138,     1.8) /* SlayerDamageBonus */
      , (27836, 144,    0.07) /* ManaConversionMod */
      , (27836, 147,    0.25) /* CriticalFrequency */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/27837 Bound Singularity Scepter of Life Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/27837 Bound Singularity Scepter of Life Magic.sql
@@ -37,7 +37,7 @@ VALUES (27837,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (27837,   5,  -0.033) /* ManaRate */
      , (27837,  29,    1.07) /* WeaponDefense */
-     , (27837, 138,     1.4) /* SlayerDamageBonus */
+     , (27837, 138,     1.8) /* SlayerDamageBonus */
      , (27837, 144,    0.07) /* ManaConversionMod */
      , (27837, 147,    0.25) /* CriticalFrequency */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/27838 Ultimate Singularity Scepter of Life Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/27838 Ultimate Singularity Scepter of Life Magic.sql
@@ -38,7 +38,7 @@ VALUES (27838,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (27838,   5,  -0.033) /* ManaRate */
      , (27838,  29,    1.08) /* WeaponDefense */
-     , (27838, 138,     1.4) /* SlayerDamageBonus */
+     , (27838, 138,     1.8) /* SlayerDamageBonus */
      , (27838, 144,    0.07) /* ManaConversionMod */
      , (27838, 147,     0.3) /* CriticalFrequency */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/27839 Ultimate Singularity Scepter of War Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/27839 Ultimate Singularity Scepter of War Magic.sql
@@ -38,7 +38,7 @@ VALUES (27839,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (27839,   5,  -0.033) /* ManaRate */
      , (27839,  29,    1.08) /* WeaponDefense */
-     , (27839, 138,     1.4) /* SlayerDamageBonus */
+     , (27839, 138,     1.8) /* SlayerDamageBonus */
      , (27839, 144,    0.07) /* ManaConversionMod */
      , (27839, 147,     0.3) /* CriticalFrequency */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/27840 Singularity Scepter of War Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/27840 Singularity Scepter of War Magic.sql
@@ -37,7 +37,7 @@ VALUES (27840,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (27840,   5,  -0.033) /* ManaRate */
      , (27840,  29,    1.07) /* WeaponDefense */
-     , (27840, 138,     1.4) /* SlayerDamageBonus */
+     , (27840, 138,     1.8) /* SlayerDamageBonus */
      , (27840, 144,    0.07) /* ManaConversionMod */
      , (27840, 147,    0.25) /* CriticalFrequency */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/27841 Bound Singularity Scepter of War Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/27841 Bound Singularity Scepter of War Magic.sql
@@ -37,7 +37,7 @@ VALUES (27841,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (27841,   5,  -0.033) /* ManaRate */
      , (27841,  29,    1.07) /* WeaponDefense */
-     , (27841, 138,     1.4) /* SlayerDamageBonus */
+     , (27841, 138,     1.8) /* SlayerDamageBonus */
      , (27841, 144,    0.07) /* ManaConversionMod */
      , (27841, 147,    0.25) /* CriticalFrequency */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/41885 Ultimate Singularity Scepter of Life Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/41885 Ultimate Singularity Scepter of Life Magic.sql
@@ -39,7 +39,7 @@ VALUES (41885,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (41885,   5,  -0.033) /* ManaRate */
      , (41885,  29,    1.15) /* WeaponDefense */
-     , (41885, 138,       2) /* SlayerDamageBonus */
+     , (41885, 138,     1.8) /* SlayerDamageBonus */
      , (41885, 144,    0.15) /* ManaConversionMod */
      , (41885, 147,     0.3) /* CriticalFrequency */
      , (41885, 152,    1.15) /* ElementalDamageMod */;

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/41886 Ultimate Singularity Scepter of War Magic.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/41886 Ultimate Singularity Scepter of War Magic.sql
@@ -39,7 +39,7 @@ VALUES (41886,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (41886,   5,  -0.033) /* ManaRate */
      , (41886,  29,    1.15) /* WeaponDefense */
-     , (41886, 138,       2) /* SlayerDamageBonus */
+     , (41886, 138,     1.8) /* SlayerDamageBonus */
      , (41886, 144,    0.15) /* ManaConversionMod */
      , (41886, 147,     0.3) /* CriticalFrequency */
      , (41886, 152,    1.15) /* ElementalDamageMod */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41879 Ultimate Singularity Axe.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41879 Ultimate Singularity Axe.sql
@@ -44,7 +44,7 @@ VALUES (41879,   5,  -0.033) /* ManaRate */
      , (41879,  29,    1.15) /* WeaponDefense */
      , (41879,  62,    1.15) /* WeaponOffense */
      , (41879, 136,     2.5) /* CriticalMultiplier */
-     , (41879, 138,       2) /* SlayerDamageBonus */
+     , (41879, 138,     1.8) /* SlayerDamageBonus */
      , (41879, 147,    0.25) /* CriticalFrequency */
      , (41879, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41882 Ultimate Singularity Dagger.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41882 Ultimate Singularity Dagger.sql
@@ -44,7 +44,7 @@ VALUES (41882,   5,  -0.033) /* ManaRate */
      , (41882,  29,    1.15) /* WeaponDefense */
      , (41882,  62,    1.15) /* WeaponOffense */
      , (41882, 136,     2.5) /* CriticalMultiplier */
-     , (41882, 138,       2) /* SlayerDamageBonus */
+     , (41882, 138,     1.8) /* SlayerDamageBonus */
      , (41882, 147,    0.25) /* CriticalFrequency */
      , (41882, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41883 Ultimate Singularity Katar.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41883 Ultimate Singularity Katar.sql
@@ -44,7 +44,7 @@ VALUES (41883,   5,  -0.033) /* ManaRate */
      , (41883,  29,    1.15) /* WeaponDefense */
      , (41883,  62,    1.15) /* WeaponOffense */
      , (41883, 136,     2.5) /* CriticalMultiplier */
-     , (41883, 138,       2) /* SlayerDamageBonus */
+     , (41883, 138,     1.8) /* SlayerDamageBonus */
      , (41883, 147,    0.25) /* CriticalFrequency */
      , (41883, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41884 Ultimate Singularity Mace.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41884 Ultimate Singularity Mace.sql
@@ -44,7 +44,7 @@ VALUES (41884,   5,  -0.033) /* ManaRate */
      , (41884,  29,    1.15) /* WeaponDefense */
      , (41884,  62,    1.15) /* WeaponOffense */
      , (41884, 136,     2.5) /* CriticalMultiplier */
-     , (41884, 138,       2) /* SlayerDamageBonus */
+     , (41884, 138,     1.8) /* SlayerDamageBonus */
      , (41884, 147,    0.25) /* CriticalFrequency */
      , (41884, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41887 Ultimate Singularity Spear.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41887 Ultimate Singularity Spear.sql
@@ -44,7 +44,7 @@ VALUES (41887,   5,  -0.033) /* ManaRate */
      , (41887,  29,    1.15) /* WeaponDefense */
      , (41887,  62,    1.15) /* WeaponOffense */
      , (41887, 136,     2.5) /* CriticalMultiplier */
-     , (41887, 138,       2) /* SlayerDamageBonus */
+     , (41887, 138,     1.8) /* SlayerDamageBonus */
      , (41887, 147,    0.25) /* CriticalFrequency */
      , (41887, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41888 Ultimate Singularity Staff.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41888 Ultimate Singularity Staff.sql
@@ -47,7 +47,7 @@ VALUES (41888,   5,  -0.033) /* ManaRate */
      , (41888,  39,    0.67) /* DefaultScale */
      , (41888,  62,    1.15) /* WeaponOffense */
      , (41888, 136,     2.5) /* CriticalMultiplier */
-     , (41888, 138,       2) /* SlayerDamageBonus */
+     , (41888, 138,     1.8) /* SlayerDamageBonus */
      , (41888, 147,    0.25) /* CriticalFrequency */
      , (41888, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41889 Ultimate Singularity Sword.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41889 Ultimate Singularity Sword.sql
@@ -47,7 +47,7 @@ VALUES (41889,   5,  -0.033) /* ManaRate */
      , (41889,  39,     1.1) /* DefaultScale */
      , (41889,  62,    1.15) /* WeaponOffense */
      , (41889, 136,     2.5) /* CriticalMultiplier */
-     , (41889, 138,       2) /* SlayerDamageBonus */
+     , (41889, 138,     1.8) /* SlayerDamageBonus */
      , (41889, 147,    0.25) /* CriticalFrequency */
      , (41889, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41890 Ultimate Singularity Greatsword.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/41890 Ultimate Singularity Greatsword.sql
@@ -47,7 +47,7 @@ VALUES (41890,   5,  -0.033) /* ManaRate */
      , (41890,  62,    1.15) /* WeaponOffense */
      , (41890,  63,       1) /* DamageMod */
      , (41890, 136,     2.5) /* CriticalMultiplier */
-     , (41890, 138,       2) /* SlayerDamageBonus */
+     , (41890, 138,     1.8) /* SlayerDamageBonus */
      , (41890, 147,    0.25) /* CriticalFrequency */
      , (41890, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/41880 Ultimate Singularity Bow.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/41880 Ultimate Singularity Bow.sql
@@ -51,7 +51,7 @@ VALUES (41880,   5,  -0.033) /* ManaRate */
      , (41880,  62,       1) /* WeaponOffense */
      , (41880,  63,     2.3) /* DamageMod */
      , (41880, 136,     2.5) /* CriticalMultiplier */
-     , (41880, 138,       2) /* SlayerDamageBonus */
+     , (41880, 138,     1.8) /* SlayerDamageBonus */
      , (41880, 147,    0.25) /* CriticalFrequency */
      , (41880, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/41881 Ultimate Singularity Crossbow.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/41881 Ultimate Singularity Crossbow.sql
@@ -48,7 +48,7 @@ VALUES (41881,   5,  -0.033) /* ManaRate */
      , (41881,  62,       1) /* WeaponOffense */
      , (41881,  63,    2.55) /* DamageMod */
      , (41881, 136,     2.5) /* CriticalMultiplier */
-     , (41881, 138,       2) /* SlayerDamageBonus */
+     , (41881, 138,     1.8) /* SlayerDamageBonus */
      , (41881, 147,    0.25) /* CriticalFrequency */
      , (41881, 155,       1) /* IgnoreArmor */;
 

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/70970 Ultimate Singularity Atlatl.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/70970 Ultimate Singularity Atlatl.sql
@@ -46,7 +46,7 @@ VALUES (70970,   5,  -0.033) /* ManaRate */
      , (70970,  62,       1) /* WeaponOffense */
      , (70970,  63,     2.3) /* DamageMod */
      , (70970, 136,     2.5) /* CriticalMultiplier */
-     , (70970, 138,       2) /* SlayerDamageBonus */
+     , (70970, 138,     1.8) /* SlayerDamageBonus */
      , (70970, 147,    0.25) /* CriticalFrequency */
      , (70970, 155,       1) /* IgnoreArmor */;
 


### PR DESCRIPTION
Well if you look at the sing weapons they are 1.8. Why would a weapon upgrade kit jump the stats plus add extra slayer bonus?
Plus if you look at the slayer bonus on acpedia and compare them to pre tod weapons they match up exactly. Why would you not believe all the other %s are not legit.
41788 had 1.8 slayer bonus already