### PR TITLE
Fix bitfield check for Asheron's Investigator

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/39288 Asheron's Investigator.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/39288 Asheron's Investigator.sql
@@ -98,7 +98,7 @@ VALUES (39288, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'InvokingStoneTu
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0, 102 /* InqQuestBitsOn */, 0, 1, NULL, 'InvokingStoneTurnIn', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 16533, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0, 102 /* InqQuestBitsOn */, 0, 1, NULL, 'InvokingStoneTurnIn', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4095, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (39288, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'InvokingStoneTurnIn', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/39288.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/39288.es
@@ -3,7 +3,7 @@ Use:
         QuestSuccess: 
             - Tell: You have done quite alot of work in helping uncover the Patriarch's plan. We must study the information we have and discern the Patriarch's next move.
         QuestFailure:
-            - InqQuestBitsOn: InvokingStoneTurnIn, 0x4095
+            - InqQuestBitsOn: InvokingStoneTurnIn, 0xFFF
                 QuestSuccess:
                     - AwardXP: 1,000,000,000
                     - Tell: You have helped us, and I thank you. The stones you have brought us have allowed us to confirm the intention of the Patriarchs. They seek to free their master T'thuun from his bonds.


### PR DESCRIPTION
Fixes the bitfield check for Asheron's Investigator (Summoning T'thuun), which was using the decimal value (as hex) instead of the correct hex value for a 12-bit completed flag.