### PR TITLE
scrying rod increase lifespan timer

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/44125 Scrying Rod.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/44125 Scrying Rod.sql
@@ -17,7 +17,7 @@ VALUES (44125,   1,       2048) /* ItemType - Gem */
      , (44125,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (44125,  94,         16) /* TargetType - Creature */
      , (44125, 114,          1) /* Attuned - Attuned */
-     , (44125, 267,       5400) /* Lifespan */
+     , (44125, 267,       7200) /* Lifespan */
      , (44125, 280,        500) /* SharedCooldown */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/44126 Scrying Rod.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/44126 Scrying Rod.sql
@@ -17,7 +17,7 @@ VALUES (44126,   1,       2048) /* ItemType - Gem */
      , (44126,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (44126,  94,         16) /* TargetType - Creature */
      , (44126, 114,          1) /* Attuned - Attuned */
-     , (44126, 267,       5400) /* Lifespan */
+     , (44126, 267,       7200) /* Lifespan */
      , (44126, 280,        500) /* SharedCooldown */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/44128 Scrying Rod.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/44128 Scrying Rod.sql
@@ -17,7 +17,7 @@ VALUES (44128,   1,       2048) /* ItemType - Gem */
      , (44128,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (44128,  94,         16) /* TargetType - Creature */
      , (44128, 114,          1) /* Attuned - Attuned */
-     , (44128, 267,       5400) /* Lifespan */
+     , (44128, 267,       7200) /* Lifespan */
      , (44128, 280,        500) /* SharedCooldown */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/71395 Scrying Rod.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/71395 Scrying Rod.sql
@@ -17,7 +17,7 @@ VALUES (71395,   1,       2048) /* ItemType - Gem */
      , (71395,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (71395,  94,         16) /* TargetType - Creature */
      , (71395, 114,          1) /* Attuned - Attuned */
-     , (71395, 267,       5400) /* Lifespan */
+     , (71395, 267,       7200) /* Lifespan */
      , (71395, 280,        500) /* SharedCooldown */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)


### PR DESCRIPTION
increased lifespan from 90 min to 2 hrs per wiki

https://asheron.fandom.com/wiki/Scrying_Rod