### PR TITLE
Faster Hoshino Town Respawn

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/4AE1.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4AE1.sql
@@ -37,7 +37,7 @@ VALUES (0x74AE100A, 46545, 0x4AE10118, 131.972, 6.75137, 57.437, 0, 0, 0, -1, Fa
 /* @teleloc 0x4AE10118 [131.972000 6.751370 57.437000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x74AE100B,  1154, 0x4AE10100, 105.863, 58.367, 62.405, 0.418158, 0, 0, -0.908374, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x74AE100B,  7924, 0x4AE10100, 105.863, 58.367, 62.405, 0.418158, 0, 0, -0.908374, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x4AE10100 [105.862999 58.367001 62.404999] 0.418158 0.000000 0.000000 -0.908374 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/4BE1.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4BE1.sql
@@ -65,7 +65,7 @@ VALUES (0x74BE100F,   720, 0x4BE1003A, 172.49, 36, 83.6, 0.707107, 0, 0, -0.7071
 /* @teleloc 0x4BE1003A [172.490005 36.000000 83.599998] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x74BE1010,  1154, 0x4BE10104, 20.2217, 16.2225, 66.005, -0.257567, 0, 0, -0.96626, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x74BE1010,  7924, 0x4BE10104, 20.2217, 16.2225, 66.005, -0.257567, 0, 0, -0.96626, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x4BE10104 [20.221701 16.222500 66.004997] -0.257567 0.000000 0.000000 -0.966260 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/4CE1.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4CE1.sql
@@ -65,7 +65,7 @@ VALUES (0x74CE100F,   720, 0x4CE1000C, 33.5, 75.325, 64.025, 1, 0, 0, 0, False, 
 /* @teleloc 0x4CE1000C [33.500000 75.324997 64.025002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x74CE1010,  1154, 0x4CE10124, 131.994, 138.095, 53.5, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x74CE1010,  7924, 0x4CE10124, 131.994, 138.095, 53.5, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x4CE10124 [131.994003 138.095001 53.500000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/4CE2.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4CE2.sql
@@ -21,7 +21,7 @@ VALUES (0x74CE201C, 49449, 0x4CE20102, 83.9104, 184.643, 68.437, 0.999958, 0, 0,
 /* @teleloc 0x4CE20102 [83.910400 184.643005 68.436996] 0.999958 0.000000 0.000000 -0.009157 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x74CE201D,  1154, 0x4CE20106, 77.505, 177.95, 64.805, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x74CE201D,  7924, 0x4CE20106, 77.505, 177.95, 64.805, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x4CE20106 [77.504997 177.949997 64.805000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/4CE3.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4CE3.sql
@@ -53,7 +53,7 @@ VALUES (0x74CE300D,   720, 0x4CE3001A, 84, 38.975, 61.6, 0, 0, 0, -1, False, '20
 /* @teleloc 0x4CE3001A [84.000000 38.974998 61.599998] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x74CE300E,  1154, 0x4CE30104, 29.9093, 28.848, 60, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x74CE300E,  7924, 0x4CE30104, 29.9093, 28.848, 60, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x4CE30104 [29.909300 28.848000 60.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)


### PR DESCRIPTION
Respawn time for static spawns (including sarcophagi) in the Hoshino area towns is reduced to 5 min to match the encounters generator respawn times.