### PR TITLE
Fixed cooldown display text

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Empyrean/44950 Chafulumisa.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Empyrean/44950 Chafulumisa.sql
@@ -74,7 +74,7 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  10 /* Tell */, 1, 1, NULL, 'You''d better hurry up, time is ticking.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  18 /* DirectBroadcast */, 1, 1, NULL, 'You have %mxqt left to adjust your attributes.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  1,  18 /* DirectBroadcast */, 1, 1, NULL, 'You have %tqt left to adjust your attributes.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (44950, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'UsedFreeAttributeReset', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Empyrean/44950.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Empyrean/44950.es
@@ -8,7 +8,7 @@ Use:
         QuestSuccess:
             - Delay: 1, Tell: You'd better hurry up, time is ticking.
             # the following line is not retail
-            - Delay: 1, DirectBroadcast: You have %mxqt left to adjust your attributes.
+            - Delay: 1, DirectBroadcast: You have %tqt left to adjust your attributes.
         QuestFailure:
             - InqQuest: UsedFreeAttributeReset
                 QuestSuccess:


### PR DESCRIPTION
Timer cooldown text was referring to this NPC, not the player. Fixes "You have 10675199 day , 2 hour , 48 minute and 5 second left to adjust your attributes." error to the more meaningful, and accurate display of <30min (quest was working properly, just wrong display string)