### PR TITLE
updating crown to magloot corpse log mins

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/00296 Crown.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/00296 Crown.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 296;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (296, 'crown', 2, '2021-11-01 00:00:00') /* Clothing */;
+VALUES (296, 'crown', 2, '2023-01-14 00:00:00') /* Clothing */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (296,   1,          2) /* ItemType - Armor */
@@ -31,10 +31,10 @@ VALUES (296,  12,    0.66) /* Shade */
      , (296,  13,     1.3) /* ArmorModVsSlash */
      , (296,  14,       1) /* ArmorModVsPierce */
      , (296,  15,       1) /* ArmorModVsBludgeon */
-     , (296,  16,       0) /* ArmorModVsCold */
-     , (296,  17,       0) /* ArmorModVsFire */
+     , (296,  16,     0.4) /* ArmorModVsCold */
+     , (296,  17,     0.4) /* ArmorModVsFire */
      , (296,  18,     0.6) /* ArmorModVsAcid */
-     , (296,  19,       0) /* ArmorModVsElectric */
+     , (296,  19,     0.4) /* ArmorModVsElectric */
      , (296, 110,       1) /* BulkMod */
      , (296, 111,       1) /* SizeMod */;
 


### PR DESCRIPTION
Despite 16PY having 0.0 modifiers for protection against 3 of the 4 elements, magloot corpse logs from retail showed these values never dropping below 0.4 for this item.

Some possibilities:

- They changed the base data on this item some point after 16PY, possibly during UCoN when diadems/circlets/coronets/etc. were added?

- There was special logic in the loot mutation system for jewelry w/ armor specifically, with the minimum ArmorModVsTypes there. Jewelry w/ armor already seemed to be sort of a weird outlier there.

If unmutated crowns were sold at vendors, and if there is a pcap of someone appraising one in retail from a vendor store, then it could possibly be differentiated there if the base weenie was modified, or if something was going on in the loot mutation system for jewelry w/ armor.