### PR TITLE
Vissidal Clear Drop Spawns

### DIFF
--- a/Database/Patches/1 RegionDescExtendedData/C8E2.sql
+++ b/Database/Patches/1 RegionDescExtendedData/C8E2.sql
@@ -8,12 +8,4 @@ VALUES (0xC8E2, 70106, 0, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E2, 70106, 1, 6, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E2, 70106, 2, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E2, 70106, 2, 5, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 3, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 4, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 4, 7, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 5, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 5, 7, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 6, 1, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 6, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 6, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E2, 70106, 7, 1, '2021-11-01 00:00:00') /* Vissidal West Area Gen */;
+     , (0xC8E2, 70106, 4, 7, '2021-11-01 00:00:00') /* Vissidal West Area Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/C8E3.sql
+++ b/Database/Patches/1 RegionDescExtendedData/C8E3.sql
@@ -13,7 +13,5 @@ VALUES (0xC8E3, 70106, 0, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E3, 70106, 4, 7, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E3, 70106, 5, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E3, 70106, 5, 7, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E3, 70106, 6, 1, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC8E3, 70106, 6, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E3, 70106, 6, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC8E3, 70106, 7, 1, '2021-11-01 00:00:00') /* Vissidal West Area Gen */;
+     , (0xC8E3, 70106, 6, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */;

--- a/Database/Patches/1 RegionDescExtendedData/C9E2.sql
+++ b/Database/Patches/1 RegionDescExtendedData/C9E2.sql
@@ -1,12 +1,7 @@
 DELETE FROM `encounter` WHERE `landblock` = 0xC9E2;
 
 INSERT INTO `encounter` (`landblock`, `weenie_Class_Id`, `cell_X`, `cell_Y`, `last_Modified`)
-VALUES (0xC9E2, 70106, 0, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC9E2, 70106, 0, 5, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC9E2, 70106, 0, 6, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC9E2, 70106, 1, 5, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC9E2, 70106, 1, 6, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
-     , (0xC9E2, 70106, 2, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
+VALUES (0xC9E2, 70106, 2, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC9E2, 70106, 2, 5, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC9E2, 70106, 3, 4, '2021-11-01 00:00:00') /* Vissidal West Area Gen */
      , (0xC9E2, 70106, 4, 2, '2021-11-01 00:00:00') /* Vissidal West Area Gen */


### PR DESCRIPTION
Cleared the spawns from the Vissidal drop to match Hells retail video:

https://www.twitch.tv/videos/48337756?t=0h48m18s

There were no spawns at the drop, and going toward town.