### PR TITLE
Fletching Updates

### DIFF
--- a/Database/Patches/4 CraftTable/00323 Arrow.sql
+++ b/Database/Patches/4 CraftTable/00323 Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 323;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (323, 0, 37 /* Fletching */, 5, 0, 300 /* Arrow */, 100, 'You make a bundle of arrows.', 0, 0, 'You fail to make any arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 323;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (323, 4586 /* Bundle of Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00324 Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00324 Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 324;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (324, 0, 37 /* Fletching */, 5, 0, 305 /* Quarrel */, 100, 'You make a bundle of quarrels.', 0, 0, 'You fail to make any quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 324;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (324, 4586 /* Bundle of Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00325 Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/00325 Acid Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 325;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (325, 0, 37 /* Fletching */, 60, 0, 4181 /* Acid Arrow */, 100, 'You make a bundle of acid arrows.', 0, 0, 'You fail to make any acid arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 325;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (325, 5340 /* Bundle of Acid Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00326 Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00326 Acid Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 326;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (326, 0, 37 /* Fletching */, 60, 0, 4185 /* Acid Quarrel */, 100, 'You make a bundle of acid quarrels.', 0, 0, 'You fail to make any acid quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 326;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (326, 5340 /* Bundle of Acid Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00327 Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/00327 Armor Piercing Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 327;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (327, 0, 37 /* Fletching */, 20, 0, 3598 /* Armor Piercing Arrow */, 100, 'You make a bundle of armor-piercing arrows.', 0, 0, 'You fail to make any armor-piercing arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 327;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (327, 5347 /* Bundle of Armor Piercing Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00328 Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00328 Armor Piercing Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 328;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (328, 0, 37 /* Fletching */, 20, 0, 3602 /* Armor Piercing Quarrel */, 100, 'You make a bundle of armor-piercing quarrels.', 0, 0, 'You fail to make any armor-piercing quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 328;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (328, 5347 /* Bundle of Armor Piercing Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00329 Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/00329 Blunt Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 329;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (329, 0, 37 /* Fletching */, 10, 0, 3599 /* Blunt Arrow */, 100, 'You make a bundle of blunt arrows.', 0, 0, 'You fail to make any blunt arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 329;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (329, 5344 /* Bundle of Blunt Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00330 Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00330 Blunt Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 330;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (330, 0, 37 /* Fletching */, 10, 0, 3603 /* Blunt Quarrel */, 100, 'You make a bundle of blunt quarrels.', 0, 0, 'You fail to make any blunt quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 330;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (330, 5344 /* Bundle of Blunt Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00331 Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/00331 Broadhead Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 331;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (331, 0, 37 /* Fletching */, 10, 0, 3600 /* Broadhead Arrow */, 100, 'You make a bundle of broadhead arrows.', 0, 0, 'You fail to make any arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 331;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (331, 5345 /* Bundle of Broad Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00332 Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00332 Broadhead Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 332;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (332, 0, 37 /* Fletching */, 10, 0, 3604 /* Broadhead Quarrel */, 100, 'You make a bundle of broadhead quarrels.', 0, 0, 'You fail to make any broad quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 332;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (332, 5345 /* Bundle of Broad Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00333 Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/00333 Fire Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 333;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (333, 0, 37 /* Fletching */, 60, 0, 1437 /* Fire Arrow */, 100, 'You make a bundle of fire arrows.', 0, 0, 'You fail to make any fire arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 333;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (333, 5341 /* Bundle of Fire Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00334 Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00334 Fire Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 334;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (334, 0, 37 /* Fletching */, 60, 0, 4188 /* Fire Quarrel */, 100, 'You make a bundle of fire quarrels.', 0, 0, 'You fail to make any fire quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 334;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (334, 5341 /* Bundle of Fire Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00335 Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/00335 Frog Crotch Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 335;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (335, 0, 37 /* Fletching */, 20, 0, 3601 /* Frog Crotch Arrow */, 100, 'You make a bundle of frog crotch arrows.', 0, 0, 'You fail to make any frog crotch arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 335;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (335, 5346 /* Bundle of Frog Crotch Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00336 Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00336 Frog Crotch Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 336;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (336, 0, 37 /* Fletching */, 20, 0, 3605 /* Frog Crotch Quarrel */, 100, 'You make a bundle of frog crotch quarrels.', 0, 0, 'You fail to make any frog crotch quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 336;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (336, 5346 /* Bundle of Frog Crotch Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00337 Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/00337 Frost Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 337;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (337, 0, 37 /* Fletching */, 60, 0, 4182 /* Frost Arrow */, 100, 'You make a bundle of frost arrows.', 0, 0, 'You fail to make any frost arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 337;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (337, 5342 /* Bundle of Frost Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00338 Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00338 Frost Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 338;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (338, 0, 37 /* Fletching */, 60, 0, 4186 /* Frost Quarrel */, 100, 'You make a bundle of frost quarrels.', 0, 0, 'You fail to make any frost quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 338;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (338, 5342 /* Bundle of Frost Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00339 Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/00339 Lightning Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 339;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (339, 0, 37 /* Fletching */, 60, 0, 4183 /* Lightning Arrow */, 100, 'You make a bundle of lightning arrows.', 0, 0, 'You fail to make any lightning arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 339;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (339, 5343 /* Bundle of Lightning Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00340 Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00340 Lightning Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 340;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (340, 0, 37 /* Fletching */, 60, 0, 4187 /* Lightning Quarrel */, 100, 'You make a bundle of lightning quarrels.', 0, 0, 'You fail to make any lightning quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 340;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (340, 5343 /* Bundle of Lightning Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00341 Greater Arrow.sql
+++ b/Database/Patches/4 CraftTable/00341 Greater Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 341;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (341, 0, 37 /* Fletching */, 120, 0, 5304 /* Greater Arrow */, 100, 'You make a bundle of greater arrows.', 0, 0, 'You fail to make any greater arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 341;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (341, 5348 /* Bundle of Greater Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00342 Greater Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00342 Greater Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 342;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (342, 0, 37 /* Fletching */, 120, 0, 5313 /* Greater Quarrel */, 100, 'You make a bundle of greater quarrels.', 0, 0, 'You fail to make any greater quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 342;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (342, 5348 /* Bundle of Greater Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00343 Greater Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/00343 Greater Acid Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 343;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (343, 0, 37 /* Fletching */, 200, 0, 5306 /* Greater Acid Arrow */, 100, 'You make a bundle of greater acid arrows.', 0, 0, 'You fail to make any greater acid arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 343;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (343, 5349 /* Bundle of Greater Acid Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00344 Greater Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00344 Greater Acid Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 344;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (344, 0, 37 /* Fletching */, 200, 0, 5314 /* Greater Acid Quarrel */, 100, 'You make a bundle of greater acid quarrels.', 0, 0, 'You fail to make any greater acid quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 344;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (344, 5349 /* Bundle of Greater Acid Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00345 Greater Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/00345 Greater Armor Piercing Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 345;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (345, 0, 37 /* Fletching */, 160, 0, 5309 /* Greater Armor Piercing Arrow */, 100, 'You make a bundle of greater armor-piercing arrows.', 0, 0, 'You fail to make any greater armor-piercing arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 345;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (345, 5356 /* Bundle of Greater Armor Piercing Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00346 Greater Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00346 Greater Armor Piercing Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 346;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (346, 0, 37 /* Fletching */, 160, 0, 5318 /* Greater Armor Piercing Quarrel */, 100, 'You make a bundle of greater armor-piercing quarrels.', 0, 0, 'You fail to make any greater armor-piercing quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 346;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (346, 5356 /* Bundle of Greater Armor Piercing Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00347 Greater Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/00347 Greater Blunt Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 347;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (347, 0, 37 /* Fletching */, 140, 0, 5310 /* Greater Blunt Arrow */, 100, 'You make a bundle of greater blunt arrows.', 0, 0, 'You fail to make any greater blunt arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 347;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (347, 5353 /* Bundle of Greater Blunt Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00348 Greater Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00348 Greater Blunt Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 348;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (348, 0, 37 /* Fletching */, 140, 0, 5319 /* Greater Blunt Quarrel */, 100, 'You make a bundle of greater blunt quarrels.', 0, 0, 'You fail to make any greater blunt quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 348;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (348, 5353 /* Bundle of Greater Blunt Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00349 Greater Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/00349 Greater Broadhead Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 349;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (349, 0, 37 /* Fletching */, 140, 0, 5357 /* Greater Broadhead Arrow */, 100, 'You make a bundle of greater broadhead arrows.', 0, 0, 'You fail to make any greater broadhead arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 349;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (349, 5354 /* Bundle of Greater Broad Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00350 Greater Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00350 Greater Broadhead Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 350;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (350, 0, 37 /* Fletching */, 140, 0, 5320 /* Greater Broadhead Quarrel */, 100, 'You make a bundle of greater broadhead quarrels.', 0, 0, 'You fail to make any greater broadhead quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 350;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (350, 5354 /* Bundle of Greater Broad Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00351 Greater Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/00351 Greater Fire Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 351;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (351, 0, 37 /* Fletching */, 200, 0, 5305 /* Greater Fire Arrow */, 100, 'You make a bundle of greater fire arrows.', 0, 0, 'You fail to make any greater fire arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 351;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (351, 5350 /* Bundle of Greater Fire Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00352 Greater Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00352 Greater Fire Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 352;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (352, 0, 37 /* Fletching */, 200, 0, 5317 /* Greater Fire Quarrel */, 100, 'You make a bundle of greater fire quarrels.', 0, 0, 'You fail to make any greater fire quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 352;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (352, 5350 /* Bundle of Greater Fire Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00353 Greater Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/00353 Greater Frog Crotch Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 353;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (353, 0, 37 /* Fletching */, 160, 0, 5312 /* Greater Frog Crotch Arrow */, 100, 'You make a bundle of greater frog crotch arrows.', 0, 0, 'You fail to make any greater frog crotch arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 353;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (353, 5355 /* Bundle of Greater Frog Crotch Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00354 Greater Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00354 Greater Frog Crotch Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 354;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (354, 0, 37 /* Fletching */, 160, 0, 5321 /* Greater Frog Crotch Quarrel */, 100, 'You make a bundle of greater frog crotch quarrels.', 0, 0, 'You fail to make any greater frog crotch quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 354;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (354, 5355 /* Bundle of Greater Frog Crotch Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00355 Greater Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/00355 Greater Frost Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 355;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (355, 0, 37 /* Fletching */, 200, 0, 5307 /* Greater Frost Arrow */, 100, 'You make a bundle of greater frost arrows.', 0, 0, 'You fail to make any greater frost arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 355;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (355, 5351 /* Bundle of Greater Frost Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00356 Greater Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00356 Greater Frost Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 356;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (356, 0, 37 /* Fletching */, 200, 0, 5315 /* Greater Frost Quarrel */, 100, 'You make a bundle of greater frost quarrels.', 0, 0, 'You fail to make any greater frost quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 356;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (356, 5351 /* Bundle of Greater Frost Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00357 Greater Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/00357 Greater Lightning Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 357;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (357, 0, 37 /* Fletching */, 200, 0, 5308 /* Greater Lightning Arrow */, 100, 'You make a bundle of greater lightning arrows.', 0, 0, 'You fail to make any greater lightning arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 357;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (357, 5352 /* Bundle of Greater Lightning Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00358 Greater Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/00358 Greater Lightning Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 358;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (358, 0, 37 /* Fletching */, 200, 0, 5316 /* Greater Lightning Quarrel */, 100, 'You make a bundle of greater lightning quarrels.', 0, 0, 'You fail to make any greater lightning quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 358;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (358, 5352 /* Bundle of Greater Lightning Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00402 Spike.sql
+++ b/Database/Patches/4 CraftTable/00402 Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 402;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (402, 0, 37 /* Fletching */, 5, 0, 23873 /* Spike */, 100, 'You make a bundle of spikes.', 0, 0, 'You fail to make any spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 402;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (402, 4586 /* Bundle of Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00403 Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/00403 Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 403;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (403, 0, 37 /* Fletching */, 60, 0, 23874 /* Acid Spike */, 100, 'You make a bundle of acid spikes.', 0, 0, 'You fail to make any acid spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 403;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (403, 5340 /* Bundle of Acid Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00404 Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/00404 Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 404;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (404, 0, 37 /* Fletching */, 5, 0, 23875 /* Blunt Spike */, 100, 'You make a bundle of blunt spikes.', 0, 0, 'You fail to make any blunt spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 404;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (404, 5344 /* Bundle of Blunt Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00405 Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/00405 Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 405;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (405, 0, 37 /* Fletching */, 5, 0, 23876 /* Broad Spike */, 100, 'You make a bundle of broadhead spikes.', 0, 0, 'You fail to make any broadhead spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 405;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (405, 5345 /* Bundle of Broad Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00406 Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/00406 Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 406;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (406, 0, 37 /* Fletching */, 60, 0, 23878 /* Fire Spike */, 100, 'You make a bundle of fire spikes.', 0, 0, 'You fail to make any fire spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 406;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (406, 5341 /* Bundle of Fire Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00407 Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/00407 Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 407;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (407, 0, 37 /* Fletching */, 60, 0, 23879 /* Frost Spike */, 100, 'You make a bundle of frost spikes.', 0, 0, 'You fail to make any frost spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 407;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (407, 5342 /* Bundle of Frost Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00408 Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/00408 Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 408;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (408, 0, 37 /* Fletching */, 60, 0, 23877 /* Lightning Spike */, 100, 'You make a bundle of lightning spikes.', 0, 0, 'You fail to make any lightning spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 408;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (408, 5343 /* Bundle of Lightning Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00409 Deadly Spike.sql
+++ b/Database/Patches/4 CraftTable/00409 Deadly Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 409;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (409, 0, 37 /* Fletching */, 150, 0, 23859 /* Deadly Spike */, 100, 'You make a bundle of deadly spikes.', 0, 0, 'You fail to make any deadly spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 409;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (409, 15411 /* Bundle of Deadly Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00410 Deadly Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/00410 Deadly Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 410;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (410, 0, 37 /* Fletching */, 225, 0, 23860 /* Deadly Acid Spike */, 100, 'You make a bundle of deadly acid spikes.', 0, 0, 'You fail to make any deadly acid spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 410;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (410, 15412 /* Bundle of Deadly Acid Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00411 Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/00411 Deadly Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 411;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (411, 0, 37 /* Fletching */, 150, 0, 23861 /* Deadly Blunt Spike */, 100, 'You make a bundle of deadly blunt spikes.', 0, 0, 'You fail to make any deadly blunt spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 411;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (411, 15414 /* Bundle of Deadly Blunt Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00412 Deadly Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/00412 Deadly Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 412;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (412, 0, 37 /* Fletching */, 150, 0, 23862 /* Deadly Broad Spike */, 100, 'You make a bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any deadly broadhead spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 412;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (412, 15415 /* Bundle of Deadly Broad Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00413 Deadly Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/00413 Deadly Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 413;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (413, 0, 37 /* Fletching */, 225, 0, 23864 /* Deadly Fire Spike */, 100, 'You make a bundle of deadly fire spikes.', 0, 0, 'You fail to make any deadly fire spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 413;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (413, 15417 /* Bundle of Deadly Fire Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00414 Deadly Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/00414 Deadly Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 414;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (414, 0, 37 /* Fletching */, 225, 0, 23865 /* Deadly Frost Spike */, 100, 'You make a bundle of deadly frost spikes.', 0, 0, 'You fail to make any deadly frost spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 414;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (414, 15419 /* Bundle of Deadly Frost Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00415 Deadly Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/00415 Deadly Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 415;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (415, 0, 37 /* Fletching */, 225, 0, 23863 /* Deadly Lightning Spike */, 100, 'You make a bundle of deadly lightning spikes.', 0, 0, 'You fail to make any deadly lightning spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 415;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (415, 15416 /* Bundle of Deadly Lightning Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00416 Greater Spike.sql
+++ b/Database/Patches/4 CraftTable/00416 Greater Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 416;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (416, 0, 37 /* Fletching */, 120, 0, 23866 /* Greater Spike */, 100, 'You make a bundle of greater spikes.', 0, 0, 'You fail to make any greater spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 416;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (416, 5348 /* Bundle of Greater Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00417 Greater Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/00417 Greater Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 417;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (417, 0, 37 /* Fletching */, 200, 0, 23867 /* Greater Acid Spike */, 100, 'You make a bundle of greater acid spikes.', 0, 0, 'You fail to make any greater acid spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 417;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (417, 5349 /* Bundle of Greater Acid Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00418 Greater Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/00418 Greater Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 418;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (418, 0, 37 /* Fletching */, 120, 0, 23868 /* Greater Blunt Spike */, 100, 'You make a bundle of greater blunt spikes.', 0, 0, 'You fail to make any greater blunt spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 418;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (418, 5353 /* Bundle of Greater Blunt Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00419 Greater Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/00419 Greater Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 419;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (419, 0, 37 /* Fletching */, 120, 0, 23869 /* Greater Broad Spike */, 100, 'You make a bundle of greater broadhead spikes.', 0, 0, 'You fail to make any greater broadhead spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 419;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (419, 5354 /* Bundle of Greater Broad Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00420 Greater Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/00420 Greater Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 420;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (420, 0, 37 /* Fletching */, 200, 0, 23871 /* Greater Fire Spike */, 100, 'You make a bundle of greater fire spikes.', 0, 0, 'You fail to make any greater fire spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 420;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (420, 5350 /* Bundle of Greater Fire Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00421 Greater Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/00421 Greater Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 421;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (421, 0, 37 /* Fletching */, 200, 0, 23872 /* Greater Frost Spike */, 100, 'You make a bundle of greater frost spikes.', 0, 0, 'You fail to make any greater frost spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:52:02');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 421;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (421, 5351 /* Bundle of Greater Frost Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00422 Greater Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/00422 Greater Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 422;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (422, 0, 37 /* Fletching */, 200, 0, 23870 /* Greater Lightning Spike */, 100, 'You make a bundle of greater lightning spikes.', 0, 0, 'You fail to make any greater lightning spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 422;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (422, 5352 /* Bundle of Greater Lightning Arrowheads */, 23857 /* Bundle of Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00423 Spike.sql
+++ b/Database/Patches/4 CraftTable/00423 Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 423;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (423, 0, 37 /* Fletching */, 35, 0, 23873 /* Spike */, 1000, 'You make a big bundle of spikes.', 0, 0, 'You fail to make any spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 423;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (423, 9359 /* Wrapped Bundle of Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00424 Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/00424 Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 424;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (424, 0, 37 /* Fletching */, 90, 0, 23874 /* Acid Spike */, 1000, 'You make a big bundle of acid spikes.', 0, 0, 'You fail to make any acid spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 424;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (424, 9360 /* Wrapped Bundle of Acid Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00425 Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/00425 Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 425;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (425, 0, 37 /* Fletching */, 35, 0, 23875 /* Blunt Spike */, 1000, 'You make a big bundle of blunt spikes.', 0, 0, 'You fail to make any blunt spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 425;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (425, 9362 /* Wrapped Bundle of Blunt Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00426 Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/00426 Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 426;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (426, 0, 37 /* Fletching */, 35, 0, 23876 /* Broad Spike */, 1000, 'You make a big bundle of broadhead spikes.', 0, 0, 'You fail to make any broadhead spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 426;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (426, 9363 /* Wrapped Bundle of Broad Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00427 Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/00427 Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 427;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (427, 0, 37 /* Fletching */, 90, 0, 23878 /* Fire Spike */, 1000, 'You make a big bundle of fire spikes.', 0, 0, 'You fail to make any fire spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 427;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (427, 9365 /* Wrapped Bundle of Fire Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00428 Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/00428 Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 428;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (428, 0, 37 /* Fletching */, 90, 0, 23879 /* Frost Spike */, 1000, 'You make a big bundle of frost spikes.', 0, 0, 'You fail to make any frost spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 428;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (428, 9367 /* Wrapped Bundle of Frost Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00429 Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/00429 Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 429;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (429, 0, 37 /* Fletching */, 90, 0, 23877 /* Lightning Spike */, 1000, 'You make a big bundle of lightning spikes.', 0, 0, 'You fail to make any lightning spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 429;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (429, 9364 /* Wrapped Bundle of Lightning Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00430 Deadly Spike.sql
+++ b/Database/Patches/4 CraftTable/00430 Deadly Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 430;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (430, 0, 37 /* Fletching */, 175, 0, 23859 /* Deadly Spike */, 1000, 'You make a big bundle of deadly spikes.', 0, 0, 'You fail to make any deadly spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 430;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (430, 15420 /* Wrapped Bundle of Deadly Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00431 Deadly Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/00431 Deadly Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 431;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (431, 0, 37 /* Fletching */, 250, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a big bundle of deadly acid spikes.', 0, 0, 'You fail to make any deadly acid spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 431;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (431, 15421 /* Wrapped Bundle of Deadly Acid Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00432 Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/00432 Deadly Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 432;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (432, 0, 37 /* Fletching */, 180, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a big bundle of deadly blunt spikes.', 0, 0, 'You fail to make any deadly blunt spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 432;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (432, 15423 /* Wrapped Bundle of Deadly Blunt Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00433 Deadly Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/00433 Deadly Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 433;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (433, 0, 37 /* Fletching */, 180, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a big bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any deadly broadhead spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 433;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (433, 15424 /* Wrapped Bundle of Deadly Broad Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00434 Deadly Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/00434 Deadly Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 434;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (434, 0, 37 /* Fletching */, 250, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a big bundle of deadly fire spikes.', 0, 0, 'You fail to make any deadly fire spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 434;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (434, 15426 /* Wrapped Bundle of Deadly Fire Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00435 Deadly Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/00435 Deadly Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 435;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (435, 0, 37 /* Fletching */, 250, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a big bundle of deadly frost spikes.', 0, 0, 'You fail to make any deadly frost spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 435;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (435, 15428 /* Wrapped Bundle of Deadly Frost Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00436 Deadly Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/00436 Deadly Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 436;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (436, 0, 37 /* Fletching */, 250, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a big bundle of deadly lightning spikes.', 0, 0, 'You fail to make any deadly lightning spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 436;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (436, 15425 /* Wrapped Bundle of Deadly Lightning Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00437 Greater Spike.sql
+++ b/Database/Patches/4 CraftTable/00437 Greater Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 437;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (437, 0, 37 /* Fletching */, 150, 0, 23866 /* Greater Spike */, 1000, 'You make a big bundle of greater spikes.', 0, 0, 'You fail to make any greater spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 437;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (437, 9368 /* Wrapped Bundle of Greater Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00438 Greater Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/00438 Greater Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 438;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (438, 0, 37 /* Fletching */, 230, 0, 23867 /* Greater Acid Spike */, 1000, 'You make a big bundle of greater acid spikes.', 0, 0, 'You fail to make any greater acid spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 438;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (438, 9369 /* Wrapped Bundle of Greater Acid Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00439 Greater Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/00439 Greater Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 439;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (439, 0, 37 /* Fletching */, 150, 0, 23868 /* Greater Blunt Spike */, 1000, 'You make a big bundle of greater blunt spikes.', 0, 0, 'You fail to make any greater blunt spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 439;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (439, 9371 /* Wrapped Bundle of Greater Blunt Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00440 Greater Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/00440 Greater Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 440;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (440, 0, 37 /* Fletching */, 150, 0, 23869 /* Greater Broad Spike */, 1000, 'You make a big bundle of greater broadhead spikes.', 0, 0, 'You fail to make any greater broadhead spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 440;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (440, 9372 /* Wrapped Bundle of Greater Broad Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00441 Greater Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/00441 Greater Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 441;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (441, 0, 37 /* Fletching */, 230, 0, 23871 /* Greater Fire Spike */, 1000, 'You make a big bundle of greater fire spikes.', 0, 0, 'You fail to make any greater fire spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 441;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (441, 9374 /* Wrapped Bundle of Greater Fire Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00442 Greater Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/00442 Greater Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 442;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (442, 0, 37 /* Fletching */, 230, 0, 23872 /* Greater Frost Spike */, 1000, 'You make a big bundle of greater frost spikes.', 0, 0, 'You fail to make any greater frost spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 442;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (442, 9376 /* Wrapped Bundle of Greater Frost Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00443 Greater Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/00443 Greater Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 443;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (443, 0, 37 /* Fletching */, 230, 0, 23870 /* Greater Lightning Spike */, 1000, 'You make a big bundle of greater lightning spikes.', 0, 0, 'You fail to make any greater lightning spikes.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-19 10:49:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 443;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (443, 9373 /* Wrapped Bundle of Greater Lightning Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/00444 Bundle of Spiketails.sql
+++ b/Database/Patches/4 CraftTable/00444 Bundle of Spiketails.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 444;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (444, 0, 37 /* Fletching */, 60, 0, 23857 /* Bundle of Spiketails */, 10, 'You separate the spikes.', 0, 0, 'You fail to separate the spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:32:20');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 444;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (444, 5778 /* Whittling Knife */, 23858 /* Bundle of Wrapped Spiketails */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01899 Bloodletter Arrow.sql
+++ b/Database/Patches/4 CraftTable/01899 Bloodletter Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1899;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1899, 0, 37 /* Fletching */, 80, 0, 9230 /* Bloodletter Arrow */, 100, 'You make a bundle of bloodletter arrows.', 0, 0, 'You fail to make any bloodletter arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1899;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1899, 9233 /* Bloodletter Arrowhead */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01900 Fleshripper Arrow.sql
+++ b/Database/Patches/4 CraftTable/01900 Fleshripper Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1900;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1900, 0, 37 /* Fletching */, 100, 0, 9231 /* Fleshripper Arrow */, 100, 'You make a bundle of fleshripper arrows.', 0, 0, 'You fail to make any fleshripper arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1900;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1900, 9234 /* Fleshripper Arrowhead */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01901 Soulrender Arrow.sql
+++ b/Database/Patches/4 CraftTable/01901 Soulrender Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1901;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1901, 0, 37 /* Fletching */, 130, 0, 9232 /* Soulrender Arrow */, 100, 'You make a bundle of soulrender arrows.', 0, 0, 'You fail to make any soulrender arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1901;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1901, 9235 /* Soulrender Arrowhead */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01902 Bloodletter Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01902 Bloodletter Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1902;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1902, 0, 37 /* Fletching */, 80, 0, 9236 /* Bloodletter Quarrel */, 100, 'You make a bundle of bloodletter quarrels.', 0, 0, 'You fail to make any bloodletter quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1902;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1902, 9233 /* Bloodletter Arrowhead */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01903 Fleshripper Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01903 Fleshripper Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1903;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1903, 0, 37 /* Fletching */, 100, 0, 9237 /* Fleshripper Quarrel */, 100, 'You make a bundle of fleshripper quarrels.', 0, 0, 'You fail to make any fleshripper quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1903;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1903, 9234 /* Fleshripper Arrowhead */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01904 Soulrender Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01904 Soulrender Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1904;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1904, 0, 37 /* Fletching */, 130, 0, 9238 /* Soulrender Quarrel */, 100, 'You make a bundle of soulrender quarrels.', 0, 0, 'You fail to make any soulrender quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1904;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1904, 9235 /* Soulrender Arrowhead */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01954 Bundle of Acid Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01954 Bundle of Acid Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1954;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1954, 0, 37 /* Fletching */, 60, 0, 5340 /* Bundle of Acid Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1954;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1954, 5778 /* Whittling Knife */,  9360 /* Wrapped Bundle of Acid Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01955 Bundle of Armor Piercing Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01955 Bundle of Armor Piercing Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1955;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1955, 0, 37 /* Fletching */, 60, 0, 5347 /* Bundle of Armor Piercing Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1955;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1955, 5778 /* Whittling Knife */,  9361 /* Wrapped Bundle of Armor Piercing Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01956 Bundle of Blunt Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01956 Bundle of Blunt Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1956;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1956, 0, 37 /* Fletching */, 60, 0, 5344 /* Bundle of Blunt Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1956;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1956, 5778 /* Whittling Knife */,  9362 /* Wrapped Bundle of Blunt Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01957 Bundle of Broad Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01957 Bundle of Broad Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1957;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1957, 0, 37 /* Fletching */, 60, 0, 5345 /* Bundle of Broad Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1957;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1957, 5778 /* Whittling Knife */,  9363 /* Wrapped Bundle of Broad Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01958 Bundle of Lightning Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01958 Bundle of Lightning Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1958;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1958, 0, 37 /* Fletching */, 60, 0, 5343 /* Bundle of Lightning Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1958;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1958, 5778 /* Whittling Knife */,  9364 /* Wrapped Bundle of Lightning Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01959 Bundle of Fire Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01959 Bundle of Fire Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1959;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1959, 0, 37 /* Fletching */, 60, 0, 5341 /* Bundle of Fire Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1959;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1959, 5778 /* Whittling Knife */,  9365 /* Wrapped Bundle of Fire Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01960 Bundle of Frog Crotch Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01960 Bundle of Frog Crotch Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1960;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1960, 0, 37 /* Fletching */, 60, 0, 5346 /* Bundle of Frog Crotch Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1960;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1960, 5778 /* Whittling Knife */,  9366 /* Wrapped Bundle of Frog Crotch Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01961 Bundle of Frost Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01961 Bundle of Frost Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1961;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1961, 0, 37 /* Fletching */, 60, 0, 5342 /* Bundle of Frost Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1961;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1961, 5778 /* Whittling Knife */,  9367 /* Wrapped Bundle of Frost Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01962 Bundle of Greater Acid Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01962 Bundle of Greater Acid Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1962;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1962, 0, 37 /* Fletching */, 60, 0, 5349 /* Bundle of Greater Acid Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1962;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1962, 5778 /* Whittling Knife */,  9369 /* Wrapped Bundle of Greater Acid Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01963 Bundle of Greater Armor Piercing Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01963 Bundle of Greater Armor Piercing Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1963;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1963, 0, 37 /* Fletching */, 60, 0, 5356 /* Bundle of Greater Armor Piercing Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1963;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1963, 5778 /* Whittling Knife */,  9370 /* Wrapped Bundle of Greater Armor Piercing Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01964 Bundle of Greater Blunt Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01964 Bundle of Greater Blunt Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1964;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1964, 0, 37 /* Fletching */, 60, 0, 5353 /* Bundle of Greater Blunt Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1964;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1964, 5778 /* Whittling Knife */,  9371 /* Wrapped Bundle of Greater Blunt Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01965 Bundle of Greater Broad Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01965 Bundle of Greater Broad Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1965;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1965, 0, 37 /* Fletching */, 60, 0, 5354 /* Bundle of Greater Broad Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1965;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1965, 5778 /* Whittling Knife */,  9372 /* Wrapped Bundle of Greater Broad Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01966 Bundle of Greater Lightning Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01966 Bundle of Greater Lightning Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1966;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1966, 0, 37 /* Fletching */, 60, 0, 5352 /* Bundle of Greater Lightning Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1966;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1966, 5778 /* Whittling Knife */,  9373 /* Wrapped Bundle of Greater Lightning Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01967 Bundle of Greater Fire Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01967 Bundle of Greater Fire Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1967;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1967, 0, 37 /* Fletching */, 60, 0, 5350 /* Bundle of Greater Fire Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1967;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1967, 5778 /* Whittling Knife */,  9374 /* Wrapped Bundle of Greater Fire Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01968 Bundle of Greater Frog Crotch Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01968 Bundle of Greater Frog Crotch Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1968;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1968, 0, 37 /* Fletching */, 60, 0, 5355 /* Bundle of Greater Frog Crotch Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1968;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1968, 5778 /* Whittling Knife */,  9375 /* Wrapped Bundle of Greater Frog Crotch Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01969 Bundle of Greater Frost Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01969 Bundle of Greater Frost Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1969;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1969, 0, 37 /* Fletching */, 60, 0, 5351 /* Bundle of Greater Frost Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1969;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1969, 5778 /* Whittling Knife */,  9376 /* Wrapped Bundle of Greater Frost Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01970 Bundle of Greater Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01970 Bundle of Greater Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1970;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1970, 0, 37 /* Fletching */, 60, 0, 5348 /* Bundle of Greater Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1970;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1970, 5778 /* Whittling Knife */,  9368 /* Wrapped Bundle of Greater Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01971 Bundle of Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01971 Bundle of Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1971;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1971, 0, 37 /* Fletching */, 60, 0, 4586 /* Bundle of Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1971;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1971, 5778 /* Whittling Knife */,  9359 /* Wrapped Bundle of Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01972 Bundle of Arrowshafts.sql
+++ b/Database/Patches/4 CraftTable/01972 Bundle of Arrowshafts.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1972;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1972, 0, 37 /* Fletching */, 60, 0, 4585 /* Bundle of Arrowshafts */, 10, 'You separate the shafts.', 0, 0, 'You fail to separate the shafts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1972;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1972, 5778 /* Whittling Knife */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01973 Bundle of Quarrelshafts.sql
+++ b/Database/Patches/4 CraftTable/01973 Bundle of Quarrelshafts.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1973;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1973, 0, 37 /* Fletching */, 60, 0, 5339 /* Bundle of Quarrelshafts */, 10, 'You separate the shafts.', 0, 0, 'You fail to separate the shafts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1973;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1973, 5778 /* Whittling Knife */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01974 Bundle of Barbed Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01974 Bundle of Barbed Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1974;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1974, 0, 37 /* Fletching */, 60, 0, 8824 /* Bundle of Barbed Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1974;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1974, 5778 /* Whittling Knife */, 24544 /* Wrapped Bundle of Barbed Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01975 Bundle of Deadly Barbed Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01975 Bundle of Deadly Barbed Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1975;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1975, 0, 37 /* Fletching */, 60, 0, 24543 /* Bundle of Deadly Barbed Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1975;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1975, 5778 /* Whittling Knife */, 24545 /* Wrapped Bundle of Deadly Barbed Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01976 Bundle of Greater Barbed Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/01976 Bundle of Greater Barbed Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1976;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1976, 0, 37 /* Fletching */, 60, 0, 8825 /* Bundle of Greater Barbed Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1976;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1976, 5778 /* Whittling Knife */, 24546 /* Wrapped Bundle of Greater Barbed Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01977 Arrow.sql
+++ b/Database/Patches/4 CraftTable/01977 Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1977;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1977, 0, 37 /* Fletching */, 35, 0, 300 /* Arrow */, 1000, 'You make a big bundle of arrows.', 0, 0, 'You fail to make any arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1977;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1977, 9359 /* Wrapped Bundle of Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01978 Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01978 Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 1978;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (1978, 0, 37 /* Fletching */, 35, 0, 305 /* Quarrel */, 1000, 'You make a big bundle of quarrels.', 0, 0, 'You fail to make any quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1978;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (1978, 9359 /* Wrapped Bundle of Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01979 Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/01979 Acid Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1979;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1979, 0, 37 /* Fletching */, 90, 0, 4181 /* Acid Arrow */, 1000, 'You make a big bundle of acid arrows.', 0, 0, 'You fail to make any acid arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1979;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1979, 9360 /* Wrapped Bundle of Acid Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01980 Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01980 Acid Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1980;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1980, 0, 37 /* Fletching */, 90, 0, 4185 /* Acid Quarrel */, 1000, 'You make a big bundle of acid quarrels.', 0, 0, 'You fail to make any acid quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1980;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1980, 9360 /* Wrapped Bundle of Acid Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01981 Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/01981 Armor Piercing Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1981;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1981, 0, 37 /* Fletching */, 50, 0, 3598 /* Armor Piercing Arrow */, 1000, 'You make a big bundle of armor-piercing arrows.', 0, 0, 'You fail to make any armor-piercing arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1981;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1981, 9361 /* Wrapped Bundle of Armor Piercing Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01982 Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01982 Armor Piercing Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1982;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1982, 0, 37 /* Fletching */, 50, 0, 3602 /* Armor Piercing Quarrel */, 1000, 'You make a big bundle of armor-piercing quarrels.', 0, 0, 'You fail to make any armor-piercing quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1982;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1982, 9361 /* Wrapped Bundle of Armor Piercing Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01983 Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/01983 Blunt Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1983;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1983, 0, 37 /* Fletching */, 40, 0, 3599 /* Blunt Arrow */, 1000, 'You make a big bundle of blunt arrows.', 0, 0, 'You fail to make any blunt arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1983;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1983, 9362 /* Wrapped Bundle of Blunt Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01984 Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01984 Blunt Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1984;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1984, 0, 37 /* Fletching */, 40, 0, 3603 /* Blunt Quarrel */, 1000, 'You make a big bundle of blunt quarrels.', 0, 0, 'You fail to make any blunt quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1984;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1984, 9362 /* Wrapped Bundle of Blunt Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01985 Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/01985 Broadhead Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1985;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1985, 0, 37 /* Fletching */, 40, 0, 3600 /* Broadhead Arrow */, 1000, 'You make a big bundle of broadhead arrows.', 0, 0, 'You fail to make any arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1985;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1985, 9363 /* Wrapped Bundle of Broad Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01986 Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01986 Broadhead Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1986;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1986, 0, 37 /* Fletching */, 40, 0, 3604 /* Broadhead Quarrel */, 1000, 'You make a big bundle of broadhead quarrels.', 0, 0, 'You fail to make any broad quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1986;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1986, 9363 /* Wrapped Bundle of Broad Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01987 Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/01987 Fire Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1987;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1987, 0, 37 /* Fletching */, 90, 0, 1437 /* Fire Arrow */, 1000, 'You make a big bundle of fire arrows.', 0, 0, 'You fail to make any fire arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1987;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1987, 9365 /* Wrapped Bundle of Fire Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01988 Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01988 Fire Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1988;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1988, 0, 37 /* Fletching */, 90, 0, 4188 /* Fire Quarrel */, 1000, 'You make a big bundle of fire quarrels.', 0, 0, 'You fail to make any fire quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1988;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1988, 9365 /* Wrapped Bundle of Fire Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01989 Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/01989 Frog Crotch Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1989;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1989, 0, 37 /* Fletching */, 50, 0, 3601 /* Frog Crotch Arrow */, 1000, 'You make a big bundle of frog crotch arrows.', 0, 0, 'You fail to make any frog crotch arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1989;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1989, 9366 /* Wrapped Bundle of Frog Crotch Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01990 Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01990 Frog Crotch Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1990;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1990, 0, 37 /* Fletching */, 50, 0, 3605 /* Frog Crotch Quarrel */, 1000, 'You make a big bundle of frog crotch quarrels.', 0, 0, 'You fail to make any frog crotch quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1990;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1990, 9366 /* Wrapped Bundle of Frog Crotch Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01991 Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/01991 Frost Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1991;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1991, 0, 37 /* Fletching */, 90, 0, 4182 /* Frost Arrow */, 1000, 'You make a big bundle of frost arrows.', 0, 0, 'You fail to make any frost arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1991;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1991, 9367 /* Wrapped Bundle of Frost Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01992 Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01992 Frost Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1992;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1992, 0, 37 /* Fletching */, 90, 0, 4186 /* Frost Quarrel */, 1000, 'You make a big bundle of frost quarrels.', 0, 0, 'You fail to make any frost quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1992;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1992, 9367 /* Wrapped Bundle of Frost Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01993 Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/01993 Lightning Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1993;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1993, 0, 37 /* Fletching */, 90, 0, 4183 /* Lightning Arrow */, 1000, 'You make a big bundle of lightning arrows.', 0, 0, 'You fail to make any lightning arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1993;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1993, 9364 /* Wrapped Bundle of Lightning Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01994 Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01994 Lightning Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1994;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1994, 0, 37 /* Fletching */, 90, 0, 4187 /* Lightning Quarrel */, 1000, 'You make a big bundle of lightning quarrels.', 0, 0, 'You fail to make any lightning quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1994;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1994, 9364 /* Wrapped Bundle of Lightning Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01995 Greater Arrow.sql
+++ b/Database/Patches/4 CraftTable/01995 Greater Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1995;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1995, 0, 37 /* Fletching */, 150, 0, 5304 /* Greater Arrow */, 1000, 'You make a big bundle of greater arrows.', 0, 0, 'You fail to make any greater arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1995;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1995, 9368 /* Wrapped Bundle of Greater Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01996 Greater Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01996 Greater Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1996;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1996, 0, 37 /* Fletching */, 150, 0, 5313 /* Greater Quarrel */, 1000, 'You make a big bundle of greater quarrels.', 0, 0, 'You fail to make any greater quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1996;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1996, 9368 /* Wrapped Bundle of Greater Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01997 Greater Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/01997 Greater Acid Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1997;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1997, 0, 37 /* Fletching */, 230, 0, 5306 /* Greater Acid Arrow */, 1000, 'You make a big bundle of greater acid arrows.', 0, 0, 'You fail to make any greater acid arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1997;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1997, 9369 /* Wrapped Bundle of Greater Acid Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01998 Greater Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/01998 Greater Acid Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1998;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1998, 0, 37 /* Fletching */, 200, 0, 5314 /* Greater Acid Quarrel */, 1000, 'You make a big bundle of greater acid quarrels.', 0, 0, 'You fail to make any greater acid quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1998;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1998, 9369 /* Wrapped Bundle of Greater Acid Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/01999 Greater Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/01999 Greater Armor Piercing Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 1999;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (1999, 0, 37 /* Fletching */, 190, 0, 5309 /* Greater Armor Piercing Arrow */, 1000, 'You make a big bundle of greater armor-piercing arrows.', 0, 0, 'You fail to make any greater armor-piercing arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 1999;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (1999, 9370 /* Wrapped Bundle of Greater Armor Piercing Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02000 Greater Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02000 Greater Armor Piercing Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2000;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2000, 0, 37 /* Fletching */, 190, 0, 5318 /* Greater Armor Piercing Quarrel */, 1000, 'You make a big bundle of greater armor-piercing quarrels.', 0, 0, 'You fail to make any greater armor-piercing quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2000;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2000, 9370 /* Wrapped Bundle of Greater Armor Piercing Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02001 Greater Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/02001 Greater Blunt Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2001;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2001, 0, 37 /* Fletching */, 170, 0, 5310 /* Greater Blunt Arrow */, 1000, 'You make a big bundle of greater blunt arrows.', 0, 0, 'You fail to make any greater blunt arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2001;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2001, 9371 /* Wrapped Bundle of Greater Blunt Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02002 Greater Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02002 Greater Blunt Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2002;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2002, 0, 37 /* Fletching */, 170, 0, 5319 /* Greater Blunt Quarrel */, 1000, 'You make a big bundle of greater blunt quarrels.', 0, 0, 'You fail to make any greater blunt quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2002;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2002, 9371 /* Wrapped Bundle of Greater Blunt Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02003 Greater Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/02003 Greater Broadhead Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2003;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2003, 0, 37 /* Fletching */, 170, 0, 5357 /* Greater Broadhead Arrow */, 1000, 'You make a big bundle of greater broadhead arrows.', 0, 0, 'You fail to make any greater broadhead arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2003;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2003, 9372 /* Wrapped Bundle of Greater Broad Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02004 Greater Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02004 Greater Broadhead Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2004;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2004, 0, 37 /* Fletching */, 170, 0, 5320 /* Greater Broadhead Quarrel */, 1000, 'You make a big bundle of greater broadhead quarrels.', 0, 0, 'You fail to make any greater broadhead quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2004;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2004, 9372 /* Wrapped Bundle of Greater Broad Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02005 Greater Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/02005 Greater Fire Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2005;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2005, 0, 37 /* Fletching */, 230, 0, 5305 /* Greater Fire Arrow */, 1000, 'You make a big bundle of greater fire arrows.', 0, 0, 'You fail to make any greater fire arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2005;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2005, 9374 /* Wrapped Bundle of Greater Fire Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02006 Greater Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02006 Greater Fire Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2006;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2006, 0, 37 /* Fletching */, 230, 0, 5317 /* Greater Fire Quarrel */, 1000, 'You make a big bundle of greater fire quarrels.', 0, 0, 'You fail to make any greater fire quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2006;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2006, 9374 /* Wrapped Bundle of Greater Fire Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02007 Greater Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/02007 Greater Frog Crotch Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2007;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2007, 0, 37 /* Fletching */, 190, 0, 5312 /* Greater Frog Crotch Arrow */, 1000, 'You make a big bundle of greater frog crotch arrows.', 0, 0, 'You fail to make any greater frog crotch arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2007;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2007, 9375 /* Wrapped Bundle of Greater Frog Crotch Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02008 Greater Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02008 Greater Frog Crotch Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2008;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2008, 0, 37 /* Fletching */, 190, 0, 5321 /* Greater Frog Crotch Quarrel */, 1000, 'You make a big bundle of greater frog crotch quarrels.', 0, 0, 'You fail to make any greater frog crotch quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2008;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2008, 9375 /* Wrapped Bundle of Greater Frog Crotch Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02009 Greater Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/02009 Greater Frost Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2009;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2009, 0, 37 /* Fletching */, 230, 0, 5307 /* Greater Frost Arrow */, 1000, 'You make a big bundle of greater frost arrows.', 0, 0, 'You fail to make any greater frost arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2009;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2009, 9376 /* Wrapped Bundle of Greater Frost Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02010 Greater Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02010 Greater Frost Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2010;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2010, 0, 37 /* Fletching */, 230, 0, 5315 /* Greater Frost Quarrel */, 1000, 'You make a big bundle of greater frost quarrels.', 0, 0, 'You fail to make any greater frost quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2010;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2010, 9376 /* Wrapped Bundle of Greater Frost Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02011 Greater Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/02011 Greater Lightning Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2011;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2011, 0, 37 /* Fletching */, 230, 0, 5308 /* Greater Lightning Arrow */, 1000, 'You make a big bundle of greater lightning arrows.', 0, 0, 'You fail to make any greater lightning arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2011;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2011, 9373 /* Wrapped Bundle of Greater Lightning Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02012 Greater Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02012 Greater Lightning Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2012;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2012, 0, 37 /* Fletching */, 230, 0, 5316 /* Greater Lightning Quarrel */, 1000, 'You make a big bundle of greater lightning quarrels.', 0, 0, 'You fail to make any greater lightning quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2012;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2012, 9373 /* Wrapped Bundle of Greater Lightning Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02567 Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02567 Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2567;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2567, 0, 37 /* Fletching */, 5, 0, 12464 /* Atlatl Dart */, 100, 'You make a bundle of atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2567;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2567, 4586 /* Bundle of Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02568 Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02568 Acid Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2568;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2568, 0, 37 /* Fletching */, 60, 0, 15279 /* Acid Atlatl Dart */, 100, 'You make a bundle of acid atlatl darts.', 0, 0, 'You fail to make any acid atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2568;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2568, 5340 /* Bundle of Acid Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02569 Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02569 Armor Piercing Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2569;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2569, 0, 37 /* Fletching */, 20, 0, 15280 /* Armor Piercing Atlatl Dart */, 100, 'You make a bundle of armor-piercing atlatl darts.', 0, 0, 'You fail to make any armor-piercing atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2569;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2569, 5347 /* Bundle of Armor Piercing Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02570 Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02570 Blunt Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2570;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2570, 0, 37 /* Fletching */, 10, 0, 15281 /* Blunt Atlatl Dart */, 100, 'You make a bundle of blunt atlatl darts.', 0, 0, 'You fail to make any blunt atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2570;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2570, 5344 /* Bundle of Blunt Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02571 Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02571 Broadhead Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2571;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2571, 0, 37 /* Fletching */, 10, 0, 15282 /* Broadhead Atlatl Dart */, 100, 'You make a bundle of broadhead atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2571;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2571, 5345 /* Bundle of Broad Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02572 Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02572 Fire Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2572;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2572, 0, 37 /* Fletching */, 60, 0, 15284 /* Fire Atlatl Dart */, 100, 'You make a bundle of fire atlatl darts.', 0, 0, 'You fail to make any fire atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2572;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2572, 5341 /* Bundle of Fire Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02573 Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02573 Frog Crotch Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2573;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2573, 0, 37 /* Fletching */, 20, 0, 15285 /* Frog Crotch Atlatl Dart */, 100, 'You make a bundle of frog crotch atlatl darts.', 0, 0, 'You fail to make any frog crotch atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2573;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2573, 5346 /* Bundle of Frog Crotch Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02574 Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02574 Frost Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2574;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2574, 0, 37 /* Fletching */, 60, 0, 15286 /* Frost Atlatl Dart */, 100, 'You make a bundle of frost atlatl darts.', 0, 0, 'You fail to make any frost atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2574;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2574, 5342 /* Bundle of Frost Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02575 Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02575 Lightning Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2575;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2575, 0, 37 /* Fletching */, 60, 0, 15283 /* Lightning Atlatl Dart */, 100, 'You make a bundle of lightning atlatl darts.', 0, 0, 'You fail to make any lightning atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2575;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2575, 5343 /* Bundle of Lightning Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02576 Greater Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02576 Greater Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2576;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2576, 0, 37 /* Fletching */, 120, 0, 15287 /* Greater Atlatl Dart */, 100, 'You make a bundle of greater atlatl darts.', 0, 0, 'You fail to make any greater atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2576;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2576, 5348 /* Bundle of Greater Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02577 Greater Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02577 Greater Acid Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2577;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2577, 0, 37 /* Fletching */, 200, 0, 15288 /* Greater Acid Atlatl Dart */, 100, 'You make a bundle of greater acid atlatl darts.', 0, 0, 'You fail to make any greater atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2577;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2577, 5349 /* Bundle of Greater Acid Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02578 Greater Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02578 Greater Armor Piercing Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2578;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2578, 0, 37 /* Fletching */, 160, 0, 15289 /* Greater Armor Piercing Atlatl Dart */, 100, 'You make a bundle of greater armor-piercing atlatl darts.', 0, 0, 'You fail to make any greater armor-piercing atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2578;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2578, 5356 /* Bundle of Greater Armor Piercing Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02579 Greater Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02579 Greater Blunt Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2579;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2579, 0, 37 /* Fletching */, 140, 0, 15290 /* Greater Blunt Atlatl Dart */, 100, 'You make a bundle of greater blunt atlatl darts.', 0, 0, 'You fail to make any greater blunt atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2579;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2579, 5353 /* Bundle of Greater Blunt Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02580 Greater Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02580 Greater Broadhead Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2580;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2580, 0, 37 /* Fletching */, 140, 0, 15291 /* Greater Broadhead Atlatl Dart */, 100, 'You make a bundle of greater broadhead atlatl darts.', 0, 0, 'You fail to make any greater broadhead atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2580;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2580, 5354 /* Bundle of Greater Broad Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02581 Greater Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02581 Greater Fire Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2581;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2581, 0, 37 /* Fletching */, 200, 0, 15293 /* Greater Fire Atlatl Dart */, 100, 'You make a bundle of greater fire atlatl darts.', 0, 0, 'You fail to make any greater fire atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2581;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2581, 5350 /* Bundle of Greater Fire Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02582 Greater Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02582 Greater Frog Crotch Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2582;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2582, 0, 37 /* Fletching */, 160, 0, 15294 /* Greater Frog Crotch Atlatl Dart */, 100, 'You make a bundle of greater frog crotch atlatl darts.', 0, 0, 'You fail to make any greater frog crotch atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2582;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2582, 5355 /* Bundle of Greater Frog Crotch Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02583 Greater Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02583 Greater Frost Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2583;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2583, 0, 37 /* Fletching */, 200, 0, 15295 /* Greater Frost Atlatl Dart */, 100, 'You make a bundle of greater frost atlatl darts.', 0, 0, 'You fail to make any greater frost atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2583;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2583, 5351 /* Bundle of Greater Frost Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02584 Greater Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02584 Greater Lightning Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2584;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2584, 0, 37 /* Fletching */, 200, 0, 15292 /* Greater Lightning Atlatl Dart */, 100, 'You make a bundle of greater lightning atlatl darts.', 0, 0, 'You fail to make any greater lightning atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2584;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2584, 5352 /* Bundle of Greater Lightning Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02586 Bundle of Atlatl Dart Shafts.sql
+++ b/Database/Patches/4 CraftTable/02586 Bundle of Atlatl Dart Shafts.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2586;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2586, 0, 37 /* Fletching */, 60, 0, 15296 /* Bundle of Atlatl Dart Shafts */, 10, 'You separate the shafts.', 0, 0, 'You fail to separate the shafts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2586;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2586, 5778 /* Whittling Knife */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02587 Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02587 Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2587;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2587, 0, 37 /* Fletching */, 35, 0, 12464 /* Atlatl Dart */, 1000, 'You make a big bundle of atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2587;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2587, 9359 /* Wrapped Bundle of Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02588 Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02588 Acid Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2588;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2588, 0, 37 /* Fletching */, 90, 0, 15279 /* Acid Atlatl Dart */, 1000, 'You make a big bundle of acid atlatl darts.', 0, 0, 'You fail to make any acid atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2588;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2588, 9360 /* Wrapped Bundle of Acid Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02589 Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02589 Armor Piercing Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2589;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2589, 0, 37 /* Fletching */, 50, 0, 15280 /* Armor Piercing Atlatl Dart */, 1000, 'You make a big bundle of armor-piercing atlatl darts.', 0, 0, 'You fail to make any armor-piercing atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2589;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2589, 9361 /* Wrapped Bundle of Armor Piercing Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02590 Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02590 Blunt Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2590;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2590, 0, 37 /* Fletching */, 40, 0, 15281 /* Blunt Atlatl Dart */, 1000, 'You make a big bundle of blunt atlatl darts.', 0, 0, 'You fail to make any blunt atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2590;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2590, 9362 /* Wrapped Bundle of Blunt Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02591 Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02591 Broadhead Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2591;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2591, 0, 37 /* Fletching */, 40, 0, 15282 /* Broadhead Atlatl Dart */, 1000, 'You make a big bundle of broadhead atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2591;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2591, 9363 /* Wrapped Bundle of Broad Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02592 Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02592 Fire Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2592;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2592, 0, 37 /* Fletching */, 90, 0, 15284 /* Fire Atlatl Dart */, 1000, 'You make a big bundle of fire atlatl darts.', 0, 0, 'You fail to make any fire atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2592;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2592, 9365 /* Wrapped Bundle of Fire Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02593 Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02593 Frog Crotch Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2593;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2593, 0, 37 /* Fletching */, 50, 0, 15285 /* Frog Crotch Atlatl Dart */, 1000, 'You make a big bundle of frog crotch atlatl darts.', 0, 0, 'You fail to make any frog crotch atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2593;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2593, 9366 /* Wrapped Bundle of Frog Crotch Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02594 Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02594 Frost Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2594;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2594, 0, 37 /* Fletching */, 90, 0, 15286 /* Frost Atlatl Dart */, 1000, 'You make a big bundle of frost atlatl darts.', 0, 0, 'You fail to make any frost atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2594;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2594, 9367 /* Wrapped Bundle of Frost Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02595 Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02595 Lightning Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2595;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2595, 0, 37 /* Fletching */, 90, 0, 15283 /* Lightning Atlatl Dart */, 1000, 'You make a big bundle of lightning atlatl darts.', 0, 0, 'You fail to make any lightning atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2595;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2595, 9364 /* Wrapped Bundle of Lightning Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02596 Greater Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02596 Greater Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2596;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2596, 0, 37 /* Fletching */, 150, 0, 15287 /* Greater Atlatl Dart */, 1000, 'You make a big bundle of greater atlatl darts.', 0, 0, 'You fail to make any greater atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2596;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2596, 9368 /* Wrapped Bundle of Greater Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02597 Greater Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02597 Greater Acid Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2597;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2597, 0, 37 /* Fletching */, 230, 0, 15288 /* Greater Acid Atlatl Dart */, 1000, 'You make a big bundle of greater acid atlatl darts.', 0, 0, 'You fail to make any greater acid atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2597;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2597, 9369 /* Wrapped Bundle of Greater Acid Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02598 Greater Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02598 Greater Armor Piercing Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2598;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2598, 0, 37 /* Fletching */, 190, 0, 15289 /* Greater Armor Piercing Atlatl Dart */, 1000, 'You make a big bundle of greater armor-piercing atlatl darts.', 0, 0, 'You fail to make any greater armor-piercing atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2598;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2598, 9370 /* Wrapped Bundle of Greater Armor Piercing Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02599 Greater Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02599 Greater Blunt Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2599;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2599, 0, 37 /* Fletching */, 170, 0, 15290 /* Greater Blunt Atlatl Dart */, 1000, 'You make a big bundle of greater blunt atlatl darts.', 0, 0, 'You fail to make any greater blunt atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2599;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2599, 9371 /* Wrapped Bundle of Greater Blunt Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02600 Greater Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02600 Greater Broadhead Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2600;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2600, 0, 37 /* Fletching */, 170, 0, 15291 /* Greater Broadhead Atlatl Dart */, 1000, 'You make a big bundle of greater broadhead atlatl darts.', 0, 0, 'You fail to make any greater broadhead atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2600;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2600, 9372 /* Wrapped Bundle of Greater Broad Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02601 Greater Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02601 Greater Fire Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2601;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2601, 0, 37 /* Fletching */, 230, 0, 15293 /* Greater Fire Atlatl Dart */, 1000, 'You make a big bundle of greater fire atlatl darts.', 0, 0, 'You fail to make any greater fire atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2601;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2601, 9374 /* Wrapped Bundle of Greater Fire Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02602 Greater Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02602 Greater Frog Crotch Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2602;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2602, 0, 37 /* Fletching */, 190, 0, 15294 /* Greater Frog Crotch Atlatl Dart */, 1000, 'You make a big bundle of greater frog crotch atlatl darts.', 0, 0, 'You fail to make any greater frog crotch atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2602;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2602, 9375 /* Wrapped Bundle of Greater Frog Crotch Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02603 Greater Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02603 Greater Frost Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2603;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2603, 0, 37 /* Fletching */, 230, 0, 15295 /* Greater Frost Atlatl Dart */, 1000, 'You make a big bundle of greater frost atlatl darts.', 0, 0, 'You fail to make any greater frost atlatl dart.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2603;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2603, 9376 /* Wrapped Bundle of Greater Frost Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02604 Greater Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02604 Greater Lightning Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2604;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2604, 0, 37 /* Fletching */, 230, 0, 15292 /* Greater Lightning Atlatl Dart */, 1000, 'You make a big bundle of greater lightning atlatl darts.', 0, 0, 'You fail to make any greater lightning atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2604;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2604, 9373 /* Wrapped Bundle of Greater Lightning Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02629 Bundle of Deadly Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02629 Bundle of Deadly Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2629;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2629, 0, 37 /* Fletching */, 75, 0, 15411 /* Bundle of Deadly Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2629;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2629, 5778 /* Whittling Knife */, 15420 /* Wrapped Bundle of Deadly Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02630 Bundle of Deadly Acid Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02630 Bundle of Deadly Acid Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2630;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2630, 0, 37 /* Fletching */, 75, 0, 15412 /* Bundle of Deadly Acid Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2630;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2630, 5778 /* Whittling Knife */, 15421 /* Wrapped Bundle of Deadly Acid Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02631 Bundle of Deadly Armor Piercing Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02631 Bundle of Deadly Armor Piercing Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2631;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2631, 0, 37 /* Fletching */, 75, 0, 15413 /* Bundle of Deadly Armor Piercing Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2631;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2631, 5778 /* Whittling Knife */, 15422 /* Wrapped Bundle of Deadly Armor Piercing Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02632 Bundle of Deadly Blunt Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02632 Bundle of Deadly Blunt Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2632;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2632, 0, 37 /* Fletching */, 75, 0, 15414 /* Bundle of Deadly Blunt Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2632;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2632, 5778 /* Whittling Knife */, 15423 /* Wrapped Bundle of Deadly Blunt Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02633 Bundle of Deadly Broad Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02633 Bundle of Deadly Broad Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2633;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2633, 0, 37 /* Fletching */, 75, 0, 15415 /* Bundle of Deadly Broad Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2633;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2633, 5778 /* Whittling Knife */, 15424 /* Wrapped Bundle of Deadly Broad Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02634 Bundle of Deadly Lightning Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02634 Bundle of Deadly Lightning Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2634;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2634, 0, 37 /* Fletching */, 75, 0, 15416 /* Bundle of Deadly Lightning Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2634;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2634, 5778 /* Whittling Knife */, 15425 /* Wrapped Bundle of Deadly Lightning Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02635 Bundle of Deadly Fire Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02635 Bundle of Deadly Fire Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2635;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2635, 0, 37 /* Fletching */, 75, 0, 15417 /* Bundle of Deadly Fire Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2635;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2635, 5778 /* Whittling Knife */, 15426 /* Wrapped Bundle of Deadly Fire Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02636 Bundle of Deadly Frog Crotch Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02636 Bundle of Deadly Frog Crotch Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2636;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2636, 0, 37 /* Fletching */, 75, 0, 15418 /* Bundle of Deadly Frog Crotch Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2636;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2636, 5778 /* Whittling Knife */, 15427 /* Wrapped Bundle of Deadly Frog Crotch Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02637 Bundle of Deadly Frost Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/02637 Bundle of Deadly Frost Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2637;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2637, 0, 37 /* Fletching */, 75, 0, 15419 /* Bundle of Deadly Frost Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2637;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2637, 5778 /* Whittling Knife */, 15428 /* Wrapped Bundle of Deadly Frost Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02638 Deadly Arrow.sql
+++ b/Database/Patches/4 CraftTable/02638 Deadly Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2638;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2638, 0, 37 /* Fletching */, 150, 0, 15429 /* Deadly Arrow */, 100, 'You make a bundle of deadly arrows.', 0, 0, 'You fail to make any deadly arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2638;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2638, 15411 /* Bundle of Deadly Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02639 Deadly Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02639 Deadly Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2639;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2639, 0, 37 /* Fletching */, 150, 0, 15438 /* Deadly Quarrel */, 100, 'You make a bundle of deadly quarrels.', 0, 0, 'You fail to make any deadly quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2639;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2639, 15411 /* Bundle of Deadly Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02640 Deadly Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02640 Deadly Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2640;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2640, 0, 37 /* Fletching */, 150, 0, 20964 /* Deadly Atlatl Dart */, 100, 'You make a bundle of deadly atlatl darts.', 0, 0, 'You fail to make any deadly atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2640;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2640, 15411 /* Bundle of Deadly Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02641 Deadly Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/02641 Deadly Acid Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2641;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2641, 0, 37 /* Fletching */, 225, 0, 15430 /* Deadly Acid Arrow */, 100, 'You make a bundle of deadly acid arrows.', 0, 0, 'You fail to make any deadly acid arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2641;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2641, 15412 /* Bundle of Deadly Acid Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02642 Deadly Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02642 Deadly Acid Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2642;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2642, 0, 37 /* Fletching */, 225, 0, 15439 /* Deadly Acid Quarrel */, 100, 'You make a bundle of deadly acid quarrels.', 0, 0, 'You fail to make any deadly acid quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2642;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2642, 15412 /* Bundle of Deadly Acid Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02643 Deadly Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02643 Deadly Acid Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2643;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2643, 0, 37 /* Fletching */, 225, 0, 20965 /* Deadly Acid Atlatl Dart */, 100, 'You make a bundle of deadly acid atlatl darts.', 0, 0, 'You fail to make any deadly acid atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2643;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2643, 15412 /* Bundle of Deadly Acid Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02644 Deadly Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/02644 Deadly Armor Piercing Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2644;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2644, 0, 37 /* Fletching */, 175, 0, 15431 /* Deadly Armor Piercing Arrow */, 100, 'You make a bundle of deadly armor-piercing arrows.', 0, 0, 'You fail to make any deadly armor-piercing arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2644;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2644, 15413 /* Bundle of Deadly Armor Piercing Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02645 Deadly Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02645 Deadly Armor Piercing Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2645;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2645, 0, 37 /* Fletching */, 175, 0, 15440 /* Deadly Armor Piercing Quarrel */, 100, 'You make a bundle of deadly armor-piercing quarrels.', 0, 0, 'You fail to make any deadly armor-piercing quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2645;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2645, 15413 /* Bundle of Deadly Armor Piercing Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02646 Deadly Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02646 Deadly Armor Piercing Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2646;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2646, 0, 37 /* Fletching */, 175, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 100, 'You make a bundle of deadly armor-piercing atlatl darts.', 0, 0, 'You fail to make any deadly armor-piercing atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2646;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2646, 15413 /* Bundle of Deadly Armor Piercing Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02647 Deadly Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/02647 Deadly Blunt Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2647;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2647, 0, 37 /* Fletching */, 150, 0, 15432 /* Deadly Blunt Arrow */, 100, 'You make a bundle of deadly blunt arrows.', 0, 0, 'You fail to make any deadly blunt arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2647;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2647, 15414 /* Bundle of Deadly Blunt Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02648 Deadly Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02648 Deadly Blunt Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2648;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2648, 0, 37 /* Fletching */, 150, 0, 15441 /* Deadly Blunt Quarrel */, 100, 'You make a bundle of deadly blunt quarrels.', 0, 0, 'You fail to make any deadly blunt quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2648;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2648, 15414 /* Bundle of Deadly Blunt Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02649 Deadly Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02649 Deadly Blunt Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2649;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2649, 0, 37 /* Fletching */, 150, 0, 20967 /* Deadly Blunt Atlatl Dart */, 100, 'You make a bundle of deadly blunt atlatl darts.', 0, 0, 'You fail to make any deadly blunt atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2649;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2649, 15414 /* Bundle of Deadly Blunt Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02650 Deadly Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/02650 Deadly Broadhead Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2650;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2650, 0, 37 /* Fletching */, 150, 0, 15433 /* Deadly Broadhead Arrow */, 100, 'You make a bundle of deadly broadhead arrows.', 0, 0, 'You fail to make any deadly broadhead arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2650;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2650, 15415 /* Bundle of Deadly Broad Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02651 Deadly Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02651 Deadly Broadhead Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2651;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2651, 0, 37 /* Fletching */, 150, 0, 15442 /* Deadly Broadhead Quarrel */, 100, 'You make a bundle of deadly broadhead quarrels.', 0, 0, 'You fail to make any deadly broadhead quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2651;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2651, 15415 /* Bundle of Deadly Broad Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02652 Deadly Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02652 Deadly Broadhead Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2652;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2652, 0, 37 /* Fletching */, 150, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 100, 'You make a bundle of deadly broadhead atlatl darts.', 0, 0, 'You fail to make any deadly broadhead atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2652;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2652, 15415 /* Bundle of Deadly Broad Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02653 Deadly Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02653 Deadly Fire Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2653;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2653, 0, 37 /* Fletching */, 225, 0, 15444 /* Deadly Fire Quarrel */, 100, 'You make a bundle of deadly fire quarrels.', 0, 0, 'You fail to make any deadly fire quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2653;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2653, 15417 /* Bundle of Deadly Fire Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02654 Deadly Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/02654 Deadly Fire Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2654;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2654, 0, 37 /* Fletching */, 225, 0, 15435 /* Deadly Fire Arrow */, 100, 'You make a bundle of deadly fire arrows.', 0, 0, 'You fail to make any deadly fire arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2654;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2654, 15417 /* Bundle of Deadly Fire Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02655 Deadly Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02655 Deadly Fire Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2655;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2655, 0, 37 /* Fletching */, 225, 0, 20970 /* Deadly Fire Atlatl Dart */, 100, 'You make a bundle of deadly fire atlatl darts.', 0, 0, 'You fail to make any deadly fire atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2655;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2655, 15417 /* Bundle of Deadly Fire Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02656 Deadly Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02656 Deadly Frog Crotch Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2656;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2656, 0, 37 /* Fletching */, 175, 0, 15445 /* Deadly Frog Crotch Quarrel */, 100, 'You make a bundle of deadly frog crotch quarrels.', 0, 0, 'You fail to make any deadly frog crotch quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2656;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2656, 15418 /* Bundle of Deadly Frog Crotch Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02657 Deadly Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/02657 Deadly Frog Crotch Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2657;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2657, 0, 37 /* Fletching */, 175, 0, 15436 /* Deadly Frog Crotch Arrow */, 100, 'You make a bundle of deadly frog crotch arrows.', 0, 0, 'You fail to make any deadly frog crotch arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2657;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2657, 15418 /* Bundle of Deadly Frog Crotch Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02658 Deadly Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02658 Deadly Frog Crotch Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2658;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2658, 0, 37 /* Fletching */, 175, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 100, 'You make a bundle of deadly frog crotch atlatl darts.', 0, 0, 'You fail to make any deadly frog crotch atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2658;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2658, 15418 /* Bundle of Deadly Frog Crotch Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02659 Deadly Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02659 Deadly Frost Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2659;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2659, 0, 37 /* Fletching */, 225, 0, 15446 /* Deadly Frost Quarrel */, 100, 'You make a bundle of deadly frost quarrels.', 0, 0, 'You fail to make any deadly frost quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2659;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2659, 15419 /* Bundle of Deadly Frost Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02660 Deadly Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/02660 Deadly Frost Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2660;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2660, 0, 37 /* Fletching */, 225, 0, 15437 /* Deadly Frost Arrow */, 100, 'You make a bundle of deadly frost arrows.', 0, 0, 'You fail to make any deadly frost arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2660;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2660, 15419 /* Bundle of Deadly Frost Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02661 Deadly Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02661 Deadly Frost Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2661;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2661, 0, 37 /* Fletching */, 225, 0, 20972 /* Deadly Frost Atlatl Dart */, 100, 'You make a bundle of deadly frost atlatl darts.', 0, 0, 'You fail to make any deadly frost atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2661;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2661, 15419 /* Bundle of Deadly Frost Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02662 Deadly Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/02662 Deadly Lightning Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2662;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2662, 0, 37 /* Fletching */, 225, 0, 15434 /* Deadly Lightning Arrow */, 100, 'You make a bundle of deadly lightning arrows.', 0, 0, 'You fail to make any deadly lightning arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2662;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2662, 15416 /* Bundle of Deadly Lightning Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02663 Deadly Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02663 Deadly Lightning Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2663;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2663, 0, 37 /* Fletching */, 225, 0, 15443 /* Deadly Lightning Quarrel */, 100, 'You make a bundle of deadly lightning quarrels.', 0, 0, 'You fail to make any deadly lightning quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2663;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2663, 15416 /* Bundle of Deadly Lightning Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02664 Deadly Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02664 Deadly Lightning Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 2664;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (2664, 0, 37 /* Fletching */, 225, 0, 20969 /* Deadly Lightning Atlatl Dart */, 100, 'You make a bundle of deadly lightning atlatl darts.', 0, 0, 'You fail to make any deadly lightning atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2664;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (2664, 15416 /* Bundle of Deadly Lightning Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02665 Deadly Arrow.sql
+++ b/Database/Patches/4 CraftTable/02665 Deadly Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2665;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2665, 0, 37 /* Fletching */, 175, 0, 15429 /* Deadly Arrow */, 1000, 'You make a big bundle of deadly arrows.', 0, 0, 'You fail to make any deadly arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2665;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2665, 15420 /* Wrapped Bundle of Deadly Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02666 Deadly Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02666 Deadly Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2666;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2666, 0, 37 /* Fletching */, 175, 0, 15438 /* Deadly Quarrel */, 1000, 'You make a big bundle of deadly quarrels.', 0, 0, 'You fail to make any deadly quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2666;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2666, 15420 /* Wrapped Bundle of Deadly Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02667 Deadly Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02667 Deadly Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2667;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2667, 0, 37 /* Fletching */, 175, 0, 20964 /* Deadly Atlatl Dart */, 1000, 'You make a big bundle of deadly atlatl darts.', 0, 0, 'You fail to make any deadly atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2667;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2667, 15420 /* Wrapped Bundle of Deadly Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02668 Deadly Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/02668 Deadly Acid Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2668;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2668, 0, 37 /* Fletching */, 250, 0, 15430 /* Deadly Acid Arrow */, 1000, 'You make a big bundle of deadly acid arrows.', 0, 0, 'You fail to make any deadly acid arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2668;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2668, 15421 /* Wrapped Bundle of Deadly Acid Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02669 Deadly Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02669 Deadly Acid Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2669;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2669, 0, 37 /* Fletching */, 250, 0, 15439 /* Deadly Acid Quarrel */, 1000, 'You make a big bundle of deadly acid quarrels.', 0, 0, 'You fail to make any deadly acid quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2669;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2669, 15421 /* Wrapped Bundle of Deadly Acid Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02670 Deadly Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02670 Deadly Acid Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2670;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2670, 0, 37 /* Fletching */, 250, 0, 20965 /* Deadly Acid Atlatl Dart */, 1000, 'You make a big bundle of deadly acid atlatl darts.', 0, 0, 'You fail to make any deadly acid atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2670;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2670, 15421 /* Wrapped Bundle of Deadly Acid Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02671 Deadly Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/02671 Deadly Armor Piercing Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2671;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2671, 0, 37 /* Fletching */, 200, 0, 15431 /* Deadly Armor Piercing Arrow */, 1000, 'You make a big bundle of deadly armor-piercing arrows.', 0, 0, 'You fail to make any deadly armor-piercing arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2671;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2671, 15422 /* Wrapped Bundle of Deadly Armor Piercing Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02672 Deadly Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02672 Deadly Armor Piercing Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2672;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2672, 0, 37 /* Fletching */, 200, 0, 15440 /* Deadly Armor Piercing Quarrel */, 1000, 'You make a big bundle of deadly armor-piercing quarrels.', 0, 0, 'You fail to make any deadly armor-piercing quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2672;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2672, 15422 /* Wrapped Bundle of Deadly Armor Piercing Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02673 Deadly Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02673 Deadly Armor Piercing Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2673;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2673, 0, 37 /* Fletching */, 200, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 1000, 'You make a big bundle of deadly armor-piercing atlatl darts.', 0, 0, 'You fail to make any deadly armor-piercing atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2673;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2673, 15422 /* Wrapped Bundle of Deadly Armor Piercing Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02674 Deadly Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/02674 Deadly Blunt Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2674;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2674, 0, 37 /* Fletching */, 180, 0, 15432 /* Deadly Blunt Arrow */, 1000, 'You make a big bundle of deadly blunt arrows.', 0, 0, 'You fail to make any deadly blunt arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2674;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2674, 15423 /* Wrapped Bundle of Deadly Blunt Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02675 Deadly Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02675 Deadly Blunt Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2675;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2675, 0, 37 /* Fletching */, 180, 0, 15441 /* Deadly Blunt Quarrel */, 1000, 'You make a big bundle of deadly blunt quarrels.', 0, 0, 'You fail to make any deadly blunt quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2675;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2675, 15423 /* Wrapped Bundle of Deadly Blunt Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02676 Deadly Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02676 Deadly Blunt Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2676;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2676, 0, 37 /* Fletching */, 180, 0, 20967 /* Deadly Blunt Atlatl Dart */, 1000, 'You make a big bundle of deadly blunt atlatl darts.', 0, 0, 'You fail to make any deadly blunt atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2676;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2676, 15423 /* Wrapped Bundle of Deadly Blunt Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02677 Deadly Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/02677 Deadly Broadhead Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2677;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2677, 0, 37 /* Fletching */, 180, 0, 15433 /* Deadly Broadhead Arrow */, 1000, 'You make a big bundle of deadly broadhead arrows.', 0, 0, 'You fail to make any deadly broadhead arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2677;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2677, 15424 /* Wrapped Bundle of Deadly Broad Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02678 Deadly Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02678 Deadly Broadhead Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2678;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2678, 0, 37 /* Fletching */, 180, 0, 15442 /* Deadly Broadhead Quarrel */, 1000, 'You make a big bundle of deadly broadhead quarrels.', 0, 0, 'You fail to make any deadly broadhead quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2678;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2678, 15424 /* Wrapped Bundle of Deadly Broad Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02679 Deadly Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02679 Deadly Broadhead Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2679;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2679, 0, 37 /* Fletching */, 180, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 1000, 'You make a big bundle of deadly broadhead atlatl darts.', 0, 0, 'You fail to make any deadly broadhead atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2679;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2679, 15424 /* Wrapped Bundle of Deadly Broad Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02680 Deadly Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/02680 Deadly Fire Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2680;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2680, 0, 37 /* Fletching */, 250, 0, 15435 /* Deadly Fire Arrow */, 1000, 'You make a big bundle of deadly fire arrows.', 0, 0, 'You fail to make any deadly fire arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2680;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2680, 15426 /* Wrapped Bundle of Deadly Fire Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02681 Deadly Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02681 Deadly Fire Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2681;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2681, 0, 37 /* Fletching */, 250, 0, 15444 /* Deadly Fire Quarrel */, 1000, 'You make a big bundle of deadly fire quarrels.', 0, 0, 'You fail to make any deadly fire quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2681;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2681, 15426 /* Wrapped Bundle of Deadly Fire Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02682 Deadly Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02682 Deadly Fire Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2682;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2682, 0, 37 /* Fletching */, 250, 0, 20970 /* Deadly Fire Atlatl Dart */, 1000, 'You make a big bundle of deadly fire atlatl darts.', 0, 0, 'You fail to make any deadly fire atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2682;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2682, 15426 /* Wrapped Bundle of Deadly Fire Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02683 Deadly Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/02683 Deadly Frog Crotch Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2683;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2683, 0, 37 /* Fletching */, 200, 0, 15436 /* Deadly Frog Crotch Arrow */, 1000, 'You make a big bundle of deadly frog crotch arrows.', 0, 0, 'You fail to make any deadly frog crotch arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2683;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2683, 15427 /* Wrapped Bundle of Deadly Frog Crotch Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02684 Deadly Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02684 Deadly Frog Crotch Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2684;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2684, 0, 37 /* Fletching */, 200, 0, 15445 /* Deadly Frog Crotch Quarrel */, 1000, 'You make a big bundle of deadly frog crotch quarrels.', 0, 0, 'You fail to make any deadly frog crotch quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2684;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2684, 15427 /* Wrapped Bundle of Deadly Frog Crotch Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02685 Deadly Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02685 Deadly Frog Crotch Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2685;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2685, 0, 37 /* Fletching */, 200, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 1000, 'You make a big bundle of deadly frog crotch atlatl darts.', 0, 0, 'You fail to make any deadly frog crotch atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2685;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2685, 15427 /* Wrapped Bundle of Deadly Frog Crotch Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02686 Deadly Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02686 Deadly Frost Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2686;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2686, 0, 37 /* Fletching */, 250, 0, 15446 /* Deadly Frost Quarrel */, 1000, 'You make a big bundle of deadly frost quarrels.', 0, 0, 'You fail to make any deadly frost quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2686;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2686, 15428 /* Wrapped Bundle of Deadly Frost Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02687 Deadly Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/02687 Deadly Frost Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2687;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2687, 0, 37 /* Fletching */, 250, 0, 15437 /* Deadly Frost Arrow */, 1000, 'You make a big bundle of deadly frost arrows.', 0, 0, 'You fail to make any deadly frost arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2687;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2687, 15428 /* Wrapped Bundle of Deadly Frost Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02688 Deadly Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02688 Deadly Frost Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2688;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2688, 0, 37 /* Fletching */, 250, 0, 20972 /* Deadly Frost Atlatl Dart */, 1000, 'You make a big bundle of deadly frost atlatl darts.', 0, 0, 'You fail to make any deadly frost atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2688;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2688, 15428 /* Wrapped Bundle of Deadly Frost Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02689 Deadly Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/02689 Deadly Lightning Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2689;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2689, 0, 37 /* Fletching */, 250, 0, 15434 /* Deadly Lightning Arrow */, 1000, 'You make a big bundle of deadly lightning arrows.', 0, 0, 'You fail to make any deadly lightning arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2689;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2689, 15425 /* Wrapped Bundle of Deadly Lightning Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02690 Deadly Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/02690 Deadly Lightning Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2690;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2690, 0, 37 /* Fletching */, 250, 0, 15443 /* Deadly Lightning Quarrel */, 1000, 'You make a big bundle of deadly lightning quarrels.', 0, 0, 'You fail to make any deadly lightning quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2690;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2690, 15425 /* Wrapped Bundle of Deadly Lightning Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/02691 Deadly Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/02691 Deadly Lightning Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 2691;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (2691, 0, 37 /* Fletching */, 250, 0, 20969 /* Deadly Lightning Atlatl Dart */, 1000, 'You make a big bundle of deadly lightning atlatl darts.', 0, 0, 'You fail to make any deadly lightning atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 2691;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (2691, 15425 /* Wrapped Bundle of Deadly Lightning Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03953 Deadly Chorizite Arrow.sql
+++ b/Database/Patches/4 CraftTable/03953 Deadly Chorizite Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3953;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3953, 0, 37 /* Fletching */, 150, 0, 21348 /* Deadly Chorizite Arrow */, 100, 'You make a bundle of deadly chorizite arrows.', 0, 0, 'You fail to make any deadly chorizite arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3953;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3953, 21998 /* Bundle of Deadly Chorizite Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03954 Chorizite Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/03954 Chorizite Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3954;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3954, 0, 37 /* Fletching */, 120, 0, 21349 /* Chorizite Atlatl Dart */, 100, 'You make a bundle of chorizite darts.', 0, 0, 'You fail to make any chorizite darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3954;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3954, 21997 /* Bundle of Chorizite Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03955 Deadly Chorizite Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/03955 Deadly Chorizite Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3955;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3955, 0, 37 /* Fletching */, 150, 0, 21350 /* Deadly Chorizite Atlatl Dart */, 100, 'You make a bundle of deadly chorizite darts.', 0, 0, 'You fail to make any deadly chorizite darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3955;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3955, 21998 /* Bundle of Deadly Chorizite Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03956 Chorizite Quarrel.sql
+++ b/Database/Patches/4 CraftTable/03956 Chorizite Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3956;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3956, 0, 37 /* Fletching */, 120, 0, 21351 /* Chorizite Quarrel */, 100, 'You make a bundle of chorizite crossbow bolts.', 0, 0, 'You fail to make any chorizite crossbow bolts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3956;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3956, 21997 /* Bundle of Chorizite Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03957 Deadly Chorizite Quarrel.sql
+++ b/Database/Patches/4 CraftTable/03957 Deadly Chorizite Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3957;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3957, 0, 37 /* Fletching */, 150, 0, 21352 /* Deadly Chorizite Quarrel */, 100, 'You make a bundle of deadly chorizite crossbow bolts.', 0, 0, 'You fail to make any deadly chorizite crossbow bolts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3957;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3957, 21998 /* Bundle of Deadly Chorizite Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03959 Chorizite Arrow.sql
+++ b/Database/Patches/4 CraftTable/03959 Chorizite Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3959;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3959, 0, 37 /* Fletching */, 120, 0, 21347 /* Chorizite Arrow */, 100, 'You make a bundle of chorizite arrows.', 0, 0, 'You fail to make any chorizite arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3959;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3959, 21997 /* Bundle of Chorizite Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03962 Chorizite Arrow.sql
+++ b/Database/Patches/4 CraftTable/03962 Chorizite Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 3962;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (3962, 0, 37 /* Fletching */, 150, 0, 21347 /* Chorizite Arrow */, 1000, 'You make a big bundle of chorizite arrows.', 0, 0, 'You fail to make any chorizite arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3962;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (3962, 21999 /* Wrapped Bundle of Chorizite Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03963 Deadly Chorizite Arrow.sql
+++ b/Database/Patches/4 CraftTable/03963 Deadly Chorizite Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 3963;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (3963, 0, 37 /* Fletching */, 175, 0, 21348 /* Deadly Chorizite Arrow */, 1000, 'You make a big bundle of deadly chorizite arrows.', 0, 0, 'You fail to make any chorizite arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3963;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (3963, 22000 /* Wrapped Bundle of Deadly Chorizite Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03964 Chorizite Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/03964 Chorizite Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 3964;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (3964, 0, 37 /* Fletching */, 150, 0, 21349 /* Chorizite Atlatl Dart */, 1000, 'You make a big bundle of chorizite atlatl darts.', 0, 0, 'You fail to make any chorizite atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3964;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (3964, 21999 /* Wrapped Bundle of Chorizite Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03965 Deadly Chorizite Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/03965 Deadly Chorizite Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 3965;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (3965, 0, 37 /* Fletching */, 175, 0, 21350 /* Deadly Chorizite Atlatl Dart */, 1000, 'You make a big bundle of deadly chorizite atlatl darts.', 0, 0, 'You fail to make any chorizite atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3965;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (3965, 22000 /* Wrapped Bundle of Deadly Chorizite Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03966 Chorizite Quarrel.sql
+++ b/Database/Patches/4 CraftTable/03966 Chorizite Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 3966;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (3966, 0, 37 /* Fletching */, 150, 0, 21351 /* Chorizite Quarrel */, 1000, 'You make a big bundle of chorizite crossbow bolts.', 0, 0, 'You fail to make any chorizite crossbow bolts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3966;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (3966, 21999 /* Wrapped Bundle of Chorizite Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03967 Deadly Chorizite Quarrel.sql
+++ b/Database/Patches/4 CraftTable/03967 Deadly Chorizite Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 3967;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (3967, 0, 37 /* Fletching */, 175, 0, 21352 /* Deadly Chorizite Quarrel */, 1000, 'You make a big bundle of deadly chorizite crossbow bolts.', 0, 0, 'You fail to make any chorizite crossbow bolts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3967;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (3967, 22000 /* Wrapped Bundle of Deadly Chorizite Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03968 Bundle of Chorizite Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/03968 Bundle of Chorizite Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3968;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3968, 0, 37 /* Fletching */, 60, 0, 21997 /* Bundle of Chorizite Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-19 10:53:29');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3968;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3968, 5778 /* Whittling Knife */, 21999 /* Wrapped Bundle of Chorizite Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/03969 Bundle of Deadly Chorizite Arrowheads.sql
+++ b/Database/Patches/4 CraftTable/03969 Bundle of Deadly Chorizite Arrowheads.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 3969;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (3969, 0, 37 /* Fletching */, 75, 0, 21998 /* Bundle of Deadly Chorizite Arrowheads */, 10, 'You separate the arrowheads.', 0, 0, 'You fail to separate the arrowheads.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 3969;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (3969, 5778 /* Whittling Knife */, 22000 /* Wrapped Bundle of Deadly Chorizite Arrowheads */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04377 Bloodletter Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04377 Bloodletter Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4377;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4377, 0, 37 /* Fletching */, 80, 0, 24130 /* Bloodletter Atlatl Dart */, 100, 'You make a bundle of bloodletter atlatl darts.', 0, 0, 'You fail to make any bloodletter atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4377;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4377, 9233 /* Bloodletter Arrowhead */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04378 Fleshripper Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04378 Fleshripper Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4378;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4378, 0, 37 /* Fletching */, 100, 0, 24131 /* Fleshripper Atlatl Dart */, 100, 'You make a bundle of fleshripper atlatl darts.', 0, 0, 'You fail to make any fleshripper atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4378;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4378, 9234 /* Fleshripper Arrowhead */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04379 Soulrender Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04379 Soulrender Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4379;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4379, 0, 37 /* Fletching */, 130, 0, 24132 /* Soulrender Atlatl Dart */, 100, 'You make a bundle of soulrender atlatl darts.', 0, 0, 'You fail to make any soulrender atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4379;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4379, 9235 /* Soulrender Arrowhead */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04461 Barbed Arrow.sql
+++ b/Database/Patches/4 CraftTable/04461 Barbed Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4461;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4461, 0, 37 /* Fletching */, 20, 0, 8826 /* Barbed Arrow */, 100, 'You make a bundle of barbed arrows.', 0, 0, 'You fail to make any barbed arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4461;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4461, 8824 /* Bundle of Barbed Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04462 Barbed Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04462 Barbed Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4462;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4462, 0, 37 /* Fletching */, 20, 0, 24548 /* Barbed Atlatl Dart */, 100, 'You make a bundle of barbed atlatl darts.', 0, 0, 'You fail to make any barbed atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4462;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4462, 8824 /* Bundle of Barbed Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04463 Barbed Quarrel.sql
+++ b/Database/Patches/4 CraftTable/04463 Barbed Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4463;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4463, 0, 37 /* Fletching */, 20, 0, 8828 /* Barbed Quarrel */, 100, 'You make a bundle of barbed quarrels.', 0, 0, 'You fail to make any barbed quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4463;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4463, 8824 /* Bundle of Barbed Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04464 Greater Barbed Arrow.sql
+++ b/Database/Patches/4 CraftTable/04464 Greater Barbed Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4464;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4464, 0, 37 /* Fletching */, 160, 0, 8827 /* Greater Barbed Arrow */, 100, 'You make a bundle of greater barbed arrows.', 0, 0, 'You fail to make any greater barbed arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4464;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4464, 8825 /* Bundle of Greater Barbed Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04465 Greater Barbed Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04465 Greater Barbed Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4465;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4465, 0, 37 /* Fletching */, 160, 0, 24550 /* Greater Barbed Atlatl Dart */, 100, 'You make a bundle of greater barbed atlatl darts.', 0, 0, 'You fail to make any greater barbed atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4465;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4465, 8825 /* Bundle of Greater Barbed Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04466 Greater Barbed Quarrel.sql
+++ b/Database/Patches/4 CraftTable/04466 Greater Barbed Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4466;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4466, 0, 37 /* Fletching */, 160, 0, 8829 /* Greater Barbed Quarrel */, 100, 'You make a bundle of greater barbed quarrels.', 0, 0, 'You fail to make any greater barbed quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4466;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4466, 8825 /* Bundle of Greater Barbed Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04467 Deadly Barbed Arrow.sql
+++ b/Database/Patches/4 CraftTable/04467 Deadly Barbed Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4467;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4467, 0, 37 /* Fletching */, 175, 0, 24547 /* Deadly Barbed Arrow */, 100, 'You make a bundle of deadly barbed arrows.', 0, 0, 'You fail to make any deadly barbed arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4467;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4467, 24543 /* Bundle of Deadly Barbed Arrowheads */,  4585 /* Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04468 Deadly Barbed Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04468 Deadly Barbed Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4468;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4468, 0, 37 /* Fletching */, 175, 0, 24549 /* Deadly Barbed Atlatl Dart */, 100, 'You make a bundle of deadly barbed atlatl darts.', 0, 0, 'You fail to make any greater deadly atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4468;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4468, 24543 /* Bundle of Deadly Barbed Arrowheads */, 15296 /* Bundle of Atlatl Dart Shafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04469 Deadly Barbed Quarrel.sql
+++ b/Database/Patches/4 CraftTable/04469 Deadly Barbed Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4469;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4469, 0, 37 /* Fletching */, 175, 0, 24551 /* Deadly Barbed Quarrel */, 100, 'You make a bundle of deadly barbed quarrels.', 0, 0, 'You fail to make any deadly barbed quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4469;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4469, 24543 /* Bundle of Deadly Barbed Arrowheads */,  5339 /* Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04470 Barbed Arrow.sql
+++ b/Database/Patches/4 CraftTable/04470 Barbed Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 4470;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (4470, 0, 37 /* Fletching */, 50, 0, 8826 /* Barbed Arrow */, 1000, 'You make a big bundle of barbed arrows.', 0, 0, 'You fail to make any barbed arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4470;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (4470, 24544 /* Wrapped Bundle of Barbed Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04471 Barbed Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04471 Barbed Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 4471;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (4471, 0, 37 /* Fletching */, 50, 0, 24548 /* Barbed Atlatl Dart */, 1000, 'You make a big bundle of barbed atlatl darts.', 0, 0, 'You fail to make any barbed atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4471;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (4471, 24544 /* Wrapped Bundle of Barbed Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04472 Barbed Quarrel.sql
+++ b/Database/Patches/4 CraftTable/04472 Barbed Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 4472;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (4472, 0, 37 /* Fletching */, 50, 0, 8828 /* Barbed Quarrel */, 1000, 'You make a big bundle of barbed quarrels.', 0, 0, 'You fail to make any barbed quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4472;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (4472, 24544 /* Wrapped Bundle of Barbed Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04473 Greater Barbed Arrow.sql
+++ b/Database/Patches/4 CraftTable/04473 Greater Barbed Arrow.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 4473;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (4473, 0, 37 /* Fletching */, 190, 0, 8827 /* Greater Barbed Arrow */, 1000, 'You make a big bundle of greater barbed arrows.', 0, 0, 'You fail to make any greater barbed arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:46:01');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4473;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (4473, 24546 /* Wrapped Bundle of Greater Barbed Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04474 Greater Barbed Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04474 Greater Barbed Atlatl Dart.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 4474;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (4474, 0, 37 /* Fletching */, 190, 0, 24550 /* Greater Barbed Atlatl Dart */, 1000, 'You make a big bundle of greater barbed atlatl darts.', 0, 0, 'You fail to make any greater barbed atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:51:39');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4474;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (4474, 24546 /* Wrapped Bundle of Greater Barbed Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04475 Greater Barbed Quarrel.sql
+++ b/Database/Patches/4 CraftTable/04475 Greater Barbed Quarrel.sql
@@ -1,9 +1,9 @@
-DELETE FROM `recipe` WHERE `id` = 6021;
+DELETE FROM `recipe` WHERE `id` = 4475;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6021, 0, 37 /* Fletching */, 390, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 1000, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
+VALUES (4475, 0, 37 /* Fletching */, 190, 0, 8829 /* Greater Barbed Quarrel */, 1000, 'You make a big bundle of greater barbed quarrels.', 0, 0, 'You fail to make any greater barbed quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:50');
 
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6021;
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4475;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6021, 44072 /* Wrapped Bundle of Deadly Prismatic Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (4475, 24546 /* Wrapped Bundle of Greater Barbed Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04476 Deadly Barbed Arrow.sql
+++ b/Database/Patches/4 CraftTable/04476 Deadly Barbed Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4476;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4476, 0, 37 /* Fletching */, 200, 0, 24547 /* Deadly Barbed Arrow */, 1000, 'You make a big bundle of deadly barbed arrows.', 0, 0, 'You fail to make any deadly barbed arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4476;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4476, 24545 /* Wrapped Bundle of Deadly Barbed Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04477 Deadly Barbed Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/04477 Deadly Barbed Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4477;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4477, 0, 37 /* Fletching */, 200, 0, 24549 /* Deadly Barbed Atlatl Dart */, 1000, 'You make a big bundle of deadly barbed atlatl darts.', 0, 0, 'You fail to make any deadly barbed atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4477;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4477, 24545 /* Wrapped Bundle of Deadly Barbed Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/04478 Deadly Barbed Quarrel.sql
+++ b/Database/Patches/4 CraftTable/04478 Deadly Barbed Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 4478;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (4478, 0, 37 /* Fletching */, 200, 0, 24551 /* Deadly Barbed Quarrel */, 1000, 'You make a big bundle of deadly barbed quarrels.', 0, 0, 'You fail to make any deadly barbed quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2005-02-09 10:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 4478;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (4478, 24545 /* Wrapped Bundle of Deadly Barbed Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2005-02-09 10:00:00');

--- a/Database/Patches/4 CraftTable/06004 Prismatic Arrow.sql
+++ b/Database/Patches/4 CraftTable/06004 Prismatic Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6004;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6004, 0, 37 /* Fletching */, 250, 0, 43952 /* Prismatic Arrow */, 10, 'You make a bundle of prismatic arrows.', 0, 0, 'You fail to make a bundle of prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6004, 0, 37 /* Fletching */, 250, 0, 43952 /* Prismatic Arrow */, 100, 'You make a bundle of prismatic arrows.', 0, 0, 'You fail to make a bundle of prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6004;
 

--- a/Database/Patches/4 CraftTable/06005 Prismatic Arrow.sql
+++ b/Database/Patches/4 CraftTable/06005 Prismatic Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6005;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6005, 0, 37 /* Fletching */, 275, 0, 43952 /* Prismatic Arrow */, 500, 'You make a big bundle of prismatic arrows.', 0, 0, 'You fail to make a bundle of prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6005, 0, 37 /* Fletching */, 275, 0, 43952 /* Prismatic Arrow */, 1000, 'You make a big bundle of prismatic arrows.', 0, 0, 'You fail to make a bundle of prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6005;
 

--- a/Database/Patches/4 CraftTable/06006 Greater Prismatic Arrow.sql
+++ b/Database/Patches/4 CraftTable/06006 Greater Prismatic Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6006;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6006, 0, 37 /* Fletching */, 370, 0, 43942 /* Greater Prismatic Arrow */, 10, 'You make a bundle of greater prismatic arrows.', 0, 0, 'You fail to make a bundle of greater prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6006, 0, 37 /* Fletching */, 370, 0, 43942 /* Greater Prismatic Arrow */, 100, 'You make a bundle of greater prismatic arrows.', 0, 0, 'You fail to make a bundle of greater prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6006;
 

--- a/Database/Patches/4 CraftTable/06007 Greater Prismatic Arrow.sql
+++ b/Database/Patches/4 CraftTable/06007 Greater Prismatic Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6007;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6007, 0, 37 /* Fletching */, 375, 0, 43942 /* Greater Prismatic Arrow */, 500, 'You make a big bundle of greater prismatic arrows.', 0, 0, 'You fail to make a bundle of greater prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6007, 0, 37 /* Fletching */, 375, 0, 43942 /* Greater Prismatic Arrow */, 1000, 'You make a big bundle of greater prismatic arrows.', 0, 0, 'You fail to make a bundle of greater prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:47:50');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6007;
 

--- a/Database/Patches/4 CraftTable/06008 Deadly Prismatic Arrow.sql
+++ b/Database/Patches/4 CraftTable/06008 Deadly Prismatic Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6008;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6008, 0, 37 /* Fletching */, 385, 0, 43951 /* Deadly Prismatic Arrow */, 10, 'You make a bundle of deadly prismatic arrows.', 0, 0, 'You fail to make a bundle of deadly prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6008, 0, 37 /* Fletching */, 385, 0, 43951 /* Deadly Prismatic Arrow */, 100, 'You make a bundle of deadly prismatic arrows.', 0, 0, 'You fail to make a bundle of deadly prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6008;
 

--- a/Database/Patches/4 CraftTable/06009 Deadly Prismatic Arrow.sql
+++ b/Database/Patches/4 CraftTable/06009 Deadly Prismatic Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6009;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6009, 0, 37 /* Fletching */, 400, 0, 43951 /* Deadly Prismatic Arrow */, 500, 'You make a big bundle of deadly prismatic arrows.', 0, 0, 'You fail to make a bundle of deadly prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6009, 0, 37 /* Fletching */, 400, 0, 43951 /* Deadly Prismatic Arrow */, 1000, 'You make a big bundle of deadly prismatic arrows.', 0, 0, 'You fail to make a bundle of deadly prismatic arrows.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6009;
 

--- a/Database/Patches/4 CraftTable/06010 Prismatic Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06010 Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6010;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6010, 0, 37 /* Fletching */, 210, 0, 43958 /* Prismatic Quarrel */, 10, 'You make a bundle of prismatic quarrels.', 0, 0, 'You fail to make a bundle of prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6010, 0, 37 /* Fletching */, 210, 0, 43958 /* Prismatic Quarrel */, 100, 'You make a bundle of prismatic quarrels.', 0, 0, 'You fail to make a bundle of prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6010;
 

--- a/Database/Patches/4 CraftTable/06011 Prismatic Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06011 Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6011;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6011, 0, 37 /* Fletching */, 230, 0, 43958 /* Prismatic Quarrel */, 500, 'You make a big bundle of prismatic quarrels.', 0, 0, 'You fail to make a big bundle of prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6011, 0, 37 /* Fletching */, 230, 0, 43958 /* Prismatic Quarrel */, 1000, 'You make a big bundle of prismatic quarrels.', 0, 0, 'You fail to make a big bundle of prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6011;
 

--- a/Database/Patches/4 CraftTable/06012 Greater Prismatic Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06012 Greater Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6012;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6012, 0, 37 /* Fletching */, 370, 0, 43957 /* Greater Prismatic Quarrel */, 10, 'You make a bundle of greater prismatic quarrels.', 0, 0, 'You fail to make a bundle of greater prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6012, 0, 37 /* Fletching */, 370, 0, 43957 /* Greater Prismatic Quarrel */, 100, 'You make a bundle of greater prismatic quarrels.', 0, 0, 'You fail to make a bundle of greater prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6012;
 

--- a/Database/Patches/4 CraftTable/06013 Greater Prismatic Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06013 Greater Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6013;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6013, 0, 37 /* Fletching */, 375, 0, 43957 /* Greater Prismatic Quarrel */, 500, 'You make a big bundle of greater prismatic quarrels.', 0, 0, 'You fail to make a bundle of greater prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6013, 0, 37 /* Fletching */, 375, 0, 43957 /* Greater Prismatic Quarrel */, 1000, 'You make a big bundle of greater prismatic quarrels.', 0, 0, 'You fail to make a bundle of greater prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:48:37');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6013;
 

--- a/Database/Patches/4 CraftTable/06014 Deadly Prismatic Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06014 Deadly Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6014;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6014, 0, 37 /* Fletching */, 385, 0, 43956 /* Deadly Prismatic Quarrel */, 10, 'You make a bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6014, 0, 37 /* Fletching */, 385, 0, 43956 /* Deadly Prismatic Quarrel */, 100, 'You make a bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6014;
 

--- a/Database/Patches/4 CraftTable/06015 Deadly Prismatic Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06015 Deadly Prismatic Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6015;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6015, 0, 37 /* Fletching */, 400, 0, 43956 /* Deadly Prismatic Quarrel */, 500, 'You make a big bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6015, 0, 37 /* Fletching */, 400, 0, 43956 /* Deadly Prismatic Quarrel */, 1000, 'You make a big bundle of deadly prismatic quarrels.', 0, 0, 'You fail to make a bundle of deadly prismatic quarrels.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6015;
 

--- a/Database/Patches/4 CraftTable/06016 Prismatic Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06016 Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6016;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6016, 0, 37 /* Fletching */, 210, 0, 43955 /* Prismatic Atlatl Dart */, 10, 'You make a bundle of prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6016, 0, 37 /* Fletching */, 210, 0, 43955 /* Prismatic Atlatl Dart */, 100, 'You make a bundle of prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6016;
 

--- a/Database/Patches/4 CraftTable/06017 Prismatic Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06017 Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6017;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6017, 0, 37 /* Fletching */, 230, 0, 43955 /* Prismatic Atlatl Dart */, 500, 'You make a big bundle of prismatic atlatl darts.', 0, 0, 'You fail to make a big bundle of prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6017, 0, 37 /* Fletching */, 230, 0, 43955 /* Prismatic Atlatl Dart */, 1000, 'You make a big bundle of prismatic atlatl darts.', 0, 0, 'You fail to make a big bundle of prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6017;
 

--- a/Database/Patches/4 CraftTable/06018 Greater Prismatic Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06018 Greater Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6018;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6018, 0, 37 /* Fletching */, 370, 0, 43954 /* Greater Prismatic Atlatl Dart */, 10, 'You make a bundle of greater prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of greater prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6018, 0, 37 /* Fletching */, 370, 0, 43954 /* Greater Prismatic Atlatl Dart */, 100, 'You make a bundle of greater prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of greater prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6018;
 

--- a/Database/Patches/4 CraftTable/06019 Greater Prismatic Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06019 Greater Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6019;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6019, 0, 37 /* Fletching */, 375, 0, 43954 /* Greater Prismatic Atlatl Dart */, 500, 'You make a big bundle of greater prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of greater prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6019, 0, 37 /* Fletching */, 375, 0, 43954 /* Greater Prismatic Atlatl Dart */, 1000, 'You make a big bundle of greater prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of greater prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:52:04');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6019;
 

--- a/Database/Patches/4 CraftTable/06020 Deadly Prismatic Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06020 Deadly Prismatic Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6020;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6020, 0, 37 /* Fletching */, 385, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 10, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6020, 0, 37 /* Fletching */, 385, 0, 43953 /* Deadly Prismatic Atlatl Dart */, 100, 'You make a bundle of deadly prismatic atlatl darts.', 0, 0, 'You fail to make a bundle of deadly prismatic atlatl darts.', 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6020;
 

--- a/Database/Patches/4 CraftTable/06174 Deadly Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/06174 Deadly Broadhead Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6174;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6174, 0, 37 /* Fletching */, 250, 0, 15433 /* Deadly Broadhead Arrow */, 10, 'You make a bundle of Deadly broadhead arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6174, 0, 37 /* Fletching */, 250, 0, 15433 /* Deadly Broadhead Arrow */, 100, 'You make a bundle of Deadly broadhead arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6174;
 

--- a/Database/Patches/4 CraftTable/06175 Deadly Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06175 Deadly Broadhead Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6175;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6175, 0, 37 /* Fletching */, 250, 0, 15442 /* Deadly Broadhead Quarrel */, 10, 'You make a bundle of Deadly broadhead quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6175, 0, 37 /* Fletching */, 250, 0, 15442 /* Deadly Broadhead Quarrel */, 100, 'You make a bundle of Deadly broadhead quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6175;
 

--- a/Database/Patches/4 CraftTable/06176 Deadly Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06176 Deadly Broadhead Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6176;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6176, 0, 37 /* Fletching */, 250, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 10, 'You make a bundle of Deadly broadhead Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6176, 0, 37 /* Fletching */, 250, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 100, 'You make a bundle of Deadly broadhead Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6176;
 

--- a/Database/Patches/4 CraftTable/06177 Deadly Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/06177 Deadly Acid Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6177;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6177, 0, 37 /* Fletching */, 250, 0, 15430 /* Deadly Acid Arrow */, 10, 'You make a bundle of Deadly Acid Arrows', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6177, 0, 37 /* Fletching */, 250, 0, 15430 /* Deadly Acid Arrow */, 100, 'You make a bundle of Deadly Acid Arrows', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6177;
 

--- a/Database/Patches/4 CraftTable/06178 Deadly Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06178 Deadly Acid Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6178;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6178, 0, 37 /* Fletching */, 250, 0, 15439 /* Deadly Acid Quarrel */, 10, 'You make a bundle of Deadly Acid Quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6178, 0, 37 /* Fletching */, 250, 0, 15439 /* Deadly Acid Quarrel */, 100, 'You make a bundle of Deadly Acid Quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6178;
 

--- a/Database/Patches/4 CraftTable/06179 Deadly Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06179 Deadly Acid Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6179;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6179, 0, 37 /* Fletching */, 250, 0, 20965 /* Deadly Acid Atlatl Dart */, 10, 'You make a bundle of Deadly Acid Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6179, 0, 37 /* Fletching */, 250, 0, 20965 /* Deadly Acid Atlatl Dart */, 100, 'You make a bundle of Deadly Acid Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6179;
 

--- a/Database/Patches/4 CraftTable/06180 Deadly Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/06180 Deadly Armor Piercing Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6180;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6180, 0, 37 /* Fletching */, 250, 0, 15431 /* Deadly Armor Piercing Arrow */, 10, 'You make a bundle of Deadly Armor Piercing Arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6180, 0, 37 /* Fletching */, 250, 0, 15431 /* Deadly Armor Piercing Arrow */, 100, 'You make a bundle of Deadly Armor Piercing Arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6180;
 

--- a/Database/Patches/4 CraftTable/06181 Deadly Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06181 Deadly Armor Piercing Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6181;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6181, 0, 37 /* Fletching */, 250, 0, 15440 /* Deadly Armor Piercing Quarrel */, 10, 'You make a bundle of Deadly Armor Piercing Quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6181, 0, 37 /* Fletching */, 250, 0, 15440 /* Deadly Armor Piercing Quarrel */, 100, 'You make a bundle of Deadly Armor Piercing Quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6181;
 

--- a/Database/Patches/4 CraftTable/06182 Deadly Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06182 Deadly Armor Piercing Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6182;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6182, 0, 37 /* Fletching */, 250, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 10, 'You make a bundle of Deadly Armor Piercing Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6182, 0, 37 /* Fletching */, 250, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 100, 'You make a bundle of Deadly Armor Piercing Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6182;
 

--- a/Database/Patches/4 CraftTable/06183 Deadly Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/06183 Deadly Blunt Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6183;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6183, 0, 37 /* Fletching */, 250, 0, 15432 /* Deadly Blunt Arrow */, 10, 'You make a bundle of Deadly Blunt arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6183, 0, 37 /* Fletching */, 250, 0, 15432 /* Deadly Blunt Arrow */, 100, 'You make a bundle of Deadly Blunt arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6183;
 

--- a/Database/Patches/4 CraftTable/06184 Deadly Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06184 Deadly Blunt Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6184;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6184, 0, 37 /* Fletching */, 250, 0, 15441 /* Deadly Blunt Quarrel */, 10, 'You make a bundle of Deadly Blunt quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6184, 0, 37 /* Fletching */, 250, 0, 15441 /* Deadly Blunt Quarrel */, 100, 'You make a bundle of Deadly Blunt quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6184;
 

--- a/Database/Patches/4 CraftTable/06185 Deadly Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06185 Deadly Blunt Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6185;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6185, 0, 37 /* Fletching */, 250, 0, 20967 /* Deadly Blunt Atlatl Dart */, 10, 'You make a bundle of Deadly Blunt Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6185, 0, 37 /* Fletching */, 250, 0, 20967 /* Deadly Blunt Atlatl Dart */, 100, 'You make a bundle of Deadly Blunt Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6185;
 

--- a/Database/Patches/4 CraftTable/06186 Deadly Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/06186 Deadly Lightning Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6186;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6186, 0, 37 /* Fletching */, 250, 0, 15434 /* Deadly Lightning Arrow */, 10, 'You make a bundle of Deadly Lightning arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6186, 0, 37 /* Fletching */, 250, 0, 15434 /* Deadly Lightning Arrow */, 100, 'You make a bundle of Deadly Lightning arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6186;
 

--- a/Database/Patches/4 CraftTable/06187 Deadly Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06187 Deadly Lightning Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6187;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6187, 0, 37 /* Fletching */, 250, 0, 15443 /* Deadly Lightning Quarrel */, 10, 'You make a bundle of Deadly Lightning quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6187, 0, 37 /* Fletching */, 250, 0, 15443 /* Deadly Lightning Quarrel */, 100, 'You make a bundle of Deadly Lightning quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6187;
 

--- a/Database/Patches/4 CraftTable/06188 Deadly Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06188 Deadly Lightning Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6188;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6188, 0, 37 /* Fletching */, 250, 0, 20969 /* Deadly Lightning Atlatl Dart */, 10, 'You make a bundle of Deadly Lightning Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6188, 0, 37 /* Fletching */, 250, 0, 20969 /* Deadly Lightning Atlatl Dart */, 100, 'You make a bundle of Deadly Lightning Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6188;
 

--- a/Database/Patches/4 CraftTable/06189 Deadly Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/06189 Deadly Fire Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6189;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6189, 0, 37 /* Fletching */, 250, 0, 15435 /* Deadly Fire Arrow */, 10, 'You make a bundle of Deadly Fire arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6189, 0, 37 /* Fletching */, 250, 0, 15435 /* Deadly Fire Arrow */, 100, 'You make a bundle of Deadly Fire arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6189;
 

--- a/Database/Patches/4 CraftTable/06190 Deadly Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06190 Deadly Fire Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6190;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6190, 0, 37 /* Fletching */, 250, 0, 15444 /* Deadly Fire Quarrel */, 10, 'You make a bundle of Deadly Fire quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6190, 0, 37 /* Fletching */, 250, 0, 15444 /* Deadly Fire Quarrel */, 100, 'You make a bundle of Deadly Fire quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6190;
 

--- a/Database/Patches/4 CraftTable/06191 Deadly Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06191 Deadly Fire Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6191;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6191, 0, 37 /* Fletching */, 250, 0, 20970 /* Deadly Fire Atlatl Dart */, 10, 'You make a bundle of Deadly Fire Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6191, 0, 37 /* Fletching */, 250, 0, 20970 /* Deadly Fire Atlatl Dart */, 100, 'You make a bundle of Deadly Fire Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6191;
 

--- a/Database/Patches/4 CraftTable/06192 Deadly Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/06192 Deadly Frog Crotch Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6192;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6192, 0, 37 /* Fletching */, 250, 0, 15436 /* Deadly Frog Crotch Arrow */, 10, 'You make a bundle of Deadly Frog Crotch arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6192, 0, 37 /* Fletching */, 250, 0, 15436 /* Deadly Frog Crotch Arrow */, 100, 'You make a bundle of Deadly Frog Crotch arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6192;
 

--- a/Database/Patches/4 CraftTable/06193 Deadly Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06193 Deadly Frog Crotch Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6193;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6193, 0, 37 /* Fletching */, 250, 0, 15445 /* Deadly Frog Crotch Quarrel */, 10, 'You make a bundle of Deadly Frog Crotch quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6193, 0, 37 /* Fletching */, 250, 0, 15445 /* Deadly Frog Crotch Quarrel */, 100, 'You make a bundle of Deadly Frog Crotch quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:28:55');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6193;
 

--- a/Database/Patches/4 CraftTable/06194 Deadly Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06194 Deadly Frog Crotch Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6194;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6194, 0, 37 /* Fletching */, 250, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 10, 'You make a bundle of Deadly Frog Crotch Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6194, 0, 37 /* Fletching */, 250, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 100, 'You make a bundle of Deadly Frog Crotch Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6194;
 

--- a/Database/Patches/4 CraftTable/06195 Deadly Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/06195 Deadly Frost Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6195;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6195, 0, 37 /* Fletching */, 250, 0, 15437 /* Deadly Frost Arrow */, 10, 'You make a bundle of Deadly Frost arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6195, 0, 37 /* Fletching */, 250, 0, 15437 /* Deadly Frost Arrow */, 100, 'You make a bundle of Deadly Frost arrows', 0, 0, 'You fail to make any arrows', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6195;
 

--- a/Database/Patches/4 CraftTable/06196 Deadly Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/06196 Deadly Frost Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6196;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6196, 0, 37 /* Fletching */, 250, 0, 15446 /* Deadly Frost Quarrel */, 10, 'You make a bundle of Deadly Frost quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6196, 0, 37 /* Fletching */, 250, 0, 15446 /* Deadly Frost Quarrel */, 100, 'You make a bundle of Deadly Frost quarrels', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6196;
 

--- a/Database/Patches/4 CraftTable/06197 Deadly Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/06197 Deadly Frost Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 6197;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6197, 0, 37 /* Fletching */, 250, 0, 20972 /* Deadly Frost Atlatl Dart */, 10, 'You make a bundle of Deadly Frost Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
+VALUES (6197, 0, 37 /* Fletching */, 250, 0, 20972 /* Deadly Frost Atlatl Dart */, 100, 'You make a bundle of Deadly Frost Atlatl Darts', 0, 0, 'You fail to make any darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:32:58');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6197;
 

--- a/Database/Patches/4 CraftTable/07056 Greater Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/07056 Greater Deadly Blunt Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 7056;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (7056, 0, 37 /* Fletching */, 300, 0, 44371 /* Greater Deadly Blunt Spike */, 1000, 'You make a Big Bundle of Greater Deadly Blunt Spikes.', 0, 0, 'You fail to make a Big Bundle of Greater Deadly Blunt Spikes.', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (7056, 0, 37 /* Fletching */, 300, 0, 44371 /* Greater Deadly Blunt Spike */, 2500, 'You make a Big Bundle of Greater Deadly Blunt Spikes.', 0, 0, 'You fail to make a Big Bundle of Greater Deadly Blunt Spikes.', 1, 1, '', 1, 1, '', 1, 1, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 7056;
 

--- a/Database/Patches/4 CraftTable/09134 Deadly Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/09134 Deadly Broadhead Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9134;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9134, 0, 37 /* Fletching */, 180, 0, 15433 /* Deadly Broadhead Arrow */, 1000, 'You make a bundle of deadly broadhead arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9134, 0, 37 /* Fletching */, 180, 0, 15433 /* Deadly Broadhead Arrow */, 1000, 'You make a big bundle of deadly broadhead arrows.', 0, 0, 'You fail to make any deadly broadhead arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9134;
 

--- a/Database/Patches/4 CraftTable/09134 Deadly Broadhead Arrow.sql
+++ b/Database/Patches/4 CraftTable/09134 Deadly Broadhead Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9134;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9134, 0, 37 /* Fletching */, 180, 0, 15433 /* Deadly Broadhead Arrow */, 1000, 'You make a bundle of deadly broadhead arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9134;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9134, 30074 /* Infinite Deadly Broad Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09135 Deadly Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09135 Deadly Broadhead Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9135;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9135, 0, 37 /* Fletching */, 180, 0, 15442 /* Deadly Broadhead Quarrel */, 1000, 'You make a bundle of deadly broadhead quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9135, 0, 37 /* Fletching */, 180, 0, 15442 /* Deadly Broadhead Quarrel */, 1000, 'You make a big bundle of deadly broadhead quarrels.', 0, 0, 'You fail to make any deadly broadhead quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9135;
 

--- a/Database/Patches/4 CraftTable/09135 Deadly Broadhead Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09135 Deadly Broadhead Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9135;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9135, 0, 37 /* Fletching */, 180, 0, 15442 /* Deadly Broadhead Quarrel */, 1000, 'You make a bundle of deadly broadhead quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9135;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9135, 30074 /* Infinite Deadly Broad Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09136 Deadly Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09136 Deadly Broadhead Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9136;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9136, 0, 37 /* Fletching */, 180, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 1000, 'You make a bundle of deadly broadhead atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9136;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9136, 30074 /* Infinite Deadly Broad Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09136 Deadly Broadhead Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09136 Deadly Broadhead Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9136;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9136, 0, 37 /* Fletching */, 180, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 1000, 'You make a bundle of deadly broadhead atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9136, 0, 37 /* Fletching */, 180, 0, 20968 /* Deadly Broadhead Atlatl Dart */, 1000, 'You make a big bundle of deadly broadhead atlatl darts.', 0, 0, 'You fail to make any deadly broadhead atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9136;
 

--- a/Database/Patches/4 CraftTable/09137 Deadly Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/09137 Deadly Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9137;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9137, 0, 37 /* Fletching */, 180, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9137;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9137, 30074 /* Infinite Deadly Broad Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09137 Deadly Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/09137 Deadly Broad Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9137;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9137, 0, 37 /* Fletching */, 180, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9137, 0, 37 /* Fletching */, 180, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a big bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any deadly broadhead spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9137;
 

--- a/Database/Patches/4 CraftTable/09138 Deadly Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/09138 Deadly Broad Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9138;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9138, 0, 37 /* Fletching */, 150, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9138;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9138, 30074 /* Infinite Deadly Broad Arrowheads */, 23857 /* Bundle of Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09138 Deadly Broad Spike.sql
+++ b/Database/Patches/4 CraftTable/09138 Deadly Broad Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9138;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9138, 0, 37 /* Fletching */, 150, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9138, 0, 37 /* Fletching */, 150, 0, 23862 /* Deadly Broad Spike */, 1000, 'You make a bundle of deadly broadhead spikes.', 0, 0, 'You fail to make any deadly broadhead spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9138;
 

--- a/Database/Patches/4 CraftTable/09139 Deadly Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/09139 Deadly Acid Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9139;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9139, 0, 37 /* Fletching */, 250, 0, 15430 /* Deadly Acid Arrow */, 1000, 'You make a bundle of deadly acid arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9139;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9139, 30075 /* Infinite Deadly Acid Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09139 Deadly Acid Arrow.sql
+++ b/Database/Patches/4 CraftTable/09139 Deadly Acid Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9139;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9139, 0, 37 /* Fletching */, 250, 0, 15430 /* Deadly Acid Arrow */, 1000, 'You make a bundle of deadly acid arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9139, 0, 37 /* Fletching */, 250, 0, 15430 /* Deadly Acid Arrow */, 1000, 'You make a big bundle of deadly acid arrows.', 0, 0, 'You fail to make any deadly acid arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9139;
 

--- a/Database/Patches/4 CraftTable/09140 Deadly Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09140 Deadly Acid Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9140;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9140, 0, 37 /* Fletching */, 250, 0, 15439 /* Deadly Acid Quarrel */, 1000, 'You make a bundle of deadly acid quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9140;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9140, 30075 /* Infinite Deadly Acid Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09140 Deadly Acid Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09140 Deadly Acid Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9140;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9140, 0, 37 /* Fletching */, 250, 0, 15439 /* Deadly Acid Quarrel */, 1000, 'You make a bundle of deadly acid quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9140, 0, 37 /* Fletching */, 250, 0, 15439 /* Deadly Acid Quarrel */, 1000, 'You make a big bundle of deadly acid quarrels.', 0, 0, 'You fail to make any deadly acid quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9140;
 

--- a/Database/Patches/4 CraftTable/09141 Deadly Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09141 Deadly Acid Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9141;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9141, 0, 37 /* Fletching */, 250, 0, 20965 /* Deadly Acid Atlatl Dart */, 1000, 'You make a bundle of deadly acid atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9141, 0, 37 /* Fletching */, 250, 0, 20965 /* Deadly Acid Atlatl Dart */, 1000, 'You make a big bundle of deadly acid atlatl darts.', 0, 0, 'You fail to make any deadly acid atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9141;
 

--- a/Database/Patches/4 CraftTable/09141 Deadly Acid Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09141 Deadly Acid Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9141;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9141, 0, 37 /* Fletching */, 250, 0, 20965 /* Deadly Acid Atlatl Dart */, 1000, 'You make a bundle of deadly acid atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9141;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9141, 30075 /* Infinite Deadly Acid Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09142 Deadly Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/09142 Deadly Acid Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9142;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9142, 0, 37 /* Fletching */, 250, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a bundle of deadly acid spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9142, 0, 37 /* Fletching */, 250, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a big bundle of deadly acid spikes.', 0, 0, 'You fail to make any deadly acid spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9142;
 

--- a/Database/Patches/4 CraftTable/09142 Deadly Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/09142 Deadly Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9142;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9142, 0, 37 /* Fletching */, 250, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a bundle of deadly acid spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9142;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9142, 30075 /* Infinite Deadly Acid Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09143 Deadly Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/09143 Deadly Acid Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9143;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9143, 0, 37 /* Fletching */, 225, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a bundle of deadly acid spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9143, 0, 37 /* Fletching */, 225, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a bundle of deadly acid spikes.', 0, 0, 'You fail to make any deadly acid spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9143;
 

--- a/Database/Patches/4 CraftTable/09143 Deadly Acid Spike.sql
+++ b/Database/Patches/4 CraftTable/09143 Deadly Acid Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9143;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9143, 0, 37 /* Fletching */, 225, 0, 23860 /* Deadly Acid Spike */, 1000, 'You make a bundle of deadly acid spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9143;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9143, 30075 /* Infinite Deadly Acid Arrowheads */, 23857 /* Bundle of Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09144 Deadly Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/09144 Deadly Armor Piercing Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9144;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9144, 0, 37 /* Fletching */, 200, 0, 15431 /* Deadly Armor Piercing Arrow */, 1000, 'You make a bundle of deadly armor-piercing arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9144;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9144, 30076 /* Infinite Deadly Armor Piercing Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09144 Deadly Armor Piercing Arrow.sql
+++ b/Database/Patches/4 CraftTable/09144 Deadly Armor Piercing Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9144;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9144, 0, 37 /* Fletching */, 200, 0, 15431 /* Deadly Armor Piercing Arrow */, 1000, 'You make a bundle of deadly armor-piercing arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9144, 0, 37 /* Fletching */, 200, 0, 15431 /* Deadly Armor Piercing Arrow */, 1000, 'You make a big bundle of deadly armor-piercing arrows.', 0, 0, 'You fail to make any deadly armor-piercing arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9144;
 

--- a/Database/Patches/4 CraftTable/09145 Deadly Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09145 Deadly Armor Piercing Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9145;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9145, 0, 37 /* Fletching */, 200, 0, 15440 /* Deadly Armor Piercing Quarrel */, 1000, 'You make a bundle of deadly armor-piercing quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9145;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9145, 30076 /* Infinite Deadly Armor Piercing Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09145 Deadly Armor Piercing Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09145 Deadly Armor Piercing Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9145;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9145, 0, 37 /* Fletching */, 200, 0, 15440 /* Deadly Armor Piercing Quarrel */, 1000, 'You make a bundle of deadly armor-piercing quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9145, 0, 37 /* Fletching */, 200, 0, 15440 /* Deadly Armor Piercing Quarrel */, 1000, 'You make a big bundle of deadly armor-piercing quarrels.', 0, 0, 'You fail to make any deadly armor-piercing quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9145;
 

--- a/Database/Patches/4 CraftTable/09146 Deadly Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09146 Deadly Armor Piercing Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9146;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9146, 0, 37 /* Fletching */, 200, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 1000, 'You make a bundle of deadly armor-piercing atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9146, 0, 37 /* Fletching */, 200, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 1000, 'You make a big bundle of deadly armor-piercing atlatl darts.', 0, 0, 'You fail to make any deadly armor-piercing atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9146;
 

--- a/Database/Patches/4 CraftTable/09146 Deadly Armor Piercing Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09146 Deadly Armor Piercing Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9146;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9146, 0, 37 /* Fletching */, 200, 0, 20966 /* Deadly Armor Piercing Atlatl Dart */, 1000, 'You make a bundle of deadly armor-piercing atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9146;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9146, 30076 /* Infinite Deadly Armor Piercing Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09147 Deadly Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/09147 Deadly Blunt Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9147;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9147, 0, 37 /* Fletching */, 180, 0, 15432 /* Deadly Blunt Arrow */, 1000, 'You make a bundle of deadly blunt arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9147;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9147, 30077 /* Infinite Deadly Blunt Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09147 Deadly Blunt Arrow.sql
+++ b/Database/Patches/4 CraftTable/09147 Deadly Blunt Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9147;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9147, 0, 37 /* Fletching */, 180, 0, 15432 /* Deadly Blunt Arrow */, 1000, 'You make a bundle of deadly blunt arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9147, 0, 37 /* Fletching */, 180, 0, 15432 /* Deadly Blunt Arrow */, 1000, 'You make a big bundle of deadly blunt arrows.', 0, 0, 'You fail to make any deadly blunt arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9147;
 

--- a/Database/Patches/4 CraftTable/09148 Deadly Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09148 Deadly Blunt Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9148;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9148, 0, 37 /* Fletching */, 180, 0, 15441 /* Deadly Blunt Quarrel */, 1000, 'You make a bundle of deadly blunt quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9148, 0, 37 /* Fletching */, 180, 0, 15441 /* Deadly Blunt Quarrel */, 1000, 'You make a big bundle of deadly blunt quarrels.', 0, 0, 'You fail to make any deadly blunt quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9148;
 

--- a/Database/Patches/4 CraftTable/09148 Deadly Blunt Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09148 Deadly Blunt Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9148;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9148, 0, 37 /* Fletching */, 180, 0, 15441 /* Deadly Blunt Quarrel */, 1000, 'You make a bundle of deadly blunt quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9148;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9148, 30077 /* Infinite Deadly Blunt Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09149 Deadly Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09149 Deadly Blunt Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9149;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9149, 0, 37 /* Fletching */, 180, 0, 20967 /* Deadly Blunt Atlatl Dart */, 1000, 'You make a bundle of deadly blunt atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9149, 0, 37 /* Fletching */, 180, 0, 20967 /* Deadly Blunt Atlatl Dart */, 1000, 'You make a big bundle of deadly blunt atlatl darts.', 0, 0, 'You fail to make any deadly blunt atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9149;
 

--- a/Database/Patches/4 CraftTable/09149 Deadly Blunt Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09149 Deadly Blunt Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9149;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9149, 0, 37 /* Fletching */, 180, 0, 20967 /* Deadly Blunt Atlatl Dart */, 1000, 'You make a bundle of deadly blunt atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9149;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9149, 30077 /* Infinite Deadly Blunt Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09150 Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/09150 Deadly Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9150;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9150, 0, 37 /* Fletching */, 180, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a bundle of deadly blunt spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9150;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9150, 30077 /* Infinite Deadly Blunt Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09150 Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/09150 Deadly Blunt Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9150;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9150, 0, 37 /* Fletching */, 180, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a bundle of deadly blunt spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9150, 0, 37 /* Fletching */, 180, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a big bundle of deadly blunt spikes.', 0, 0, 'You fail to make any deadly blunt spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9150;
 

--- a/Database/Patches/4 CraftTable/09151 Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/09151 Deadly Blunt Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9151;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9151, 0, 37 /* Fletching */, 150, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a bundle of deadly blunt spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9151, 0, 37 /* Fletching */, 150, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a bundle of deadly blunt spikes.', 0, 0, 'You fail to make any deadly blunt spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9151;
 

--- a/Database/Patches/4 CraftTable/09151 Deadly Blunt Spike.sql
+++ b/Database/Patches/4 CraftTable/09151 Deadly Blunt Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9151;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9151, 0, 37 /* Fletching */, 150, 0, 23861 /* Deadly Blunt Spike */, 1000, 'You make a bundle of deadly blunt spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9151;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9151, 30077 /* Infinite Deadly Blunt Arrowheads */, 23857 /* Bundle of Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09152 Deadly Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/09152 Deadly Lightning Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9152;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9152, 0, 37 /* Fletching */, 250, 0, 15434 /* Deadly Lightning Arrow */, 1000, 'You make a bundle of deadly lightning arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9152, 0, 37 /* Fletching */, 250, 0, 15434 /* Deadly Lightning Arrow */, 1000, 'You make a big bundle of deadly lightning arrows.', 0, 0, 'You fail to make any deadly lightning arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9152;
 

--- a/Database/Patches/4 CraftTable/09152 Deadly Lightning Arrow.sql
+++ b/Database/Patches/4 CraftTable/09152 Deadly Lightning Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9152;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9152, 0, 37 /* Fletching */, 250, 0, 15434 /* Deadly Lightning Arrow */, 1000, 'You make a bundle of deadly lightning arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9152;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9152, 30078 /* Infinite Deadly Lightning Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09153 Deadly Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09153 Deadly Lightning Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9153;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9153, 0, 37 /* Fletching */, 250, 0, 15443 /* Deadly Lightning Quarrel */, 1000, 'You make a bundle of deadly lightning quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9153, 0, 37 /* Fletching */, 250, 0, 15443 /* Deadly Lightning Quarrel */, 1000, 'You make a big bundle of deadly lightning quarrels.', 0, 0, 'You fail to make any deadly lightning quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9153;
 

--- a/Database/Patches/4 CraftTable/09153 Deadly Lightning Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09153 Deadly Lightning Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9153;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9153, 0, 37 /* Fletching */, 250, 0, 15443 /* Deadly Lightning Quarrel */, 1000, 'You make a bundle of deadly lightning quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9153;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9153, 30078 /* Infinite Deadly Lightning Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09154 Deadly Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09154 Deadly Lightning Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9154;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9154, 0, 37 /* Fletching */, 250, 0, 20969 /* Deadly Lightning Atlatl Dart */, 1000, 'You make a bundle of deadly lightning atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9154, 0, 37 /* Fletching */, 250, 0, 20969 /* Deadly Lightning Atlatl Dart */, 1000, 'You make a big bundle of deadly lightning atlatl darts.', 0, 0, 'You fail to make any deadly lightning atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9154;
 

--- a/Database/Patches/4 CraftTable/09154 Deadly Lightning Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09154 Deadly Lightning Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9154;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9154, 0, 37 /* Fletching */, 250, 0, 20969 /* Deadly Lightning Atlatl Dart */, 1000, 'You make a bundle of deadly lightning atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9154;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9154, 30078 /* Infinite Deadly Lightning Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09155 Deadly Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/09155 Deadly Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9155;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9155, 0, 37 /* Fletching */, 250, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a bundle of deadly lightning spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9155;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9155, 30078 /* Infinite Deadly Lightning Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09155 Deadly Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/09155 Deadly Lightning Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9155;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9155, 0, 37 /* Fletching */, 250, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a bundle of deadly lightning spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9155, 0, 37 /* Fletching */, 250, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a big bundle of deadly lightning spikes.', 0, 0, 'You fail to make any deadly lightning spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9155;
 

--- a/Database/Patches/4 CraftTable/09156 Deadly Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/09156 Deadly Lightning Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9156;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9156, 0, 37 /* Fletching */, 225, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a bundle of deadly lightning spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9156;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9156, 30078 /* Infinite Deadly Lightning Arrowheads */, 23857 /* Bundle of Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09156 Deadly Lightning Spike.sql
+++ b/Database/Patches/4 CraftTable/09156 Deadly Lightning Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9156;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9156, 0, 37 /* Fletching */, 225, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a bundle of deadly lightning spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9156, 0, 37 /* Fletching */, 225, 0, 23863 /* Deadly Lightning Spike */, 1000, 'You make a bundle of deadly lightning spikes.', 0, 0, 'You fail to make any deadly lightning spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9156;
 

--- a/Database/Patches/4 CraftTable/09157 Deadly Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/09157 Deadly Fire Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9157;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9157, 0, 37 /* Fletching */, 250, 0, 15435 /* Deadly Fire Arrow */, 1000, 'You make a bundle of deadly fire arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9157;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9157, 30079 /* Infinite Deadly Fire Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09157 Deadly Fire Arrow.sql
+++ b/Database/Patches/4 CraftTable/09157 Deadly Fire Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9157;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9157, 0, 37 /* Fletching */, 250, 0, 15435 /* Deadly Fire Arrow */, 1000, 'You make a bundle of deadly fire arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9157, 0, 37 /* Fletching */, 250, 0, 15435 /* Deadly Fire Arrow */, 1000, 'You make a big bundle of deadly fire arrows.', 0, 0, 'You fail to make any deadly fire arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9157;
 

--- a/Database/Patches/4 CraftTable/09158 Deadly Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09158 Deadly Fire Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9158;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9158, 0, 37 /* Fletching */, 250, 0, 15444 /* Deadly Fire Quarrel */, 1000, 'You make a bundle of deadly fire quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9158;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9158, 30079 /* Infinite Deadly Fire Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09158 Deadly Fire Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09158 Deadly Fire Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9158;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9158, 0, 37 /* Fletching */, 250, 0, 15444 /* Deadly Fire Quarrel */, 1000, 'You make a bundle of deadly fire quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9158, 0, 37 /* Fletching */, 250, 0, 15444 /* Deadly Fire Quarrel */, 1000, 'You make a big bundle of deadly fire quarrels.', 0, 0, 'You fail to make any deadly fire quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9158;
 

--- a/Database/Patches/4 CraftTable/09159 Deadly Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09159 Deadly Fire Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9159;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9159, 0, 37 /* Fletching */, 250, 0, 20970 /* Deadly Fire Atlatl Dart */, 1000, 'You make a bundle of deadly fire atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9159;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9159, 30079 /* Infinite Deadly Fire Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09159 Deadly Fire Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09159 Deadly Fire Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9159;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9159, 0, 37 /* Fletching */, 250, 0, 20970 /* Deadly Fire Atlatl Dart */, 1000, 'You make a bundle of deadly fire atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9159, 0, 37 /* Fletching */, 250, 0, 20970 /* Deadly Fire Atlatl Dart */, 1000, 'You make a big bundle of deadly fire atlatl darts.', 0, 0, 'You fail to make any deadly fire atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9159;
 

--- a/Database/Patches/4 CraftTable/09160 Deadly Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/09160 Deadly Fire Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9160;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9160, 0, 37 /* Fletching */, 250, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a bundle of deadly fire spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9160, 0, 37 /* Fletching */, 250, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a big bundle of deadly fire spikes.', 0, 0, 'You fail to make any deadly fire spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9160;
 

--- a/Database/Patches/4 CraftTable/09160 Deadly Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/09160 Deadly Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9160;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9160, 0, 37 /* Fletching */, 250, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a bundle of deadly fire spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9160;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9160, 30079 /* Infinite Deadly Fire Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09161 Deadly Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/09161 Deadly Fire Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9161;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9161, 0, 37 /* Fletching */, 225, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a bundle of deadly fire spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9161;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9161, 30079 /* Infinite Deadly Fire Arrowheads */, 23857 /* Bundle of Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09161 Deadly Fire Spike.sql
+++ b/Database/Patches/4 CraftTable/09161 Deadly Fire Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9161;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9161, 0, 37 /* Fletching */, 225, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a bundle of deadly fire spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9161, 0, 37 /* Fletching */, 225, 0, 23864 /* Deadly Fire Spike */, 1000, 'You make a bundle of deadly fire spikes.', 0, 0, 'You fail to make any deadly fire spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9161;
 

--- a/Database/Patches/4 CraftTable/09162 Deadly Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/09162 Deadly Frog Crotch Arrow.sql
@@ -1,9 +1,9 @@
 DELETE FROM `recipe` WHERE `id` = 9162;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9162, 0, 37 /* Fletching */, 200, 0, 15436 /* Deadly Frog Crotch Arrow */, 1000, 'You make a bundle of deadly frog crotch arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9162, 0, 37 /* Fletching */, 200, 0, 15436 /* Deadly Frog Crotch Arrow */, 1000, 'You make a big bundle of deadly frog crotch arrows.', 0, 0, 'You fail to make any deadly frog crotch arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9162;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (9162, 30080 /* Infinite Deadly Frog Crotch Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');
+VALUES (9162, 30080 /* Infinite Deadly Frog-Crotch Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09162 Deadly Frog Crotch Arrow.sql
+++ b/Database/Patches/4 CraftTable/09162 Deadly Frog Crotch Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9162;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9162, 0, 37 /* Fletching */, 200, 0, 15436 /* Deadly Frog Crotch Arrow */, 1000, 'You make a bundle of deadly frog crotch arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9162;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9162, 30080 /* Infinite Deadly Frog Crotch Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09163 Deadly Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09163 Deadly Frog Crotch Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9163;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9163, 0, 37 /* Fletching */, 200, 0, 15445 /* Deadly Frog Crotch Quarrel */, 1000, 'You make a bundle of deadly frog crotch quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9163;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9163, 30080 /* Infinite Deadly Frog Crotch Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09163 Deadly Frog Crotch Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09163 Deadly Frog Crotch Quarrel.sql
@@ -1,9 +1,9 @@
 DELETE FROM `recipe` WHERE `id` = 9163;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9163, 0, 37 /* Fletching */, 200, 0, 15445 /* Deadly Frog Crotch Quarrel */, 1000, 'You make a bundle of deadly frog crotch quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9163, 0, 37 /* Fletching */, 200, 0, 15445 /* Deadly Frog Crotch Quarrel */, 1000, 'You make a big bundle of deadly frog crotch quarrels.', 0, 0, 'You fail to make any deadly frog crotch quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9163;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (9163, 30080 /* Infinite Deadly Frog Crotch Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');
+VALUES (9163, 30080 /* Infinite Deadly Frog-Crotch Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09164 Deadly Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09164 Deadly Frog Crotch Atlatl Dart.sql
@@ -1,9 +1,9 @@
 DELETE FROM `recipe` WHERE `id` = 9164;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9164, 0, 37 /* Fletching */, 200, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 1000, 'You make a bundle of deadly frog crotch atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9164, 0, 37 /* Fletching */, 200, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 1000, 'You make a big bundle of deadly frog crotch atlatl darts.', 0, 0, 'You fail to make any deadly frog crotch atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9164;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (9164, 30080 /* Infinite Deadly Frog Crotch Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');
+VALUES (9164, 30080 /* Infinite Deadly Frog-Crotch Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09164 Deadly Frog Crotch Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09164 Deadly Frog Crotch Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9164;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9164, 0, 37 /* Fletching */, 200, 0, 20971 /* Deadly Frog Crotch Atlatl Dart */, 1000, 'You make a bundle of deadly frog crotch atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9164;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9164, 30080 /* Infinite Deadly Frog Crotch Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09165 Deadly Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/09165 Deadly Frost Arrow.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9165;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9165, 0, 37 /* Fletching */, 250, 0, 15437 /* Deadly Frost Arrow */, 1000, 'You make a bundle of deadly frost arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9165;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9165, 30081 /* Infinite Deadly Frost Arrowheads */,  9377 /* Wrapped Bundle of Arrowshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09165 Deadly Frost Arrow.sql
+++ b/Database/Patches/4 CraftTable/09165 Deadly Frost Arrow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9165;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9165, 0, 37 /* Fletching */, 250, 0, 15437 /* Deadly Frost Arrow */, 1000, 'You make a bundle of deadly frost arrows.', 0, 0, 'You fail to make any arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9165, 0, 37 /* Fletching */, 250, 0, 15437 /* Deadly Frost Arrow */, 1000, 'You make a big bundle of deadly frost arrows.', 0, 0, 'You fail to make any deadly frost arrows.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9165;
 

--- a/Database/Patches/4 CraftTable/09166 Deadly Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09166 Deadly Frost Quarrel.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9166;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9166, 0, 37 /* Fletching */, 250, 0, 15446 /* Deadly Frost Quarrel */, 1000, 'You make a bundle of deadly frost quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9166;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9166, 30081 /* Infinite Deadly Frost Arrowheads */,  9378 /* Wrapped Bundle of Quarrelshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09166 Deadly Frost Quarrel.sql
+++ b/Database/Patches/4 CraftTable/09166 Deadly Frost Quarrel.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9166;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9166, 0, 37 /* Fletching */, 250, 0, 15446 /* Deadly Frost Quarrel */, 1000, 'You make a bundle of deadly frost quarrels.', 0, 0, 'You fail to make any quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9166, 0, 37 /* Fletching */, 250, 0, 15446 /* Deadly Frost Quarrel */, 1000, 'You make a big bundle of deadly frost quarrels.', 0, 0, 'You fail to make any deadly frost quarrels.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9166;
 

--- a/Database/Patches/4 CraftTable/09167 Deadly Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09167 Deadly Frost Atlatl Dart.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9167;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9167, 0, 37 /* Fletching */, 250, 0, 20972 /* Deadly Frost Atlatl Dart */, 1000, 'You make a bundle of deadly frost atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9167;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9167, 30081 /* Infinite Deadly Frost Arrowheads */, 15298 /* Wrapped Bundle of Atlatl Dartshafts */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09167 Deadly Frost Atlatl Dart.sql
+++ b/Database/Patches/4 CraftTable/09167 Deadly Frost Atlatl Dart.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9167;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9167, 0, 37 /* Fletching */, 250, 0, 20972 /* Deadly Frost Atlatl Dart */, 1000, 'You make a bundle of deadly frost atlatl darts.', 0, 0, 'You fail to make any atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9167, 0, 37 /* Fletching */, 250, 0, 20972 /* Deadly Frost Atlatl Dart */, 1000, 'You make a big bundle of deadly frost atlatl darts.', 0, 0, 'You fail to make any deadly frost atlatl darts.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9167;
 

--- a/Database/Patches/4 CraftTable/09168 Deadly Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/09168 Deadly Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9168;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9168, 0, 37 /* Fletching */, 250, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a bundle of deadly frost spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9168;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9168, 30081 /* Infinite Deadly Frost Arrowheads */, 23858 /* Bundle of Wrapped Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09168 Deadly Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/09168 Deadly Frost Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9168;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9168, 0, 37 /* Fletching */, 250, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a bundle of deadly frost spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9168, 0, 37 /* Fletching */, 250, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a big bundle of deadly frost spikes.', 0, 0, 'You fail to make any deadly frost spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9168;
 

--- a/Database/Patches/4 CraftTable/09169 Deadly Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/09169 Deadly Frost Spike.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9169;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9169, 0, 37 /* Fletching */, 225, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a bundle of deadly frost spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9169;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9169, 30081 /* Infinite Deadly Frost Arrowheads */, 23857 /* Bundle of Spiketails */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09169 Deadly Frost Spike.sql
+++ b/Database/Patches/4 CraftTable/09169 Deadly Frost Spike.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9169;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9169, 0, 37 /* Fletching */, 225, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a bundle of deadly frost spikes.', 0, 0, 'You fail to make any spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
+VALUES (9169, 0, 37 /* Fletching */, 225, 0, 23865 /* Deadly Frost Spike */, 1000, 'You make a bundle of deadly frost spikes.', 0, 0, 'You fail to make any deadly frost spikes.', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2022-08-18 21:25:59');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9169;
 

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30074 Infinite Deadly Broad Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30074 Infinite Deadly Broad Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30074,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30074,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30074,  17,        155) /* RareId */
      , (30074,  19,          0) /* Value */
+     , (30074,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30074,  33,         -1) /* Bonded - Slippery */
      , (30074,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30074,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30075 Infinite Deadly Acid Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30075 Infinite Deadly Acid Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30075,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30075,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30075,  17,        159) /* RareId */
      , (30075,  19,          0) /* Value */
+     , (30075,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30075,  33,         -1) /* Bonded - Slippery */
      , (30075,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30075,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30076 Infinite Deadly Armor Piercing Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30076 Infinite Deadly Armor Piercing Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30076,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30076,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30076,  17,        157) /* RareId */
      , (30076,  19,          0) /* Value */
+     , (30076,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30076,  33,         -1) /* Bonded - Slippery */
      , (30076,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30076,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30077 Infinite Deadly Blunt Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30077 Infinite Deadly Blunt Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30077,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30077,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30077,  17,        158) /* RareId */
      , (30077,  19,          0) /* Value */
+     , (30077,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30077,  33,         -1) /* Bonded - Slippery */
      , (30077,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30077,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30078 Infinite Deadly Lightning Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30078 Infinite Deadly Lightning Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30078,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30078,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30078,  17,        162) /* RareId */
      , (30078,  19,          0) /* Value */
+     , (30078,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30078,  33,         -1) /* Bonded - Slippery */
      , (30078,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30078,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30079 Infinite Deadly Fire Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30079 Infinite Deadly Fire Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30079,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30079,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30079,  17,        160) /* RareId */
      , (30079,  19,          0) /* Value */
+     , (30079,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30079,  33,         -1) /* Bonded - Slippery */
      , (30079,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30079,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30080 Infinite Deadly Frog-Crotch Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30080 Infinite Deadly Frog-Crotch Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30080,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30080,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30080,  17,        156) /* RareId */
      , (30080,  19,          0) /* Value */
+     , (30080,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30080,  33,         -1) /* Bonded - Slippery */
      , (30080,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30080,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;
@@ -27,9 +28,9 @@ VALUES (30080,  11, True ) /* IgnoreCollisions */
      , (30080,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (30080,   1, 'Infinite Deadly Frog Crotch Arrowheads') /* Name */
+VALUES (30080,   1, 'Infinite Deadly Frog-Crotch Arrowheads') /* Name */
      , (30080,  14, 'This item is used in fletching.') /* Use */
-     , (30080,  16, 'A stack of deadly frog crotch arrowheads. No matter how many of these are used the number of arrowheads never diminishes.') /* LongDesc */;
+     , (30080,  16, 'A stack of deadly frog-crotch arrowheads. No matter how many of these are used the number of arrowheads never diminishes.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (30080,   1, 0x020005F6) /* Setup */

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30081 Infinite Deadly Frost Arrowheads.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftFletchingIntermediate/30081 Infinite Deadly Frost Arrowheads.sql
@@ -15,6 +15,7 @@ VALUES (30081,   1,  134217728) /* ItemType - CraftFletchingIntermediate */
      , (30081,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
      , (30081,  17,        161) /* RareId */
      , (30081,  19,          0) /* Value */
+     , (30081,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (30081,  33,         -1) /* Bonded - Slippery */
      , (30081,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (30081,  94,  134217728) /* TargetType - CraftFletchingIntermediate */;


### PR DESCRIPTION
- Updated the yield on most bundle/wrapped bundle fletching recipes to match end-of-retail & verified results with available pcaps.
- Added Infinite Deadly + Wrapped Bundle recipes (same difficulty as using standard recipes)
- Added TOD flag to Infinite Rare Arrowheads to match data

Current Values: http://ac.yotesfan.com/temp/recipes/fletching.php
New Values with this Update: http://ac.yotesfan.com/temp/recipes/fletching-proposed.php

References:
https://asheron.fandom.com/wiki/Lost_City_of_Neftet (May 2011)
`The yield for combining Wrapped Bundles of arrowheads with shafts has increased from 250 to 500. This applies to the Rare item infinite arrowheads as well.`

https://asheron.fandom.com/wiki/Announcements_-_2013/12_-_The_Holiday_Rush (December 2013)
`Non-wrapped bundles of ammo that previously yielded 10 will now yield 100.`
`Wrapped bundles that previously yielded 500 will now yield 1000.`
`Whittling interactions of wrapped fletching components adjusted accordingly.`
