### PR TITLE
GY Spawn Fix

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Generic/None/72217 GY Corrupted Gravestone Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72217 GY Corrupted Gravestone Gen.sql
@@ -26,4 +26,4 @@ VALUES (72217,   1, 0x0200026B) /* Setup */
      , (72217,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72217, -1, 52305, 0, 4, 4, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Gravestone (52305) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72217, -1, 52305, 60, 4, 4, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Gravestone (52305) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72219 GY Night Exhumed Bones Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72219 GY Night Exhumed Bones Gen.sql
@@ -29,4 +29,4 @@ VALUES (72219,   1, 0x0200026B) /* Setup */
      , (72219,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72219, -1, 35251, 0, 4, 4, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72219, -1, 35251, 60, 4, 4, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72220 GY Day Rat Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72220 GY Day Rat Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72220,   1, True ) /* Stuck */
      , (72220,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72220,  41,     360) /* RegenerationInterval */
+VALUES (72220,  41,     180) /* RegenerationInterval */
      , (72220,  43,       8) /* GeneratorRadius */
      , (72220, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,4 +29,4 @@ VALUES (72220,   1, 0x0200026B) /* Setup */
      , (72220,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72220, -1, 35100, 0, 6, 6, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x6 up to max of 6) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72220, -1, 35100, 120, 6, 6, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x6 up to max of 6) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72221 GY Day Pyre Skeleton Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72221 GY Day Pyre Skeleton Camp Gen.sql
@@ -29,5 +29,5 @@ VALUES (72221,   1, 0x0200026B) /* Setup */
      , (72221,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72221, -1, 35097, 0, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72221, -1, 35099, 0, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72221, -1, 35097, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72221, -1, 35099, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72222 GY Day Pyre Champion Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72222 GY Day Pyre Champion Camp Gen.sql
@@ -29,6 +29,6 @@ VALUES (72222,   1, 0x0200026B) /* Setup */
      , (72222,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72222, -1, 35097, 0, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72222, -1, 35099, 0, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72222, -1, 35098, 0, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (35098) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72222, -1, 35097, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72222, -1, 35099, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72222, -1, 35098, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (35098) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72224 GY Night Pyre Champion Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72224 GY Night Pyre Champion Camp Gen.sql
@@ -29,6 +29,6 @@ VALUES (72224,   1, 0x0200026B) /* Setup */
      , (72224,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72224, -1, 41963, 0, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72224, -1, 52308, 0, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72224, -1, 46816, 0, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72224, -1, 41963, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72224, -1, 52308, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72224, -1, 46816, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72225 GY Night Undead Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72225 GY Night Undead Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72225,   1, True ) /* Stuck */
      , (72225,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72225,  41,     120) /* RegenerationInterval */
+VALUES (72225,  41,     180) /* RegenerationInterval */
      , (72225,  43,       8) /* GeneratorRadius */
      , (72225, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,6 +29,6 @@ VALUES (72225,   1, 0x0200026B) /* Setup */
      , (72225,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72225, -1, 46815, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72225, -1, 41968, 60, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (41968) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72225, -1, 41966, 60, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72225, -1, 46815, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72225, -1, 41968, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (41968) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72225, -1, 41966, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72226 GY Night Ghost Wanderer Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72226 GY Night Ghost Wanderer Gen.sql
@@ -17,7 +17,7 @@ VALUES (72226,   1, True ) /* Stuck */
      , (72226,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72226,  41,     120) /* RegenerationInterval */
+VALUES (72226,  41,     180) /* RegenerationInterval */
      , (72226,  43,       8) /* GeneratorRadius */
      , (72226, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,4 +29,4 @@ VALUES (72226,   1, 0x0200026B) /* Setup */
      , (72226,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72226, -1, 35268, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Dread (35268) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72226, -1, 35268, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Dread (35268) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72227 GY Night Wisp Wanderer Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72227 GY Night Wisp Wanderer Gen.sql
@@ -17,7 +17,7 @@ VALUES (72227,   1, True ) /* Stuck */
      , (72227,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72227,  41,     120) /* RegenerationInterval */
+VALUES (72227,  41,     180) /* RegenerationInterval */
      , (72227,  43,       8) /* GeneratorRadius */
      , (72227, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,6 +29,6 @@ VALUES (72227,   1, 0x0200026B) /* Setup */
      , (72227,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72227, 0.33, 35059, 60, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (35059) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72227, 0.66, 35089, 60, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Despair Wisp (35089) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72227, 1, 35090, 60, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (35090) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72227, 0.33, 35059, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (35059) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72227, 0.66, 35089, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Despair Wisp (35089) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72227, 1, 35090, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (35090) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87012 GY Night Bunker Top Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87012 GY Night Bunker Top Gen.sql
@@ -29,5 +29,5 @@ VALUES (87012,   1, 0x0200026B) /* Setup */
      , (87012,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87012, -1, 46816, 60, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (87012, -1, 46815, 60, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+VALUES (87012, -1, 46816, 120, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (87012, -1, 46815, 120, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;


### PR DESCRIPTION
Added line item delays to prevent instant respawn. These were previously set to 0.
Adjusted regen interval on some generators to match the rest.