### PR TITLE
Update 43808 Carefully rolled scroll.sql

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Book/Writable/43808 Carefully rolled scroll.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Writable/43808 Carefully rolled scroll.sql
@@ -21,9 +21,8 @@ VALUES (43808,  54,       1) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (43808,   1, 'Carefully rolled scroll') /* Name */
-     , (43808,  16, 'A carefully rolled scroll, covered in meticulously written Dericostian script.') /* LongDesc */
-     , (43808,  33, 'GregorsCarefullyRolledScrollPickedUp') /* Quest */;
-
+     , (43808,  16, 'A carefully rolled scroll, covered in meticulously written Dericostian script.') /* LongDesc */;
+     
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (43808,   1, 0x02000158) /* Setup */
      , (43808,   3, 0x20000014) /* SoundTable */


### PR DESCRIPTION
removed pickup timer. There was no pickup timer for this scroll in retail. Ran the quest alot. When I picked up the first scroll, go turn in, come back thru and you could pick up another with no timer. Besides why have a timer on the scroll, it does nothing but move you to the next step of the quest, no way to exploit or abuse.