### PR TITLE
Remove Extra Properties on Silifis

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22952 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22952 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22952,   5,   -0.05) /* ManaRate */
      , (22952,  22,     0.5) /* DamageVariance */
      , (22952,  29,    1.12) /* WeaponDefense */
      , (22952,  39,    1.25) /* DefaultScale */
-     , (22952,  62,    1.12) /* WeaponOffense */
-     , (22952, 136,       3) /* CriticalMultiplier */
-     , (22952, 147,     0.2) /* CriticalFrequency */;
+     , (22952,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22952,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22953 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22953 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22953,   5,   -0.05) /* ManaRate */
      , (22953,  22,     0.5) /* DamageVariance */
      , (22953,  29,    1.12) /* WeaponDefense */
      , (22953,  39,    1.25) /* DefaultScale */
-     , (22953,  62,    1.12) /* WeaponOffense */
-     , (22953, 136,       3) /* CriticalMultiplier */
-     , (22953, 147,     0.2) /* CriticalFrequency */;
+     , (22953,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22953,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22954 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22954 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22954,   5,   -0.05) /* ManaRate */
      , (22954,  22,     0.5) /* DamageVariance */
      , (22954,  29,    1.12) /* WeaponDefense */
      , (22954,  39,    1.25) /* DefaultScale */
-     , (22954,  62,    1.12) /* WeaponOffense */
-     , (22954, 136,       3) /* CriticalMultiplier */
-     , (22954, 147,     0.2) /* CriticalFrequency */;
+     , (22954,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22954,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22955 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22955 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22955,   5,   -0.05) /* ManaRate */
      , (22955,  22,     0.5) /* DamageVariance */
      , (22955,  29,    1.12) /* WeaponDefense */
      , (22955,  39,    1.25) /* DefaultScale */
-     , (22955,  62,    1.12) /* WeaponOffense */
-     , (22955, 136,       3) /* CriticalMultiplier */
-     , (22955, 147,     0.2) /* CriticalFrequency */;
+     , (22955,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22955,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22956 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22956 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22956,   5,   -0.05) /* ManaRate */
      , (22956,  22,     0.5) /* DamageVariance */
      , (22956,  29,    1.12) /* WeaponDefense */
      , (22956,  39,    1.25) /* DefaultScale */
-     , (22956,  62,    1.12) /* WeaponOffense */
-     , (22956, 136,       3) /* CriticalMultiplier */
-     , (22956, 147,     0.2) /* CriticalFrequency */;
+     , (22956,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22956,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22957 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22957 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22957,   5,   -0.05) /* ManaRate */
      , (22957,  22,     0.5) /* DamageVariance */
      , (22957,  29,    1.12) /* WeaponDefense */
      , (22957,  39,    1.25) /* DefaultScale */
-     , (22957,  62,    1.12) /* WeaponOffense */
-     , (22957, 136,       3) /* CriticalMultiplier */
-     , (22957, 147,     0.2) /* CriticalFrequency */;
+     , (22957,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22957,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22958 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22958 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22958,   5,   -0.05) /* ManaRate */
      , (22958,  22,     0.5) /* DamageVariance */
      , (22958,  29,    1.12) /* WeaponDefense */
      , (22958,  39,    1.25) /* DefaultScale */
-     , (22958,  62,    1.12) /* WeaponOffense */
-     , (22958, 136,       3) /* CriticalMultiplier */
-     , (22958, 147,     0.2) /* CriticalFrequency */;
+     , (22958,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22958,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22959 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22959 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22959,   5,   -0.05) /* ManaRate */
      , (22959,  22,     0.5) /* DamageVariance */
      , (22959,  29,    1.12) /* WeaponDefense */
      , (22959,  39,    1.25) /* DefaultScale */
-     , (22959,  62,    1.12) /* WeaponOffense */
-     , (22959, 136,       3) /* CriticalMultiplier */
-     , (22959, 147,     0.2) /* CriticalFrequency */;
+     , (22959,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22959,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22960 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22960 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22960,   5,   -0.05) /* ManaRate */
      , (22960,  22,     0.5) /* DamageVariance */
      , (22960,  29,    1.12) /* WeaponDefense */
      , (22960,  39,    1.25) /* DefaultScale */
-     , (22960,  62,    1.12) /* WeaponOffense */
-     , (22960, 136,       3) /* CriticalMultiplier */
-     , (22960, 147,     0.2) /* CriticalFrequency */;
+     , (22960,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22960,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22961 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22961 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22961,   5,   -0.05) /* ManaRate */
      , (22961,  22,     0.5) /* DamageVariance */
      , (22961,  29,    1.12) /* WeaponDefense */
      , (22961,  39,    1.25) /* DefaultScale */
-     , (22961,  62,    1.12) /* WeaponOffense */
-     , (22961, 136,       3) /* CriticalMultiplier */
-     , (22961, 147,     0.2) /* CriticalFrequency */;
+     , (22961,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22961,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22962 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22962 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22962,   5,   -0.05) /* ManaRate */
      , (22962,  22,     0.5) /* DamageVariance */
      , (22962,  29,    1.12) /* WeaponDefense */
      , (22962,  39,    1.25) /* DefaultScale */
-     , (22962,  62,    1.12) /* WeaponOffense */
-     , (22962, 136,       3) /* CriticalMultiplier */
-     , (22962, 147,     0.2) /* CriticalFrequency */;
+     , (22962,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22962,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22963 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22963 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22963,   5,   -0.05) /* ManaRate */
      , (22963,  22,     0.5) /* DamageVariance */
      , (22963,  29,    1.12) /* WeaponDefense */
      , (22963,  39,    1.25) /* DefaultScale */
-     , (22963,  62,    1.12) /* WeaponOffense */
-     , (22963, 136,       3) /* CriticalMultiplier */
-     , (22963, 147,     0.2) /* CriticalFrequency */;
+     , (22963,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22963,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22964 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22964 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22964,   5,   -0.05) /* ManaRate */
      , (22964,  22,     0.5) /* DamageVariance */
      , (22964,  29,    1.12) /* WeaponDefense */
      , (22964,  39,    1.25) /* DefaultScale */
-     , (22964,  62,    1.12) /* WeaponOffense */
-     , (22964, 136,       3) /* CriticalMultiplier */
-     , (22964, 147,     0.2) /* CriticalFrequency */;
+     , (22964,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22964,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22965 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22965 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22965,   5,   -0.05) /* ManaRate */
      , (22965,  22,     0.5) /* DamageVariance */
      , (22965,  29,    1.12) /* WeaponDefense */
      , (22965,  39,    1.25) /* DefaultScale */
-     , (22965,  62,    1.12) /* WeaponOffense */
-     , (22965, 136,       3) /* CriticalMultiplier */
-     , (22965, 147,     0.2) /* CriticalFrequency */;
+     , (22965,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22965,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22966 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22966 Silifi of Crimson Stars.sql
@@ -42,9 +42,7 @@ VALUES (22966,   5,   -0.05) /* ManaRate */
      , (22966,  22,     0.5) /* DamageVariance */
      , (22966,  29,    1.12) /* WeaponDefense */
      , (22966,  39,    1.25) /* DefaultScale */
-     , (22966,  62,    1.12) /* WeaponOffense */
-     , (22966, 136,       3) /* CriticalMultiplier */
-     , (22966, 147,     0.2) /* CriticalFrequency */;
+     , (22966,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22966,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22967 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22967 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22967,   5,   -0.05) /* ManaRate */
      , (22967,  22,     0.5) /* DamageVariance */
      , (22967,  29,    1.12) /* WeaponDefense */
      , (22967,  39,    1.25) /* DefaultScale */
-     , (22967,  62,    1.12) /* WeaponOffense */
-     , (22967, 136,       3) /* CriticalMultiplier */
-     , (22967, 147,     0.2) /* CriticalFrequency */;
+     , (22967,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22967,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22968 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22968 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22968,   5,   -0.05) /* ManaRate */
      , (22968,  22,     0.5) /* DamageVariance */
      , (22968,  29,    1.12) /* WeaponDefense */
      , (22968,  39,    1.25) /* DefaultScale */
-     , (22968,  62,    1.12) /* WeaponOffense */
-     , (22968, 136,       3) /* CriticalMultiplier */
-     , (22968, 147,     0.2) /* CriticalFrequency */;
+     , (22968,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22968,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22969 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22969 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22969,   5,   -0.05) /* ManaRate */
      , (22969,  22,     0.5) /* DamageVariance */
      , (22969,  29,    1.12) /* WeaponDefense */
      , (22969,  39,    1.25) /* DefaultScale */
-     , (22969,  62,    1.12) /* WeaponOffense */
-     , (22969, 136,       3) /* CriticalMultiplier */
-     , (22969, 147,     0.2) /* CriticalFrequency */;
+     , (22969,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22969,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22970 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22970 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22970,   5,   -0.05) /* ManaRate */
      , (22970,  22,     0.5) /* DamageVariance */
      , (22970,  29,    1.12) /* WeaponDefense */
      , (22970,  39,    1.25) /* DefaultScale */
-     , (22970,  62,    1.12) /* WeaponOffense */
-     , (22970, 136,       3) /* CriticalMultiplier */
-     , (22970, 147,     0.2) /* CriticalFrequency */;
+     , (22970,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22970,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22971 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22971 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22971,   5,   -0.05) /* ManaRate */
      , (22971,  22,     0.5) /* DamageVariance */
      , (22971,  29,    1.12) /* WeaponDefense */
      , (22971,  39,    1.25) /* DefaultScale */
-     , (22971,  62,    1.12) /* WeaponOffense */
-     , (22971, 136,       3) /* CriticalMultiplier */
-     , (22971, 147,     0.2) /* CriticalFrequency */;
+     , (22971,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22971,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22972 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22972 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22972,   5,   -0.05) /* ManaRate */
      , (22972,  22,     0.5) /* DamageVariance */
      , (22972,  29,    1.12) /* WeaponDefense */
      , (22972,  39,    1.25) /* DefaultScale */
-     , (22972,  62,    1.12) /* WeaponOffense */
-     , (22972, 136,       3) /* CriticalMultiplier */
-     , (22972, 147,     0.2) /* CriticalFrequency */;
+     , (22972,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22972,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22973 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22973 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22973,   5,   -0.05) /* ManaRate */
      , (22973,  22,     0.5) /* DamageVariance */
      , (22973,  29,    1.12) /* WeaponDefense */
      , (22973,  39,    1.25) /* DefaultScale */
-     , (22973,  62,    1.12) /* WeaponOffense */
-     , (22973, 136,       3) /* CriticalMultiplier */
-     , (22973, 147,     0.2) /* CriticalFrequency */;
+     , (22973,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22973,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22974 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22974 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22974,   5,   -0.05) /* ManaRate */
      , (22974,  22,     0.5) /* DamageVariance */
      , (22974,  29,    1.12) /* WeaponDefense */
      , (22974,  39,    1.25) /* DefaultScale */
-     , (22974,  62,    1.12) /* WeaponOffense */
-     , (22974, 136,       3) /* CriticalMultiplier */
-     , (22974, 147,     0.2) /* CriticalFrequency */;
+     , (22974,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22974,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22975 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22975 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22975,   5,   -0.05) /* ManaRate */
      , (22975,  22,     0.5) /* DamageVariance */
      , (22975,  29,    1.12) /* WeaponDefense */
      , (22975,  39,    1.25) /* DefaultScale */
-     , (22975,  62,    1.12) /* WeaponOffense */
-     , (22975, 136,       3) /* CriticalMultiplier */
-     , (22975, 147,     0.2) /* CriticalFrequency */;
+     , (22975,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22975,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22976 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22976 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (22976,   5,   -0.05) /* ManaRate */
      , (22976,  22,     0.5) /* DamageVariance */
      , (22976,  29,    1.12) /* WeaponDefense */
      , (22976,  39,    1.25) /* DefaultScale */
-     , (22976,  62,    1.12) /* WeaponOffense */
-     , (22976, 136,       3) /* CriticalMultiplier */
-     , (22976, 147,     0.2) /* CriticalFrequency */;
+     , (22976,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22976,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22977 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/22977 Silifi of Crimson Stars.sql
@@ -37,9 +37,7 @@ VALUES (22977,  21,    0.95) /* WeaponLength */
      , (22977,  22,     0.5) /* DamageVariance */
      , (22977,  29,    1.12) /* WeaponDefense */
      , (22977,  39,    1.25) /* DefaultScale */
-     , (22977,  62,    1.12) /* WeaponOffense */
-     , (22977, 136,       3) /* CriticalMultiplier */
-     , (22977, 147,     0.2) /* CriticalFrequency */;
+     , (22977,  62,    1.12) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (22977,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23004 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23004 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23004,   5,   -0.05) /* ManaRate */
      , (23004,  22,     0.5) /* DamageVariance */
      , (23004,  29,    1.15) /* WeaponDefense */
      , (23004,  39,    1.25) /* DefaultScale */
-     , (23004,  62,    1.15) /* WeaponOffense */
-     , (23004, 136,       3) /* CriticalMultiplier */
-     , (23004, 147,     0.2) /* CriticalFrequency */;
+     , (23004,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23004,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23005 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23005 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23005,   5,   -0.05) /* ManaRate */
      , (23005,  22,     0.5) /* DamageVariance */
      , (23005,  29,    1.15) /* WeaponDefense */
      , (23005,  39,    1.25) /* DefaultScale */
-     , (23005,  62,    1.15) /* WeaponOffense */
-     , (23005, 136,       3) /* CriticalMultiplier */
-     , (23005, 147,     0.2) /* CriticalFrequency */;
+     , (23005,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23005,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23006 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23006 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23006,   5,   -0.05) /* ManaRate */
      , (23006,  22,     0.5) /* DamageVariance */
      , (23006,  29,    1.15) /* WeaponDefense */
      , (23006,  39,    1.25) /* DefaultScale */
-     , (23006,  62,    1.15) /* WeaponOffense */
-     , (23006, 136,       3) /* CriticalMultiplier */
-     , (23006, 147,     0.2) /* CriticalFrequency */;
+     , (23006,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23006,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23007 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23007 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23007,   5,   -0.05) /* ManaRate */
      , (23007,  22,     0.5) /* DamageVariance */
      , (23007,  29,    1.15) /* WeaponDefense */
      , (23007,  39,    1.25) /* DefaultScale */
-     , (23007,  62,    1.15) /* WeaponOffense */
-     , (23007, 136,       3) /* CriticalMultiplier */
-     , (23007, 147,     0.2) /* CriticalFrequency */;
+     , (23007,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23007,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23008 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23008 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23008,   5,   -0.05) /* ManaRate */
      , (23008,  22,     0.5) /* DamageVariance */
      , (23008,  29,    1.15) /* WeaponDefense */
      , (23008,  39,    1.25) /* DefaultScale */
-     , (23008,  62,    1.15) /* WeaponOffense */
-     , (23008, 136,       3) /* CriticalMultiplier */
-     , (23008, 147,     0.2) /* CriticalFrequency */;
+     , (23008,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23008,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23009 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23009 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23009,   5,   -0.05) /* ManaRate */
      , (23009,  22,     0.5) /* DamageVariance */
      , (23009,  29,    1.15) /* WeaponDefense */
      , (23009,  39,    1.25) /* DefaultScale */
-     , (23009,  62,    1.15) /* WeaponOffense */
-     , (23009, 136,       3) /* CriticalMultiplier */
-     , (23009, 147,     0.2) /* CriticalFrequency */;
+     , (23009,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23009,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23010 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23010 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23010,   5,   -0.05) /* ManaRate */
      , (23010,  22,     0.5) /* DamageVariance */
      , (23010,  29,    1.15) /* WeaponDefense */
      , (23010,  39,    1.25) /* DefaultScale */
-     , (23010,  62,    1.15) /* WeaponOffense */
-     , (23010, 136,       3) /* CriticalMultiplier */
-     , (23010, 147,     0.2) /* CriticalFrequency */;
+     , (23010,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23010,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23011 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23011 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23011,   5,   -0.05) /* ManaRate */
      , (23011,  22,     0.5) /* DamageVariance */
      , (23011,  29,    1.15) /* WeaponDefense */
      , (23011,  39,    1.25) /* DefaultScale */
-     , (23011,  62,    1.15) /* WeaponOffense */
-     , (23011, 136,       3) /* CriticalMultiplier */
-     , (23011, 147,     0.2) /* CriticalFrequency */;
+     , (23011,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23011,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23012 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23012 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23012,   5,   -0.05) /* ManaRate */
      , (23012,  22,     0.5) /* DamageVariance */
      , (23012,  29,    1.15) /* WeaponDefense */
      , (23012,  39,    1.25) /* DefaultScale */
-     , (23012,  62,    1.15) /* WeaponOffense */
-     , (23012, 136,       3) /* CriticalMultiplier */
-     , (23012, 147,     0.2) /* CriticalFrequency */;
+     , (23012,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23012,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23013 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23013 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23013,   5,   -0.05) /* ManaRate */
      , (23013,  22,     0.5) /* DamageVariance */
      , (23013,  29,    1.15) /* WeaponDefense */
      , (23013,  39,    1.25) /* DefaultScale */
-     , (23013,  62,    1.15) /* WeaponOffense */
-     , (23013, 136,       3) /* CriticalMultiplier */
-     , (23013, 147,     0.2) /* CriticalFrequency */;
+     , (23013,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23013,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23014 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23014 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23014,   5,   -0.05) /* ManaRate */
      , (23014,  22,     0.5) /* DamageVariance */
      , (23014,  29,    1.15) /* WeaponDefense */
      , (23014,  39,    1.25) /* DefaultScale */
-     , (23014,  62,    1.15) /* WeaponOffense */
-     , (23014, 136,       3) /* CriticalMultiplier */
-     , (23014, 147,     0.2) /* CriticalFrequency */;
+     , (23014,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23014,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23015 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23015 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23015,   5,   -0.05) /* ManaRate */
      , (23015,  22,     0.5) /* DamageVariance */
      , (23015,  29,    1.15) /* WeaponDefense */
      , (23015,  39,    1.25) /* DefaultScale */
-     , (23015,  62,    1.15) /* WeaponOffense */
-     , (23015, 136,       3) /* CriticalMultiplier */
-     , (23015, 147,     0.2) /* CriticalFrequency */;
+     , (23015,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23015,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23016 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23016 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23016,   5,   -0.05) /* ManaRate */
      , (23016,  22,     0.5) /* DamageVariance */
      , (23016,  29,    1.15) /* WeaponDefense */
      , (23016,  39,    1.25) /* DefaultScale */
-     , (23016,  62,    1.15) /* WeaponOffense */
-     , (23016, 136,       3) /* CriticalMultiplier */
-     , (23016, 147,     0.2) /* CriticalFrequency */;
+     , (23016,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23016,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23017 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23017 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23017,   5,   -0.05) /* ManaRate */
      , (23017,  22,     0.5) /* DamageVariance */
      , (23017,  29,    1.15) /* WeaponDefense */
      , (23017,  39,    1.25) /* DefaultScale */
-     , (23017,  62,    1.15) /* WeaponOffense */
-     , (23017, 136,       3) /* CriticalMultiplier */
-     , (23017, 147,     0.2) /* CriticalFrequency */;
+     , (23017,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23017,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23018 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23018 Silifi of Crimson Stars.sql
@@ -43,9 +43,7 @@ VALUES (23018,   5,   -0.05) /* ManaRate */
      , (23018,  22,     0.5) /* DamageVariance */
      , (23018,  29,    1.15) /* WeaponDefense */
      , (23018,  39,    1.25) /* DefaultScale */
-     , (23018,  62,    1.15) /* WeaponOffense */
-     , (23018, 136,       3) /* CriticalMultiplier */
-     , (23018, 147,     0.2) /* CriticalFrequency */;
+     , (23018,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23018,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23019 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23019 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23019,   5,   -0.05) /* ManaRate */
      , (23019,  22,     0.5) /* DamageVariance */
      , (23019,  29,    1.15) /* WeaponDefense */
      , (23019,  39,    1.25) /* DefaultScale */
-     , (23019,  62,    1.15) /* WeaponOffense */
-     , (23019, 136,       3) /* CriticalMultiplier */
-     , (23019, 147,     0.2) /* CriticalFrequency */;
+     , (23019,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23019,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23020 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23020 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23020,   5,   -0.05) /* ManaRate */
      , (23020,  22,     0.5) /* DamageVariance */
      , (23020,  29,    1.15) /* WeaponDefense */
      , (23020,  39,    1.25) /* DefaultScale */
-     , (23020,  62,    1.15) /* WeaponOffense */
-     , (23020, 136,       3) /* CriticalMultiplier */
-     , (23020, 147,     0.2) /* CriticalFrequency */;
+     , (23020,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23020,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23021 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23021 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23021,   5,   -0.05) /* ManaRate */
      , (23021,  22,     0.5) /* DamageVariance */
      , (23021,  29,    1.15) /* WeaponDefense */
      , (23021,  39,    1.25) /* DefaultScale */
-     , (23021,  62,    1.15) /* WeaponOffense */
-     , (23021, 136,       3) /* CriticalMultiplier */
-     , (23021, 147,     0.2) /* CriticalFrequency */;
+     , (23021,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23021,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23022 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23022 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23022,   5,   -0.05) /* ManaRate */
      , (23022,  22,     0.5) /* DamageVariance */
      , (23022,  29,    1.15) /* WeaponDefense */
      , (23022,  39,    1.25) /* DefaultScale */
-     , (23022,  62,    1.15) /* WeaponOffense */
-     , (23022, 136,       3) /* CriticalMultiplier */
-     , (23022, 147,     0.2) /* CriticalFrequency */;
+     , (23022,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23022,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23023 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23023 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23023,   5,   -0.05) /* ManaRate */
      , (23023,  22,     0.5) /* DamageVariance */
      , (23023,  29,    1.15) /* WeaponDefense */
      , (23023,  39,    1.25) /* DefaultScale */
-     , (23023,  62,    1.15) /* WeaponOffense */
-     , (23023, 136,       3) /* CriticalMultiplier */
-     , (23023, 147,     0.2) /* CriticalFrequency */;
+     , (23023,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23023,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23024 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23024 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23024,   5,   -0.05) /* ManaRate */
      , (23024,  22,     0.5) /* DamageVariance */
      , (23024,  29,    1.15) /* WeaponDefense */
      , (23024,  39,    1.25) /* DefaultScale */
-     , (23024,  62,    1.15) /* WeaponOffense */
-     , (23024, 136,       3) /* CriticalMultiplier */
-     , (23024, 147,     0.2) /* CriticalFrequency */;
+     , (23024,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23024,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23025 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23025 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23025,   5,   -0.05) /* ManaRate */
      , (23025,  22,     0.5) /* DamageVariance */
      , (23025,  29,    1.15) /* WeaponDefense */
      , (23025,  39,    1.25) /* DefaultScale */
-     , (23025,  62,    1.15) /* WeaponOffense */
-     , (23025, 136,       3) /* CriticalMultiplier */
-     , (23025, 147,     0.2) /* CriticalFrequency */;
+     , (23025,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23025,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23026 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23026 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23026,   5,   -0.05) /* ManaRate */
      , (23026,  22,     0.5) /* DamageVariance */
      , (23026,  29,    1.15) /* WeaponDefense */
      , (23026,  39,    1.25) /* DefaultScale */
-     , (23026,  62,    1.15) /* WeaponOffense */
-     , (23026, 136,       3) /* CriticalMultiplier */
-     , (23026, 147,     0.2) /* CriticalFrequency */;
+     , (23026,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23026,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23027 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23027 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23027,   5,   -0.05) /* ManaRate */
      , (23027,  22,     0.5) /* DamageVariance */
      , (23027,  29,    1.15) /* WeaponDefense */
      , (23027,  39,    1.25) /* DefaultScale */
-     , (23027,  62,    1.15) /* WeaponOffense */
-     , (23027, 136,       3) /* CriticalMultiplier */
-     , (23027, 147,     0.2) /* CriticalFrequency */;
+     , (23027,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23027,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23028 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23028 Silifi of Crimson Stars.sql
@@ -45,9 +45,7 @@ VALUES (23028,   5,   -0.05) /* ManaRate */
      , (23028,  22,     0.5) /* DamageVariance */
      , (23028,  29,    1.15) /* WeaponDefense */
      , (23028,  39,    1.25) /* DefaultScale */
-     , (23028,  62,    1.15) /* WeaponOffense */
-     , (23028, 136,       3) /* CriticalMultiplier */
-     , (23028, 147,     0.2) /* CriticalFrequency */;
+     , (23028,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23028,   1, 'Silifi of Crimson Stars') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23029 Silifi of Crimson Stars.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/23029 Silifi of Crimson Stars.sql
@@ -38,9 +38,7 @@ VALUES (23029,  21,    0.95) /* WeaponLength */
      , (23029,  22,     0.5) /* DamageVariance */
      , (23029,  29,    1.15) /* WeaponDefense */
      , (23029,  39,    1.25) /* DefaultScale */
-     , (23029,  62,    1.15) /* WeaponOffense */
-     , (23029, 136,       3) /* CriticalMultiplier */
-     , (23029, 147,     0.2) /* CriticalFrequency */;
+     , (23029,  62,    1.15) /* WeaponOffense */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (23029,   1, 'Silifi of Crimson Stars') /* Name */


### PR DESCRIPTION
- Remove CriticalMultiplier and CriticalFrequency that were mistakenly added to some of the Silifi of Crimson Stars, as the former is added with the Crimson Night gem and the latter was pre-MoA