### PR TITLE
Update magic skill levels on the 4 corners pillars

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/52260 Pillar of Frost.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/52260 Pillar of Frost.sql
@@ -82,9 +82,9 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (52260,  6, 0, 3, 0, 457, 0, 0) /* MeleeDefense        Specialized */
      , (52260,  7, 0, 3, 0, 450, 0, 0) /* MissileDefense      Specialized */
      , (52260, 15, 0, 3, 0, 154, 0, 0) /* MagicDefense        Specialized */
-     , (52260, 31, 0, 3, 0, 215, 0, 0) /* CreatureEnchantment Specialized */
-     , (52260, 33, 0, 3, 0, 215, 0, 0) /* LifeMagic           Specialized */
-     , (52260, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
+     , (52260, 31, 0, 3, 0, 450, 0, 0) /* CreatureEnchantment Specialized */
+     , (52260, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
+     , (52260, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
      , (52260, 45, 0, 3, 0, 173, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/52261 Pillar of Lightning.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/52261 Pillar of Lightning.sql
@@ -78,6 +78,15 @@ VALUES (52261,   1,  3555, 0, 0, 3600) /* MaxHealth */
      , (52261,   3,   100, 0, 0, 190) /* MaxStamina */
      , (52261,   5,   300, 0, 0, 450) /* MaxMana */;
 
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (52261,  6, 0, 3, 0, 457, 0, 0) /* MeleeDefense        Specialized */
+     , (52261,  7, 0, 3, 0, 450, 0, 0) /* MissileDefense      Specialized */
+     , (52261, 15, 0, 3, 0, 154, 0, 0) /* MagicDefense        Specialized */
+     , (52261, 31, 0, 3, 0, 450, 0, 0) /* CreatureEnchantment Specialized */
+     , (52261, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
+     , (52261, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
+     , (52261, 45, 0, 3, 0, 173, 0, 0) /* LightWeapons        Specialized */;
+
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (52261,  0,  4,  0,    0,  300,  350,  350,  350,  350,  350,  250,  550,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (52261,  1,  4,  0,    0,  300,  350,  350,  350,  350,  350,  250,  550,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/52262 Pillar of Acid.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/52262 Pillar of Acid.sql
@@ -83,9 +83,9 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (52262,  6, 0, 3, 0, 457, 0, 0) /* MeleeDefense        Specialized */
      , (52262,  7, 0, 3, 0, 450, 0, 0) /* MissileDefense      Specialized */
      , (52262, 15, 0, 3, 0, 154, 0, 0) /* MagicDefense        Specialized */
-     , (52262, 31, 0, 3, 0, 215, 0, 0) /* CreatureEnchantment Specialized */
-     , (52262, 33, 0, 3, 0, 215, 0, 0) /* LifeMagic           Specialized */
-     , (52262, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
+     , (52262, 31, 0, 3, 0, 450, 0, 0) /* CreatureEnchantment Specialized */
+     , (52262, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
+     , (52262, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
      , (52262, 45, 0, 3, 0, 173, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/52263 Pillar of Fire.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/52263 Pillar of Fire.sql
@@ -81,9 +81,9 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (52263,  6, 0, 3, 0, 457, 0, 0) /* MeleeDefense        Specialized */
      , (52263,  7, 0, 3, 0, 450, 0, 0) /* MissileDefense      Specialized */
      , (52263, 15, 0, 3, 0, 154, 0, 0) /* MagicDefense        Specialized */
-     , (52263, 31, 0, 3, 0, 215, 0, 0) /* CreatureEnchantment Specialized */
-     , (52263, 33, 0, 3, 0, 215, 0, 0) /* LifeMagic           Specialized */
-     , (52263, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
+     , (52263, 31, 0, 3, 0, 450, 0, 0) /* CreatureEnchantment Specialized */
+     , (52263, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
+     , (52263, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
      , (52263, 45, 0, 3, 0, 173, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)


### PR DESCRIPTION
Updates the magic skills of the pillars spawns on the Four Corners of Dereth quest. Their associated PCAP (PCAP Part 3/miscpcaps1/pkt_2017-1-29_1485719326_log.pcap) unfortunately had a 0% resist rate at 412 magic defense so I can't get much actual data. I figured matching the skill levels of the other high skill pillars (e.g. 51831) was reasonable enough with what I do have.