### PR TITLE
Writ of Apology

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/7D64.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7D64.sql
@@ -337,3 +337,16 @@ VALUES (0x77D64073, 32085, 0x7D64014C, 91.2676, 38.6012, 12.005, -0.174972, 0, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x77D64074, 42737, 0x7D64010E, 86.6307, 139.512, 12.005, 0.170397, 0, 0, 0.985376,  True, '2022-03-19 04:04:39'); /* Tailor's Apprentice */
 /* @teleloc 0x7D64010E [86.630699 139.511993 12.005000] 0.170397 0.000000 0.000000 0.985376 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x77D64075, 37518, 0x7D640018, 66.1992, 183.29, 12.005, 0.999911, 0, 0, -0.013339,  False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0x7D640018 [66.199200 183.290000 12.005000] 0.999911 0.000000 0.000000 -0.013339 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x77D64076, 37518, 0x7D64002C, 140.955, 87.8733, 15.4975, 0.759906, 0, 0, -0.650033,  False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0x7D64002C [140.955000 87.873300 15.497500] 0.759906 0.000000 0.000000 -0.650033 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x77D64077, 37518, 0x7D640019, 83.6504, 4.37371, 12.005, 0.321405, 0, 0, -0.946942,  False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0x7D640019 [83.650400 4.373710 12.005000] 0.321405 0.000000 0.000000 -0.946942 */
+

--- a/Database/Patches/6 LandBlockExtendedData/977B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/977B.sql
@@ -229,17 +229,18 @@ VALUES (0x7977B04E, 43066, 0x977B002F, 140.431, 149.259, 0.198001, -0.940774, 0,
 /* @teleloc 0x977B002F [140.431000 149.259003 0.198001] -0.940774 0.000000 0.000000 -0.339034 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7977B3FA, 37538, 0x977B0040, 178.506, 176.695, 0.005, -0.090255, 0, 0, -0.995919, False, '2021-11-01 00:00:00'); /* Royal Quartermaster */
+VALUES (0x7977B3FA, 37538, 0x977B0040, 178.506, 176.695, 0.005, -0.090255, 0, 0, -0.995919, False, '2021-11-01 00:00:00');
 /* @teleloc 0x977B0040 [178.505997 176.695007 0.005000] -0.090255 0.000000 0.000000 -0.995919 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7977B419, 37518, 0x977B000C, 34.4417, 92.3116, 0.005, -0.316255, 0, 0, -0.948674, False, '2021-11-01 00:00:00'); /* Royal Guard */
+VALUES (0x7977B3FB, 37518, 0x977B000C, 34.4417, 92.3116, 0.005, -0.316255, 0, 0, -0.948674, False, '2021-11-01 00:00:00'); /* Royal Guard */
 /* @teleloc 0x977B000C [34.441700 92.311600 0.005000] -0.316255 0.000000 0.000000 -0.948674 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7977B41C, 37518, 0x977B0038, 148.78, 182.922, 8.805, -0.715105, 0, 0, -0.699017, False, '2021-11-01 00:00:00'); /* Royal Guard */
+VALUES (0x7977B3FC, 37518, 0x977B0038, 148.78, 182.922, 8.805, -0.715105, 0, 0, -0.699017, False, '2021-11-01 00:00:00'); /* Royal Guard */
 /* @teleloc 0x977B0038 [148.779999 182.921997 8.805000] -0.715105 0.000000 0.000000 -0.699017 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7977B41D, 37518, 0x977B003F, 185.792, 152.635, 8.805, -0.683419, 0, 0, 0.730026, False, '2021-11-01 00:00:00'); /* Royal Guard */
+VALUES (0x7977B3FD, 37518, 0x977B003F, 185.792, 152.635, 8.805, -0.683419, 0, 0, 0.730026, False, '2021-11-01 00:00:00'); /* Royal Guard */
 /* @teleloc 0x977B003F [185.792007 152.634995 8.805000] -0.683419 0.000000 0.000000 0.730026 */
+

--- a/Database/Patches/6 LandBlockExtendedData/A9B4.sql
+++ b/Database/Patches/6 LandBlockExtendedData/A9B4.sql
@@ -437,3 +437,16 @@ VALUES (0x7A9B46AC, 42736, 0xA9B4012A, 61.1951, 135.937, 66.005, -0.730577, 0, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7A9B46AD, 39983, 0xA9B40032, 154.569, 36.2015, 96.005, 0.052418, 0, 0, -0.998625,  True, '2022-06-06 04:05:48'); /* Rand, Game Hunter */
 /* @teleloc 0xA9B40032 [154.569000 36.201500 96.004997] 0.052418 0.000000 0.000000 -0.998625 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7A9B46AE, 37518, 0xA9B40021, 115.251, 6.48831, 94.005, -0.86921, 0, 0, -0.494442,  False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0xA9B40021 [115.251000 6.488310 94.005000] -0.869210 0.000000 0.000000 -0.494442 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7A9B46AF, 37518, 0xA9B40005, 9.89043, 114.139, 66.98183, 0.707137, 0, 0, 0.707076,  False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0xA9B40005 [9.890430 114.139000 66.981830] 0.707137 0.000000 0.000000 0.707076 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7A9B46B0, 37518, 0xA9B4003D, 176.73, 106.375, 65.2775, 0.643583, 0, 0, -0.765377,  False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0xA9B4003D [176.730000 106.375000 65.277500] 0.643583 0.000000 0.000000 -0.765377 */
+

--- a/Database/Patches/6 LandBlockExtendedData/DA55.sql
+++ b/Database/Patches/6 LandBlockExtendedData/DA55.sql
@@ -453,3 +453,15 @@ VALUES (0x7DA5509B, 87810, 0xDA550132, 59.1611, 185.809, 24.455, -0.717982, 0, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7DA5509C, 42738, 0xDA55019C, 78.5093, 61.7248, 20.045, 0.668719, 0, 0, -0.743515,  True, '2022-04-12 04:33:53'); /* Tailor's Apprentice */
 /* @teleloc 0xDA55019C [78.509300 61.724800 20.045000] 0.668719 0.000000 0.000000 -0.743515 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7DA5509D, 37518, 0xDA550032, 154.009, 44.9607, 20.005, -0.401215, 0, 0, 0.915984, False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0xDA550032 [154.009003 44.960701 20.004999] -0.401215 0.000000 0.000000 0.915984 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7DA5509E, 37518, 0xDA550002, 20.4033, 39.7434, 20.005, -0.354652, 0, 0, -0.934998, False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0xDA550002 [20.403299 39.743401 20.004999] -0.354652 0.000000 0.000000 -0.934998 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7DA5509F, 37518, 0xDA550008, 13.727, 172.056, 20.005, 0.925961, 0, 0, 0.377619, False, '2019-02-10 00:00:00'); /* Royal Guard */
+/* @teleloc 0xDA550008 [13.727000 172.056000 20.005001] 0.925961 0.000000 0.000000 0.377619 */

--- a/Database/Patches/8 QuestDefDB/WritOfApology_0508.sql
+++ b/Database/Patches/8 QuestDefDB/WritOfApology_0508.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'WritOfApology_0508';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('WritOfApology_0508', 0, 1, 'Writ of Apology Quest - Player can get 1 Writ if they have this quest bestowed', '2022-10-17 00:00:00');

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/37518 Royal Guard.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/37518 Royal Guard.sql
@@ -1,0 +1,343 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37518;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37518, 'ace37518-royalguard', 10, '2022-10-17 04:07:36') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37518,   1,         16) /* ItemType - Creature */
+     , (37518,   2,         31) /* CreatureType - Human */
+     , (37518,   6,         -1) /* ItemsCapacity */
+     , (37518,   7,         -1) /* ContainersCapacity */
+     , (37518,  16,         32) /* ItemUseable - Remote */
+     , (37518,  25,         40) /* Level */
+     , (37518,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (37518,  95,          8) /* RadarBlipColor - Yellow */
+     , (37518, 113,          1) /* Gender - Male */
+     , (37518, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (37518, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (37518, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37518,   1, True ) /* Stuck */
+     , (37518,   8, True ) /* AllowGive */
+     , (37518,  12, True ) /* ReportCollisions */
+     , (37518,  13, False) /* Ethereal */
+     , (37518,  19, False) /* Attackable */
+     , (37518,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (37518,  42, True ) /* AllowEdgeSlide */
+     , (37518,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37518,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37518,   1, 'Royal Guard') /* Name */
+     , (37518,   5, 'Soldier') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37518,   1, 0x02000001) /* Setup */
+     , (37518,   2, 0x09000001) /* MotionTable */
+     , (37518,   3, 0x20000001) /* SoundTable */
+     , (37518,   6, 0x0400007E) /* PaletteBase */
+     , (37518,   8, 0x06000FF1) /* Icon */
+     , (37518,   9, 0x05001130) /* EyesTexture */
+     , (37518,  10, 0x05001179) /* NoseTexture */
+     , (37518,  11, 0x050011C8) /* MouthTexture */
+     , (37518,  15, 0x04001FC0) /* HairPalette */
+     , (37518,  16, 0x040002BD) /* EyesPalette */
+     , (37518,  17, 0x040002BA) /* SkinPalette */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (37518, 0, 0x00000000, 0, 0, 0, 0, 0, 0, 0) /* Undef */
+/* @teleloc 0x00000000 [0.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 0.000000 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (37518,   1, 130, 0, 0) /* Strength */
+     , (37518,   2, 100, 0, 0) /* Endurance */
+     , (37518,   3, 100, 0, 0) /* Quickness */
+     , (37518,   4, 130, 0, 0) /* Coordination */
+     , (37518,   5,  70, 0, 0) /* Focus */
+     , (37518,   6,  60, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (37518,   1,    10, 0, 0, 60) /* MaxHealth */
+     , (37518,   3,    10, 0, 0, 110) /* MaxStamina */
+     , (37518,   5,    10, 0, 0, 70) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  1 /* Refuse */,      1, 37559 /* Writ of Apology */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Please take this to the Royal Quartermaster in Samsur.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  5 /* HeartBeat */,  0.001, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'All''s quiet on this front!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37519, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 37516 /* Enhanced Mana Elixir */, 20, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37520, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30094 /* Foolproof Aquamarine */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37521, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30095 /* Foolproof Black Garnet */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37522, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30096 /* Foolproof Black Opal */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37523, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30097 /* Foolproof Emerald */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37524, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30098 /* Foolproof Fire Opal */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37525, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30099 /* Foolproof Imperial Topaz */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37526, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30100 /* Foolproof Jet */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37527, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30101 /* Foolproof Peridot */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37528, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30102 /* Foolproof Red Garnet */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37529, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30103 /* Foolproof Sunstone */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37530, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30105 /* Foolproof Yellow Topaz */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37531, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30106 /* Foolproof Zircon */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37532, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 37515 /* Pack Aerbax */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37533, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30255 /* Grand Casino Golden Keyring */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37534, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30256 /* Grand Casino Golden Keyring */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37535, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30257 /* Grand Casino Golden Keyring */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37536, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37537, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 37517 /* Enhanced Health Elixir */, 20, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  6 /* Give */,      1, 37560, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'Here you go - once again, sorry for the problems.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 36628 /* Foolproof */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  21 /* InqQuest */, 0, 1, NULL, 'WritOfApology_0508', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'WritOfApology_0508', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  31 /* EraseQuest */, 0, 1, NULL, 'WritOfApology_0508', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Greetings.  Due to the instability you have recently experienced within the world of Asheron''s Call, we would like to extend our heartfelt apologies.  Please accept this as a token of our regret.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 37559 /* Writ of Apology */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37518, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'WritOfApology_0508', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Greetings, friend.  I am standing watch against any threats which may appear on the horizon.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (37518, 2,   127,  0, 14, 0.4909, False) /* Create Pants (127) for Wield */
+     , (37518, 2,   130,  0, 14, 0.5, False) /* Create Shirt (130) for Wield */
+     , (37518, 2, 21153,  0, 21, 0.4286, False) /* Create Covenant Gauntlets (21153) for Wield */
+     , (37518, 2, 21151,  0, 21, 0.4286, False) /* Create Covenant Bracers (21151) for Wield */
+     , (37518, 2, 21157,  0, 21, 0.4286, False) /* Create Covenant Pauldrons (21157) for Wield */
+     , (37518, 2, 21152,  0, 21, 0.4286, False) /* Create Covenant Breastplate (21152) for Wield */
+     , (37518, 2, 21154,  0, 21, 0.4286, False) /* Create Covenant Girth (21154) for Wield */
+     , (37518, 2, 21159,  0, 21, 0.4286, False) /* Create Covenant Tassets (21159) for Wield */
+     , (37518, 2, 21155,  0, 21, 0.4286, False) /* Create Covenant Greaves (21155) for Wield */
+     , (37518, 2, 21150,  0, 21, 0.4286, False) /* Create Covenant Sollerets (21150) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/37518.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/37518.es
@@ -1,0 +1,138 @@
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.001
+    - Extent: 20, Say: All's quiet on this front!
+
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqQuest: WritOfApology_0508
+        QuestFailure:
+            - Tell: Greetings, friend.  I am standing watch against any threats which may appear on the horizon.
+        QuestSuccess:
+            - EraseQuest: WritOfApology_0508
+            - Tell: Greetings.  Due to the instability you have recently experienced within the world of Asheron's Call, we would like to extend our heartfelt apologies.  Please accept this as a token of our regret.
+            - Give: Writ of Apology (37559)
+
+Refuse: Writ of Apology (37559)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Please take this to the Royal Quartermaster in Samsur.
+
+Give: Enhanced Mana Elixir Orders (37519)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Enhanced Mana Elixir (37516), 20
+
+Give: Foolproof Aquamarine Orders (37520)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Aquamarine Foolproof (30094)
+
+Give: Foolproof Black Garnet Orders (37521)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Black Garnet Foolproof (30095)
+
+Give: Foolproof Black Opal Orders (37522)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Black Opal Foolproof (30096)
+    
+Give: Foolproof Emerald Orders (37523)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Emerald Foolproof (30097)
+
+Give: Foolproof Fire Opal Orders (37524)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Fire Opal Foolproof (30098)
+
+Give: Foolproof Imperial Topaz Orders (37525)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Imperial Topaz Foolproof (30099)
+
+Give: Foolproof Jet Orders (37526)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Jet Foolproof (30100)
+
+Give: Foolproof Peridot Orders (37527)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Peridot Foolproof (30101)
+
+Give: Foolproof Red Garnet Orders (37528)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Red Garnet Foolproof (30102)
+
+Give: Foolproof Sunstone Orders (37529)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Sunstone Foolproof (30103)
+
+Give: Foolproof Yellow Topaz Orders (37530)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Yellow Topaz Foolproof (30105)
+
+Give: Foolproof Zircon Orders (37531)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Zircon Foolproof (30106)
+
+Give: Aerbax Pack Doll Orders (37532)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Pack Aerbax (37515)
+
+Give: Aluvian Casino Key Orders (37533)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Grand Casino Golden Keyring (30255)
+
+Give: Gharu'ndim Casino Key Orders (37534)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Grand Casino Golden Keyring (30256)
+
+Give: Sho Casino Key Orders (37535)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Grand Casino Golden Keyring (30257)
+
+Give: Experience Orders (37536)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - AwardLevelProportionalXP: 100%
+
+Give: Enhanced Health Elixir Orders (37537)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: Enhanced Health Elixir (37517), 20
+
+Give: Foolproof White Sapphire Orders (37560)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Here you go - once again, sorry for the problems.
+    - Give: White Sapphire Foolproof (36628)

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/37515 Pack Aerbax.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/37515 Pack Aerbax.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37515;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37515, 'ace37515-packaerbax', 38, '2022-10-17 11:15:59') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37515,   1,       2048) /* ItemType - Gem */
+     , (37515,   5,         10) /* EncumbranceVal */
+     , (37515,  16,         32) /* ItemUseable - Remote */
+     , (37515,  19,          0) /* Value */
+     , (37515,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37515,  94,         16) /* TargetType - Creature */
+     , (37515, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37515,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37515,  39,     0.3) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37515,   1, 'Pack Aerbax') /* Name */
+     , (37515,  14, 'The Pack Aerbax can be placed on floor and yard hooks.') /* Use */
+     , (37515,  16, 'A miniature doll of Aerbax - once a valued member of the Virindi Singularity who split from it and gradually began to realize its own independence.  Its research culminated in the discovery of a Kemeroi, one of the great evil beings hidden deep within the world, which further twisted it towards Shadow and destruction.  Aerbax hatched a plot to dominate the creatures of Auberean by crafting prodigal versions of several selected different races.  Aerbax''s shadow has now been sundered from it, but Aerbax still exists and may one day again attempt to guide the course of history from afar.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37515,   1, 0x020017F5) /* Setup */
+     , (37515,   2, 0x090001EB) /* MotionTable */
+     , (37515,   8, 0x060067D9) /* Icon */
+     , (37515,  22, 0x34000029) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37519 Enhanced Mana Elixir Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37519 Enhanced Mana Elixir Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37519;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37519, 'ace37519-enhancedmanaelixirorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37519,   1,        128) /* ItemType - Misc */
+     , (37519,  16,          1) /* ItemUseable - No */
+     , (37519,  33,          1) /* Bonded - Bonded */
+     , (37519,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37519, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37519,  23, True ) /* DestroyOnSell */
+     , (37519,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37519,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37519,   1, 'Enhanced Mana Elixir Orders') /* Name */
+     , (37519,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37519,  15, 'This paper details that the bearer should receive twenty Enhanced Mana Elixirs, which restore 200 mana upon use, force the consumer to wait 5 minutes before their next use, and may not be traded.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37519,   1, 0x020000F8) /* Setup */
+     , (37519,   3, 0x20000014) /* SoundTable */
+     , (37519,   8, 0x060067DA) /* Icon */
+     , (37519,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37520 Foolproof Aquamarine Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37520 Foolproof Aquamarine Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37520;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37520, 'ace37520-foolproofaquamarineorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37520,   1,        128) /* ItemType - Misc */
+     , (37520,  16,          1) /* ItemUseable - No */
+     , (37520,  33,          1) /* Bonded - Bonded */
+     , (37520,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37520, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37520,  23, True ) /* DestroyOnSell */
+     , (37520,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37520,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37520,   1, 'Foolproof Aquamarine Orders') /* Name */
+     , (37520,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37520,  15, 'This paper details that the bearer should receive one bag of Foolproof Aquamarine salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37520,   1, 0x020000F8) /* Setup */
+     , (37520,   3, 0x20000014) /* SoundTable */
+     , (37520,   8, 0x060067DA) /* Icon */
+     , (37520,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37521 Foolproof Black Garnet Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37521 Foolproof Black Garnet Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37521;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37521, 'ace37521-foolproofblackgarnetorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37521,   1,        128) /* ItemType - Misc */
+     , (37521,  16,          1) /* ItemUseable - No */
+     , (37521,  33,          1) /* Bonded - Bonded */
+     , (37521,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37521, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37521,  23, True ) /* DestroyOnSell */
+     , (37521,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37521,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37521,   1, 'Foolproof Black Garnet Orders') /* Name */
+     , (37521,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37521,  15, 'This paper details that the bearer should receive one bag of Foolproof Black Garnet salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37521,   1, 0x020000F8) /* Setup */
+     , (37521,   3, 0x20000014) /* SoundTable */
+     , (37521,   8, 0x060067DA) /* Icon */
+     , (37521,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37522 Foolproof Black Opal Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37522 Foolproof Black Opal Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37522;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37522, 'ace37522-foolproofblackopalorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37522,   1,        128) /* ItemType - Misc */
+     , (37522,  16,          1) /* ItemUseable - No */
+     , (37522,  33,          1) /* Bonded - Bonded */
+     , (37522,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37522, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37522,  23, True ) /* DestroyOnSell */
+     , (37522,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37522,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37522,   1, 'Foolproof Black Opal Orders') /* Name */
+     , (37522,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37522,  15, 'This paper details that the bearer should receive one bag of Foolproof Black Opal salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37522,   1, 0x020000F8) /* Setup */
+     , (37522,   3, 0x20000014) /* SoundTable */
+     , (37522,   8, 0x060067DA) /* Icon */
+     , (37522,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37523 Foolproof Emerald Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37523 Foolproof Emerald Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37523;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37523, 'ace37523-foolproofemeraldorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37523,   1,        128) /* ItemType - Misc */
+     , (37523,  16,          1) /* ItemUseable - No */
+     , (37523,  33,          1) /* Bonded - Bonded */
+     , (37523,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37523, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37523,  23, True ) /* DestroyOnSell */
+     , (37523,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37523,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37523,   1, 'Foolproof Emerald Orders') /* Name */
+     , (37523,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37523,  15, 'This paper details that the bearer should receive one bag of Foolproof Emerald salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37523,   1, 0x020000F8) /* Setup */
+     , (37523,   3, 0x20000014) /* SoundTable */
+     , (37523,   8, 0x060067DA) /* Icon */
+     , (37523,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37524 Foolproof Fire Opal Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37524 Foolproof Fire Opal Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37524;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37524, 'ace37524-foolprooffireopalorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37524,   1,        128) /* ItemType - Misc */
+     , (37524,  16,          1) /* ItemUseable - No */
+     , (37524,  33,          1) /* Bonded - Bonded */
+     , (37524,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37524, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37524,  23, True ) /* DestroyOnSell */
+     , (37524,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37524,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37524,   1, 'Foolproof Fire Opal Orders') /* Name */
+     , (37524,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37524,  15, 'This paper details that the bearer should receive one bag of Foolproof Fire Opal salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37524,   1, 0x020000F8) /* Setup */
+     , (37524,   3, 0x20000014) /* SoundTable */
+     , (37524,   8, 0x060067DA) /* Icon */
+     , (37524,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37525 Foolproof Imperial Topaz Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37525 Foolproof Imperial Topaz Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37525;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37525, 'ace37525-foolproofimperialtopazorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37525,   1,        128) /* ItemType - Misc */
+     , (37525,  16,          1) /* ItemUseable - No */
+     , (37525,  33,          1) /* Bonded - Bonded */
+     , (37525,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37525, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37525,  23, True ) /* DestroyOnSell */
+     , (37525,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37525,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37525,   1, 'Foolproof Imperial Topaz Orders') /* Name */
+     , (37525,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37525,  15, 'This paper details that the bearer should receive one bag of Foolproof Imperial Topaz salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37525,   1, 0x020000F8) /* Setup */
+     , (37525,   3, 0x20000014) /* SoundTable */
+     , (37525,   8, 0x060067DA) /* Icon */
+     , (37525,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37526 Foolproof Jet Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37526 Foolproof Jet Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37526;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37526, 'ace37526-foolproofjetorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37526,   1,        128) /* ItemType - Misc */
+     , (37526,  16,          1) /* ItemUseable - No */
+     , (37526,  33,          1) /* Bonded - Bonded */
+     , (37526,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37526, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37526,  23, True ) /* DestroyOnSell */
+     , (37526,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37526,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37526,   1, 'Foolproof Jet Orders') /* Name */
+     , (37526,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37526,  15, 'This paper details that the bearer should receive one bag of Foolproof Jet salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37526,   1, 0x020000F8) /* Setup */
+     , (37526,   3, 0x20000014) /* SoundTable */
+     , (37526,   8, 0x060067DA) /* Icon */
+     , (37526,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37527 Foolproof Peridot Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37527 Foolproof Peridot Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37527;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37527, 'ace37527-foolproofperidotorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37527,   1,        128) /* ItemType - Misc */
+     , (37527,  16,          1) /* ItemUseable - No */
+     , (37527,  33,          1) /* Bonded - Bonded */
+     , (37527,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37527, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37527,  23, True ) /* DestroyOnSell */
+     , (37527,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37527,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37527,   1, 'Foolproof Peridot Orders') /* Name */
+     , (37527,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37527,  15, 'This paper details that the bearer should receive one bag of Foolproof Peridot salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37527,   1, 0x020000F8) /* Setup */
+     , (37527,   3, 0x20000014) /* SoundTable */
+     , (37527,   8, 0x060067DA) /* Icon */
+     , (37527,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37528 Foolproof Red Garnet Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37528 Foolproof Red Garnet Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37528;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37528, 'ace37528-foolproofredgarnetorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37528,   1,        128) /* ItemType - Misc */
+     , (37528,  16,          1) /* ItemUseable - No */
+     , (37528,  33,          1) /* Bonded - Bonded */
+     , (37528,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37528, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37528,  23, True ) /* DestroyOnSell */
+     , (37528,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37528,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37528,   1, 'Foolproof Red Garnet Orders') /* Name */
+     , (37528,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37528,  15, 'This paper details that the bearer should receive one bag of Foolproof Red Garnet salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37528,   1, 0x020000F8) /* Setup */
+     , (37528,   3, 0x20000014) /* SoundTable */
+     , (37528,   8, 0x060067DA) /* Icon */
+     , (37528,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37529 Foolproof Sunstone Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37529 Foolproof Sunstone Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37529;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37529, 'ace37529-foolproofsunstoneorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37529,   1,        128) /* ItemType - Misc */
+     , (37529,  16,          1) /* ItemUseable - No */
+     , (37529,  33,          1) /* Bonded - Bonded */
+     , (37529,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37529, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37529,  23, True ) /* DestroyOnSell */
+     , (37529,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37529,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37529,   1, 'Foolproof Sunstone Orders') /* Name */
+     , (37529,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37529,  15, 'This paper details that the bearer should receive one bag of Foolproof Sunstone salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37529,   1, 0x020000F8) /* Setup */
+     , (37529,   3, 0x20000014) /* SoundTable */
+     , (37529,   8, 0x060067DA) /* Icon */
+     , (37529,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37530 Foolproof Yellow Topaz Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37530 Foolproof Yellow Topaz Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37530;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37530, 'ace37530-foolproofyellowtopazorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37530,   1,        128) /* ItemType - Misc */
+     , (37530,  16,          1) /* ItemUseable - No */
+     , (37530,  33,          1) /* Bonded - Bonded */
+     , (37530,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37530, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37530,  23, True ) /* DestroyOnSell */
+     , (37530,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37530,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37530,   1, 'Foolproof Yellow Topaz Orders') /* Name */
+     , (37530,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37530,  15, 'This paper details that the bearer should receive one bag of Foolproof Yellow Topaz salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37530,   1, 0x020000F8) /* Setup */
+     , (37530,   3, 0x20000014) /* SoundTable */
+     , (37530,   8, 0x060067DA) /* Icon */
+     , (37530,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37531 Foolproof Zircon Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37531 Foolproof Zircon Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37531;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37531, 'ace37531-foolproofzirconorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37531,   1,        128) /* ItemType - Misc */
+     , (37531,  16,          1) /* ItemUseable - No */
+     , (37531,  33,          1) /* Bonded - Bonded */
+     , (37531,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37531, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37531,  23, True ) /* DestroyOnSell */
+     , (37531,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37531,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37531,   1, 'Foolproof Zircon Orders') /* Name */
+     , (37531,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37531,  15, 'This paper details that the bearer should receive one bag of Foolproof Zircon salvage.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37531,   1, 0x020000F8) /* Setup */
+     , (37531,   3, 0x20000014) /* SoundTable */
+     , (37531,   8, 0x060067DA) /* Icon */
+     , (37531,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37532 Aerbax Pack Doll Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37532 Aerbax Pack Doll Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37532;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37532, 'ace37532-aerbaxpackdollorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37532,   1,        128) /* ItemType - Misc */
+     , (37532,  16,          1) /* ItemUseable - No */
+     , (37532,  33,          1) /* Bonded - Bonded */
+     , (37532,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37532, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37532,  23, True ) /* DestroyOnSell */
+     , (37532,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37532,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37532,   1, 'Aerbax Pack Doll Orders') /* Name */
+     , (37532,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37532,  15, 'This paper details that the bearer should receive one Aerbax Pack Doll.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37532,   1, 0x020000F8) /* Setup */
+     , (37532,   3, 0x20000014) /* SoundTable */
+     , (37532,   8, 0x060067DA) /* Icon */
+     , (37532,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37533 Aluvian Casino Key Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37533 Aluvian Casino Key Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37533;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37533, 'ace37533-aluviancasinokeyorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37533,   1,        128) /* ItemType - Misc */
+     , (37533,  16,          1) /* ItemUseable - No */
+     , (37533,  33,          1) /* Bonded - Bonded */
+     , (37533,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37533, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37533,  23, True ) /* DestroyOnSell */
+     , (37533,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37533,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37533,   1, 'Aluvian Casino Key Orders') /* Name */
+     , (37533,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37533,  15, 'This paper details that the bearer should receive one Golden Keyring worth twenty-five uses for the Holtburg Casino.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37533,   1, 0x020000F8) /* Setup */
+     , (37533,   3, 0x20000014) /* SoundTable */
+     , (37533,   8, 0x060067DA) /* Icon */
+     , (37533,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37534 Gharu'ndim Casino Key Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37534 Gharu'ndim Casino Key Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37534;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37534, 'ace37534-gharundimcasinokeyorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37534,   1,        128) /* ItemType - Misc */
+     , (37534,  16,          1) /* ItemUseable - No */
+     , (37534,  33,          1) /* Bonded - Bonded */
+     , (37534,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37534, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37534,  23, True ) /* DestroyOnSell */
+     , (37534,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37534,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37534,   1, 'Gharu''ndim Casino Key Orders') /* Name */
+     , (37534,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37534,  15, 'This paper details that the bearer should receive one Golden Keyring worth twenty-five uses for the Yaraq Casino.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37534,   1, 0x020000F8) /* Setup */
+     , (37534,   3, 0x20000014) /* SoundTable */
+     , (37534,   8, 0x060067DA) /* Icon */
+     , (37534,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37535 Sho Casino Key Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37535 Sho Casino Key Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37535;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37535, 'ace37535-shocasinokeyorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37535,   1,        128) /* ItemType - Misc */
+     , (37535,  16,          1) /* ItemUseable - No */
+     , (37535,  33,          1) /* Bonded - Bonded */
+     , (37535,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37535, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37535,  23, True ) /* DestroyOnSell */
+     , (37535,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37535,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37535,   1, 'Sho Casino Key Orders') /* Name */
+     , (37535,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37535,  15, 'This paper details that the bearer should receive one Golden Keyring worth twenty-five uses for the Shoushi Casino.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37535,   1, 0x020000F8) /* Setup */
+     , (37535,   3, 0x20000014) /* SoundTable */
+     , (37535,   8, 0x060067DA) /* Icon */
+     , (37535,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37536 Experience Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37536 Experience Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37536;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37536, 'ace37536-experienceorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37536,   1,        128) /* ItemType - Misc */
+     , (37536,  16,          1) /* ItemUseable - No */
+     , (37536,  33,          1) /* Bonded - Bonded */
+     , (37536,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37536, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37536,  23, True ) /* DestroyOnSell */
+     , (37536,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37536,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37536,   1, 'Experience Orders') /* Name */
+     , (37536,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37536,  15, 'This paper details that the bearer should receive one level worth of experience.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37536,   1, 0x02000B8B) /* Setup */
+     , (37536,   3, 0x20000014) /* SoundTable */
+     , (37536,   8, 0x060067DA) /* Icon */
+     , (37536,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37537 Enhanced Health Elixir Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37537 Enhanced Health Elixir Orders.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37537;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37537, 'ace37537-enhancedhealthelixirorders', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37537,   1,        128) /* ItemType - Misc */
+     , (37537,  16,          1) /* ItemUseable - No */
+     , (37537,  33,          1) /* Bonded - Bonded */
+     , (37537,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (37537, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37537,  23, True ) /* DestroyOnSell */
+     , (37537,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37537,  39,     2.5) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37537,   1, 'Enhanced Health Elixir Orders') /* Name */
+     , (37537,  14, 'Give this to a Royal Guard in Samsur, Holtburg, Yaraq, or Shoushi.') /* Use */
+     , (37537,  15, 'This paper details that the bearer should receive twenty Enhanced Health Elixirs, which restore 200 health upon use, force the consumer to wait 5 minutes before their next use, and  may not be traded.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37537,   1, 0x02000B8B) /* Setup */
+     , (37537,   3, 0x20000014) /* SoundTable */
+     , (37537,   8, 0x060067DA) /* Icon */
+     , (37537,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Stackable/Misc/37559 Writ of Apology.sql
+++ b/Database/Patches/9 WeenieDefaults/Stackable/Misc/37559 Writ of Apology.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37559;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37559, 'ace37559-writofapology', 51, '2021-11-01 00:00:00') /* Stackable */;
+VALUES (37559, 'ace37559-writofapology', 51, '2019-02-10 00:00:00') /* Stackable */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37559,   1,        128) /* ItemType - Misc */
@@ -17,7 +17,8 @@ VALUES (37559,   1,        128) /* ItemType - Misc */
      , (37559, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (37559,  69, False) /* IsSellable */;
+VALUES (37559,  23, True ) /* DestroyOnSell */
+     , (37559,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (37559,  39,     2.5) /* DefaultScale */;

--- a/Database/Patches/9 WeenieDefaults/Vendor/Creature/37538 Royal Quartermaster.sql
+++ b/Database/Patches/9 WeenieDefaults/Vendor/Creature/37538 Royal Quartermaster.sql
@@ -1,0 +1,180 @@
+DELETE FROM `weenie` WHERE `class_Id` = 37538;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (37538, 'ace37538-royalquartermaster', 12, '2022-10-17 03:02:01') /* Vendor */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (37538,   1,         16) /* ItemType - Creature */
+     , (37538,   2,         31) /* CreatureType - Human */
+     , (37538,   6,         -1) /* ItemsCapacity */
+     , (37538,   7,         -1) /* ContainersCapacity */
+     , (37538,   8,        120) /* Mass */
+     , (37538,  16,         32) /* ItemUseable - Remote */
+     , (37538,  25,        150) /* Level */
+     , (37538,  27,          0) /* ArmorType - None */
+     , (37538,  74,          0) /* MerchandiseItemTypes - None */
+     , (37538,  75,          0) /* MerchandiseMinValue */
+     , (37538,  76,     100000) /* MerchandiseMaxValue */
+     , (37538,  93,    2098200) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment */
+     , (37538, 113,          2) /* Gender - Female */
+     , (37538, 126,        500) /* VendorHappyMean */
+     , (37538, 127,        500) /* VendorHappyVariance */
+     , (37538, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (37538, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (37538, 188,          2) /* HeritageGroup - Gharundim */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (37538,   1, True ) /* Stuck */
+     , (37538,  12, True ) /* ReportCollisions */
+     , (37538,  13, False) /* Ethereal */
+     , (37538,  19, False) /* Attackable */
+     , (37538,  39, True ) /* DealMagicalItems */
+     , (37538,  41, True ) /* ReportCollisionsAsEnvironment */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (37538,   1,       5) /* HeartbeatInterval */
+     , (37538,   2,       0) /* HeartbeatTimestamp */
+     , (37538,   3,    0.16) /* HealthRate */
+     , (37538,   4,       5) /* StaminaRate */
+     , (37538,   5,       1) /* ManaRate */
+     , (37538,  11,     300) /* ResetInterval */
+     , (37538,  13,     0.9) /* ArmorModVsSlash */
+     , (37538,  14,       1) /* ArmorModVsPierce */
+     , (37538,  15,     1.1) /* ArmorModVsBludgeon */
+     , (37538,  16,     0.4) /* ArmorModVsCold */
+     , (37538,  17,     0.4) /* ArmorModVsFire */
+     , (37538,  18,       1) /* ArmorModVsAcid */
+     , (37538,  19,     0.6) /* ArmorModVsElectric */
+     , (37538,  37,       1) /* BuyPrice */
+     , (37538,  38,       1) /* SellPrice */
+     , (37538,  54,       3) /* UseRadius */
+     , (37538,  64,       1) /* ResistSlash */
+     , (37538,  65,       1) /* ResistPierce */
+     , (37538,  66,       1) /* ResistBludgeon */
+     , (37538,  67,       1) /* ResistFire */
+     , (37538,  68,       1) /* ResistCold */
+     , (37538,  69,       1) /* ResistAcid */
+     , (37538,  70,       1) /* ResistElectric */
+     , (37538,  71,       1) /* ResistHealthBoost */
+     , (37538,  72,       1) /* ResistStaminaDrain */
+     , (37538,  73,       1) /* ResistStaminaBoost */
+     , (37538,  74,       1) /* ResistManaDrain */
+     , (37538,  75,       1) /* ResistManaBoost */
+     , (37538, 104,      10) /* ObviousRadarRange */
+     , (37538, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (37538,   1, 'Royal Quartermaster') /* Name */
+     , (37538,   5, 'Soldier') /* Template */
+     , (37538,  24, 'Samsur') /* TownName */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (37538,   1, 0x0200004E) /* Setup */
+     , (37538,   2, 0x09000001) /* MotionTable */
+     , (37538,   3, 0x20000002) /* SoundTable */
+     , (37538,   4, 0x30000000) /* CombatTable */
+     , (37538,   8, 0x06001036) /* Icon */
+     , (37538,  57,      37559) /* AlternateCurrency - Writ of Apology */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (37538,   1, 170, 0, 0) /* Strength */
+     , (37538,   2, 150, 0, 0) /* Endurance */
+     , (37538,   3, 150, 0, 0) /* Quickness */
+     , (37538,   4, 200, 0, 0) /* Coordination */
+     , (37538,   5, 220, 0, 0) /* Focus */
+     , (37538,   6, 220, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (37538,   1,    60, 0, 0, 80) /* MaxHealth */
+     , (37538,   3,    70, 0, 0, 110) /* MaxStamina */
+     , (37538,   5,    60, 0, 0, 80) /* MaxMana */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (37538,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (37538,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (37538,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (37538,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (37538,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (37538,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (37538,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (37538,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (37538,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,    0.8, NULL, NULL, NULL, NULL, 1 /* Open */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Greetings, friend. If you have a Writ of Apology, I can exchange one of my items for it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,    0.8, NULL, NULL, NULL, NULL, 2 /* Close */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Pleasant journeys to you!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,    0.8, NULL, NULL, NULL, NULL, 4 /* Buy */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'We sincerely apologize for your difficulties, and hope you enjoy your future in Dereth. Bring this order to one of the royal guards stationed here, in Holtburg, in Shoushi, or in Yaraq.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,  0.125, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x13000087 /* Wave */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,   0.25, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x1300007D /* BowDeep */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,  0.375, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x13000086 /* Shrug */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37538,  2 /* Vendor */,    0.5, NULL, NULL, NULL, NULL, 5 /* Heartbeat */, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x13000083 /* Nod */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (37538, 2, 28068,  0, 17, 0.7019, False) /* Create Guardian's Uniform (28068) for Wield */
+     , (37538, 4, 37532, -1, 0, 0, False) /* Create  (37532) for Shop */
+     , (37538, 4, 37536, -1, 0, 0, False) /* Create  (37536) for Shop */
+     , (37538, 4, 37533, -1, 0, 0, False) /* Create  (37533) for Shop */
+     , (37538, 4, 37534, -1, 0, 0, False) /* Create  (37534) for Shop */
+     , (37538, 4, 37535, -1, 0, 0, False) /* Create  (37535) for Shop */
+     , (37538, 4, 37520, -1, 0, 0, False) /* Create  (37520) for Shop */
+     , (37538, 4, 37521, -1, 0, 0, False) /* Create  (37521) for Shop */
+     , (37538, 4, 37522, -1, 0, 0, False) /* Create  (37522) for Shop */
+     , (37538, 4, 37523, -1, 0, 0, False) /* Create  (37523) for Shop */
+     , (37538, 4, 37524, -1, 0, 0, False) /* Create  (37524) for Shop */
+     , (37538, 4, 37525, -1, 0, 0, False) /* Create  (37525) for Shop */
+     , (37538, 4, 37526, -1, 0, 0, False) /* Create  (37526) for Shop */
+     , (37538, 4, 37528, -1, 0, 0, False) /* Create  (37528) for Shop */
+     , (37538, 4, 37529, -1, 0, 0, False) /* Create  (37529) for Shop */
+     , (37538, 4, 37560, -1, 0, 0, False) /* Create  (37560) for Shop */
+     , (37538, 4, 37527, -1, 0, 0, False) /* Create  (37527) for Shop */
+     , (37538, 4, 37530, -1, 0, 0, False) /* Create  (37530) for Shop */
+     , (37538, 4, 37531, -1, 0, 0, False) /* Create  (37531) for Shop */
+     , (37538, 4, 37537, -1, 0, 0, False) /* Create  (37537) for Shop */
+     , (37538, 4, 37519, -1, 0, 0, False) /* Create  (37519) for Shop */;


### PR DESCRIPTION
Adds all the NPCs and Items for the Writ of Apology.

https://asheron.fandom.com/wiki/Writ_of_Apology

Admin would need to manually bestow the quest "WritOfApology_0508" on any player(s) who deserve an apology, at which point it gets removed from their quest log when complete, allowing it to be re-added if needed.

Note: This does not add a login message as the tech for that does not currently exist.