### PR TITLE
Fix bug on dark isle trophy turn-ins

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Human/33673 Tyrina of Arwic.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/33673 Tyrina of Arwic.sql
@@ -211,7 +211,7 @@ VALUES (33673, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenc
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@1-89', NULL, 1, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@0-89', NULL, 0, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33673, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenceTurnInTimer', NULL, NULL, NULL);
@@ -244,7 +244,7 @@ VALUES (33673, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenc
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@1-89_2', NULL, 1, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@0-89_2', NULL, 0, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33673, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenceTurnInTimer@2', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/33673.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/33673.es
@@ -24,7 +24,7 @@ Refuse: Corrupted Essence (44470)
                                                         TestSuccess:
                                                             - Goto: Has1
                                         QuestFailure:
-                                            - InqQuestSolves: CorruptedEssenceCount, 1 - 89
+                                            - InqQuestSolves: CorruptedEssenceCount, 0 - 89
                                                 QuestSuccess:
                                                     - InqOwnsItems: Corrupted Essence (44470), 10
                                                         TestSuccess:
@@ -111,7 +111,7 @@ Refuse: Lesser Corrupted Essence (44469)
                                                         TestSuccess:
                                                             - Goto: Has1LesserEssence
                                         QuestFailure:
-                                            - InqQuestSolves: CorruptedEssenceCount, 1 - 89
+                                            - InqQuestSolves: CorruptedEssenceCount, 0 - 89
                                                 QuestSuccess:
                                                     - InqOwnsItems: Lesser Corrupted Essence (44469), 10
                                                         TestSuccess:

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/33675 Francois di Terli.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/33675 Francois di Terli.sql
@@ -215,7 +215,7 @@ VALUES (33675, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenc
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@1-89', NULL, 1, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@0-89', NULL, 0, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33675, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenceTurnInTimer', NULL, NULL, NULL);
@@ -248,7 +248,7 @@ VALUES (33675, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenc
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@1-89_2', NULL, 1, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@0-89_2', NULL, 0, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33675, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenceTurnInTimer@2', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/33675.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/33675.es
@@ -24,7 +24,7 @@ Refuse: Corrupted Essence (44470)
                                                         TestSuccess:
                                                             - Goto: Has1
                                         QuestFailure:
-                                            - InqQuestSolves: CorruptedEssenceCount, 1 - 89
+                                            - InqQuestSolves: CorruptedEssenceCount, 0 - 89
                                                 QuestSuccess:
                                                     - InqOwnsItems: Corrupted Essence (44470), 10
                                                         TestSuccess:
@@ -111,7 +111,7 @@ Refuse: Lesser Corrupted Essence (44469)
                                                         TestSuccess:
                                                             - Goto: Has1LesserEssence
                                         QuestFailure:
-                                            - InqQuestSolves: CorruptedEssenceCount, 1 - 89
+                                            - InqQuestSolves: CorruptedEssenceCount, 0 - 89
                                                 QuestSuccess:
                                                     - InqOwnsItems: Lesser Corrupted Essence (44469), 10
                                                         TestSuccess:

--- a/Database/Patches/9 WeenieDefaults/Creature/Unknown/33674 The Deep.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unknown/33674 The Deep.sql
@@ -212,7 +212,7 @@ VALUES (33674, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenc
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@1-89', NULL, 1, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@0-89', NULL, 0, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33674, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenceTurnInTimer', NULL, NULL, NULL);
@@ -245,7 +245,7 @@ VALUES (33674, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenc
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@1-89_2', NULL, 1, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  30 /* InqQuestSolves */, 0, 1, NULL, 'CorruptedEssenceCount@0-89_2', NULL, 0, 89, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33674, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'CorruptedEssenceTurnInTimer@2', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unknown/33674.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unknown/33674.es
@@ -24,7 +24,7 @@ Refuse: Corrupted Essence (44470)
                                                         TestSuccess:
                                                             - Goto: Has1
                                         QuestFailure:
-                                            - InqQuestSolves: CorruptedEssenceCount, 1 - 89
+                                            - InqQuestSolves: CorruptedEssenceCount, 0 - 89
                                                 QuestSuccess:
                                                     - InqOwnsItems: Corrupted Essence (44470), 10
                                                         TestSuccess:
@@ -111,7 +111,7 @@ Refuse: Lesser Corrupted Essence (44469)
                                                         TestSuccess:
                                                             - Goto: Has1LesserEssence
                                         QuestFailure:
-                                            - InqQuestSolves: CorruptedEssenceCount, 1 - 89
+                                            - InqQuestSolves: CorruptedEssenceCount, 0 - 89
                                                 QuestSuccess:
                                                     - InqOwnsItems: Lesser Corrupted Essence (44469), 10
                                                         TestSuccess:


### PR DESCRIPTION
Bug repro: Will use Tyrina of Arwic (33673) for this example. Have character A with 10 Lesser Corrupted Essences (44469) and a non-existent or expired turn-in timer (CorruptedEssenceTurnInTimer). Have character B with a lesser corrupted essence. Initiate a turn-in with character A, leading to an InqYesNo prompt. Place character B behind Tyrina and hand in an essence. While she doing her TurnToTarget towards character B, click No on character A's prompt. This will fail since she is currently busy. This will result in putting character A on timer, but with no CorruptedEssenceCount value (since it was erased earlier in the interaction). Since there is no valid emote path for 0 count and active timer, they will be locked out from turning in any essences until the timer expires. 
This simply lowers the lower bound of the last CorruptedEssenceCount check to 0.