### PR TITLE
Update Bulb of Harvests

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/3150.sql
+++ b/Database/Patches/6 LandBlockExtendedData/3150.sql
@@ -18,52 +18,16 @@ VALUES (0x73150004,  1154, 0x31500480, 94.1194, 95.981, -35.595, 0.328346, 0, 0,
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x73150004, 0x73150005, '2022-05-17 03:47:03') /* Adrenkus (47172) */
-     , (0x73150004, 0x73150006, '2022-05-17 03:47:03') /* Sanctum Guardian Spirit (88215) */
-     , (0x73150004, 0x73150007, '2022-05-17 03:47:03') /* Bulb of Harvests (88219) */;
+     , (0x73150004, 0x73150007, '2022-05-17 03:47:03') /* Bulb of Harvests (88219) */
+     , (0x73150004, 0x73150056, '2023-02-03 09:18:02') /* Sanctum Guardian Spirit (88215) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x73150005, 47172, 0x31500480, 94.1194, 95.981, -35.595, 0.328346, 0, 0, -0.944557,  True, '2022-05-17 03:47:03'); /* Adrenkus */
 /* @teleloc 0x31500480 [94.119400 95.981003 -35.595001] 0.328346 0.000000 0.000000 -0.944557 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150006, 88215, 0x3150041C, 81.8906, 99.3746, -41.595, 1, 0, 0, 0,  True, '2022-05-17 03:47:03'); /* Sanctum Guardian Spirit */
-/* @teleloc 0x3150041C [81.890602 99.374603 -41.595001] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x73150007, 88219, 0x3150033A, 153.118, 86.9316, -53.545, 0.707107, 0, 0, -0.707107,  True, '2022-05-17 03:47:03'); /* Bulb of Harvests */
 /* @teleloc 0x3150033A [153.117996 86.931602 -53.544998] 0.707107 0.000000 0.000000 -0.707107 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150009, 88221, 0x31500140, 30.4653, 119.382, -83.6, -0.031604, 0, 0, 0.999501, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500140 [30.465300 119.382004 -83.599998] -0.031604 0.000000 0.000000 0.999501 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315000A, 88221, 0x3150013F, 30.4165, 123.758, -83.6, -0.999647, 0, 0, 0.026585, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x3150013F [30.416500 123.758003 -83.599998] -0.999647 0.000000 0.000000 0.026585 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315000B, 88221, 0x3150013F, 30.9113, 131.299, -83.6, -0.999647, 0, 0, 0.026585, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x3150013F [30.911301 131.298996 -83.599998] -0.999647 0.000000 0.000000 0.026585 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315000C, 88221, 0x3150013E, 31.9178, 140.922, -83.6, -0.999647, 0, 0, 0.026585, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x3150013E [31.917801 140.921997 -83.599998] -0.999647 0.000000 0.000000 0.026585 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315000D, 88221, 0x31500144, 40.8876, 118.643, -83.545, 0.999988, 0, 0, 0.004924, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500144 [40.887600 118.642998 -83.544998] 0.999988 0.000000 0.000000 0.004924 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315000E, 88221, 0x31500143, 40.7986, 127.685, -83.545, 0.999988, 0, 0, 0.004924, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500143 [40.798599 127.684998 -83.544998] 0.999988 0.000000 0.000000 0.004924 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315000F, 88221, 0x31500142, 40.7448, 133.149, -83.545, 0.999988, 0, 0, 0.004924, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500142 [40.744801 133.149002 -83.544998] 0.999988 0.000000 0.000000 0.004924 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150010, 88221, 0x31500141, 40.6472, 143.064, -83.545, 0.999988, 0, 0, 0.004924, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500141 [40.647202 143.063995 -83.544998] 0.999988 0.000000 0.000000 0.004924 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x73150011, 15759, 0x31500270, 138.155, 128.001, -65.245, -0.704319, 0, 0, 0.709883, False, '2022-05-17 03:47:03'); /* Linkable Item Generator */
@@ -77,76 +41,12 @@ VALUES (0x73150012, 47837, 0x31500270, 138.146, 126.791, -65.3, -0.704319, 0, 0,
 /* @teleloc 0x31500270 [138.145996 126.791000 -65.300003] -0.704319 0.000000 0.000000 0.709883 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150013, 88221, 0x3150010A, 151.358, 108.927, -101.545, 0.999629, 0, 0, 0.027256, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x3150010A [151.358002 108.927002 -101.544998] 0.999629 0.000000 0.000000 0.027256 */
+VALUES (0x7315001B, 88222, 0x315002EF, 51.6126, 178.719, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x315002EF [51.612598 178.718994 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150014, 88221, 0x31500109, 151.561, 115.881, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500109 [151.561005 115.880997 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150015, 88221, 0x31500108, 151.411, 122.493, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500108 [151.410995 122.492996 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150016, 88221, 0x31500107, 151.192, 132.078, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500107 [151.192001 132.078003 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150017, 88221, 0x31500104, 142.108, 132.66, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500104 [142.108002 132.660004 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150018, 88221, 0x31500105, 142.248, 126.496, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500105 [142.248001 126.496002 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150019, 88221, 0x31500106, 142.392, 120.195, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500106 [142.391998 120.195000 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315001A, 88221, 0x31500106, 142.535, 113.912, -101.545, 0.999935, 0, 0, 0.011396, False, '2022-05-17 03:47:03'); /* Vine Hotspot Generator */
-/* @teleloc 0x31500106 [142.535004 113.912003 -101.544998] 0.999935 0.000000 0.000000 0.011396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315001B, 88222, 0x315002EF, 51.6126, 178.719, -53.545, -0.71053, 0, 0, -0.703667, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x315002EF [51.612598 178.718994 -53.544998] -0.710530 0.000000 0.000000 -0.703667 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315001E, 88222, 0x31500308, 102.631, 169.332, -53.545, 0.635873, 0, 0, -0.771794, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x31500308 [102.630997 169.332001 -53.544998] 0.635873 0.000000 0.000000 -0.771794 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315001F, 88222, 0x31500335, 152.701, 189.719, -53.545, 0.885119, 0, 0, -0.465365, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x31500335 [152.701004 189.718994 -53.544998] 0.885119 0.000000 0.000000 -0.465365 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150020, 88222, 0x3150034A, 167.519, 165.706, -53.545, -0.089077, 0, 0, -0.996025, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x3150034A [167.518997 165.705994 -53.544998] -0.089077 0.000000 0.000000 -0.996025 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150021, 88222, 0x31500341, 160.774, 142.087, -53.545, -0.631079, 0, 0, -0.775719, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x31500341 [160.774002 142.087006 -53.544998] -0.631079 0.000000 0.000000 -0.775719 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150022, 88222, 0x315002DA, 35.3548, 183.664, -53.545, -0.946022, 0, 0, -0.324104, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x315002DA [35.354801 183.664001 -53.544998] -0.946022 0.000000 0.000000 -0.324104 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150023, 88222, 0x315002FF, 75.714, 178.985, -53.545, 0.858236, 0, 0, 0.513256, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
-/* @teleloc 0x315002FF [75.713997 178.985001 -53.544998] 0.858236 0.000000 0.000000 0.513256 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150024, 88220, 0x31500353, 184.482, 126.715, -52.1, -0.368351, 0, 0, -0.929687, False, '2022-05-17 03:47:03'); /* Vine */
-/* @teleloc 0x31500353 [184.481995 126.714996 -52.099998] -0.368351 0.000000 0.000000 -0.929687 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150025, 88220, 0x31500354, 182.039, 122.475, -52.1, -0.09871, 0, 0, -0.995116, False, '2022-05-17 03:47:03'); /* Vine */
-/* @teleloc 0x31500354 [182.039001 122.474998 -52.099998] -0.098710 0.000000 0.000000 -0.995116 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150026, 88220, 0x31500357, 185.797, 117.342, -52.1, 0.682811, 0, 0, -0.730595, False, '2022-05-17 03:47:03'); /* Vine */
-/* @teleloc 0x31500357 [185.796997 117.342003 -52.099998] 0.682811 0.000000 0.000000 -0.730595 */
+VALUES (0x73150023, 88222, 0x315002FF, 75.714, 178.985, -53.545, 1, 0, 0, 0, False, '2022-05-17 03:47:03'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x315002FF [75.713997 178.985001 -53.544998] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x73150027, 88223, 0x315002AC, 112.051, 147.605, -59.545, 0.000614, 0, 0, -1, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
@@ -281,8 +181,8 @@ VALUES (0x73150047, 88223, 0x31500124, 112.549, 107.863, -95.545, -0.729039, 0, 
 /* @teleloc 0x31500124 [112.549004 107.862999 -95.544998] -0.729039 0.000000 0.000000 -0.684472 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150048, 88223, 0x3150025B, 124.961, 86.9211, -65.545, 0.69862, 0, 0, -0.715493, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x3150025B [124.960999 86.921097 -65.544998] 0.698620 0.000000 0.000000 -0.715493 */
+VALUES (0x73150048, 88223, 0x3150025B, 124.961, 86.9211, -65.545, 0.707107, 0, 0, -0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x3150025B [124.960999 86.921097 -65.544998] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x73150049, 88223, 0x315002ED, 42.8234, 78.7763, -53.545, -0.912629, 0, 0, 0.408788, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
@@ -293,32 +193,32 @@ VALUES (0x7315004A, 88223, 0x315002EB, 39.1815, 93.6769, -53.545, -0.901923, 0, 
 /* @teleloc 0x315002EB [39.181499 93.676903 -53.544998] -0.901923 0.000000 0.000000 0.431898 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315004B, 88223, 0x315002E7, 42.1667, 136.152, -53.545, 0.009466, 0, 0, 0.999955, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x315002E7 [42.166698 136.151993 -53.544998] 0.009466 0.000000 0.000000 0.999955 */
+VALUES (0x7315004B, 88223, 0x315002E7, 42.1667, 136.152, -53.545, 0, 0, 0, -1, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x315002E7 [42.166698 136.151993 -53.544998] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315004C, 88223, 0x315002E3, 40.1765, 156.688, -53.545, -0.729393, 0, 0, 0.684095, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x315002E3 [40.176498 156.688004 -53.544998] -0.729393 0.000000 0.000000 0.684095 */
+VALUES (0x7315004C, 88223, 0x315002E3, 40.1765, 156.988, -53.545, 0.707107, 0, 0, -0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x315002E3 [40.176498 156.988007 -53.544998] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315004D, 88223, 0x315002E1, 45.8095, 182.396, -53.545, 0.626281, 0, 0, 0.779597, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x315002E1 [45.809502 182.395996 -53.544998] 0.626281 0.000000 0.000000 0.779597 */
+VALUES (0x7315004D, 88223, 0x315002E1, 45.8095, 182.396, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x315002E1 [45.809502 182.395996 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315004E, 88223, 0x315002FF, 69.2092, 180.305, -53.545, 0.707126, 0, 0, 0.707088, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x315002FF [69.209198 180.304993 -53.544998] 0.707126 0.000000 0.000000 0.707088 */
+VALUES (0x7315004E, 88223, 0x315002FF, 69.2092, 180.305, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x315002FF [69.209198 180.304993 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7315004F, 88223, 0x31500305, 87.0649, 173.019, -53.545, 0.711203, 0, 0, 0.702987, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x31500305 [87.064903 173.018997 -53.544998] 0.711203 0.000000 0.000000 0.702987 */
+VALUES (0x7315004F, 88223, 0x31500305, 87.0649, 173.019, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x31500305 [87.064903 173.018997 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150050, 88223, 0x31500307, 106.488, 173.2, -53.545, 0.662315, 0, 0, 0.749225, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x31500307 [106.487999 173.199997 -53.544998] 0.662315 0.000000 0.000000 0.749225 */
+VALUES (0x73150050, 88223, 0x31500307, 106.488, 173.2, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x31500307 [106.487999 173.199997 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150051, 88223, 0x31500334, 153.009, 192.654, -53.545, -0.75859, 0, 0, -0.651569, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x31500334 [153.009003 192.654007 -53.544998] -0.758590 0.000000 0.000000 -0.651569 */
+VALUES (0x73150051, 88223, 0x31500334, 153.009, 192.654, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x31500334 [153.009003 192.654007 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x73150052, 88223, 0x31500348, 167.488, 177.359, -53.545, -0.908224, 0, 0, -0.418485, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
@@ -329,5 +229,177 @@ VALUES (0x73150053, 88223, 0x3150034B, 168.439, 155.085, -53.545, -0.995871, 0, 
 /* @teleloc 0x3150034B [168.438995 155.085007 -53.544998] -0.995871 0.000000 0.000000 -0.090783 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x73150054, 88223, 0x31500337, 151.869, 140.188, -53.545, -0.844354, 0, 0, -0.535786, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
-/* @teleloc 0x31500337 [151.869003 140.188004 -53.544998] -0.844354 0.000000 0.000000 -0.535786 */
+VALUES (0x73150054, 88223, 0x31500337, 151.869, 140.188, -53.545, 0.707107, 0, 0, 0.707107, False, '2022-05-17 03:47:03'); /* Adrenkus Cave Generator */
+/* @teleloc 0x31500337 [151.869003 140.188004 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150055,  7924, 0x31500485, 99.0517, 88.5662, -35.545, 1, 0, 0, 0, False, '2023-02-03 09:06:01'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x31500485 [99.051697 88.566200 -35.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x73150055, 0x73150057, '2023-02-03 09:21:29') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150058, '2023-02-03 09:22:21') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150059, '2023-02-03 09:22:52') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x7315005A, '2023-02-03 09:23:32') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x7315005B, '2023-02-03 09:23:56') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x7315005C, '2023-02-03 09:25:00') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x7315005D, '2023-02-03 09:25:10') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x7315005E, '2023-02-03 09:25:53') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x7315005F, '2023-02-03 09:27:16') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150060, '2023-02-03 09:27:38') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150062, '2023-02-03 09:28:48') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150064, '2023-02-03 09:30:33') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150065, '2023-02-03 09:31:02') /* Adolescent Ash Gromnie (72786) */
+     , (0x73150055, 0x73150066, '2023-02-03 09:31:15') /* Adolescent Ash Gromnie (72786) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150056, 88215, 0x3150041C, 81.7718, 97.0093, -41.295, 1, 0, 0, 0,  True, '2023-02-03 09:18:02'); /* Sanctum Guardian Spirit */
+/* @teleloc 0x3150041C [81.771797 97.009300 -41.294998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150057, 72786, 0x31500401, 71.9423, 144.06, -41.5925, 1, 0, 0, 0,  True, '2023-02-03 09:21:29'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x31500401 [71.942299 144.059998 -41.592499] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150058, 72786, 0x315003F3, 61.9224, 127.315, -41.5925, 0, 0, 0, -1,  True, '2023-02-03 09:22:21'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003F3 [61.922401 127.315002 -41.592499] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150059, 72786, 0x315003DD, 42.0587, 109.295, -41.5925, 0, 0, 0, -1,  True, '2023-02-03 09:22:52'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003DD [42.058701 109.294998 -41.592499] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315005A, 72786, 0x315003E2, 41.1553, 77.0362, -41.5925, 0.707107, 0, 0, -0.707107,  True, '2023-02-03 09:23:32'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003E2 [41.155300 77.036201 -41.592499] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315005B, 72786, 0x315003FA, 61.916, 88.381, -41.5925, 0, 0, 0, -1,  True, '2023-02-03 09:23:56'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003FA [61.916000 88.380997 -41.592499] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315005C, 72786, 0x31500464, 132.55, 127.351, -41.5925, 1, 0, 0, 0,  True, '2023-02-03 09:25:00'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x31500464 [132.550003 127.350998 -41.592499] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315005D, 72786, 0x31500450, 122.817, 137.787, -41.5925, 1, 0, 0, 0,  True, '2023-02-03 09:25:10'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x31500450 [122.817001 137.787003 -41.592499] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315005E, 72786, 0x3150043A, 112.271, 146.463, -41.5925, 0.707107, 0, 0, 0.707107,  True, '2023-02-03 09:25:53'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x3150043A [112.271004 146.462997 -41.592499] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315005F, 72786, 0x31500444, 111.891, 106.767, -41.5925, 0, 0, 0, -1,  True, '2023-02-03 09:27:16'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x31500444 [111.890999 106.766998 -41.592499] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150060, 72786, 0x3150045F, 120.528, 87.0563, -41.5925, 0.707107, 0, 0, -0.707107,  True, '2023-02-03 09:27:38'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x3150045F [120.528000 87.056297 -41.592499] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150062, 72786, 0x31500425, 92.0863, 116.75, -41.5925, 0, 0, 0, -1,  True, '2023-02-03 09:28:48'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x31500425 [92.086304 116.750000 -41.592499] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150064, 72786, 0x315003BD, 21.8407, 96.2638, -41.5925, 1, 0, 0, 0,  True, '2023-02-03 09:30:33'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003BD [21.840700 96.263802 -41.592499] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150065, 72786, 0x315003B3, 22.0046, 137.037, -41.5925, 0, 0, 0, -1,  True, '2023-02-03 09:31:02'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003B3 [22.004601 137.037003 -41.592499] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150066, 72786, 0x315003C5, 32.3171, 146.567, -41.5925, 0.707107, 0, 0, 0.707107,  True, '2023-02-03 09:31:15'); /* Adolescent Ash Gromnie */
+/* @teleloc 0x315003C5 [32.317101 146.567001 -41.592499] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150067, 88221, 0x3150010A, 152.114, 106.853, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:17:42'); /* Vine Hotspot Generator */
+/* @teleloc 0x3150010A [152.113998 106.852997 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150068, 88221, 0x31500109, 152.094, 117.042, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:19:53'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500109 [152.093994 117.042000 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150069, 88221, 0x31500108, 152.063, 126.898, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:20:12'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500108 [152.063004 126.898003 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315006A, 88221, 0x31500104, 141.804, 137.178, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:20:47'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500104 [141.804001 137.177994 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315006B, 88221, 0x31500105, 142.139, 126.804, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:21:09'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500105 [142.139008 126.804001 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315006C, 88221, 0x31500106, 142.029, 116.824, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:21:30'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500106 [142.029007 116.823997 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315006D, 88221, 0x31500107, 152.199, 136.933, -101.545, 1, 0, 0, 0, False, '2023-02-03 10:21:57'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500107 [152.199005 136.932999 -101.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315006E, 88222, 0x31500341, 161.133, 143.645, -53.545, 1, 0, 0, 0, False, '2023-02-03 10:41:34'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x31500341 [161.132996 143.645004 -53.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315006F, 88222, 0x3150034A, 167.971, 167.223, -53.545, 1, 0, 0, 0, False, '2023-02-03 10:42:25'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x3150034A [167.970993 167.223007 -53.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150070, 88222, 0x31500335, 152.014, 191.196, -53.545, 1, 0, 0, 0, False, '2023-02-03 10:44:09'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x31500335 [152.014008 191.195999 -53.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150071, 88222, 0x315002DA, 34.9145, 184.713, -53.545, 0.707107, 0, 0, 0.707107, False, '2023-02-03 10:48:36'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x315002DA [34.914501 184.712997 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150072, 88222, 0x31500308, 103.358, 168.841, -53.545, 0.707107, 0, 0, 0.707107, False, '2023-02-03 10:52:59'); /* Small Vine Hotspot Generator */
+/* @teleloc 0x31500308 [103.358002 168.841003 -53.544998] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150073, 88221, 0x31500141, 42.0628, 147.053, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:01:09'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500141 [42.062801 147.052994 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150074, 88221, 0x3150013D, 32.0905, 146.973, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:01:14'); /* Vine Hotspot Generator */
+/* @teleloc 0x3150013D [32.090500 146.973007 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150075, 88221, 0x3150013E, 31.9972, 137.049, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:01:35'); /* Vine Hotspot Generator */
+/* @teleloc 0x3150013E [31.997200 137.048996 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150077, 88221, 0x31500140, 32.0238, 117.009, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:02:09'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500140 [32.023800 117.009003 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150078, 88221, 0x3150013F, 31.9682, 127.048, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:02:22'); /* Vine Hotspot Generator */
+/* @teleloc 0x3150013F [31.968201 127.047997 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x73150079, 88221, 0x31500144, 41.9914, 116.975, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:02:45'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500144 [41.991402 116.974998 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315007A, 88221, 0x31500143, 41.9851, 126.957, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:02:51'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500143 [41.985100 126.957001 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315007B, 88221, 0x31500142, 41.9981, 137.027, -83.545, 0, 0, 0, -1, False, '2023-02-03 11:02:59'); /* Vine Hotspot Generator */
+/* @teleloc 0x31500142 [41.998100 137.026993 -83.544998] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315007C, 88220, 0x31500364, 187.416, 117.155, -53.545, 1, 0, 0, 0, False, '2023-02-03 11:20:42'); /* Vine */
+/* @teleloc 0x31500364 [187.416000 117.154999 -53.544998] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315007D, 88220, 0x31500353, 182.113, 125.716, -53.545, -0.719576, 0, 0, 0.694414, False, '2023-02-03 11:21:18'); /* Vine */
+/* @teleloc 0x31500353 [182.113007 125.716003 -53.544998] -0.719576 0.000000 0.000000 0.694414 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7315007E, 88220, 0x31500356, 182.9335, 118.3029, -53.545, -0.907745, 0, 0, 0.419522, False, '2023-02-03 11:22:08'); /* Vine */
+/* @teleloc 0x31500356 [182.933502 118.302902 -53.544998] -0.907745 0.000000 0.000000 0.419522 */

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88221 Vine Hotspot Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88221 Vine Hotspot Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (88221, 'ace88221-vinehotspotgenerator', 1, '2022-05-17 03:47:03') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (88221,  81,         10) /* MaxGeneratedObjects */
-     , (88221,  82,         10) /* InitGeneratedObjects */
+VALUES (88221,  81,          2) /* MaxGeneratedObjects */
+     , (88221,  82,          2) /* InitGeneratedObjects */
      , (88221,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -14,7 +14,7 @@ VALUES (88221,   1, True ) /* Stuck */
      , (88221,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (88221,  41,     300) /* RegenerationInterval */
+VALUES (88221,  41,     180) /* RegenerationInterval */
      , (88221,  43,       5) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -25,13 +25,5 @@ VALUES (88221,   1, 0x0200026B) /* Setup */
      , (88221,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88221, -1, 88220, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 88220, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 88220, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 88220, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 88220, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 88220, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 47198, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bloodroot Vine (47198) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 47198, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bloodroot Vine (47198) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88221, -1, 47198, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bloodroot Vine (47198) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+VALUES (88221, -1, 88220, 0, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Vine (88220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
      , (88221, -1, 88217, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Bloodroot Vine (88217) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/HotSpot/Misc/88220 Vine.sql
+++ b/Database/Patches/9 WeenieDefaults/HotSpot/Misc/88220 Vine.sql
@@ -21,14 +21,14 @@ VALUES (88220,   1, True ) /* Stuck */
      , (88220,  12, True ) /* ReportCollisions */
      , (88220,  13, True ) /* Ethereal */
      , (88220,  14, False) /* GravityStatus */
-     , (88220,  18, True ) /* Visibility */
      , (88220,  24, True ) /* UiHidden */
-     , (88220,  55, True ) /* IsHot */;
+     , (88220,  55, True ) /* IsHot */
+     , (88220,  57, False) /* AffectsAis */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (88220,  22,     0.5) /* DamageVariance */
-     , (88220,  39,       3) /* DefaultScale */
-     , (88220, 105,       0) /* HotspotCycleTime */
+     , (88220,  39,       1) /* DefaultScale */
+     , (88220, 105,       2) /* HotspotCycleTime */
      , (88220, 106,       0) /* HotspotCycleTimeVariance */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -36,6 +36,6 @@ VALUES (88220,   1, 'Vine') /* Name */
      , (88220,  17, 'The razor-sharp thorns pierce you for %i points of damage!') /* ActivationTalk */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (88220,   1, 0x02000638) /* Setup */
+VALUES (88220,   1, 0x02000BF5) /* Setup */
      , (88220,   3, 0x20000052) /* SoundTable */
      , (88220,   8, 0x06001049) /* Icon */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/88218 Temple Exit.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/88218 Temple Exit.sql
@@ -31,5 +31,5 @@ VALUES (88218,   1, 0x0200169D) /* Setup */
      , (88218,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88218, 2, 0x3150002D, 141.871, 114.834, 0.005, 0.037616, 0, 0, 0.999292) /* Destination */
-/* @teleloc 0x3150002D [141.871002 114.834000 0.005000] 0.037616 0.000000 0.000000 0.999292 */;
+VALUES (88218, 2, 0x3150041D, 82, 101, -41.5, 0, 0, 0, -1) /* Destination */
+/* 0x3150041D [82.000000 101.000000 -41.5] 0.000000 0.000000 0.000000 -1.000000 */;


### PR DESCRIPTION
Updated the Harvesting the Bulb of Harvests quest based on retail video:

https://www.youtube.com/watch?v=SUSow5MBOjg

- Added missing Adolescent Ash Gromnie spawns in the cave. 
- Improved vine hotspots to cover the entire area using a single large hotspot instead of multiple small hotspots spawned at random. 
- Moved Sanctum Guardian Spirit on the platform at the bottom of the case as seen in the retail video. 
- Corrected Temple Exit portal drop to match the retail video.