### PR TITLE
Fixing 3 low level creatures that were dropping red/gold letters

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/27893 Drudge Prowler.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/27893 Drudge Prowler.sql
@@ -209,10 +209,6 @@ VALUES (27893, 9,  3669,  0, 0, 0.08, False) /* Create Drudge Charm (3669) for C
      , (27893, 9,     0,  0, 0, 0.92, False) /* Create nothing for ContainTreasure */
      , (27893, 9,  7825,  0, 0, 0.03, False) /* Create Brown Beans (7825) for ContainTreasure */
      , (27893, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */
-     , (27893, 9, 45875,  0, 0, 0.02, False) /* Create Lucky Gold Letter (45875) for ContainTreasure */
-     , (27893, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
-     , (27893, 9, 45876,  0, 0, 0.06, False) /* Create Scarlet Red Letter (45876) for ContainTreasure */
-     , (27893, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
      , (27893, 9, 13222,  0, 0, 0.1, False) /* Create Peppermint Stick (13222) for ContainTreasure */
      , (27893, 9,     0,  0, 0, 0.9, False) /* Create nothing for ContainTreasure */
      , (27893, 9, 20854,  0, 0, 0.03, False) /* Create Academy Stamp (20854) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/PhyntosWasp/19435 Red Phyntos Wasp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/PhyntosWasp/19435 Red Phyntos Wasp.sql
@@ -112,6 +112,4 @@ VALUES (19435, 414) /* PLAYER_DEATH_EVENT */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (19435, 9,  3703,  0, 0, 0.15, False) /* Create Red Phyntos Wasp Wing (3703) for ContainTreasure */
-     , (19435, 9,     0,  0, 0, 0.85, False) /* Create nothing for ContainTreasure */
-     , (19435, 9, 45875,  0, 0, 0.01, False) /* Create Lucky Gold Letter (45875) for ContainTreasure */
-     , (19435, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;
+     , (19435, 9,     0,  0, 0, 0.85, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shreth/04109 Carrion Shreth.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shreth/04109 Carrion Shreth.sql
@@ -163,9 +163,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (4109, 9, 45876,  0, 0, 0.04, False) /* Create Scarlet Red Letter (45876) for ContainTreasure */
-     , (4109, 9,     0,  0, 0, 0.96, False) /* Create nothing for ContainTreasure */
-     , (4109, 9, 11687,  0, 0, 0.04, False) /* Create Little Green Seeds (11687) for ContainTreasure */
+VALUES (4109, 9, 11687,  0, 0, 0.04, False) /* Create Little Green Seeds (11687) for ContainTreasure */
      , (4109, 9,     0,  0, 0, 0.96, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)


### PR DESCRIPTION
4109 Carrion Shreth, 19435 Red Phyntos Wasp, and 27893 Drudge Prowler were dropping red and/or gold letters. They should not be doing so, as they are not level 80 creatures.