### PR TITLE
Update 72337 Geraine.sql

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Human/72337 Geraine.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/72337 Geraine.sql
@@ -170,7 +170,8 @@ VALUES (72337, 1, 72338,  1, 0, 1, False) /* Create Legendary Key (72338) for Co
      , (72337, 1, 72338,  1, 0, 1, False) /* Create Legendary Key (72338) for Contain */
      , (72337, 1, 72338,  1, 0, 1, False) /* Create Legendary Key (72338) for Contain */
      , (72337, 1, 72338,  1, 0, 1, False) /* Create Legendary Key (72338) for Contain */
-     , (72337, 1, 72338,  1, 0, 1, False) /* Create Legendary Key (72338) for Contain */;
+     , (72337, 1, 72338,  1, 0, 1, False) /* Create Legendary Key (72338) for Contain */
+     , (72337, 1, 45680,  1, 0, 1, False) /* Create Book (45680) for Contain */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (72337, -1, 72327, 180, 1, 1, 1, 4, 0, 0, 0, 0x93020157, 91.4436, -9.8174, 0.055, 1, 0, 0, 0) /* Generate Geraine Library Ring Caster Gen (72327) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;


### PR DESCRIPTION
Added the missing 45680 Book trophy on the Geraine from the Mhoire Infiltration quest to match retail as per bug report:

http://acpedia.org/wiki/Geraine_(Creature)

This makes a total of 9 books, enough for a full fellowship (8 from side rooms, 1 on body).