### PR TITLE
Killer Phyntos Wasp Kill Task Updates

### DIFF
--- a/Database/Patches/8 QuestDefDB/KillTaskPhyntosKiller1109.sql
+++ b/Database/Patches/8 QuestDefDB/KillTaskPhyntosKiller1109.sql
@@ -1,4 +1,4 @@
 DELETE FROM `quest` WHERE `name` = 'KillTaskPhyntosKiller1109';
 
 INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('KillTaskPhyntosKiller1109', 0, 20, 'Phyntos Wasp Kill Task', '2021-11-01 00:00:00');
+VALUES ('KillTaskPhyntosKiller1109', 0, 50, 'Phyntos Wasp Kill Task', '2021-11-01 00:00:00');

--- a/Database/Patches/9 WeenieDefaults/Creature/PhyntosWasp/40308 Giant Jungle Phyntos Wasp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/PhyntosWasp/40308 Giant Jungle Phyntos Wasp.sql
@@ -56,8 +56,7 @@ VALUES (40308,   1,       5) /* HeartbeatInterval */
      , (40308, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (40308,   1, 'Giant Jungle Phyntos Wasp') /* Name */
-     , (40308,  45, 'KillTaskPhyntosKiller1109') /* KillQuest */;
+VALUES (40308,   1, 'Giant Jungle Phyntos Wasp') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (40308,   1, 0x02001121) /* Setup */

--- a/Database/Patches/9 WeenieDefaults/Creature/PhyntosWasp/41799 Killer Phyntos Queen.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/PhyntosWasp/41799 Killer Phyntos Queen.sql
@@ -55,8 +55,7 @@ VALUES (41799,   1,       5) /* HeartbeatInterval */
      , (41799, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (41799,   1, 'Killer Phyntos Queen') /* Name */
-     , (41799,  45, 'KillTaskPhyntosKiller1109') /* KillQuest */;
+VALUES (41799,   1, 'Killer Phyntos Queen') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (41799,   1, 0x02001121) /* Setup */


### PR DESCRIPTION
Updated KT to 50 kills per pcap data:
You have killed 36 Killer Phyntos Swarms! You must kill 50 to complete your task.

Removed KT from Jungle wasp and queen as no evidence to backup they were part of KT.