### PR TITLE
Update Composite Bow to correct stats and allow supported upgrades

### DIFF
--- a/Database/Patches/4 CraftTable/01195 Composite Bow with Handle.sql
+++ b/Database/Patches/4 CraftTable/01195 Composite Bow with Handle.sql
@@ -17,4 +17,5 @@ VALUES (@parent_id, 3,  25, NULL, 4, 0) /* On Player.SuccessResult CopyFromSourc
 DELETE FROM `cook_book` WHERE `recipe_Id` = 1195;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (1195, 7055 /* Bone Handle */,  6963 /* Composite Bow */, '2022-06-21 15:22:25');
+VALUES (1195, 7055 /* Bone Handle */,  6963 /* Composite Bow */, '2022-06-21 15:22:25')
+     , (1195, 7055 /* Bone Handle */,  6966 /* Composite Bow with Handle (pre-patch) */, '2022-06-24 13:42:42');

--- a/Database/Patches/4 CraftTable/05300 Composite Bow with Fine Handle.sql
+++ b/Database/Patches/4 CraftTable/05300 Composite Bow with Fine Handle.sql
@@ -35,4 +35,5 @@ VALUES (5300, 33984 /* Fine Bone Handle */,  6895 /* Composite Bow */, '2022-06-
      , (5300, 33984 /* Fine Bone Handle */,  6955 /* Composite Bow */, '2022-06-21 15:22:25')
      , (5300, 33984 /* Fine Bone Handle */,  6959 /* Composite Bow */, '2022-06-21 15:22:25')
      , (5300, 33984 /* Fine Bone Handle */,  6963 /* Composite Bow */, '2022-06-21 15:22:25')
-     , (5300, 33984 /* Fine Bone Handle */, 33997 /* Composite Bow with Handle */, '2022-06-21 15:22:25');
+     , (5300, 33984 /* Fine Bone Handle */,  6966 /* Composite Bow with Handle (pre-patch) */, '2022-06-23 16:20:48')
+     , (5300, 33984 /* Fine Bone Handle */, 33997 /* Composite Bow with Handle */, '2022-06-23 16:20:48');

--- a/Database/Patches/4 CraftTable/05301 Composite Bow with Superb Handle.sql
+++ b/Database/Patches/4 CraftTable/05301 Composite Bow with Superb Handle.sql
@@ -35,4 +35,6 @@ VALUES (5301, 33983 /* Superb Bone Handle */,  6895 /* Composite Bow */, '2022-0
      , (5301, 33983 /* Superb Bone Handle */,  6955 /* Composite Bow */, '2022-06-21 15:22:25')
      , (5301, 33983 /* Superb Bone Handle */,  6959 /* Composite Bow */, '2022-06-21 15:22:25')
      , (5301, 33983 /* Superb Bone Handle */,  6963 /* Composite Bow */, '2022-06-21 15:22:25')
-     , (5301, 33983 /* Superb Bone Handle */, 33991 /* Composite Bow with Fine Handle */, '2022-06-21 15:22:25');
+     , (5301, 33983 /* Superb Bone Handle */,  6966 /* Composite Bow with Handle (pre-patch) */, '2022-06-23 16:20:48')
+     , (5301, 33983 /* Superb Bone Handle */, 33991 /* Composite Bow with Fine Handle */, '2022-06-21 15:22:25')
+     , (5301, 33983 /* Superb Bone Handle */, 33997 /* Composite Bow with Handle */, '2022-06-23 16:20:48');

--- a/Database/Patches/4 CraftTable/05302 Composite Bow with Exquisite Handle.sql
+++ b/Database/Patches/4 CraftTable/05302 Composite Bow with Exquisite Handle.sql
@@ -35,4 +35,7 @@ VALUES (5302, 33982 /* Exquisite Bone Handle */,  6895 /* Composite Bow */, '202
      , (5302, 33982 /* Exquisite Bone Handle */,  6955 /* Composite Bow */, '2022-06-21 15:22:25')
      , (5302, 33982 /* Exquisite Bone Handle */,  6959 /* Composite Bow */, '2022-06-21 15:22:25')
      , (5302, 33982 /* Exquisite Bone Handle */,  6963 /* Composite Bow */, '2022-06-21 15:22:25')
-     , (5302, 33982 /* Exquisite Bone Handle */, 33990 /* Composite Bow with Superb Handle */, '2022-06-21 15:22:25');
+     , (5302, 33982 /* Exquisite Bone Handle */,  6966 /* Composite Bow with Handle (pre-patch) */, '2022-06-23 16:20:48')
+     , (5302, 33982 /* Exquisite Bone Handle */, 33990 /* Composite Bow with Superb Handle */, '2022-06-23 16:20:48')
+     , (5302, 33982 /* Exquisite Bone Handle */, 33991 /* Composite Bow with Fine Handle */, '2022-06-21 15:22:25')
+     , (5302, 33982 /* Exquisite Bone Handle */, 33997 /* Composite Bow with Handle */, '2022-06-23 16:20:48');

--- a/Database/Patches/4 CraftTable/09069 Infinite Ivory.sql
+++ b/Database/Patches/4 CraftTable/09069 Infinite Ivory.sql
@@ -191,7 +191,7 @@ VALUES (9069, 30092 /* Infinite Ivory */,   314 /* Dagger */, '2021-11-01 00:00:
      , (9069, 30092 /* Infinite Ivory */,  6962 /* Composite Bow with Handle */, '2021-11-01 00:00:00')
      , (9069, 30092 /* Infinite Ivory */,  6964 /* Composite Bow with Handle */, '2021-11-01 00:00:00')
      , (9069, 30092 /* Infinite Ivory */,  6965 /* Composite Bow with Handle */, '2021-11-01 00:00:00')
-     , (9069, 30092 /* Infinite Ivory */,  6966 /* Composite Bow with Handle */, '2021-11-01 00:00:00')
+     , (9069, 30092 /* Infinite Ivory */,  6966 /* Composite Bow with Handle (pre-patch) */, '2024-06-24 13:42:13')
      , (9069, 30092 /* Infinite Ivory */,  6968 /* Composite Crossbow with Handle */, '2021-11-01 00:00:00')
      , (9069, 30092 /* Infinite Ivory */,  6969 /* Composite Crossbow with Handle */, '2021-11-01 00:00:00')
      , (9069, 30092 /* Infinite Ivory */,  6970 /* Composite Crossbow with Handle */, '2021-11-01 00:00:00')
@@ -715,4 +715,8 @@ VALUES (9069, 30092 /* Infinite Ivory */,   314 /* Dagger */, '2021-11-01 00:00:
      , (9069, 30092 /* Infinite Ivory */, 30676 /* Barren Bow */, '2021-11-01 00:00:00')
      , (9069, 30092 /* Infinite Ivory */, 30677 /* Anemic Atlatl */, '2021-11-01 00:00:00')
      , (9069, 30092 /* Infinite Ivory */, 30678 /* Insensate Axe */, '2021-11-01 00:00:00')
-     , (9069, 30092 /* Infinite Ivory */, 30679 /* Sterile Sword */, '2021-11-01 00:00:00');
+     , (9069, 30092 /* Infinite Ivory */, 30679 /* Sterile Sword */, '2021-11-01 00:00:00')
+     , (9069, 30092 /* Infinite Ivory */, 33990 /* Composite Bow with Superb Handle */, '2024-06-24 13:42:13')
+     , (9069, 30092 /* Infinite Ivory */, 33991 /* Composite Bow with Fine Handle */, '2024-06-24 13:42:13')
+     , (9069, 30092 /* Infinite Ivory */, 33996 /* Composite Bow with Exquisite Handle */, '2024-06-24 13:42:13')
+     , (9069, 30092 /* Infinite Ivory */, 33997 /* Composite Bow with Handle */, '2024-06-24 13:42:13');

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/33997 Composite Bow with Handle.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/33997 Composite Bow with Handle.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 33997;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (33997, 'ace33997-compositebowwithhandle', 3, '2022-06-21 15:22:25') /* MissileLauncher */;
+VALUES (33997, 'ace33997-compositebowwithhandle', 3, '2022-06-23 16:20:42') /* MissileLauncher */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (33997,   1,        256) /* ItemType - MissileWeapon */
@@ -23,7 +23,7 @@ VALUES (33997,   1,        256) /* ItemType - MissileWeapon */
      , (33997,  60,        192) /* WeaponRange */
      , (33997,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (33997, 106,        250) /* ItemSpellcraft */
-     , (33997, 107,          0) /* ItemCurMana */
+     , (33997, 107,        500) /* ItemCurMana */
      , (33997, 108,        500) /* ItemMaxMana */
      , (33997, 109,        170) /* ItemDifficulty */
      , (33997, 114,          1) /* Attuned - Attuned */
@@ -31,7 +31,7 @@ VALUES (33997,   1,        256) /* ItemType - MissileWeapon */
      , (33997, 151,          2) /* HookType - Wall */
      , (33997, 158,          2) /* WieldRequirements - RawSkill */
      , (33997, 159,         47) /* WieldSkillType - MissileWeapons */
-     , (33997, 160,        250) /* WieldDifficulty */
+     , (33997, 160,        240) /* WieldDifficulty */
      , (33997, 353,          8) /* WeaponType - Bow */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -43,7 +43,7 @@ VALUES (33997,  22, True ) /* Inscribable */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (33997,   5,   -0.05) /* ManaRate */
      , (33997,  26,    27.3) /* MaximumVelocity */
-     , (33997,  29,    1.29) /* WeaponDefense */
+     , (33997,  29,    1.12) /* WeaponDefense */
      , (33997,  39,     1.1) /* DefaultScale */
      , (33997,  62,       1) /* WeaponOffense */
      , (33997,  63,    2.35) /* DamageMod */


### PR DESCRIPTION
**Summary**
- Initial Mana: per retail starts full (existing weenie starts empty)
- MeleeD Mod: 12% (existing weenie has BD7 applied)
- Allow handle upgrades (Handle -> Fine -> Superb -> Exquisite)
- Allow stat upgrades from pre-patch bows (6966) created prior to recipe updates in 2022.06 to post-patch (33997) bows by re-applying an intricately carved high undead (dark revenant thighbone) handle.
- Make upgraded bows a valid target for infinite ivory (note this is irrelevant due to Bug#1 below)

**Unfixed bugs in recipe (trying to keep this PR tight):**
1. Upgraded bows should not be pre-ivoried with the wieldable-by set, just ivoryable.
2. Only a perfectly crafted bow (6966) is eligible for new handles, but the recent recipe update allows crap bows to get the better stats. Source: memory and item description indicating a perfectly crafted (6966/33997) bow is required.

**Tests:**
```
@ci 6963 (perfectly crafted w/o handle)
@ci 6966 (perfectly crafted w/handle)
@ci 7055 (intricate/high dark rev)
@ci 33984 (fine bone handle)
@ci 33983 (superb bone handle)
@ci 33982 (exquisite bone handle)
@ci 30092 (infinite ivory)
```
Confirm pre-patch bow is upgradeable
Check spawned mana (500/500)
Check spawned MeleeD (12%)

Use 7055 (handle) on 6963 (no handle bow) - now a 33997 (bow w/handle)
Use 7055 (handle) on 6966 (pre-patch bow) - now a 33997 (bow w/handle)
  use 33984  on bow/handle - now bow/fine
  use 7055 on bow/fine (fails - no downgrade)
  use 33983  on bow/fine - now bow w/superb
  use 7055 on bow/superb (fails - no downgrade)
  use 33984 on bow/superb (fails - no downgrade)
  use 33982 on bow/superb - now bow w/exquisite
  use 7055 on bow/exquisite (fails - no downgrade)
  use 33984 on bow/exquisite (fails - no downgrade)
  use 33092 on bow/exquisite (fails - no downgrade)

**Supporting evidence:**

PCAPS:
Original: 6966 http://ac.yotesfan.com/weenies/items/6966
Post-Patch: 33997 http://ac.yotesfan.com/weenies/items/33997

2012 Video showing in-game stats https://youtu.be/3RsmCPwMNsI?t=648 also confirms item has full mana upon crafting as of Jan 2012.

Player notes:
https://acportalstorm.com/wiki/Composite_Bow#Composite_Bow_with_Handle
http://acpedia.org/wiki/Composite_Bow_with_Handle
https://asheron.fandom.com/wiki/Composite_Weapons_Quest
https://asheron.fandom.com/wiki/Composite_Bow_with_Handle#Composite_Bow_with_Handle_(High)
https://asheron.fandom.com/wiki/Bone_Handle_(High)
http://acpedia.org/wiki/Missile_Weaponry/Bows
http://acpedia.org/wiki/Composite_Bow (incorrectly says bow 250 vs 240)

**Perfectly crafted component improvements:**

Shaped Great Mattekar Horn	+6% Melee Defense
Cured Large Lugian Sinew	Bow: Speed 35
Excellent Oiled String	Bow: +110% Damage

Bone Handle (High) (successful Dark Rev)
Made from intricately carving a Dark Revenant Thighbone.
Can be attached to a Composite Bow, Composite Crossbow, or Composite Atlatl
Improves weapon by adding +6% to melee, +25% to damage modifier (bow), Armor Cleaving, Cast on Strike, Brittlemail VI, Defender VI, Boon of Refinement, Swift Killer VI, Strathelar's Boon, Infected Caress. It also makes the weapon heavier (1,520 burden instead of 980 for bow)
Requirements: Arcane Lore skill 170+, Bow Skill 240+.

**Correct un-buffed final Composite Bow with Handle:**

Value: 400
Burden: 1,520
Skill: Missile Weapons (Bow)
Damage Bonus: 0
Damage Modifier: +135%
Speed: Average (35)
Range: 80 yds
Uses arrows as ammunition.
Bonus to Melee Defense: +12%
Spells: Brittlemail VI, Aura of Defender VI, Boon of Refinement, Swift Killer VI, Missile Weapon Mastery Other VII, Aura of Infected Caress
Properties: Armor Cleaving, Cast on Strike, Attuned, Bonded, Ivoryable
Wield requires Missile Weapons 240
Activation requires Arcane Lore: 170
This item cannot be sold.
Spellcraft: 250
Mana: 500
Mana Cost: 1 point per 20 seconds