### PR TITLE
Fix Exquisite Lense Spellcraft to be 220

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/71446 Exquisite Lense.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/71446 Exquisite Lense.sql
@@ -15,7 +15,7 @@ VALUES (71446,   1,      32768) /* ItemType - Caster */
      , (71446,  46,        512) /* DefaultCombatStyle - Magic */
      , (71446,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (71446,  94,         16) /* TargetType - Creature */
-     , (71446, 106,        100) /* ItemSpellcraft */
+     , (71446, 106,        220) /* ItemSpellcraft */
      , (71446, 107,       6000) /* ItemCurMana */
      , (71446, 108,       6000) /* ItemMaxMana */
      , (71446, 117,        100) /* ItemManaCost */


### PR DESCRIPTION
I noticed the spellcraft on the Exquisite Lense (level IV spells) is set to 100.  This appears to be a mistake since it should be 220.  I looked through the other lenses and they all seem to be correct, so I think it's just this one.

See here: http://acpedia.org/wiki/Exquisite_Lense