### PR TITLE
Viridian Rise Spawn Revision

### DIFF
--- a/Database/Patches/1 RegionDescExtendedData/B448.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B448.sql
@@ -1,6 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB448;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB448, 70847, 6, 5, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB448, 70847, 5, 6, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB448, 70847, 7, 7, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B449.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B449.sql
@@ -1,7 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB449;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB449, 70846, 1, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB449, 70847, 6, 0, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB449, 70847, 6, 3, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB449, 70847, 4, 1, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B44B.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B44B.sql
@@ -1,12 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB44B;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB44B, 70846, 0, 1, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 3, 0, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 5, 1, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 6, 4, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 5, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 7, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 1, 4, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 3, 3, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB44B, 70846, 2, 6, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B548.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B548.sql
@@ -1,8 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB548;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB548, 70847, 6, 7, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB548, 70847, 4, 6, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB548, 70847, 6, 4, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB548, 70847, 2, 3, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB548, 70847, 1, 6, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B549.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B549.sql
@@ -1,7 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB549;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB549, 70847, 4, 3, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB549, 70847, 1, 3, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB549, 70847, 2, 0, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB549, 70847, 6, 2, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B54A.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B54A.sql
@@ -1,0 +1,1 @@
+DELETE FROM `encounter` WHERE `landblock` = 0xB54A;

--- a/Database/Patches/1 RegionDescExtendedData/B54B.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B54B.sql
@@ -1,12 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB54B;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB54B, 70846, 1, 3, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 1, 5, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 1, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 2, 4, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 4, 4, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 7, 2, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 6, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 3, 6, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB54B, 70846, 6, 5, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B648.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B648.sql
@@ -1,6 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB648;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB648, 70847, 3, 6, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB648, 70847, 1, 7, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB648, 70847, 0, 4, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B649.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B649.sql
@@ -1,12 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB649;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB649, 70847, 6, 0, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 4, 1, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 0, 1, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 1, 4, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 1, 5, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 1, 6, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 5, 6, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 7, 7, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */
-     , (0xB649, 70847, 3, 4, '2021-11-01 00:00:00') /* Viridian Inner Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B64A.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B64A.sql
@@ -1,9 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB64A;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB64A, 70846, 6, 4, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64A, 70846, 5, 2, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64A, 70846, 3, 1, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64A, 70846, 2, 0, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64A, 70846, 6, 6, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64A, 70846, 6, 0, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/B64B.sql
+++ b/Database/Patches/1 RegionDescExtendedData/B64B.sql
@@ -1,8 +1,1 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xB64B;
-
-INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xB64B, 70846, 1, 6, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64B, 70846, 2, 6, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64B, 70846, 1, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64B, 70846, 4, 7, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */
-     , (0xB64B, 70846, 5, 0, '2021-11-01 00:00:00') /* Viridian Outer Camp Gen */;

--- a/Database/Patches/6 LandBlockExtendedData/B34A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B34A.sql
@@ -30,3 +30,31 @@ VALUES (0x7B34A004, 53035, 0xB34A0025, 107, 109.3, 112.6, 0.382683, 0, 0, -0.923
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B34A005, 53036, 0xB34A0030, 128.4, 183, 111.5, 0.382683, 0, 0, -0.92388,  True, '2021-11-01 00:00:00'); /* Ancient Statue of the Viridian Rise */
 /* @teleloc 0xB34A0030 [128.399994 183.000000 111.500000] 0.382683 0.000000 0.000000 -0.923880 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A006, 70851, 0xB34A0039, 168.006, 0.561971, 116.055, -0.999894, 0, 0, -0.014582, False, '2022-06-07 15:59:48'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A0039 [168.005997 0.561971 116.055000] -0.999894 0.000000 0.000000 -0.014582 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A007, 70851, 0xB34A002B, 124.182, 71.1517, 116.055, 0.993515, 0, 0, -0.113701, False, '2022-06-07 16:02:49'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A002B [124.181999 71.151703 116.055000] 0.993515 0.000000 0.000000 -0.113701 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A008, 70851, 0xB34A0036, 146.676, 141.651, 116.055, 0.994865, 0, 0, -0.101213, False, '2022-06-07 16:03:14'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A0036 [146.675995 141.651001 116.055000] 0.994865 0.000000 0.000000 -0.101213 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A009, 70851, 0xB34A0034, 152.384, 94.8879, 116.055, -0.067387, 0, 0, -0.997727, False, '2022-06-08 13:26:29'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A0034 [152.384003 94.887901 116.055000] -0.067387 0.000000 0.000000 -0.997727 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A00A, 70851, 0xB34A003B, 175.079, 60.2712, 116.645, -0.358158, 0, 0, -0.933661, False, '2022-06-08 14:59:12'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A003B [175.078995 60.271198 116.644997] -0.358158 0.000000 0.000000 -0.933661 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A00B, 70851, 0xB34A002A, 138.448, 33.966, 116.055, -0.397292, 0, 0, 0.917692, False, '2022-06-08 15:05:57'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A002A [138.447998 33.966000 116.055000] -0.397292 0.000000 0.000000 0.917692 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B34A00C, 70851, 0xB34A0038, 155.0261, 172.177, 111.7069, -0.445662, 0, 0, 0.895202, False, '2022-06-08 15:07:25'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB34A0038 [155.026093 172.177002 111.706902] -0.445662 0.000000 0.000000 0.895202 */

--- a/Database/Patches/6 LandBlockExtendedData/B448.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B448.sql
@@ -1,0 +1,21 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB448;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B448000, 70847, 0xB4480036, 154.915, 141.032, 112.055, 0.941203, 0, 0, 0.337841, False, '2022-06-07 16:55:33'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB4480036 [154.914993 141.031998 112.055000] 0.941203 0.000000 0.000000 0.337841 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B448001, 70847, 0xB448002F, 121.294, 145.755, 112.055, 0.840462, 0, 0, -0.54187, False, '2022-06-07 16:55:44'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB448002F [121.293999 145.755005 112.055000] 0.840462 0.000000 0.000000 -0.541870 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B448002, 70847, 0xB4480038, 167.2, 169.899, 116.055, 0.999832, 0, 0, -0.018352, False, '2022-06-07 16:55:54'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB4480038 [167.199997 169.899002 116.055000] 0.999832 0.000000 0.000000 -0.018352 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B448003, 70847, 0xB448001F, 90.6199, 166.386, 111.921, -0.940038, 0, 0, 0.341069, False, '2022-06-07 16:56:47'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB448001F [90.619904 166.386002 111.920998] -0.940038 0.000000 0.000000 0.341069 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B448004, 70847, 0xB4480020, 72.18738, 176.228, 112.055, -0.726418, 0, 0, 0.687253, False, '2022-06-07 16:57:31'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB4480020 [72.187378 176.227997 112.055000] -0.726418 0.000000 0.000000 0.687253 */

--- a/Database/Patches/6 LandBlockExtendedData/B449.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B449.sql
@@ -17,16 +17,8 @@ VALUES (0x7B449135, 53375, 0xB4490002, 9.55664, 34.861, 10.3081, 0.803579, 0, 0,
 /* @teleloc 0xB4490002 [9.556640 34.861000 10.308100] 0.803579 0.000000 0.000000 -0.595198 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B449136, 53375, 0xB4490013, 57.2472, 56.9894, 9.982, 0.36322, 0, 0, 0.931703,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB4490013 [57.247200 56.989399 9.982000] 0.363220 0.000000 0.000000 0.931703 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44913B, 53375, 0xB449003F, 176.594, 154.136, 13.563, 0.686407, 0, 0, -0.727218,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB449003F [176.593994 154.136002 13.563000] 0.686407 0.000000 0.000000 -0.727218 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B449140, 53375, 0xB449003F, 181.013, 152.243, 15.4042, 0.686407, 0, 0, -0.727218,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB449003F [181.013000 152.242996 15.404200] 0.686407 0.000000 0.000000 -0.727218 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B449141, 53375, 0xB4490002, 7.23455, 32.7976, 10.3728, 0.803579, 0, 0, -0.595198,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -77,9 +69,7 @@ VALUES (0x7B44918C, 0x7B449123, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (533
      , (0x7B44918C, 0x7B449128, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44918C, 0x7B449134, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44918C, 0x7B449135, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44918C, 0x7B449136, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44918C, 0x7B44913B, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44918C, 0x7B449140, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44918C, 0x7B449141, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44918C, 0x7B449142, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44918C, 0x7B449143, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
@@ -108,3 +98,31 @@ VALUES (0x7B449191, 72183, 0xB4490037, 162.432, 164.512, 10.055, 0.379718, 0, 0,
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B449192, 72184, 0xB4490030, 128.291, 178.217, 12.6093, -0.048381, 0, 0, 0.998829, False, '2021-11-01 00:00:00'); /* Viridian Root Portal 4 Gen */
 /* @teleloc 0xB4490030 [128.291000 178.216995 12.609300] -0.048381 0.000000 0.000000 0.998829 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B449194, 70847, 0xB449003A, 174.672, 24.4187, 116.055, -0.533605, 0, 0, -0.845734, False, '2022-06-07 16:56:21'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB449003A [174.671997 24.418699 116.055000] -0.533605 0.000000 0.000000 -0.845734 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B449195, 70847, 0xB4490029, 143.402, 3.18789, 116.055, 0.567876, 0, 0, -0.823114, False, '2022-06-07 16:56:40'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB4490029 [143.401993 3.187890 116.055000] 0.567876 0.000000 0.000000 -0.823114 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B449196, 70847, 0xB4490021, 113.538, 22.2555, 116.055, -0.761111, 0, 0, 0.648621, False, '2022-06-07 16:57:11'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB4490021 [113.538002 22.255501 116.055000] -0.761111 0.000000 0.000000 0.648621 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B449197, 70847, 0xB449002B, 136.351, 65.4885, 116.055, 0.221526, 0, 0, -0.975155, False, '2022-06-07 16:57:50'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB449002B [136.350998 65.488503 116.055000] 0.221526 0.000000 0.000000 -0.975155 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B449198, 70847, 0xB449003B, 182.294, 48.7575, 116.055, -0.839286, 0, 0, -0.54369, False, '2022-06-07 16:58:16'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB449003B [182.294006 48.757500 116.055000] -0.839286 0.000000 0.000000 -0.543690 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B449199, 70847, 0xB449003C, 191.985, 92.0016, 117.722, 0.369733, 0, 0, 0.929138, False, '2022-06-07 16:58:46'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB449003C [191.985001 92.001602 117.722000] 0.369733 0.000000 0.000000 0.929138 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44919B, 70851, 0xB4490007, 22.7757, 151.186, 116.157, 0.108067, 0, 0, 0.994144, False, '2022-06-08 15:03:46'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB4490007 [22.775700 151.186005 116.156998] 0.108067 0.000000 0.000000 0.994144 */

--- a/Database/Patches/6 LandBlockExtendedData/B44A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B44A.sql
@@ -1,16 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0xB44A;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A155, 53375, 0xB44A0035, 164.381, 105.611, 10.8795, -0.192015, 0, 0, 0.981392,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A0035 [164.380997 105.611000 10.879500] -0.192015 0.000000 0.000000 0.981392 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44A15D, 53375, 0xB44A002B, 137.018, 59.9914, 11.5631, 0.061326, 0, 0, 0.998118,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB44A002B [137.018005 59.991402 11.563100] 0.061326 0.000000 0.000000 0.998118 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A16A, 53375, 0xB44A002A, 137.806, 37.2385, 9.982, -0.104239, 0, 0, 0.994552,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A002A [137.806000 37.238499 9.982000] -0.104239 0.000000 0.000000 0.994552 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44A16B, 53375, 0xB44A002B, 134.267, 59.5364, 11.7544, 0.061326, 0, 0, 0.998118,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -21,28 +13,12 @@ VALUES (0x7B44A16E, 53375, 0xB44A0036, 159.594, 123.034, 9.982, 0.564685, 0, 0, 
 /* @teleloc 0xB44A0036 [159.593994 123.033997 9.982000] 0.564685 0.000000 0.000000 0.825307 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A16F, 53375, 0xB44A002C, 136.978, 89.0523, 11.1399, 0.12356, 0, 0, 0.992337,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A002C [136.977997 89.052299 11.139900] 0.123560 0.000000 0.000000 0.992337 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44A170, 53375, 0xB44A002A, 136.952, 41.028, 9.982, -0.104239, 0, 0, 0.994552,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB44A002A [136.951996 41.028000 9.982000] -0.104239 0.000000 0.000000 0.994552 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A171, 53375, 0xB44A002B, 134.54, 54.5504, 11.0737, 0.061326, 0, 0, 0.998118,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A002B [134.539993 54.550400 11.073700] 0.061326 0.000000 0.000000 0.998118 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44A172, 53375, 0xB44A0035, 161.642, 102.238, 10.9324, -0.192015, 0, 0, 0.981392,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB44A0035 [161.641998 102.237999 10.932400] -0.192015 0.000000 0.000000 0.981392 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A173, 53375, 0xB44A0036, 161.652, 122.973, 9.982, 0.564685, 0, 0, 0.825307,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A0036 [161.651993 122.973000 9.982000] 0.564685 0.000000 0.000000 0.825307 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A17E, 53375, 0xB44A0036, 160.021, 120.212, 9.982, -0.958443, 0, 0, -0.285284,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A0036 [160.020996 120.211998 9.982000] -0.958443 0.000000 0.000000 -0.285284 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44A180, 53375, 0xB44A002C, 135.973, 85.109, 11.5585, 0.975087, 0, 0, -0.221823,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -57,10 +33,6 @@ VALUES (0x7B44A182, 53375, 0xB44A002A, 134.915, 40.0937, 9.982, -0.104239, 0, 0,
 /* @teleloc 0xB44A002A [134.914993 40.093700 9.982000] -0.104239 0.000000 0.000000 0.994552 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B44A183, 53375, 0xB44A002B, 131.384, 57.3306, 11.5371, 0.061326, 0, 0, 0.998118,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB44A002B [131.384003 57.330601 11.537100] 0.061326 0.000000 0.000000 0.998118 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44A185, 53375, 0xB44A0036, 165.6, 126.046, 9.982, 0.564685, 0, 0, 0.825307,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB44A0036 [165.600006 126.045998 9.982000] 0.564685 0.000000 0.000000 0.825307 */
 
@@ -73,20 +45,41 @@ VALUES (0x7B44A198,  7924, 0xB44A002B, 135.868, 58.8222, 11.5615, 0.061326, 0, 0
 /* @teleloc 0xB44A002B [135.867996 58.822201 11.561500] 0.061326 0.000000 0.000000 0.998118 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7B44A198, 0x7B44A155, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A15D, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A16A, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
+VALUES (0x7B44A198, 0x7B44A15D, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A16B, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A16E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A16F, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A170, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A171, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A172, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A173, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A17E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A180, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A181, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A182, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B44A198, 0x7B44A183, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A185, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B44A198, 0x7B44A197, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A199, 70851, 0xB44A0011, 48.012, 0.45831, 116.055, 1, 0, 0, 0, False, '2022-06-07 16:00:48'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A0011 [48.012001 0.458310 116.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A19A, 70851, 0xB44A0006, 0.467506, 143.97, 116.055, 0.999997, 0, 0, -0.002423, False, '2022-06-07 16:03:28'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A0006 [0.467506 143.970001 116.055000] 0.999997 0.000000 0.000000 -0.002423 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A19B, 70851, 0xB44A001F, 76.6022, 167.287, 116.055, -0.995737, 0, 0, -0.092234, False, '2022-06-07 16:03:52'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A001F [76.602203 167.287003 116.055000] -0.995737 0.000000 0.000000 -0.092234 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A19D, 70851, 0xB44A000B, 43.63, 68.391, 116.419, 0.95506, 0, 0, -0.296413, False, '2022-06-07 16:04:51'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A000B [43.630001 68.390999 116.418999] 0.955060 0.000000 0.000000 -0.296413 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A19E, 70851, 0xB44A0005, 13.5327, 100.593, 116.927, -0.918339, 0, 0, 0.395795, False, '2022-06-07 16:05:27'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A0005 [13.532700 100.593002 116.927002] -0.918339 0.000000 0.000000 0.395795 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A19F, 70851, 0xB44A0016, 61.2322, 127.614, 116.055, -0.369605, 0, 0, 0.929189, False, '2022-06-08 15:09:16'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A0016 [61.232201 127.613998 116.055000] -0.369605 0.000000 0.000000 0.929189 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44A1A0, 70851, 0xB44A001A, 75.8563, 46.95781, 115.4123, 0.235046, 0, 0, 0.971984, False, '2022-06-08 15:09:46'); /* Viridian Entrance Camp Gen */
+/* @teleloc 0xB44A001A [75.856300 46.957809 115.412300] 0.235046 0.000000 0.000000 0.971984 */

--- a/Database/Patches/6 LandBlockExtendedData/B44B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B44B.sql
@@ -30,3 +30,47 @@ VALUES (0x7B44B004, 53051, 0xB44B0017, 55.5, 159, 113.5, 0.382683, 0, 0, -0.9238
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B44B005, 53057, 0xB44B0038, 167.3, 188.2, 116.1, 0, 0, 0, -1,  True, '2021-11-01 00:00:00'); /* Ancient Statue of the Viridian Rise */
 /* @teleloc 0xB44B0038 [167.300003 188.199997 116.099998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B007, 70846, 0xB44B000C, 27.3329, 93.6758, 116.055, -0.999101, 0, 0, 0.042385, False, '2022-06-07 16:10:08'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B000C [27.332899 93.675797 116.055000] -0.999101 0.000000 0.000000 0.042385 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B008, 70846, 0xB44B002F, 120.002, 167.435, 116.055, 1, 0, 0, 0, False, '2022-06-07 16:10:41'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B002F [120.001999 167.434998 116.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B009, 70846, 0xB44B003F, 173.174, 167.602, 116.055, -0.312996, 0, 0, -0.949755, False, '2022-06-07 16:11:12'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B003F [173.173996 167.602005 116.055000] -0.312996 0.000000 0.000000 -0.949755 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B00C, 70846, 0xB44B0022, 118.182, 25.3368, 116.055, -0.996223, 0, 0, -0.086827, False, '2022-06-07 16:11:51'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0022 [118.181999 25.336800 116.055000] -0.996223 0.000000 0.000000 -0.086827 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B00D, 70846, 0xB44B0019, 73.8034, 18.2172, 116.055, 0.980032, 0, 0, 0.198839, False, '2022-06-07 16:12:33'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0019 [73.803398 18.217199 116.055000] 0.980032 0.000000 0.000000 0.198839 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B00E, 70846, 0xB44B0014, 71.7547, 72.0716, 116.055, -0.995584, 0, 0, -0.093877, False, '2022-06-07 16:13:25'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0014 [71.754700 72.071602 116.055000] -0.995584 0.000000 0.000000 -0.093877 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B00F, 70846, 0xB44B0009, 25.429, 20.2, 116.055, -0.915019, 0, 0, -0.403411, False, '2022-06-08 13:27:44'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0009 [25.429001 20.200001 116.055000] -0.915019 0.000000 0.000000 -0.403411 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B010, 70846, 0xB44B0016, 70.8596, 140.481, 116.055, 0.097199, 0, 0, -0.995265, False, '2022-06-08 13:28:13'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0016 [70.859596 140.481003 116.055000] 0.097199 0.000000 0.000000 -0.995265 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B011, 70846, 0xB44B0032, 167.261, 29.7906, 116.055, -0.866113, 0, 0, -0.499848, False, '2022-06-08 13:29:16'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0032 [167.261002 29.790600 116.055000] -0.866113 0.000000 0.000000 -0.499848 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B012, 70846, 0xB44B0024, 119.67, 91.4048, 116.055, 0.992219, 0, 0, -0.124503, False, '2022-06-08 13:29:54'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0024 [119.669998 91.404800 116.055000] 0.992219 0.000000 0.000000 -0.124503 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B44B013, 70846, 0xB44B0034, 162.3309, 76.70393, 116.055, 0.485552, 0, 0, -0.874208, False, '2022-06-08 13:32:10'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB44B0034 [162.330902 76.703934 116.055000] 0.485552 0.000000 0.000000 -0.874208 */

--- a/Database/Patches/6 LandBlockExtendedData/B548.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B548.sql
@@ -1,0 +1,41 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB548;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548000, 70847, 0xB5480040, 173.631, 171.121, 116.055, -0.940799, 0, 0, -0.338966, False, '2022-06-07 16:53:56'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5480040 [173.630997 171.121002 116.055000] -0.940799 0.000000 0.000000 -0.338966 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548001, 70847, 0xB548002F, 141.131, 167.67, 116.294, -0.950734, 0, 0, 0.310008, False, '2022-06-07 16:54:07'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB548002F [141.130997 167.669998 116.293999] -0.950734 0.000000 0.000000 0.310008 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548002, 70847, 0xB548003D, 175.653, 115.173, 112.055, 0.921804, 0, 0, 0.387657, False, '2022-06-07 16:54:15'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB548003D [175.653000 115.172997 112.055000] 0.921804 0.000000 0.000000 0.387657 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548003, 70847, 0xB548002E, 120.99, 124.664, 116.055, 0.971684, 0, 0, -0.236285, False, '2022-06-07 16:54:23'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB548002E [120.989998 124.664001 116.055000] 0.971684 0.000000 0.000000 -0.236285 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548004, 70847, 0xB548001E, 95.5908, 142.015, 116.055, 0.998842, 0, 0, -0.048115, False, '2022-06-07 16:54:32'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB548001E [95.590797 142.014999 116.055000] 0.998842 0.000000 0.000000 -0.048115 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548005, 70847, 0xB5480018, 65.8058, 169.295, 117.947, -0.179041, 0, 0, 0.983842, False, '2022-06-07 16:54:42'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5480018 [65.805801 169.294998 117.946999] -0.179041 0.000000 0.000000 0.983842 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548006, 70847, 0xB548001D, 89.2931, 97.314, 116.055, 0.958412, 0, 0, -0.285389, False, '2022-06-07 16:55:07'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB548001D [89.293098 97.314003 116.055000] 0.958412 0.000000 0.000000 -0.285389 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548007, 70847, 0xB548000E, 27.1488, 126.637, 116.055, 0.933444, 0, 0, -0.358723, False, '2022-06-07 16:55:26'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB548000E [27.148800 126.637001 116.055000] 0.933444 0.000000 0.000000 -0.358723 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548008, 70847, 0xB5480008, 20.5817, 177.948, 116.055, 0.391741, 0, 0, -0.920076, False, '2022-06-07 16:56:01'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5480008 [20.581699 177.947998 116.055000] 0.391741 0.000000 0.000000 -0.920076 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B548009, 70847, 0xB5480016, 60.6961, 143.5975, 116.055, -0.777583, 0, 0, 0.62878, False, '2022-06-07 16:56:10'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5480016 [60.696098 143.597504 116.055000] -0.777583 0.000000 0.000000 0.628780 */

--- a/Database/Patches/6 LandBlockExtendedData/B549.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B549.sql
@@ -1,20 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0xB549;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B549038, 53375, 0xB5490028, 115.571, 188.982, 19.982, 0.974881, 0, 0, 0.222727,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB5490028 [115.570999 188.981995 19.982000] 0.974881 0.000000 0.000000 0.222727 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54903D, 53375, 0xB5490028, 118.464, 184.48, 19.982, 0.974881, 0, 0, 0.222727,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB5490028 [118.463997 184.479996 19.982000] 0.974881 0.000000 0.000000 0.222727 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54903E, 53375, 0xB5490028, 114.874, 186.079, 19.982, 0.974881, 0, 0, 0.222727,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB5490028 [114.874001 186.078995 19.982000] 0.974881 0.000000 0.000000 0.222727 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54903F, 53375, 0xB5490028, 118.42, 189.594, 19.982, 0.974881, 0, 0, 0.222727,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB5490028 [118.419998 189.593994 19.982000] 0.974881 0.000000 0.000000 0.222727 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B549040, 53375, 0xB5490028, 119.302, 187.659, 19.982, 0.974881, 0, 0, 0.222727,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -25,10 +13,7 @@ VALUES (0x7B549041,  7924, 0xB5490028, 115.571, 188.982, 19.982, 0.974881, 0, 0,
 /* @teleloc 0xB5490028 [115.570999 188.981995 19.982000] 0.974881 0.000000 0.000000 0.222727 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7B549041, 0x7B549038, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B549041, 0x7B54903D, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B549041, 0x7B54903E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B549041, 0x7B54903F, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
+VALUES (0x7B549041, 0x7B54903E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B549041, 0x7B549040, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -38,3 +23,39 @@ VALUES (0x7B549042, 53114, 0xB5490005, 10.8286, 115.757, 118.055, 1, 0, 0, 0, Fa
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B549043, 70836, 0xB5490005, 10.8286, 117.757, 118, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Viridian Deru Portal Gen */
 /* @teleloc 0xB5490005 [10.828600 117.757004 118.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B549044, 70847, 0xB5490025, 101.509, 96.6043, 118.055, 0.799763, 0, 0, -0.600316, False, '2022-06-07 16:51:50'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490025 [101.509003 96.604301 118.055000] 0.799763 0.000000 0.000000 -0.600316 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B549045, 70847, 0xB549000C, 41.8973, 94.0644, 117.894, -0.421515, 0, 0, 0.906821, False, '2022-06-07 16:52:10'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB549000C [41.897301 94.064400 117.893997] -0.421515 0.000000 0.000000 0.906821 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B549046, 70847, 0xB5490012, 57.1699, 45.613, 116.819, 0.926487, 0, 0, 0.376327, False, '2022-06-07 16:52:33'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490012 [57.169899 45.612999 116.819000] 0.926487 0.000000 0.000000 0.376327 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B549047, 70847, 0xB5490009, 42.6774, 22.2537, 117.91, -0.996572, 0, 0, 0.082732, False, '2022-06-07 16:52:45'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490009 [42.677399 22.253700 117.910004] -0.996572 0.000000 0.000000 0.082732 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B549048, 70847, 0xB5490023, 98.9191, 53.8704, 118.055, 0.228751, 0, 0, 0.973485, False, '2022-06-07 16:53:01'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490023 [98.919098 53.870399 118.055000] 0.228751 0.000000 0.000000 0.973485 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B549049, 70847, 0xB5490021, 101.814, 17.6367, 117.525, -0.968612, 0, 0, -0.248576, False, '2022-06-07 16:53:07'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490021 [101.814003 17.636700 117.525002] -0.968612 0.000000 0.000000 -0.248576 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54904A, 70847, 0xB5490033, 144.131, 49.1486, 118.055, 0.513766, 0, 0, 0.85793, False, '2022-06-07 16:53:21'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490033 [144.130997 49.148602 118.055000] 0.513766 0.000000 0.000000 0.857930 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54904B, 70847, 0xB549003B, 174.701, 50.9048, 118.055, 0.562608, 0, 0, 0.826724, False, '2022-06-07 16:53:41'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB549003B [174.701004 50.904800 118.055000] 0.562608 0.000000 0.000000 0.826724 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54904C, 70847, 0xB5490031, 156.682, 4.90688, 116.055, 0.857882, 0, 0, 0.513846, False, '2022-06-07 16:53:47'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB5490031 [156.682007 4.906880 116.055000] 0.857882 0.000000 0.000000 0.513846 */

--- a/Database/Patches/6 LandBlockExtendedData/B54A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B54A.sql
@@ -101,31 +101,16 @@ VALUES (0x7B54A013,  1154, 0xB54A0021, 113.183, 1.83517, 27.0228, 0.974881, 0, 0
 /* @teleloc 0xB54A0021 [113.182999 1.835170 27.022800] 0.974881 0.000000 0.000000 0.222727 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7B54A013, 0x7B54A014, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A015, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
+VALUES (0x7B54A013, 0x7B54A015, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A016, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A017, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A018, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A019, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A01A, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A01B, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A01C, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A01D, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A01E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A01F, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A020, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A021, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A022, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A023, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A024, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A025, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B54A013, 0x7B54A026, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A027, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B54A013, 0x7B54A028, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A014, 53375, 0xB54A0020, 85.6971, 188.88, 14.3207, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0020 [85.697098 188.880005 14.320700] 0.669118 0.000000 0.000000 0.743157 */
+     , (0x7B54A013, 0x7B54A027, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A015, 53375, 0xB54A003A, 174.412, 34.1043, 19.982, 0.848695, 0, 0, -0.528883,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -140,10 +125,6 @@ VALUES (0x7B54A017, 53375, 0xB54A0028, 112.509, 191.229, 11.1019, 0.669118, 0, 0
 /* @teleloc 0xB54A0028 [112.509003 191.229004 11.101900] 0.669118 0.000000 0.000000 0.743157 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A018, 53375, 0xB54A003A, 177.975, 33.0368, 19.982, 0.848695, 0, 0, -0.528883,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A003A [177.975006 33.036800 19.982000] 0.848695 0.000000 0.000000 -0.528883 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A019, 53375, 0xB54A0038, 152.219, 174.835, 9.982, 0.731321, 0, 0, 0.682033,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB54A0038 [152.218994 174.835007 9.982000] 0.731321 0.000000 0.000000 0.682033 */
 
@@ -152,48 +133,16 @@ VALUES (0x7B54A01A, 53375, 0xB54A0040, 174.788, 171.798, 11.5644, 0.314811, 0, 0
 /* @teleloc 0xB54A0040 [174.787994 171.798004 11.564400] 0.314811 0.000000 0.000000 0.949154 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A01B, 53375, 0xB54A003A, 179.8, 30.2218, 19.982, 0.848695, 0, 0, -0.528883,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A003A [179.800003 30.221800 19.982000] 0.848695 0.000000 0.000000 -0.528883 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A01C, 53375, 0xB54A0020, 83.214, 188.361, 14.4409, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0020 [83.213997 188.360992 14.440900] 0.669118 0.000000 0.000000 0.743157 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A01D, 53375, 0xB54A0040, 177.776, 173.346, 12.2095, 0.314811, 0, 0, 0.949154,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0040 [177.776001 173.345993 12.209500] 0.314811 0.000000 0.000000 0.949154 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A01E, 53375, 0xB54A0038, 151.251, 172.027, 9.982, 0.731321, 0, 0, 0.682033,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0038 [151.251007 172.026993 9.982000] 0.731321 0.000000 0.000000 0.682033 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A01F, 53375, 0xB54A0028, 113.878, 187.973, 10.3311, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB54A0028 [113.877998 187.973007 10.331100] 0.669118 0.000000 0.000000 0.743157 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A020, 53375, 0xB54A0040, 178.082, 170.131, 10.8699, 0.314811, 0, 0, 0.949154,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0040 [178.082001 170.130997 10.869900] 0.314811 0.000000 0.000000 0.949154 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A021, 53375, 0xB54A0028, 111.253, 188.704, 10.8905, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0028 [111.252998 188.703995 10.890500] 0.669118 0.000000 0.000000 0.743157 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A022, 53375, 0xB54A003A, 177.362, 30.6245, 19.982, 0.848695, 0, 0, -0.528883,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB54A003A [177.362000 30.624500 19.982000] 0.848695 0.000000 0.000000 -0.528883 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A023, 53375, 0xB54A0038, 154.799, 176.178, 9.982, 0.731321, 0, 0, 0.682033,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0038 [154.798996 176.177994 9.982000] 0.731321 0.000000 0.000000 0.682033 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A024, 53375, 0xB54A0038, 151.717, 176.987, 9.982, 0.731321, 0, 0, 0.682033,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB54A0038 [151.716995 176.987000 9.982000] 0.731321 0.000000 0.000000 0.682033 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A025, 53375, 0xB54A003A, 174.259, 30.9072, 19.982, 0.848695, 0, 0, -0.528883,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A003A [174.259003 30.907200 19.982000] 0.848695 0.000000 0.000000 -0.528883 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A026, 53375, 0xB54A0040, 180.376, 174.562, 12.7164, 0.314811, 0, 0, 0.949154,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -202,7 +151,3 @@ VALUES (0x7B54A026, 53375, 0xB54A0040, 180.376, 174.562, 12.7164, 0.314811, 0, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B54A027, 53375, 0xB54A0020, 82.778, 190.577, 14.8467, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB54A0020 [82.778000 190.576996 14.846700] 0.669118 0.000000 0.000000 0.743157 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54A028, 53375, 0xB54A0028, 108.41, 191.625, 11.8511, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54A0028 [108.410004 191.625000 11.851100] 0.669118 0.000000 0.000000 0.743157 */

--- a/Database/Patches/6 LandBlockExtendedData/B54B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B54B.sql
@@ -35,9 +35,46 @@ INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `ori
 VALUES (0x7B54B006,  1154, 0xB54B0019, 82.062, 0.154556, 15.1049, 0.669118, 0, 0, 0.743157, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
 /* @teleloc 0xB54B0019 [82.061996 0.154556 15.104900] 0.669118 0.000000 0.000000 0.743157 */
 
-INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7B54B006, 0x7B54B007, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B008, 70846, 0xB54B000C, 24.3367, 77.6953, 116.055, -0.999602, 0, 0, -0.028215, False, '2022-06-07 16:14:43'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B000C [24.336700 77.695297 116.055000] -0.999602 0.000000 0.000000 -0.028215 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B54B007, 53375, 0xB54B0019, 82.062, 0.154556, 15.1049, 0.669118, 0, 0, 0.743157,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB54B0019 [82.061996 0.154556 15.104900] 0.669118 0.000000 0.000000 0.743157 */
+VALUES (0x7B54B009, 70846, 0xB54B000F, 25.6743, 164.121, 116.055, 0.995859, 0, 0, 0.090908, False, '2022-06-07 16:16:39'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B000F [25.674299 164.121002 116.055000] 0.995859 0.000000 0.000000 0.090908 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B00C, 70846, 0xB54B0036, 144.863, 124.092, 116.055, 0.992309, 0, 0, 0.123788, False, '2022-06-07 16:20:14'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B0036 [144.863007 124.092003 116.055000] 0.992309 0.000000 0.000000 0.123788 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B011, 70846, 0xB54B0015, 68.8113, 115.317, 116.055, 0.991849, 0, 0, -0.127421, False, '2022-06-08 13:34:53'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B0015 [68.811302 115.317001 116.055000] 0.991849 0.000000 0.000000 -0.127421 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B012, 70846, 0xB54B0020, 74.8264, 169.326, 116.055, 0.282599, 0, 0, 0.959238, False, '2022-06-08 13:36:10'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B0020 [74.826401 169.326004 116.055000] 0.282599 0.000000 0.000000 0.959238 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B014, 70846, 0xB54B001C, 72.2261, 76.7168, 116.055, -0.603017, 0, 0, -0.797729, False, '2022-06-08 13:37:57'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B001C [72.226097 76.716797 116.055000] -0.603017 0.000000 0.000000 -0.797729 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B015, 70846, 0xB54B003B, 170.499, 51.8143, 116.055, -0.975441, 0, 0, -0.220263, False, '2022-06-08 13:38:40'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B003B [170.498993 51.814301 116.055000] -0.975441 0.000000 0.000000 -0.220263 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B016, 70846, 0xB54B003C, 173.649, 94.8029, 116.055, -0.872247, 0, 0, -0.489066, False, '2022-06-08 13:38:57'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B003C [173.649002 94.802902 116.055000] -0.872247 0.000000 0.000000 -0.489066 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B017, 70846, 0xB54B0028, 118.764, 171.975, 116.055, -0.379487, 0, 0, 0.925197, False, '2022-06-08 13:41:59'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B0028 [118.764000 171.975006 116.055000] -0.379487 0.000000 0.000000 0.925197 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B018, 70846, 0xB54B0037, 159.588, 165.417, 116.055, 0.365088, 0, 0, 0.930973, False, '2022-06-08 13:46:20'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B0037 [159.587997 165.417007 116.055000] 0.365088 0.000000 0.000000 0.930973 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54B019, 70846, 0xB54B0006, 16.6329, 122.255, 116.055, 0.253951, 0, 0, -0.967217, False, '2022-06-08 13:47:18'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54B0006 [16.632900 122.254997 116.055000] 0.253951 0.000000 0.000000 -0.967217 */

--- a/Database/Patches/6 LandBlockExtendedData/B54C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B54C.sql
@@ -1,0 +1,17 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB54C;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54C002, 70846, 0xB54C003A, 169.507, 25.2066, 116.055, 0.957975, 0, 0, 0.286853, False, '2022-06-07 16:19:56'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54C003A [169.507004 25.206600 116.055000] 0.957975 0.000000 0.000000 0.286853 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54C003, 70846, 0xB54C0001, 3.33022, 19.6989, 116.055, -0.946296, 0, 0, -0.3233, False, '2022-06-08 13:43:53'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54C0001 [3.330220 19.698900 116.055000] -0.946296 0.000000 0.000000 -0.323300 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54C004, 70846, 0xB54C0012, 50.8537, 28.684, 116.055, -0.314917, 0, 0, 0.949119, False, '2022-06-08 13:44:21'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54C0012 [50.853699 28.684000 116.055000] -0.314917 0.000000 0.000000 0.949119 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B54C005, 70846, 0xB54C0022, 101.7281, 27.17897, 116.055, -0.18592, 0, 0, -0.982565, False, '2022-06-08 13:44:46'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB54C0022 [101.728104 27.178970 116.055000] -0.185920 0.000000 0.000000 -0.982565 */

--- a/Database/Patches/6 LandBlockExtendedData/B648.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B648.sql
@@ -1,0 +1,13 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB648;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B648000, 70847, 0xB648000F, 28.8514, 163.487, 116.055, 0.909865, 0, 0, -0.414904, False, '2022-06-07 16:46:05'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB648000F [28.851400 163.487000 116.055000] 0.909865 0.000000 0.000000 -0.414904 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B648001, 70847, 0xB6480017, 65.4821, 167.111, 116.055, 0.465231, 0, 0, -0.88519, False, '2022-06-07 16:46:10'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6480017 [65.482101 167.110992 116.055000] 0.465231 0.000000 0.000000 -0.885190 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B648002, 70847, 0xB6480005, 19.66799, 115.548, 112.055, 0.976546, 0, 0, -0.215309, False, '2022-06-07 16:48:24'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6480005 [19.667990 115.547997 112.055000] 0.976546 0.000000 0.000000 -0.215309 */

--- a/Database/Patches/6 LandBlockExtendedData/B649.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B649.sql
@@ -30,3 +30,75 @@ VALUES (0x7B649004, 53080, 0xB649001D, 77.2, 99.6, 116.1, 0.92388, 0, 0, -0.3826
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B649005, 53110, 0xB6490004, 4, 92.2, 117.683, 0.707107, 0, 0, -0.707107,  True, '2021-11-01 00:00:00'); /* Ancient Statue of the Viridian Rise */
 /* @teleloc 0xB6490004 [4.000000 92.199997 117.682999] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649006, 70847, 0xB649003E, 181.767, 129.793, 116.055, 0.366035, 0, 0, 0.930601, False, '2022-06-07 16:38:36'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649003E [181.766998 129.792999 116.055000] 0.366035 0.000000 0.000000 0.930601 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649007, 70847, 0xB6490034, 163.988, 76.8802, 116.055, -0.969812, 0, 0, 0.243856, False, '2022-06-07 16:39:05'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490034 [163.988007 76.880203 116.055000] -0.969812 0.000000 0.000000 0.243856 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649008, 70847, 0xB649002B, 138.184, 49.8555, 116.055, -0.773416, 0, 0, -0.633899, False, '2022-06-07 16:39:36'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649002B [138.184006 49.855499 116.055000] -0.773416 0.000000 0.000000 -0.633899 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649009, 70847, 0xB6490031, 147.372, 9.35879, 113.615, 0.725604, 0, 0, 0.688112, False, '2022-06-07 16:40:04'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490031 [147.371994 9.358790 113.614998] 0.725604 0.000000 0.000000 0.688112 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64900A, 70847, 0xB6490021, 113.414, 23.1359, 116.055, 0.813819, 0, 0, -0.581119, False, '2022-06-07 16:40:19'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490021 [113.414001 23.135900 116.055000] 0.813819 0.000000 0.000000 -0.581119 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64900C, 70847, 0xB649001C, 92.1702, 81.8089, 116.055, 0.613803, 0, 0, -0.789459, False, '2022-06-07 16:41:16'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649001C [92.170197 81.808899 116.055000] 0.613803 0.000000 0.000000 -0.789459 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64900D, 70847, 0xB6490012, 64.3528, 47.6926, 116.055, 0.968489, 0, 0, -0.249058, False, '2022-06-07 16:41:26'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490012 [64.352798 47.692600 116.055000] 0.968489 0.000000 0.000000 -0.249058 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64900E, 70847, 0xB6490019, 79.8184, 16.2107, 116.055, 0.961012, 0, 0, 0.276507, False, '2022-06-07 16:41:48'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490019 [79.818398 16.210699 116.055000] 0.961012 0.000000 0.000000 0.276507 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64900F, 70847, 0xB6490009, 35.4154, 15.211, 116.055, -0.586439, 0, 0, 0.809993, False, '2022-06-07 16:42:27'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490009 [35.415401 15.211000 116.055000] -0.586439 0.000000 0.000000 0.809993 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649010, 70847, 0xB6490002, 20.3047, 45.348, 116.363, -0.517126, 0, 0, 0.855909, False, '2022-06-07 16:42:35'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490002 [20.304701 45.348000 116.362999] -0.517126 0.000000 0.000000 0.855909 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649011, 70847, 0xB6490004, 18.1448, 89.0024, 117.472, -0.641093, 0, 0, 0.767463, False, '2022-06-07 16:42:57'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490004 [18.144800 89.002403 117.472000] -0.641093 0.000000 0.000000 0.767463 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649012, 70847, 0xB649000E, 24.5539, 121.372, 118.055, -0.518754, 0, 0, 0.854924, False, '2022-06-07 16:43:07'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649000E [24.553900 121.372002 118.055000] -0.518754 0.000000 0.000000 0.854924 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649013, 70847, 0xB6490015, 62.4104, 103.73, 116.055, 0.746048, 0, 0, 0.665892, False, '2022-06-07 16:43:19'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490015 [62.410400 103.730003 116.055000] 0.746048 0.000000 0.000000 0.665892 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649014, 70847, 0xB649000F, 24.5594, 148.772, 118.055, -0.928525, 0, 0, -0.37127, False, '2022-06-07 16:43:36'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649000F [24.559401 148.772003 118.055000] -0.928525 0.000000 0.000000 -0.371270 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649015, 70847, 0xB649001F, 77.184, 164.127, 116.055, -0.45972, 0, 0, 0.888064, False, '2022-06-07 16:43:48'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649001F [77.183998 164.126999 116.055000] -0.459720 0.000000 0.000000 0.888064 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649016, 70847, 0xB6490037, 157.796, 166.945, 116.055, -0.907555, 0, 0, 0.419933, False, '2022-06-07 16:44:13'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB6490037 [157.796005 166.945007 116.055000] -0.907555 0.000000 0.000000 0.419933 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649017, 70847, 0xB649003A, 190.795, 44.5039, 112.437, 0.129592, 0, 0, 0.991567, False, '2022-06-07 16:45:04'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649003A [190.794998 44.503899 112.436996] 0.129592 0.000000 0.000000 0.991567 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B649018, 70847, 0xB649001D, 86.20833, 116.3642, 116.055, -0.885414, 0, 0, 0.464803, False, '2022-06-07 16:46:49'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB649001D [86.208328 116.364197 116.055000] -0.885414 0.000000 0.000000 0.464803 */

--- a/Database/Patches/6 LandBlockExtendedData/B64A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B64A.sql
@@ -36,40 +36,22 @@ VALUES (0x7B64A006,  1154, 0xB64A0004, 7.10046, 89.7877, 19.982, 0.980849, 0, 0,
 /* @teleloc 0xB64A0004 [7.100460 89.787697 19.982000] 0.980849 0.000000 0.000000 0.194768 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7B64A006, 0x7B64A007, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64A006, 0x7B64A008, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64A006, 0x7B64A009, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64A006, 0x7B64A00A, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
+VALUES (0x7B64A006, 0x7B64A008, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A00B, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A00C, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A00D, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64A006, 0x7B64A00E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A00F, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A010, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A011, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64A006, 0x7B64A012, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A013, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64A006, 0x7B64A014, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A015, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A016, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A017, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64A006, 0x7B64A018, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64A007, 53375, 0xB64A0004, 7.10046, 89.7877, 19.982, 0.980849, 0, 0, 0.194768,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64A0004 [7.100460 89.787697 19.982000] 0.980849 0.000000 0.000000 0.194768 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64A008, 53375, 0xB64A0003, 14.1838, 58.072, 19.982, 0.999479, 0, 0, -0.032279,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB64A0003 [14.183800 58.071999 19.982000] 0.999479 0.000000 0.000000 -0.032279 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64A009, 53375, 0xB64A0003, 9.90514, 55.7837, 19.982, 0.999479, 0, 0, -0.032279,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64A0003 [9.905140 55.783699 19.982000] 0.999479 0.000000 0.000000 -0.032279 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64A00A, 53375, 0xB64A000D, 43.1285, 104.993, 19.982, 0.993914, 0, 0, 0.110158,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64A000D [43.128502 104.992996 19.982000] 0.993914 0.000000 0.000000 0.110158 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64A00B, 53375, 0xB64A0004, 8.34733, 87.2742, 19.982, 0.980849, 0, 0, 0.194768,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -84,10 +66,6 @@ VALUES (0x7B64A00D, 53375, 0xB64A0004, 9.83767, 90.2529, 19.982, 0.980849, 0, 0,
 /* @teleloc 0xB64A0004 [9.837670 90.252899 19.982000] 0.980849 0.000000 0.000000 0.194768 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64A00E, 53375, 0xB64A000D, 41.1103, 101.411, 19.982, 0.993914, 0, 0, 0.110158,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64A000D [41.110298 101.411003 19.982000] 0.993914 0.000000 0.000000 0.110158 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64A00F, 53375, 0xB64A000D, 40.9152, 105.32, 19.982, 0.993914, 0, 0, 0.110158,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB64A000D [40.915199 105.320000 19.982000] 0.993914 0.000000 0.000000 0.110158 */
 
@@ -100,16 +78,8 @@ VALUES (0x7B64A011, 53375, 0xB64A0018, 65.4043, 179.215, 15.3092, 0.977176, 0, 0
 /* @teleloc 0xB64A0018 [65.404297 179.214996 15.309200] 0.977176 0.000000 0.000000 0.212430 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64A012, 53375, 0xB64A0017, 50.7503, 150.384, 19.982, 0.99465, 0, 0, 0.103306,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64A0017 [50.750301 150.384003 19.982000] 0.994650 0.000000 0.000000 0.103306 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64A013, 53375, 0xB64A0003, 7.61919, 53.2767, 19.982, 0.999479, 0, 0, -0.032279,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB64A0003 [7.619190 53.276699 19.982000] 0.999479 0.000000 0.000000 -0.032279 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64A014, 53375, 0xB64A0003, 11.5268, 53.1485, 19.982, 0.999479, 0, 0, -0.032279,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64A0003 [11.526800 53.148499 19.982000] 0.999479 0.000000 0.000000 -0.032279 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64A015, 53375, 0xB64A0017, 53.1251, 146.633, 19.982, 0.99465, 0, 0, 0.103306,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
@@ -126,3 +96,43 @@ VALUES (0x7B64A017, 53375, 0xB64A0010, 41.5077, 174.906, 19.982, 0.760991, 0, 0,
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64A018, 53375, 0xB64A0017, 55.0302, 151.242, 19.982, 0.99465, 0, 0, 0.103306,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB64A0017 [55.030201 151.242004 19.982000] 0.994650 0.000000 0.000000 0.103306 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A019, 70846, 0xB64A0033, 161.079, 68.6659, 116.055, -0.671579, 0, 0, 0.740934, False, '2022-06-07 16:32:11'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0033 [161.078995 68.665901 116.055000] -0.671579 0.000000 0.000000 0.740934 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A01A, 70846, 0xB64A0036, 157.698, 122.937, 116.055, -0.897543, 0, 0, 0.440928, False, '2022-06-07 16:32:33'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0036 [157.697998 122.936996 116.055000] -0.897543 0.000000 0.000000 0.440928 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A01B, 70846, 0xB64A002F, 140.412, 145.57, 116.055, -0.888239, 0, 0, 0.459381, False, '2022-06-07 16:32:40'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A002F [140.412003 145.570007 116.055000] -0.888239 0.000000 0.000000 0.459381 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A01C, 70846, 0xB64A0040, 177.004, 176.674, 116.055, 0.334569, 0, 0, 0.942371, False, '2022-06-07 16:33:01'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0040 [177.003998 176.673996 116.055000] 0.334569 0.000000 0.000000 0.942371 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A01D, 70846, 0xB64A002C, 128.572, 89.2704, 116.055, -0.988256, 0, 0, 0.152809, False, '2022-06-07 16:33:15'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A002C [128.572006 89.270401 116.055000] -0.988256 0.000000 0.000000 0.152809 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A020, 70846, 0xB64A0011, 56.7882, 14.205, 116.055, 0.889268, 0, 0, -0.457387, False, '2022-06-07 16:34:35'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0011 [56.788200 14.205000 116.055000] 0.889268 0.000000 0.000000 -0.457387 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A022, 70846, 0xB64A0029, 142.239, 15.3161, 116.055, 0.996717, 0, 0, -0.080969, False, '2022-06-07 16:35:27'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0029 [142.238998 15.316100 116.055000] 0.996717 0.000000 0.000000 -0.080969 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A023, 70846, 0xB64A0039, 181.435, 22.7691, 116.055, 0.496196, 0, 0, -0.868211, False, '2022-06-07 16:35:39'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0039 [181.434998 22.769100 116.055000] 0.496196 0.000000 0.000000 -0.868211 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A024, 70846, 0xB64A0021, 97.4148, 19.2607, 116.055, 0.844588, 0, 0, 0.535417, False, '2022-06-08 13:56:35'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0021 [97.414803 19.260700 116.055000] 0.844588 0.000000 0.000000 0.535417 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64A025, 70846, 0xB64A0023, 99.2606, 51.4645, 116.055, 0.560883, 0, 0, -0.827895, False, '2022-06-08 13:57:11'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64A0023 [99.260597 51.464500 116.055000] 0.560883 0.000000 0.000000 -0.827895 */

--- a/Database/Patches/6 LandBlockExtendedData/B64B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B64B.sql
@@ -9,10 +9,6 @@ VALUES (0x7B64B038, 53375, 0xB64B003E, 178.296, 138.446, 9.982, 0.760034, 0, 0, 
 /* @teleloc 0xB64B003E [178.296005 138.445999 9.982000] 0.760034 0.000000 0.000000 0.649883 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7B64B03A, 53375, 0xB64B0026, 102.666, 127.137, 9.982, 0.671321, 0, 0, 0.741167,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
-/* @teleloc 0xB64B0026 [102.666000 127.137001 9.982000] 0.671321 0.000000 0.000000 0.741167 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64B03B, 53375, 0xB64B0019, 80.9046, 15.3713, 9.982, -0.310633, 0, 0, 0.95053,  True, '2021-11-01 00:00:00'); /* Sath'tik Eyestalk */
 /* @teleloc 0xB64B0019 [80.904602 15.371300 9.982000] -0.310633 0.000000 0.000000 0.950530 */
 
@@ -35,7 +31,6 @@ VALUES (0x7B64B041,  7924, 0xB64B003E, 174.56, 139.003, 9.982, 0.760034, 0, 0, 0
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7B64B041, 0x7B64B037, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64B041, 0x7B64B038, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
-     , (0x7B64B041, 0x7B64B03A, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64B041, 0x7B64B03B, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64B041, 0x7B64B03E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B64B041, 0x7B64B03F, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
@@ -48,3 +43,27 @@ VALUES (0x7B64B042, 53112, 0xB64B0030, 126.047, 172.471, 116.155, 1, 0, 0, 0, Fa
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7B64B043, 70835, 0xB64B0030, 126.015, 174.672, 116.055, 0.000111, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Viridian Bridge Portal Gen */
 /* @teleloc 0xB64B0030 [126.014999 174.671997 116.055000] 0.000111 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64B045, 70846, 0xB64B000E, 25.4694, 124.487, 116.055, 0.989344, 0, 0, 0.145601, False, '2022-06-07 16:26:33'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64B000E [25.469400 124.487000 116.055000] 0.989344 0.000000 0.000000 0.145601 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64B046, 70846, 0xB64B000F, 31.9409, 163.648, 116.055, 0.980636, 0, 0, -0.19584, False, '2022-06-07 16:26:43'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64B000F [31.940901 163.647995 116.055000] 0.980636 0.000000 0.000000 -0.195840 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64B047, 70846, 0xB64B0028, 102.101, 186.485, 116.055, 0.751925, 0, 0, 0.659248, False, '2022-06-07 16:27:16'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64B0028 [102.100998 186.485001 116.055000] 0.751925 0.000000 0.000000 0.659248 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64B048, 70846, 0xB64B0010, 47.8922, 188.527, 116.037, 0.980811, 0, 0, 0.194962, False, '2022-06-07 16:28:18'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64B0010 [47.892200 188.526993 116.037003] 0.980811 0.000000 0.000000 0.194962 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64B049, 70846, 0xB64B0020, 80.4986, 173.998, 115.055, -0.136781, 0, 0, -0.990601, False, '2022-06-07 16:28:31'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64B0020 [80.498596 173.998001 115.055000] -0.136781 0.000000 0.000000 -0.990601 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64B04A, 70846, 0xB64B0031, 154.02, 19.7833, 116.055, -0.918548, 0, 0, 0.395309, False, '2022-06-08 13:53:57'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64B0031 [154.020004 19.783300 116.055000] -0.918548 0.000000 0.000000 0.395309 */

--- a/Database/Patches/6 LandBlockExtendedData/B64C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B64C.sql
@@ -1,0 +1,5 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB64C;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B64C000, 70846, 0xB64C0001, 20.24827, 17.55791, 112.6803, 0.526127, 0, 0, -0.850406, False, '2022-06-07 16:27:55'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB64C0001 [20.248270 17.557911 112.680298] 0.526127 0.000000 0.000000 -0.850406 */

--- a/Database/Patches/6 LandBlockExtendedData/B749.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B749.sql
@@ -1,0 +1,17 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB749;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B749000, 70847, 0xB7490003, 2.10583, 56.2898, 112.406, 0.968286, 0, 0, 0.249846, False, '2022-06-07 16:39:14'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB7490003 [2.105830 56.289799 112.405998] 0.968286 0.000000 0.000000 0.249846 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B749001, 70847, 0xB7490006, 22.0315, 142.333, 116.055, 0.897966, 0, 0, -0.440065, False, '2022-06-07 16:44:44'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB7490006 [22.031500 142.332993 116.055000] 0.897966 0.000000 0.000000 -0.440065 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B749002, 70847, 0xB7490017, 55.9677, 167.189, 112.055, 0.419425, 0, 0, 0.90779, False, '2022-06-07 16:44:52'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB7490017 [55.967701 167.188995 112.055000] 0.419425 0.000000 0.000000 0.907790 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B749003, 70847, 0xB7490005, 13.09943, 102.018, 116.055, -0.97217, 0, 0, 0.234277, False, '2022-06-08 14:00:13'); /* Viridian Inner Camp Gen */
+/* @teleloc 0xB7490005 [13.099430 102.017998 116.055000] -0.972170 0.000000 0.000000 0.234277 */

--- a/Database/Patches/6 LandBlockExtendedData/B74A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B74A.sql
@@ -1,0 +1,29 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xB74A;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A001, 70846, 0xB74A0015, 49.6571, 118.2, 116.055, 0.998618, 0, 0, -0.052554, False, '2022-06-07 16:30:52'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A0015 [49.657101 118.199997 116.055000] 0.998618 0.000000 0.000000 -0.052554 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A003, 70846, 0xB74A000A, 46.7738, 25.1602, 116.055, 0.983711, 0, 0, 0.179758, False, '2022-06-07 16:31:22'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A000A [46.773800 25.160200 116.055000] 0.983711 0.000000 0.000000 0.179758 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A004, 70846, 0xB74A0003, 12.249, 49.2993, 116.055, 0.941788, 0, 0, -0.336206, False, '2022-06-07 16:31:39'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A0003 [12.249000 49.299301 116.055000] 0.941788 0.000000 0.000000 -0.336206 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A006, 70846, 0xB74A000C, 30.4232, 77.8641, 116.055, -0.989244, 0, 0, 0.146276, False, '2022-06-07 16:36:48'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A000C [30.423201 77.864098 116.055000] -0.989244 0.000000 0.000000 0.146276 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A007, 70846, 0xB74A0017, 52.8741, 166.247, 116.055, 0.711604, 0, 0, 0.702581, False, '2022-06-08 13:54:12'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A0017 [52.874100 166.246994 116.055000] 0.711604 0.000000 0.000000 0.702581 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A008, 70846, 0xB74A0006, 23.9318, 132.382, 116.055, 0.999646, 0, 0, 0.026623, False, '2022-06-08 13:54:27'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A0006 [23.931801 132.382004 116.055000] 0.999646 0.000000 0.000000 0.026623 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74A009, 70846, 0xB74A0014, 66.42764, 82.31772, 116.055, 0.923, 0, 0, 0.384801, False, '2022-06-08 13:55:00'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74A0014 [66.427643 82.317719 116.055000] 0.923000 0.000000 0.000000 0.384801 */

--- a/Database/Patches/6 LandBlockExtendedData/B74B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/B74B.sql
@@ -25,3 +25,7 @@ VALUES (0x7B74B021, 0x7B74B01D, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (533
      , (0x7B74B021, 0x7B74B01E, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B74B021, 0x7B74B01F, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */
      , (0x7B74B021, 0x7B74B020, '2021-11-01 00:00:00') /* Sath'tik Eyestalk (53375) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7B74B022, 70846, 0xB74B0009, 24.18103, 14.77004, 116.055, 0.972942, 0, 0, 0.231048, False, '2022-06-07 16:30:20'); /* Viridian Outer Camp Gen */
+/* @teleloc 0xB74B0009 [24.181030 14.770040 116.055000] 0.972942 0.000000 0.000000 0.231048 */

--- a/Database/Patches/9 WeenieDefaults/Generic/None/70846 Viridian Outer Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/70846 Viridian Outer Camp Gen.sql
@@ -14,8 +14,8 @@ VALUES (70846,   1, True ) /* Stuck */
      , (70846,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (70846,  41,     180) /* RegenerationInterval */
-     , (70846,  43,      20) /* GeneratorRadius */;
+VALUES (70846,  41,     300) /* RegenerationInterval */
+     , (70846,  43,      15) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70846,   1, 'Viridian Outer Camp Gen') /* Name */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/70847 Viridian Inner Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/70847 Viridian Inner Camp Gen.sql
@@ -14,8 +14,8 @@ VALUES (70847,   1, True ) /* Stuck */
      , (70847,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (70847,  41,     180) /* RegenerationInterval */
-     , (70847,  43,      20) /* GeneratorRadius */;
+VALUES (70847,  41,     300) /* RegenerationInterval */
+     , (70847,  43,      15) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70847,   1, 'Viridian Inner Camp Gen') /* Name */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/70851 Viridian Entrance Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/70851 Viridian Entrance Camp Gen.sql
@@ -14,8 +14,8 @@ VALUES (70851,   1, True ) /* Stuck */
      , (70851,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (70851,  41,     180) /* RegenerationInterval */
-     , (70851,  43,      20) /* GeneratorRadius */;
+VALUES (70851,  41,     300) /* RegenerationInterval */
+     , (70851,  43,      15) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70851,   1, 'Viridian Entrance Camp Gen') /* Name */;


### PR DESCRIPTION
Now using landblocks instead of encounters for spawns for a spawn distribution closer to retail, and to correct issues with encounters spawns (generators and spawns ending up inside shrubbery).

The last area now has denser spawns as in retail. It should be more difficult to run through.

Increased respawn time to 5 min (from 3 min), and reduced generator radius to 15 (from 20).

Reduced slithis spawn density by one eyestalk to match retail screenshots.