### PR TITLE
On Strike Quest

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/519C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/519C.sql
@@ -1,0 +1,5 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x519C;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7519C000, 47840, 0x519C0009, 26.1896, 19.4786, 0.301933, 0.973678, 0, 0, 0.227926, False, '2023-03-12 13:16:19'); /* Colton Reeyan's Sanctuary */
+/* @teleloc 0x519C0009 [26.189600 19.478600 0.301933] 0.973678 0.000000 0.000000 0.227926 */

--- a/Database/Patches/6 LandBlockExtendedData/5860.sql
+++ b/Database/Patches/6 LandBlockExtendedData/5860.sql
@@ -130,7 +130,7 @@ VALUES (0x7586000B, 72978, 0x58600321, 175.412, -104.922, 30.001, 0.707107, 0, 0
 /* @teleloc 0x58600321 [175.412003 -104.921997 30.000999] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7586000C, 72990, 0x58600314, 164.75, -110.002, 30.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:34:56'); /* Door */
+VALUES (0x7586000C, 72990, 0x58600314, 164.75, -110.002, 30.055, 0.707107, 0, 0, -0.707107, True, '2023-03-12 19:34:56'); /* Door */
 /* @teleloc 0x58600314 [164.750000 -110.001999 30.055000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -166,15 +166,18 @@ VALUES (0x75860014,   278, 0x58600175, 110, -114.752, 0.055, 0, 0, 0, -1, False,
 /* @teleloc 0x58600175 [110.000000 -114.751999 0.055000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860015,   278, 0x586002C8, 44.75, -160, 30.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:39:10'); /* Door */
+VALUES (0x75860015, 72990, 0x586002C8, 44.75, -160, 30.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:39:10'); /* Door */
 /* @teleloc 0x586002C8 [44.750000 -160.000000 30.055000] 0.707107 0.000000 0.000000 -0.707107 */
 
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x75860015, 0x75860017, '2023-03-12 18:38:00') /* Door (72990) */;
+
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860016,   278, 0x58600338, 195.25, -100, 30.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:39:40'); /* Door */
+VALUES (0x75860016, 72990, 0x58600338, 195.25, -100, 30.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:39:40'); /* Door */
 /* @teleloc 0x58600338 [195.250000 -100.000000 30.055000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860017, 72990, 0x586002ED, 75.25, -150.002, 30.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:39:59'); /* Door */
+VALUES (0x75860017, 72990, 0x586002ED, 75.25, -150.002, 30.055, 0.707107, 0, 0, 0.707107,  True, '2023-03-12 19:39:59'); /* Door */
 /* @teleloc 0x586002ED [75.250000 -150.001999 30.055000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -350,12 +353,12 @@ VALUES (0x7586004A,  7924, 0x586002E5, 68.3688, -161.721, 30.055, 1, 0, 0, 0, Fa
 /* @teleloc 0x586002E5 [68.368797 -161.720993 30.055000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7586004A, 0x7586007B, '2023-03-13 17:11:21') /* Mosswart Director (72971) */
-     , (0x7586004A, 0x7586007C, '2023-03-13 17:11:52') /* Mosswart Grunt (72973) */
-     , (0x7586004A, 0x7586007D, '2023-03-13 17:12:59') /* Mosswart Grunt (72973) */
-     , (0x7586004A, 0x7586007E, '2023-03-13 17:15:44') /* Mosswart Director (72993) */
-     , (0x7586004A, 0x75860080, '2023-03-13 17:16:34') /* Mosswart Worker (72972) */
-     , (0x7586004A, 0x75860081, '2023-03-13 17:17:19') /* Mosswart Worker (72972) */;
+VALUES (0x7586004A, 0x75860089, '2023-03-16 11:26:51') /* Mosswart Director (72971) */
+     , (0x7586004A, 0x7586008A, '2023-03-16 11:27:11') /* Mosswart Grunt (72973) */
+     , (0x7586004A, 0x7586008B, '2023-03-16 11:27:17') /* Mosswart Grunt (72973) */
+     , (0x7586004A, 0x7586008C, '2023-03-16 11:43:19') /* Mosswart Director (72993) */
+     , (0x7586004A, 0x7586008D, '2023-03-16 11:43:32') /* Mosswart Worker (72972) */
+     , (0x7586004A, 0x7586008E, '2023-03-16 11:43:38') /* Mosswart Worker (72972) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7586004C, 72983, 0x586001C6, 179.933, -149.9, 0.008, 0.999978, 0, 0, -0.006575,  True, '2023-03-12 21:14:00'); /* Scavenging Rat */
@@ -494,25 +497,28 @@ VALUES (0x75860074, 72972, 0x58600197, 125.659, 0.775438, 0.0066, 0.760228, 0, 0
 /* @teleloc 0x58600197 [125.658997 0.775438 0.006600] 0.760228 0.000000 0.000000 -0.649656 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7586007B, 72971, 0x586002E1, 64.3331, -167.531, 30.0066, 0.849241, 0, 0, 0.528005,  True, '2023-03-13 17:11:21'); /* Mosswart Director */
-/* @teleloc 0x586002E1 [64.333099 -167.531006 30.006599] 0.849241 0.000000 0.000000 0.528005 */
+VALUES (0x75860089, 72971, 0x586002E4, 72.0681, -149.967, 30.0066, 0.707107, 0, 0, 0.707107,  True, '2023-03-16 11:26:51'); /* Mosswart Director */
+/* @teleloc 0x586002E4 [72.068100 -149.966995 30.006599] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7586007C, 72973, 0x586002E0, 55.8266, -155.855, 30.0066, 0.540907, 0, 0, 0.841082,  True, '2023-03-13 17:11:52'); /* Mosswart Grunt */
-/* @teleloc 0x586002E0 [55.826599 -155.854996 30.006599] 0.540907 0.000000 0.000000 0.841082 */
+VALUES (0x7586008A, 72973, 0x586002E4, 72.6687, -148.335, 30.0066, 0.707107, 0, 0, 0.707107,  True, '2023-03-16 11:27:11'); /* Mosswart Grunt */
+/* @teleloc 0x586002E4 [72.668701 -148.335007 30.006599] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7586007D, 72973, 0x586002E4, 65.8775, -154.163, 30.0066, -0.930656, 0, 0, -0.365896,  True, '2023-03-13 17:12:59'); /* Mosswart Grunt */
-/* @teleloc 0x586002E4 [65.877502 -154.162994 30.006599] -0.930656 0.000000 0.000000 -0.365896 */
+VALUES (0x7586008B, 72973, 0x586002E4, 72.7294, -151.588, 30.0066, 0.707107, 0, 0, 0.707107,  True, '2023-03-16 11:27:17'); /* Mosswart Grunt */
+/* @teleloc 0x586002E4 [72.729401 -151.587997 30.006599] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7586007E, 72993, 0x58600320, 182.363, -94.112, 30.0066, 0.530233, 0, 0, -0.847852,  True, '2023-03-13 17:15:44'); /* Mosswart Director */
-/* @teleloc 0x58600320 [182.363007 -94.112000 30.006599] 0.530233 0.000000 0.000000 -0.847852 */
+VALUES (0x7586008C, 72993, 0x5860031D, 167.814, -110.102, 30.0066, 0.707107, 0, 0, -0.707107,  True, '2023-03-16 11:43:19'); /* Mosswart Director */
+/* @teleloc 0x5860031D [167.813995 -110.101997 30.006599] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860080, 72972, 0x58600322, 181.084, -107.71, 30.0066, 0.853437, 0, 0, 0.521196,  True, '2023-03-13 17:16:34'); /* Mosswart Worker */
-/* @teleloc 0x58600322 [181.084000 -107.709999 30.006599] 0.853437 0.000000 0.000000 0.521196 */
+VALUES (0x7586008D, 72972, 0x5860031D, 166.692, -111.743, 30.0066, 0.707107, 0, 0, -0.707107,  True, '2023-03-16 11:43:32'); /* Mosswart Worker */
+/* @teleloc 0x5860031D [166.692001 -111.742996 30.006599] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860081, 72972, 0x5860031B, 172.255, -90.8424, 30.0066, -0.500755, 0, 0, 0.865589,  True, '2023-03-13 17:17:19'); /* Mosswart Worker */
-/* @teleloc 0x5860031B [172.255005 -90.842400 30.006599] -0.500755 0.000000 0.000000 0.865589 */
+VALUES (0x7586008E, 72972, 0x5860031D, 166.607, -108.225, 30.0066, 0.707107, 0, 0, -0.707107,  True, '2023-03-16 11:43:38'); /* Mosswart Worker */
+/* @teleloc 0x5860031D [166.606995 -108.224998 30.006599] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x75860016, 0x7586000C, '2023-03-12 18:38:00') /* Door (72990) */;

--- a/Database/Patches/6 LandBlockExtendedData/5860.sql
+++ b/Database/Patches/6 LandBlockExtendedData/5860.sql
@@ -1,0 +1,518 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x5860;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860000,  7923, 0x58600195, 120.778, -152.623, 0.055, 1, 0, 0, 0, False, '2023-03-12 15:25:38'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x58600195 [120.778000 -152.623001 0.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x75860000, 0x75860004, '2023-03-12 15:55:49') /* Mosswart Messenger (72970) */
+     , (0x75860000, 0x7586001D, '2023-03-12 20:41:09') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586001E, '2023-03-12 20:41:41') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586001F, '2023-03-12 20:42:06') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860020, '2023-03-12 20:43:12') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860021, '2023-03-12 20:44:38') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860022, '2023-03-12 20:44:52') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860025, '2023-03-12 20:46:31') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860026, '2023-03-12 20:46:47') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860027, '2023-03-12 20:47:40') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860028, '2023-03-12 20:48:25') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860029, '2023-03-12 20:50:12') /* Mosswart Tribesman (72982) */
+     , (0x75860000, 0x7586002A, '2023-03-12 20:50:51') /* Mosswart Tribesman (72982) */
+     , (0x75860000, 0x7586002B, '2023-03-12 20:51:20') /* Mosswart Tribesman (72982) */
+     , (0x75860000, 0x7586002C, '2023-03-12 20:51:42') /* Mosswart Tribesman (72982) */
+     , (0x75860000, 0x7586002D, '2023-03-12 20:52:03') /* Mosswart Tribesman (72982) */
+     , (0x75860000, 0x7586002E, '2023-03-12 20:52:28') /* Mosswart Tribesman (72982) */
+     , (0x75860000, 0x7586002F, '2023-03-12 20:55:36') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860031, '2023-03-12 20:56:23') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860032, '2023-03-12 20:56:53') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860033, '2023-03-12 20:57:13') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860034, '2023-03-12 20:57:37') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860035, '2023-03-12 20:57:54') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860036, '2023-03-12 20:58:51') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860037, '2023-03-12 20:59:29') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860038, '2023-03-12 20:59:39') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586003A, '2023-03-12 21:00:23') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586003B, '2023-03-12 21:01:09') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586003C, '2023-03-12 21:01:30') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586003D, '2023-03-12 21:01:40') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586003E, '2023-03-12 21:02:04') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586003F, '2023-03-12 21:02:27') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860040, '2023-03-12 21:02:42') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860041, '2023-03-12 21:05:10') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860042, '2023-03-12 21:05:24') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860043, '2023-03-12 21:06:29') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860044, '2023-03-12 21:06:42') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860045, '2023-03-12 21:06:50') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860046, '2023-03-12 21:07:00') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860047, '2023-03-12 21:07:52') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x7586004C, '2023-03-12 21:14:00') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x7586004F, '2023-03-12 21:16:12') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860050, '2023-03-12 21:17:04') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860051, '2023-03-12 21:17:35') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860052, '2023-03-12 21:17:45') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860053, '2023-03-12 21:18:05') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860054, '2023-03-12 21:18:18') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860055, '2023-03-12 21:18:32') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860056, '2023-03-12 21:19:18') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860057, '2023-03-12 21:20:03') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860058, '2023-03-12 21:20:23') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860059, '2023-03-12 21:20:39') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586005A, '2023-03-12 21:22:05') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586005B, '2023-03-12 21:22:37') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x7586005C, '2023-03-12 21:22:50') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586005D, '2023-03-12 21:23:06') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586005E, '2023-03-12 21:23:23') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x7586005F, '2023-03-12 21:23:39') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860060, '2023-03-12 21:24:01') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860063, '2023-03-12 21:26:16') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860064, '2023-03-12 21:26:45') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860065, '2023-03-12 21:27:18') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860066, '2023-03-12 21:27:27') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860067, '2023-03-12 21:27:45') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860068, '2023-03-12 21:28:11') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860069, '2023-03-12 21:29:27') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x7586006D, '2023-03-12 21:33:23') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586006E, '2023-03-12 21:33:47') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x7586006F, '2023-03-12 21:34:04') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860070, '2023-03-12 21:34:17') /* Mosswart Grunt (72973) */
+     , (0x75860000, 0x75860071, '2023-03-12 21:34:43') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860072, '2023-03-12 21:35:53') /* Mosswart Worker (72972) */
+     , (0x75860000, 0x75860073, '2023-03-12 21:36:46') /* Scavenging Rat (72983) */
+     , (0x75860000, 0x75860074, '2023-03-12 21:37:45') /* Mosswart Worker (72972) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860001, 72981, 0x586001AC, 130, -108.482, -0.063, 1, 0, 0, 0, False, '2023-03-12 15:51:40'); /* Surface */
+/* @teleloc 0x586001AC [130.000000 -108.482002 -0.063000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860002, 72981, 0x58600173, 110, -108.482, -0.063, 1, 0, 0, 0, False, '2023-03-12 15:51:54'); /* Surface */
+/* @teleloc 0x58600173 [110.000000 -108.482002 -0.063000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860003,  4139, 0x58600194, 119.998, -144.752, 0.055, 0, 0, 0, -1, False, '2023-03-12 15:53:39'); /* Door */
+/* @teleloc 0x58600194 [119.998001 -144.751999 0.055000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860004, 72970, 0x58600195, 119.998, -146.965, 0.0066, 0, 0, 0, -1,  True, '2023-03-12 15:55:49'); /* Mosswart Messenger */
+/* @teleloc 0x58600195 [119.998001 -146.964996 0.006600] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860005, 72984, 0x586002E7, 69.9805, -175.285, 30.055, 1, 0, 0, 0, False, '2023-03-12 17:22:21'); /* Shady's Cage Door */
+/* @teleloc 0x586002E7 [69.980499 -175.285004 30.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860006, 15274, 0x58600195, 122.492, -152.586, 0.055, 1, 0, 0, 0, False, '2023-03-12 18:35:06'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x58600195 [122.491997 -152.585999 0.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x75860006, 0x75860007, '2023-03-12 18:38:00') /* Shady (72974) */
+     , (0x75860006, 0x75860008, '2023-03-12 18:54:56') /* Bubba (72976) */
+     , (0x75860006, 0x7586000B, '2023-03-12 19:00:53') /* Spot (72978) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860007, 72974, 0x586002DF, 60.6504, -147.502, 30.0042, 0, 0, 0, -1,  True, '2023-03-12 18:38:00'); /* Shady */
+/* @teleloc 0x586002DF [60.650398 -147.501999 30.004200] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860008, 72976, 0x58600197, 132.381, 1.81641, 0.0044, 0.382684, 0, 0, 0.92388,  True, '2023-03-12 18:54:56'); /* Bubba */
+/* @teleloc 0x58600197 [132.380997 1.816410 0.004400] 0.382684 0.000000 0.000000 0.923880 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860009, 72986, 0x5860015C, 104.779, -0.03125, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 18:56:54'); /* Bubba's Cage Door */
+/* @teleloc 0x5860015C [104.778999 -0.031250 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586000A, 72988, 0x5860031A, 170.01, -84.7305, 30.055, 1, 0, 0, 0, False, '2023-03-12 18:58:23'); /* Spot's Cage Door */
+/* @teleloc 0x5860031A [170.009995 -84.730499 30.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586000B, 72978, 0x58600321, 175.412, -104.922, 30.001, 0.707107, 0, 0, -0.707107,  True, '2023-03-12 19:00:53'); /* Spot */
+/* @teleloc 0x58600321 [175.412003 -104.921997 30.000999] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586000C, 72990, 0x58600314, 164.75, -110.002, 30.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:34:56'); /* Door */
+/* @teleloc 0x58600314 [164.750000 -110.001999 30.055000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586000D,   278, 0x58600168, 114.754, -60.0019, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:35:32'); /* Door */
+/* @teleloc 0x58600168 [114.753998 -60.001900 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586000E,   278, 0x5860016E, 114.754, -80.002, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:35:58'); /* Door */
+/* @teleloc 0x5860016E [114.753998 -80.001999 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586000F,   278, 0x586001A4, 125.244, -70, 0.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:36:22'); /* Door */
+/* @teleloc 0x586001A4 [125.244003 -70.000000 0.055000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860010,   278, 0x586001AE, 130, -114.752, 0.055, 0, 0, 0, -1, False, '2023-03-12 19:37:07'); /* Door */
+/* @teleloc 0x586001AE [130.000000 -114.751999 0.055000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860011,   278, 0x5860016B, 114.754, -70, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:37:32'); /* Door */
+/* @teleloc 0x5860016B [114.753998 -70.000000 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860012,   278, 0x586001A1, 125.244, -60.0019, 0.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:37:50'); /* Door */
+/* @teleloc 0x586001A1 [125.244003 -60.001900 0.055000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860013,   278, 0x586001A7, 125.244, -80.002, 0.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:38:09'); /* Door */
+/* @teleloc 0x586001A7 [125.244003 -80.001999 0.055000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860014,   278, 0x58600175, 110, -114.752, 0.055, 0, 0, 0, -1, False, '2023-03-12 19:38:29'); /* Door */
+/* @teleloc 0x58600175 [110.000000 -114.751999 0.055000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860015,   278, 0x586002C8, 44.75, -160, 30.055, 0.707107, 0, 0, -0.707107, False, '2023-03-12 19:39:10'); /* Door */
+/* @teleloc 0x586002C8 [44.750000 -160.000000 30.055000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860016,   278, 0x58600338, 195.25, -100, 30.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:39:40'); /* Door */
+/* @teleloc 0x58600338 [195.250000 -100.000000 30.055000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860017, 72990, 0x586002ED, 75.25, -150.002, 30.055, 0.707107, 0, 0, 0.707107, False, '2023-03-12 19:39:59'); /* Door */
+/* @teleloc 0x586002ED [75.250000 -150.001999 30.055000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860018, 30764, 0x5860025D, 100, -150, 12.055, 1, 0, 0, 0, False, '2023-03-12 19:56:20'); /* "Mag-Ma!" */
+/* @teleloc 0x5860025D [100.000000 -150.000000 12.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860019, 30764, 0x5860025F, 110, -140, 12.055, 1, 0, 0, 0, False, '2023-03-12 19:57:51'); /* "Mag-Ma!" */
+/* @teleloc 0x5860025F [110.000000 -140.000000 12.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586001A, 30764, 0x58600261, 140, -110, 12.055, 1, 0, 0, 0, False, '2023-03-12 20:03:41'); /* "Mag-Ma!" */
+/* @teleloc 0x58600261 [140.000000 -110.000000 12.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586001D, 72973, 0x586002EE, 85.3398, -69.8301, 30.0066, 1, 0, 0, 0,  True, '2023-03-12 20:41:09'); /* Mosswart Grunt */
+/* @teleloc 0x586002EE [85.339798 -69.830101 30.006599] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586001E, 72973, 0x58600313, 149.962, -190.056, 30.0066, 1, 0, 0, 0,  True, '2023-03-12 20:41:41'); /* Mosswart Grunt */
+/* @teleloc 0x58600313 [149.962006 -190.056000 30.006599] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586001F, 72973, 0x586001DE, 200.229, -189.996, 0.0066, 0.707769, 0, 0, -0.706444,  True, '2023-03-12 20:42:06'); /* Mosswart Grunt */
+/* @teleloc 0x586001DE [200.229004 -189.996002 0.006600] 0.707769 0.000000 0.000000 -0.706444 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860020, 72973, 0x5860015E, 110.197, -2.87354, 0.0066, 0.707107, 0, 0, -0.707107,  True, '2023-03-12 20:43:12'); /* Mosswart Grunt */
+/* @teleloc 0x5860015E [110.196999 -2.873540 0.006600] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860021, 72973, 0x586002F0, 90.0215, -89.1914, 30.0066, 1, 0, 0, 0,  True, '2023-03-12 20:44:38'); /* Mosswart Grunt */
+/* @teleloc 0x586002F0 [90.021500 -89.191399 30.006599] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860022, 72973, 0x5860013C, 49.9766, -79.248, 0.0066, 1, 0, 0, 0,  True, '2023-03-12 20:44:52'); /* Mosswart Grunt */
+/* @teleloc 0x5860013C [49.976601 -79.248001 0.006600] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860025, 72973, 0x58600305, 141.476, -142.53, 30.0066, 0.908262, 0, 0, -0.418402,  True, '2023-03-12 20:46:31'); /* Mosswart Grunt */
+/* @teleloc 0x58600305 [141.475998 -142.529999 30.006599] 0.908262 0.000000 0.000000 -0.418402 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860026, 72973, 0x586001D1, 190.9, -182.168, 0.0066, 1, 0, 0, 0,  True, '2023-03-12 20:46:47'); /* Mosswart Grunt */
+/* @teleloc 0x586001D1 [190.899994 -182.167999 0.006600] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860027, 72973, 0x5860030A, 149.979, -143.317, 30.0066, 0.002006, 0, 0, -0.999998,  True, '2023-03-12 20:47:40'); /* Mosswart Grunt */
+/* @teleloc 0x5860030A [149.979004 -143.317001 30.006599] 0.002006 0.000000 0.000000 -0.999998 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860028, 72973, 0x586002F7, 87.9163, -117.967, 30.0066, -0.511855, 0, 0, -0.859072,  True, '2023-03-12 20:48:25'); /* Mosswart Grunt */
+/* @teleloc 0x586002F7 [87.916298 -117.967003 30.006599] -0.511855 0.000000 0.000000 -0.859072 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860029, 72982, 0x58600255, 49.9727, -174.119, 12.0066, 0, 0, 0, -1,  True, '2023-03-12 20:50:12'); /* Mosswart Tribesman */
+/* @teleloc 0x58600255 [49.972698 -174.119003 12.006600] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586002A, 72982, 0x5860025B, 55.8223, -190.047, 12.0066, 0.707107, 0, 0, 0.707107,  True, '2023-03-12 20:50:51'); /* Mosswart Tribesman */
+/* @teleloc 0x5860025B [55.822300 -190.046997 12.006600] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586002B, 72982, 0x58600259, 49.9062, -205.867, 12.0066, 1, 0, 0, 0,  True, '2023-03-12 20:51:20'); /* Mosswart Tribesman */
+/* @teleloc 0x58600259 [49.906200 -205.867004 12.006600] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586002C, 72982, 0x58600263, 184.121, -69.9473, 12.0066, 0.707107, 0, 0, -0.707107,  True, '2023-03-12 20:51:42'); /* Mosswart Tribesman */
+/* @teleloc 0x58600263 [184.121002 -69.947304 12.006600] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586002D, 72982, 0x58600269, 190.02, -85.8574, 12.0066, 1, 0, 0, 0,  True, '2023-03-12 20:52:03'); /* Mosswart Tribesman */
+/* @teleloc 0x58600269 [190.020004 -85.857399 12.006600] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586002E, 72982, 0x58600265, 190.055, -54.168, 12.0066, 0, 0, 0, -1,  True, '2023-03-12 20:52:28'); /* Mosswart Tribesman */
+/* @teleloc 0x58600265 [190.054993 -54.167999 12.006600] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586002F, 72972, 0x5860014F, 71.6306, -130.004, 0.0066, 0.714427, 0, 0, -0.69971,  True, '2023-03-12 20:55:36'); /* Mosswart Worker */
+/* @teleloc 0x5860014F [71.630600 -130.003998 0.006600] 0.714427 0.000000 0.000000 -0.699710 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860031, 72972, 0x58600148, 59.9644, -124.86, 0.0066, 0.005601, 0, 0, 0.999984,  True, '2023-03-12 20:56:23'); /* Mosswart Worker */
+/* @teleloc 0x58600148 [59.964401 -124.860001 0.006600] 0.005601 0.000000 0.000000 0.999984 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860032, 72972, 0x58600134, 37.5296, -144.17, 0.0066, -0.401968, 0, 0, 0.915654,  True, '2023-03-12 20:56:53'); /* Mosswart Worker */
+/* @teleloc 0x58600134 [37.529598 -144.169998 0.006600] -0.401968 0.000000 0.000000 0.915654 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860033, 72972, 0x58600136, 35.7987, -157.613, 0.0066, 0.907591, 0, 0, -0.419856,  True, '2023-03-12 20:57:13'); /* Mosswart Worker */
+/* @teleloc 0x58600136 [35.798698 -157.613007 0.006600] 0.907591 0.000000 0.000000 -0.419856 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860034, 72972, 0x5860010B, 6.14997, -149.961, 0.0066, 0.704146, 0, 0, -0.710056,  True, '2023-03-12 20:57:37'); /* Mosswart Worker */
+/* @teleloc 0x5860010B [6.149970 -149.960999 0.006600] 0.704146 0.000000 0.000000 -0.710056 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860035, 72972, 0x5860010F, 10.0232, -169.962, 0.0066, -0.999868, 0, 0, 0.016245,  True, '2023-03-12 20:57:54'); /* Mosswart Worker */
+/* @teleloc 0x5860010F [10.023200 -169.962006 0.006600] -0.999868 0.000000 0.000000 0.016245 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860036, 72983, 0x58600122, 19.9587, -189.563, 0.008, 1, 0, 0, 0,  True, '2023-03-12 20:58:51'); /* Scavenging Rat */
+/* @teleloc 0x58600122 [19.958700 -189.563004 0.008000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860037, 72972, 0x58600143, 49.2087, -182.585, 0.0066, -0.436899, 0, 0, -0.89951,  True, '2023-03-12 20:59:29'); /* Mosswart Worker */
+/* @teleloc 0x58600143 [49.208698 -182.585007 0.006600] -0.436899 0.000000 0.000000 -0.899510 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860038, 72972, 0x58600143, 46.2948, -181.15, 0.0066, 0.306663, 0, 0, -0.951818,  True, '2023-03-12 20:59:39'); /* Mosswart Worker */
+/* @teleloc 0x58600143 [46.294800 -181.149994 0.006600] 0.306663 0.000000 0.000000 -0.951818 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586003A, 72973, 0x58600138, 42.3739, -194.363, 0.0066, -0.949773, 0, 0, 0.31294,  True, '2023-03-12 21:00:23'); /* Mosswart Grunt */
+/* @teleloc 0x58600138 [42.373901 -194.363007 0.006600] -0.949773 0.000000 0.000000 0.312940 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586003B, 72973, 0x5860012A, 26.611, -150.024, 0.0066, 0.704812, 0, 0, -0.709394,  True, '2023-03-12 21:01:09'); /* Mosswart Grunt */
+/* @teleloc 0x5860012A [26.611000 -150.024002 0.006600] 0.704812 0.000000 0.000000 -0.709394 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586003C, 72973, 0x58600126, 30.3025, -102.926, 0.0066, 0.89634, 0, 0, 0.443367,  True, '2023-03-12 21:01:30'); /* Mosswart Grunt */
+/* @teleloc 0x58600126 [30.302500 -102.926003 0.006600] 0.896340 0.000000 0.000000 0.443367 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586003D, 72972, 0x58600126, 31.7303, -100.673, 0.0066, 0.689968, 0, 0, 0.72384,  True, '2023-03-12 21:01:40'); /* Mosswart Worker */
+/* @teleloc 0x58600126 [31.730301 -100.672997 0.006600] 0.689968 0.000000 0.000000 0.723840 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586003E, 72972, 0x58600132, 38.3489, -114.985, 0.0066, -0.889976, 0, 0, 0.456007,  True, '2023-03-12 21:02:04'); /* Mosswart Worker */
+/* @teleloc 0x58600132 [38.348900 -114.985001 0.006600] -0.889976 0.000000 0.000000 0.456007 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586003F, 72983, 0x58600109, 6.78239, -110.009, 0.008, -0.704274, 0, 0, 0.709928,  True, '2023-03-12 21:02:27'); /* Scavenging Rat */
+/* @teleloc 0x58600109 [6.782390 -110.009003 0.008000] -0.704274 0.000000 0.000000 0.709928 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860040, 72983, 0x58600115, 20.0514, -89.7883, 0.008, 0.008083, 0, 0, 0.999967,  True, '2023-03-12 21:02:42'); /* Scavenging Rat */
+/* @teleloc 0x58600115 [20.051399 -89.788300 0.008000] 0.008083 0.000000 0.000000 0.999967 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860041, 72972, 0x586002EC, 80.2, -119.96, 30.0066, 0.714358, 0, 0, -0.699781,  True, '2023-03-12 21:05:10'); /* Mosswart Worker */
+/* @teleloc 0x586002EC [80.199997 -119.959999 30.006599] 0.714358 0.000000 0.000000 -0.699781 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860042, 72972, 0x586002F6, 90.0053, -108.302, 30.0066, -1, 0, 0, 0.000368,  True, '2023-03-12 21:05:24'); /* Mosswart Worker */
+/* @teleloc 0x586002F6 [90.005302 -108.302002 30.006599] -1.000000 0.000000 0.000000 0.000368 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860043, 72983, 0x586002D9, 60.0522, -114.414, 30.008, 0.003904, 0, 0, -0.999992,  True, '2023-03-12 21:06:29'); /* Scavenging Rat */
+/* @teleloc 0x586002D9 [60.052200 -114.414001 30.007999] 0.003904 0.000000 0.000000 -0.999992 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860044, 72983, 0x586002C4, 40.0142, -119.936, 30.008, 0.699126, 0, 0, -0.714999,  True, '2023-03-12 21:06:42'); /* Scavenging Rat */
+/* @teleloc 0x586002C4 [40.014198 -119.935997 30.007999] 0.699126 0.000000 0.000000 -0.714999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860045, 72983, 0x586002B8, 29.9821, -129.83, 30.008, -0.005053, 0, 0, -0.999987,  True, '2023-03-12 21:06:50'); /* Scavenging Rat */
+/* @teleloc 0x586002B8 [29.982100 -129.830002 30.007999] -0.005053 0.000000 0.000000 -0.999987 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860046, 72983, 0x586002B1, 20.1315, -139.933, 30.008, 0.696097, 0, 0, -0.717948,  True, '2023-03-12 21:07:00'); /* Scavenging Rat */
+/* @teleloc 0x586002B1 [20.131500 -139.932999 30.007999] 0.696097 0.000000 0.000000 -0.717948 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860047, 72983, 0x586002AF, 10.101, -150.082, 30.008, 0.99998, 0, 0, 0.006255,  True, '2023-03-12 21:07:52'); /* Scavenging Rat */
+/* @teleloc 0x586002AF [10.101000 -150.082001 30.007999] 0.999980 0.000000 0.000000 0.006255 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586004A,  7924, 0x586002E5, 68.3688, -161.721, 30.055, 1, 0, 0, 0, False, '2023-03-12 21:11:32'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x586002E5 [68.368797 -161.720993 30.055000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7586004A, 0x7586007B, '2023-03-13 17:11:21') /* Mosswart Director (72971) */
+     , (0x7586004A, 0x7586007C, '2023-03-13 17:11:52') /* Mosswart Grunt (72973) */
+     , (0x7586004A, 0x7586007D, '2023-03-13 17:12:59') /* Mosswart Grunt (72973) */
+     , (0x7586004A, 0x7586007E, '2023-03-13 17:15:44') /* Mosswart Director (72993) */
+     , (0x7586004A, 0x75860080, '2023-03-13 17:16:34') /* Mosswart Worker (72972) */
+     , (0x7586004A, 0x75860081, '2023-03-13 17:17:19') /* Mosswart Worker (72972) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586004C, 72983, 0x586001C6, 179.933, -149.9, 0.008, 0.999978, 0, 0, -0.006575,  True, '2023-03-12 21:14:00'); /* Scavenging Rat */
+/* @teleloc 0x586001C6 [179.932999 -149.899994 0.008000] 0.999978 0.000000 0.000000 -0.006575 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586004F, 72972, 0x586001C2, 180.093, -130.043, 0.0066, 0.707107, 0, 0, 0.707107,  True, '2023-03-12 21:16:12'); /* Mosswart Worker */
+/* @teleloc 0x586001C2 [180.093002 -130.042999 0.006600] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860050, 72983, 0x586001CF, 190.005, -136.357, 0.008, 0.707107, 0, 0, -0.707107,  True, '2023-03-12 21:17:04'); /* Scavenging Rat */
+/* @teleloc 0x586001CF [190.005005 -136.356995 0.008000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860051, 72972, 0x586001E3, 205.012, -108.243, 0.0066, -0.57597, 0, 0, -0.817471,  True, '2023-03-12 21:17:35'); /* Mosswart Worker */
+/* @teleloc 0x586001E3 [205.011993 -108.242996 0.006600] -0.575970 0.000000 0.000000 -0.817471 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860052, 72972, 0x586001D8, 202.579, -105.818, 0.0066, -0.390606, 0, 0, -0.920558,  True, '2023-03-12 21:17:45'); /* Mosswart Worker */
+/* @teleloc 0x586001D8 [202.578995 -105.818001 0.006600] -0.390606 0.000000 0.000000 -0.920558 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860053, 72973, 0x586001E4, 209.156, -120.69, 0.0066, 0.89515, 0, 0, 0.445765,  True, '2023-03-12 21:18:05'); /* Mosswart Grunt */
+/* @teleloc 0x586001E4 [209.156006 -120.690002 0.006600] 0.895150 0.000000 0.000000 0.445765 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860054, 72973, 0x58600201, 230.073, -110.01, 0.0066, 0.711388, 0, 0, 0.702799,  True, '2023-03-12 21:18:18'); /* Mosswart Grunt */
+/* @teleloc 0x58600201 [230.072998 -110.010002 0.006600] 0.711388 0.000000 0.000000 0.702799 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860055, 72983, 0x586001F0, 219.797, -100.003, 0.008, -0.697199, 0, 0, 0.716878,  True, '2023-03-12 21:18:32'); /* Scavenging Rat */
+/* @teleloc 0x586001F0 [219.796997 -100.002998 0.008000] -0.697199 0.000000 0.000000 0.716878 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860056, 72972, 0x586001FD, 230.059, -90.2936, 0.0066, 0, 0, 0, -1,  True, '2023-03-12 21:19:18'); /* Mosswart Worker */
+/* @teleloc 0x586001FD [230.059006 -90.293602 0.006600] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860057, 72972, 0x586001D5, 198.554, -66.4912, 0.0066, 0.451115, 0, 0, 0.892466,  True, '2023-03-12 21:20:03'); /* Mosswart Worker */
+/* @teleloc 0x586001D5 [198.554001 -66.491203 0.006600] 0.451115 0.000000 0.000000 0.892466 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860058, 72972, 0x586001D5, 196.704, -74.9948, 0.0066, -0.896267, 0, 0, 0.443515,  True, '2023-03-12 21:20:23'); /* Mosswart Worker */
+/* @teleloc 0x586001D5 [196.703995 -74.994797 0.006600] -0.896267 0.000000 0.000000 0.443515 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860059, 72973, 0x586001C8, 191.814, -61.6465, 0.0066, -0.493929, 0, 0, 0.869502,  True, '2023-03-12 21:20:39'); /* Mosswart Grunt */
+/* @teleloc 0x586001C8 [191.813995 -61.646500 0.006600] -0.493929 0.000000 0.000000 0.869502 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586005A, 72973, 0x586001E7, 209.2, -160.842, 0.0066, -0.891168, 0, 0, -0.453674,  True, '2023-03-12 21:22:05'); /* Mosswart Grunt */
+/* @teleloc 0x586001E7 [209.199997 -160.841995 0.006600] -0.891168 0.000000 0.000000 -0.453674 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586005B, 72973, 0x586001DB, 204.95, -149.978, 0.0066, -0.687192, 0, 0, -0.726476,  True, '2023-03-12 21:22:37'); /* Mosswart Grunt */
+/* @teleloc 0x586001DB [204.949997 -149.977997 0.006600] -0.687192 0.000000 0.000000 -0.726476 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586005C, 72972, 0x586001E5, 209.958, -138.306, 0.0066, -0.391552, 0, 0, -0.920156,  True, '2023-03-12 21:22:50'); /* Mosswart Worker */
+/* @teleloc 0x586001E5 [209.957993 -138.306000 0.006600] -0.391552 0.000000 0.000000 -0.920156 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586005D, 72972, 0x58600203, 229.912, -150.005, 0.0066, -0.704119, 0, 0, -0.710082,  True, '2023-03-12 21:23:06'); /* Mosswart Worker */
+/* @teleloc 0x58600203 [229.912003 -150.005005 0.006600] -0.704119 0.000000 0.000000 -0.710082 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586005E, 72983, 0x586001F5, 219.939, -160.074, 0.008, -0.999979, 0, 0, 0.006533,  True, '2023-03-12 21:23:23'); /* Scavenging Rat */
+/* @teleloc 0x586001F5 [219.938995 -160.074005 0.008000] -0.999979 0.000000 0.000000 0.006533 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586005F, 72983, 0x586001F7, 219.825, -169.986, 0.008, 0.701847, 0, 0, -0.712328,  True, '2023-03-12 21:23:39'); /* Scavenging Rat */
+/* @teleloc 0x586001F7 [219.824997 -169.985992 0.008000] 0.701847 0.000000 0.000000 -0.712328 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860060, 72983, 0x586001F9, 219.903, -181.596, 0.008, -0.999791, 0, 0, 0.02045,  True, '2023-03-12 21:24:01'); /* Scavenging Rat */
+/* @teleloc 0x586001F9 [219.903000 -181.595993 0.008000] -0.999791 0.000000 0.000000 0.020450 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860063, 72972, 0x5860030B, 154.963, -149.998, 30.0066, -0.416144, 0, 0, -0.909299,  True, '2023-03-12 21:26:16'); /* Mosswart Worker */
+/* @teleloc 0x5860030B [154.962997 -149.998001 30.006599] -0.416144 0.000000 0.000000 -0.909299 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860064, 72983, 0x58600318, 156.215, -170.058, 30.008, -0.716125, 0, 0, -0.697972,  True, '2023-03-12 21:26:45'); /* Scavenging Rat */
+/* @teleloc 0x58600318 [156.214996 -170.057999 30.007999] -0.716125 0.000000 0.000000 -0.697972 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860065, 72983, 0x5860033C, 199.738, -139.919, 30.008, 0.709142, 0, 0, 0.705066,  True, '2023-03-12 21:27:18'); /* Scavenging Rat */
+/* @teleloc 0x5860033C [199.738007 -139.919006 30.007999] 0.709142 0.000000 0.000000 0.705066 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860066, 72983, 0x58600348, 210.051, -129.991, 30.008, 0.703332, 0, 0, 0.710861,  True, '2023-03-12 21:27:27'); /* Scavenging Rat */
+/* @teleloc 0x58600348 [210.050995 -129.990997 30.007999] 0.703332 0.000000 0.000000 0.710861 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860067, 72972, 0x5860034F, 219.813, -119.962, 30.0066, 0.708433, 0, 0, 0.705778,  True, '2023-03-12 21:27:45'); /* Mosswart Worker */
+/* @teleloc 0x5860034F [219.813004 -119.961998 30.006599] 0.708433 0.000000 0.000000 0.705778 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860068, 72972, 0x58600351, 230.025, -110.028, 30.0066, -0.01537, 0, 0, -0.999882,  True, '2023-03-12 21:28:11'); /* Mosswart Worker */
+/* @teleloc 0x58600351 [230.024994 -110.028000 30.006599] -0.015370 0.000000 0.000000 -0.999882 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860069, 72983, 0x58600344, 210.129, -109.853, 30.008, 0.002724, 0, 0, -0.999996,  True, '2023-03-12 21:29:27'); /* Scavenging Rat */
+/* @teleloc 0x58600344 [210.128998 -109.852997 30.007999] 0.002724 0.000000 0.000000 -0.999996 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586006D, 72972, 0x586001A5, 130.343, -78.281, 0.0066, 0.578377, 0, 0, 0.815769,  True, '2023-03-12 21:33:23'); /* Mosswart Worker */
+/* @teleloc 0x586001A5 [130.343002 -78.280998 0.006600] 0.578377 0.000000 0.000000 0.815769 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586006E, 72972, 0x5860016C, 110.413, -81.2888, 0.0066, 0.827962, 0, 0, -0.560785,  True, '2023-03-12 21:33:47'); /* Mosswart Worker */
+/* @teleloc 0x5860016C [110.413002 -81.288803 0.006600] 0.827962 0.000000 0.000000 -0.560785 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586006F, 72973, 0x5860016C, 109.835, -78.341, 0.0066, 0.512071, 0, 0, -0.858943,  True, '2023-03-12 21:34:04'); /* Mosswart Grunt */
+/* @teleloc 0x5860016C [109.834999 -78.341003 0.006600] 0.512071 0.000000 0.000000 -0.858943 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860070, 72973, 0x586001A2, 130.289, -70.0635, 0.0066, -0.70988, 0, 0, -0.704323,  True, '2023-03-12 21:34:17'); /* Mosswart Grunt */
+/* @teleloc 0x586001A2 [130.289001 -70.063499 0.006600] -0.709880 0.000000 0.000000 -0.704323 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860071, 72983, 0x58600166, 109.991, -58.0405, 0.008, -0.509225, 0, 0, 0.860633,  True, '2023-03-12 21:34:43'); /* Scavenging Rat */
+/* @teleloc 0x58600166 [109.990997 -58.040501 0.008000] -0.509225 0.000000 0.000000 0.860633 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860072, 72972, 0x58600197, 127.685, -2.83834, 0.0066, 1, 0, 0, 0,  True, '2023-03-12 21:35:53'); /* Mosswart Worker */
+/* @teleloc 0x58600197 [127.684998 -2.838340 0.006600] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860073, 72983, 0x58600161, 113.425, -29.9579, 0.008, -0.702029, 0, 0, 0.712149,  True, '2023-03-12 21:36:46'); /* Scavenging Rat */
+/* @teleloc 0x58600161 [113.425003 -29.957899 0.008000] -0.702029 0.000000 0.000000 0.712149 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860074, 72972, 0x58600197, 125.659, 0.775438, 0.0066, 0.760228, 0, 0, -0.649656,  True, '2023-03-12 21:37:45'); /* Mosswart Worker */
+/* @teleloc 0x58600197 [125.658997 0.775438 0.006600] 0.760228 0.000000 0.000000 -0.649656 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586007B, 72971, 0x586002E1, 64.3331, -167.531, 30.0066, 0.849241, 0, 0, 0.528005,  True, '2023-03-13 17:11:21'); /* Mosswart Director */
+/* @teleloc 0x586002E1 [64.333099 -167.531006 30.006599] 0.849241 0.000000 0.000000 0.528005 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586007C, 72973, 0x586002E0, 55.8266, -155.855, 30.0066, 0.540907, 0, 0, 0.841082,  True, '2023-03-13 17:11:52'); /* Mosswart Grunt */
+/* @teleloc 0x586002E0 [55.826599 -155.854996 30.006599] 0.540907 0.000000 0.000000 0.841082 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586007D, 72973, 0x586002E4, 65.8775, -154.163, 30.0066, -0.930656, 0, 0, -0.365896,  True, '2023-03-13 17:12:59'); /* Mosswart Grunt */
+/* @teleloc 0x586002E4 [65.877502 -154.162994 30.006599] -0.930656 0.000000 0.000000 -0.365896 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586007E, 72993, 0x58600320, 182.363, -94.112, 30.0066, 0.530233, 0, 0, -0.847852,  True, '2023-03-13 17:15:44'); /* Mosswart Director */
+/* @teleloc 0x58600320 [182.363007 -94.112000 30.006599] 0.530233 0.000000 0.000000 -0.847852 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860080, 72972, 0x58600322, 181.084, -107.71, 30.0066, 0.853437, 0, 0, 0.521196,  True, '2023-03-13 17:16:34'); /* Mosswart Worker */
+/* @teleloc 0x58600322 [181.084000 -107.709999 30.006599] 0.853437 0.000000 0.000000 0.521196 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860081, 72972, 0x5860031B, 172.255, -90.8424, 30.0066, -0.500755, 0, 0, 0.865589,  True, '2023-03-13 17:17:19'); /* Mosswart Worker */
+/* @teleloc 0x5860031B [172.255005 -90.842400 30.006599] -0.500755 0.000000 0.000000 0.865589 */

--- a/Database/Patches/6 LandBlockExtendedData/5B9C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/5B9C.sql
@@ -75,3 +75,7 @@ VALUES (0x75B9C011, 42852, 0x5B9C002E, 123.944, 124.93, 14.198, 0.725315, 0, 0, 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x75B9C012, 37443, 0x5B9C001E, 85.3015, 122.469, 18.005, -0.689776, 0, 0, -0.724023, False, '2021-11-01 00:00:00'); /* Marcus Danby */
 /* @teleloc 0x5B9C001E [85.301498 122.469002 18.004999] -0.689776 0.000000 0.000000 -0.724023 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75B9C013, 47799, 0x5B9C001F, 87.4115, 149.268, 14.005, 0.015526, 0, 0, -0.99988, False, '2023-03-12 13:14:49'); /* Colton Reeyan */
+/* @teleloc 0x5B9C001F [87.411499 149.268005 14.005000] 0.015526 0.000000 0.000000 -0.999880 */

--- a/Database/Patches/8 QuestDefDB/DruggedMeat.sql
+++ b/Database/Patches/8 QuestDefDB/DruggedMeat.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'DruggedMeat';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('DruggedMeat', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/Petsave.sql
+++ b/Database/Patches/8 QuestDefDB/Petsave.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'Petsave';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('Petsave', 0, 7, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SaveAPetFinished_1212.sql
+++ b/Database/Patches/8 QuestDefDB/SaveAPetFinished_1212.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'SaveAPetFinished_1212';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('SaveAPetFinished_1212', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SaveAPetStarted_1212.sql
+++ b/Database/Patches/8 QuestDefDB/SaveAPetStarted_1212.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'SaveAPetStarted_1212';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('SaveAPetStarted_1212', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SavedBubba.sql
+++ b/Database/Patches/8 QuestDefDB/SavedBubba.sql
@@ -1,3 +1,0 @@
-DELETE FROM `quest` WHERE `name` = 'SavedBubba';
-INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('SavedBubba', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SavedBubba.sql
+++ b/Database/Patches/8 QuestDefDB/SavedBubba.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'SavedBubba';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('SavedBubba', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SavedShady.sql
+++ b/Database/Patches/8 QuestDefDB/SavedShady.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'SavedShady';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('SavedShady', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SavedShady.sql
+++ b/Database/Patches/8 QuestDefDB/SavedShady.sql
@@ -1,3 +1,0 @@
-DELETE FROM `quest` WHERE `name` = 'SavedShady';
-INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('SavedShady', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SavedSpot.sql
+++ b/Database/Patches/8 QuestDefDB/SavedSpot.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'SavedSpot';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('SavedSpot', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/SavedSpot.sql
+++ b/Database/Patches/8 QuestDefDB/SavedSpot.sql
@@ -1,3 +1,0 @@
-DELETE FROM `quest` WHERE `name` = 'SavedSpot';
-INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('SavedSpot', 0, 1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/8 QuestDefDB/WorkersMotivated.sql
+++ b/Database/Patches/8 QuestDefDB/WorkersMotivated.sql
@@ -1,0 +1,3 @@
+DELETE FROM `quest` WHERE `name` = 'WorkersMotivated';
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('WorkersMotivated', 0, 10, 'Counter for On Strike', '2020-01-24 19:57:17');

--- a/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974 Shady.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974 Shady.sql
@@ -1,0 +1,142 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72974;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72974, 'ace72974-shady', 10, '2023-03-12 06:41:41') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72974,   1,         16) /* ItemType - Creature */
+     , (72974,   2,         17) /* CreatureType - Armoredillo */
+     , (72974,   3,          2) /* PaletteTemplate - Brown */
+     , (72974,   6,         -1) /* ItemsCapacity */
+     , (72974,   7,         -1) /* ContainersCapacity */
+     , (72974,  16,         32) /* ItemUseable - Remote */
+     , (72974,  25,         80) /* Level */
+     , (72974,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72974,  95,          8) /* RadarBlipColor - Yellow */
+     , (72974, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72974, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72974, 146,      30000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72974,   1, True ) /* Stuck */
+     , (72974,   8, True ) /* AllowGive */
+     , (72974,  11, False) /* IgnoreCollisions */
+     , (72974,  12, True ) /* ReportCollisions */
+     , (72974,  13, False) /* Ethereal */
+     , (72974,  14, True ) /* GravityStatus */
+     , (72974,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72974,   1,       5) /* HeartbeatInterval */
+     , (72974,   2,       0) /* HeartbeatTimestamp */
+     , (72974,   3,     1.8) /* HealthRate */
+     , (72974,   4,     1.8) /* StaminaRate */
+     , (72974,   5,       2) /* ManaRate */
+     , (72974,  12,     0.5) /* Shade */
+     , (72974,  13,    0.35) /* ArmorModVsSlash */
+     , (72974,  14,     0.7) /* ArmorModVsPierce */
+     , (72974,  15,    0.35) /* ArmorModVsBludgeon */
+     , (72974,  16,    0.75) /* ArmorModVsCold */
+     , (72974,  17,    0.65) /* ArmorModVsFire */
+     , (72974,  18,     0.5) /* ArmorModVsAcid */
+     , (72974,  19,    0.75) /* ArmorModVsElectric */
+     , (72974,  31,      22) /* VisualAwarenessRange */
+     , (72974,  34,       1) /* PowerupTime */
+     , (72974,  36,       1) /* ChargeSpeed */
+     , (72974,  39,     0.4) /* DefaultScale */
+     , (72974,  54,       3) /* UseRadius */
+     , (72974,  64,     0.5) /* ResistSlash */
+     , (72974,  65,       1) /* ResistPierce */
+     , (72974,  66,     0.5) /* ResistBludgeon */
+     , (72974,  67,     0.5) /* ResistFire */
+     , (72974,  68,    0.95) /* ResistCold */
+     , (72974,  69,     0.7) /* ResistAcid */
+     , (72974,  70,    0.95) /* ResistElectric */
+     , (72974,  71,       1) /* ResistHealthBoost */
+     , (72974,  72,       1) /* ResistStaminaDrain */
+     , (72974,  73,       1) /* ResistStaminaBoost */
+     , (72974,  74,       1) /* ResistManaDrain */
+     , (72974,  75,       1) /* ResistManaBoost */
+     , (72974, 104,      10) /* ObviousRadarRange */
+     , (72974, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72974,   1, 'Shady') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72974,   1, 0x02000004) /* Setup */
+     , (72974,   2, 0x0900001C) /* MotionTable */
+     , (72974,   3, 0x20000003) /* SoundTable */
+     , (72974,   4, 0x3000000E) /* CombatTable */
+     , (72974,   6, 0x040001B5) /* PaletteBase */
+     , (72974,   7, 0x1000005B) /* ClothingBase */
+     , (72974,   8, 0x0600121F) /* Icon */
+     , (72974,  22, 0x34000015) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72974,  0,  1, 15, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1,  0.7, 0.34,    0,  0.7, 0.34,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (72974,  9,  1, 70, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1,  0.3, 0.33,    0,  0.3, 0.33,    0,    0,    0,    0,    0,    0,    0) /* Horn */
+     , (72974, 16,  1, 70,  0.5,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2,    0, 0.33,  0.3,    0, 0.33,  0.3,  0.5, 0.34,  0.3,  0.5, 0.34,  0.3) /* Torso */
+     , (72974, 17,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2,    0,    0,    0,    0,    0,    0,  0.5, 0.33,    0,  0.5, 0.33,    0) /* Tail */
+     , (72974, 19,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,    0,  0.7,    0,    0,  0.7,    0, 0.33,  0.7,    0, 0.33,  0.7) /* Leg */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72974,   1, 420, 0, 0) /* Strength */
+     , (72974,   2, 500, 0, 0) /* Endurance */
+     , (72974,   3, 420, 0, 0) /* Quickness */
+     , (72974,   4, 450, 0, 0) /* Coordination */
+     , (72974,   5, 400, 0, 0) /* Focus */
+     , (72974,   6, 400, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72974,   1,  2250, 0, 0, 2500) /* MaxHealth */
+     , (72974,   3,  2600, 0, 0, 3100) /* MaxStamina */
+     , (72974,   5,  2200, 0, 0, 2600) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72974,  6, 0, 3, 0, 223, 0, 0) /* MeleeDefense        Specialized */
+     , (72974,  7, 0, 3, 0, 326, 0, 0) /* MissileDefense      Specialized */
+     , (72974, 15, 0, 3, 0, 232, 0, 0) /* MagicDefense        Specialized */
+     , (72974, 20, 0, 3, 0,   5, 0, 0) /* Deception           Specialized */
+     , (72974, 22, 0, 3, 0,  20, 0, 0) /* Jump                Specialized */
+     , (72974, 24, 0, 3, 0,  65, 0, 0) /* Run                 Specialized */
+     , (72974, 45, 0, 3, 0, 222, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72974, 6 /* Give */, 1, 72980, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Shady quickly devours the meat.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 2, 1, NULL, 'After several moments, Shady falls to the ground. The sedative looks to have worked.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 5 /* Motion */, 0, 1, 0x40000011 /* Dead */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 81 /* StampMyQuest */, 0, 1, NULL, 'DruggedMeat', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72974, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72974, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SavedShady', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72975, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72974, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'This must be one of the pets Colton mentioned.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974 Shady.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974 Shady.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72974;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72974, 'ace72974-shady', 10, '2023-03-12 06:41:41') /* Creature */;
+VALUES (72974, 'ace72974-shady', 10, '2023-03-16 12:11:32') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72974,   1,         16) /* ItemType - Creature */
@@ -128,7 +128,7 @@ VALUES (72974, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SavedShady', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+VALUES (@parent_id, 0, 106 /* SetQuestBitsOn */, 0, 1, NULL, 'Petsave', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72975, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974.es
@@ -1,0 +1,15 @@
+Give: 72980
+    - DirectBroadcast: Shady quickly devours the meat.
+    - Motion: Twitch2
+    - Delay: 2, DirectBroadcast: After several moments, Shady falls to the ground. The sedative looks to have worked.
+    - Motion: Dead
+    - StampMyQuest: DruggedMeat
+
+Use:
+    - InqMyQuest: DruggedMeat
+        QuestSuccess:
+            - StampQuest: SavedShady
+            - Give: 72975
+            - DeleteSelf
+        QuestFailure:
+            - DirectBroadcast: This must be one of the pets Colton mentioned.

--- a/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72974.es
@@ -8,7 +8,7 @@ Give: 72980
 Use:
     - InqMyQuest: DruggedMeat
         QuestSuccess:
-            - StampQuest: SavedShady
+            - SetQuestBitsOn: Petsave, 0x1
             - Give: 72975
             - DeleteSelf
         QuestFailure:

--- a/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72985 Shady.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Armoredillo/72985 Shady.sql
@@ -1,0 +1,135 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72985;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72985, 'ace72985-shady', 10, '2023-03-12 06:41:41') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72985,   1,         16) /* ItemType - Creature */
+     , (72985,   2,         17) /* CreatureType - Armoredillo */
+     , (72985,   3,          2) /* PaletteTemplate - Brown */
+     , (72985,   6,         -1) /* ItemsCapacity */
+     , (72985,   7,         -1) /* ContainersCapacity */
+     , (72985,  16,          1) /* ItemUseable - No */
+     , (72985,  25,         80) /* Level */
+     , (72985,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72985,  95,          8) /* RadarBlipColor - Yellow */
+     , (72985, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72985, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72985, 146,      30000) /* XpOverride */
+     , (72985, 267,         30) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72985,   1, True ) /* Stuck */
+     , (72985,   8, False ) /* AllowGive */
+     , (72985,  11, False) /* IgnoreCollisions */
+     , (72985,  12, True ) /* ReportCollisions */
+     , (72985,  13, False) /* Ethereal */
+     , (72985,  14, True ) /* GravityStatus */
+     , (72985,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72985,   1,       5) /* HeartbeatInterval */
+     , (72985,   2,       0) /* HeartbeatTimestamp */
+     , (72985,   3,     1.8) /* HealthRate */
+     , (72985,   4,     1.8) /* StaminaRate */
+     , (72985,   5,       2) /* ManaRate */
+     , (72985,  12,     0.5) /* Shade */
+     , (72985,  13,    0.35) /* ArmorModVsSlash */
+     , (72985,  14,     0.7) /* ArmorModVsPierce */
+     , (72985,  15,    0.35) /* ArmorModVsBludgeon */
+     , (72985,  16,    0.75) /* ArmorModVsCold */
+     , (72985,  17,    0.65) /* ArmorModVsFire */
+     , (72985,  18,     0.5) /* ArmorModVsAcid */
+     , (72985,  19,    0.75) /* ArmorModVsElectric */
+     , (72985,  31,      22) /* VisualAwarenessRange */
+     , (72985,  34,       1) /* PowerupTime */
+     , (72985,  36,       1) /* ChargeSpeed */
+     , (72985,  39,     0.4) /* DefaultScale */
+     , (72985,  64,     0.5) /* ResistSlash */
+     , (72985,  65,       1) /* ResistPierce */
+     , (72985,  66,     0.5) /* ResistBludgeon */
+     , (72985,  67,     0.5) /* ResistFire */
+     , (72985,  68,    0.95) /* ResistCold */
+     , (72985,  69,     0.7) /* ResistAcid */
+     , (72985,  70,    0.95) /* ResistElectric */
+     , (72985,  71,       1) /* ResistHealthBoost */
+     , (72985,  72,       1) /* ResistStaminaDrain */
+     , (72985,  73,       1) /* ResistStaminaBoost */
+     , (72985,  74,       1) /* ResistManaDrain */
+     , (72985,  75,       1) /* ResistManaBoost */
+     , (72985, 104,      10) /* ObviousRadarRange */
+     , (72985, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72985,   1, 'Shady') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72985,   1, 0x02000004) /* Setup */
+     , (72985,   2, 0x0900001C) /* MotionTable */
+     , (72985,   3, 0x20000003) /* SoundTable */
+     , (72985,   4, 0x3000000E) /* CombatTable */
+     , (72985,   6, 0x040001B5) /* PaletteBase */
+     , (72985,   7, 0x1000005B) /* ClothingBase */
+     , (72985,   8, 0x0600121F) /* Icon */
+     , (72985,  22, 0x34000015) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72985,  0,  1, 15, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1,  0.7, 0.34,    0,  0.7, 0.34,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (72985,  9,  1, 70, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1,  0.3, 0.33,    0,  0.3, 0.33,    0,    0,    0,    0,    0,    0,    0) /* Horn */
+     , (72985, 16,  1, 70,  0.5,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2,    0, 0.33,  0.3,    0, 0.33,  0.3,  0.5, 0.34,  0.3,  0.5, 0.34,  0.3) /* Torso */
+     , (72985, 17,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2,    0,    0,    0,    0,    0,    0,  0.5, 0.33,    0,  0.5, 0.33,    0) /* Tail */
+     , (72985, 19,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,    0,  0.7,    0,    0,  0.7,    0, 0.33,  0.7,    0, 0.33,  0.7) /* Leg */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72985,   1, 420, 0, 0) /* Strength */
+     , (72985,   2, 500, 0, 0) /* Endurance */
+     , (72985,   3, 420, 0, 0) /* Quickness */
+     , (72985,   4, 450, 0, 0) /* Coordination */
+     , (72985,   5, 400, 0, 0) /* Focus */
+     , (72985,   6, 400, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72985,   1,  2250, 0, 0, 2500) /* MaxHealth */
+     , (72985,   3,  2600, 0, 0, 3100) /* MaxStamina */
+     , (72985,   5,  2200, 0, 0, 2600) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72985,  6, 0, 3, 0, 223, 0, 0) /* MeleeDefense        Specialized */
+     , (72985,  7, 0, 3, 0, 326, 0, 0) /* MissileDefense      Specialized */
+     , (72985, 15, 0, 3, 0, 232, 0, 0) /* MagicDefense        Specialized */
+     , (72985, 20, 0, 3, 0,   5, 0, 0) /* Deception           Specialized */
+     , (72985, 22, 0, 3, 0,  20, 0, 0) /* Jump                Specialized */
+     , (72985, 24, 0, 3, 0,  65, 0, 0) /* Run                 Specialized */
+     , (72985, 45, 0, 3, 0, 222, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72985,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72985,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72985,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72985,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/47799 Colton Reeyan.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/47799 Colton Reeyan.sql
@@ -1,0 +1,219 @@
+DELETE FROM `weenie` WHERE `class_Id` = 47799;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (47799, 'ace47799-coltonreeyan', 10, '2023-03-13 12:32:24') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (47799,   1,         16) /* ItemType - Creature */
+     , (47799,   2,         31) /* CreatureType - Human */
+     , (47799,   6,         -1) /* ItemsCapacity */
+     , (47799,   7,         -1) /* ContainersCapacity */
+     , (47799,  16,         32) /* ItemUseable - Remote */
+     , (47799,  25,        155) /* Level */
+     , (47799,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (47799,  95,          8) /* RadarBlipColor - Yellow */
+     , (47799, 113,          1) /* Gender - Male */
+     , (47799, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (47799, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (47799, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (47799,   1, True ) /* Stuck */
+     , (47799,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (47799,  54,       3) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (47799,   1, 'Colton Reeyan') /* Name */
+     , (47799,   5, 'Aristocrat') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (47799,   1, 0x02000001) /* Setup */
+     , (47799,   2, 0x09000001) /* MotionTable */
+     , (47799,   3, 0x20000001) /* SoundTable */
+     , (47799,   6, 0x0400007E) /* PaletteBase */
+     , (47799,   8, 0x06000FF1) /* Icon */
+     , (47799,   9, 0x05001151) /* EyesTexture */
+     , (47799,  10, 0x05001175) /* NoseTexture */
+     , (47799,  11, 0x050011E3) /* MouthTexture */
+     , (47799,  15, 0x04001FD9) /* HairPalette */
+     , (47799,  16, 0x040002BE) /* EyesPalette */
+     , (47799,  17, 0x040002B8) /* SkinPalette */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (47799,   1, 170, 0, 0) /* Strength */
+     , (47799,   2, 145, 0, 0) /* Endurance */
+     , (47799,   3, 180, 0, 0) /* Quickness */
+     , (47799,   4, 165, 0, 0) /* Coordination */
+     , (47799,   5, 210, 0, 0) /* Focus */
+     , (47799,   6, 225, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (47799,   1,   251, 0, 0,  323) /* MaxHealth */
+     , (47799,   3,   160, 0, 0,  305) /* MaxStamina */
+     , (47799,   5,   100, 0, 0,  325) /* MaxMana */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 36 /* InqIntStat */, 0, 1, NULL, 'Level_150-999_7', NULL, 150, 999, NULL, NULL, NULL, NULL, 25 /* Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'Level_150-999_7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetFinished_1212@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetFinished_1212@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'I will start working with the Mosswarts immediately to ensure things never regress this far again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You may complete this quest again in %tqt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SaveAPetFinished_1212@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetStarted_1212@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10_7', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SavedShady@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SavedShady@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SavedBubba@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SavedBubba@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SavedSpot@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SavedSpot@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'reward', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SavedSpot@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SavedBubba@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SavedShady@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SaveAPetStarted_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'Level_150-999_7', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'You are not powerful enough to aid me, adventurer.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'start', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'This can''t be happening. No, this CAN''T be happening!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0.5, 1, NULL, 'The workers have all gathered and they are refusing to return to work without another large increase to their wages.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0.5, 1, NULL, 'Not only that, but they are also holding my three little pets hostage to try and force my hand in meeting their demands. My poor babies must be so scared.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 47831, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 0.5, 1, NULL, 'Please bring this message to them at my sanctuary located around 22.9N, 37.0W. Hopefully they will accept the offer and return my pets. I must prepare you though.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0.5, 1, NULL, 'If they refuse the offer they can be unpredictable and may become violent. They mean well, they are a good group. The pressure of the mob mentality has forced many of the workers to act in such a manner.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0.5, 1, NULL, 'Please do your best not to kill the workers. If they are "roughed up" a bit though, they are sure to come to their senses and stop this nonsense.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 0.5, 1, NULL, 'Convince 10 of the workers to return to work. I bet once several see the errors in their way that the others will follow.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72980, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 10 /* Tell */, 0.5, 1, NULL, 'The victims in all this are my poor little pets. A Tusker, an Armoredillo and an Ursuin.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 0.5, 1, NULL, 'They aren''t much for strangers but if you feed them this meat it should make them groggy enough to where you can safely place them back in their cages. I have added a special ingredient to the food to tranquilize them very quickly.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'reward', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SaveAPetFinished_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 31 /* EraseQuest */, 0, 1, NULL, 'SaveAPetStarted_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 31 /* EraseQuest */, 0, 1, NULL, 'WorkersMotivated', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 350000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 38917 /* Braced Mana Forge Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 34 /* AddCharacterTitle */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 776 /* PetSavior */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have been awarded the title of "Pet Savior".', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 0, 1, NULL, 'You saved my babies and the workers were not killed in the process?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 10 /* Tell */, 0.5, 1, NULL, 'Thank you! Thank you so much.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 0.5, 1, NULL, 'My little ones thank you for saving them as well. I don''t know what I would have done if I had lost them!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 10 /* Tell */, 0.5, 1, NULL, 'I will start working with the Mosswarts immediately to ensure things never regress this far again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (47799, 2,  5850,  0, 93, 0, False) /* Create Faran War Master Robe (5909) for Wield */
+     , (47799, 2,  31867, -1, 17, 0, False) /* Create Diadem (31867) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/47799 Colton Reeyan.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/47799 Colton Reeyan.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 47799;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (47799, 'ace47799-coltonreeyan', 10, '2023-03-13 12:32:24') /* Creature */;
+VALUES (47799, 'ace47799-coltonreeyan', 10, '2023-03-16 12:21:01') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (47799,   1,         16) /* ItemType - Creature */
@@ -61,18 +61,18 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 36 /* InqIntStat */, 0, 1, NULL, 'Level_150-999_7', NULL, 150, 999, NULL, NULL, NULL, NULL, 25 /* Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id, 1, 36 /* InqIntStat */, 0, 1, NULL, 'Level_150-999_4', NULL, 150, 999, NULL, NULL, NULL, NULL, 25 /* Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'Level_150-999_7', NULL, NULL, NULL);
+VALUES (47799, 22 /* TestSuccess */, 1, NULL, NULL, NULL, 'Level_150-999_4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetFinished_1212@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetFinished_1212@4', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetFinished_1212@7', NULL, NULL, NULL);
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetFinished_1212@4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -81,122 +81,95 @@ VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'I will start working with the
      , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You may complete this quest again in %tqt.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SaveAPetFinished_1212@7', NULL, NULL, NULL);
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SaveAPetFinished_1212@4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetStarted_1212@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetStarted_1212@4', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@7', NULL, NULL, NULL);
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10_7', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10_4', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_7', NULL, NULL, NULL);
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SavedShady@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'CheckSaved', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SavedShady@7', NULL, NULL, NULL);
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SavedBubba@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'Please convince 10 of the workers to return to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 47831, -1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 47831, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 67 /* Goto */, 0, 1, NULL, 'CheckSaved', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SavedBubba@7', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SavedSpot@7', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SavedSpot@7', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'reward', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SavedSpot@7', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SavedBubba@7', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SavedShady@7', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_7', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@7', NULL, NULL, NULL);
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SaveAPetStarted_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'start', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'This can''t be happening. No, this CAN''T be happening!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0.5, 1, NULL, 'The workers have all gathered and they are refusing to return to work without another large increase to their wages.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 0.5, 1, NULL, 'Not only that, but they are also holding my three little pets hostage to try and force my hand in meeting their demands. My poor babies must be so scared.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 47831, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 0.5, 1, NULL, 'Please bring this message to them at my sanctuary located around 22.9N, 37.0W. Hopefully they will accept the offer and return my pets. I must prepare you though.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 10 /* Tell */, 0.5, 1, NULL, 'If they refuse the offer they can be unpredictable and may become violent. They mean well, they are a good group. The pressure of the mob mentality has forced many of the workers to act in such a manner.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 10 /* Tell */, 0.5, 1, NULL, 'Please do your best not to kill the workers. If they are "roughed up" a bit though, they are sure to come to their senses and stop this nonsense.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 0.5, 1, NULL, 'Convince 10 of the workers to return to work. I bet once several see the errors in their way that the others will follow.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72980, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 0.5, 1, NULL, 'The victims in all this are my poor little pets. A Tusker, an Armoredillo and an Ursuin.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 10 /* Tell */, 0.5, 1, NULL, 'They aren''t much for strangers but if you feed them this meat it should make them groggy enough to where you can safely place them back in their cages. I have added a special ingredient to the food to tranquilize them very quickly.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'Level_150-999_7', NULL, NULL, NULL);
+VALUES (47799, 23 /* TestFailure */, 1, NULL, NULL, NULL, 'Level_150-999_4', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'You are not powerful enough to aid me, adventurer.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'I apologize, but I have no time to talk. There is much on my mind.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'start', NULL, NULL, NULL);
+VALUES (47799, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'CheckSaved', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'This can''t be happening. No, this CAN''T be happening!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 10 /* Tell */, 0.5, 1, NULL, 'The workers have all gathered and they are refusing to return to work without another large increase to their wages.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 2, 10 /* Tell */, 0.5, 1, NULL, 'Not only that, but they are also holding my three little pets hostage to try and force my hand in meeting their demands. My poor babies must be so scared.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 3, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 47831, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 4, 10 /* Tell */, 0.5, 1, NULL, 'Please bring this message to them at my sanctuary located around 22.9N, 37.0W. Hopefully they will accept the offer and return my pets. I must prepare you though.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 5, 10 /* Tell */, 0.5, 1, NULL, 'If they refuse the offer they can be unpredictable and may become violent. They mean well, they are a good group. The pressure of the mob mentality has forced many of the workers to act in such a manner.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 6, 10 /* Tell */, 0.5, 1, NULL, 'Please do your best not to kill the workers. If they are "roughed up" a bit though, they are sure to come to their senses and stop this nonsense.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 7, 10 /* Tell */, 0.5, 1, NULL, 'Convince 10 of the workers to return to work. I bet once several see the errors in their way that the others will follow.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 8, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72980, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 9, 10 /* Tell */, 0.5, 1, NULL, 'The victims in all this are my poor little pets. A Tusker, an Armoredillo and an Ursuin.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 10, 10 /* Tell */, 0.5, 1, NULL, 'They aren''t much for strangers but if you feed them this meat it should make them groggy enough to where you can safely place them back in their cages. I have added a special ingredient to the food to tranquilize them very quickly.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 102 /* InqQuestBitsOn */, 0, 1, NULL, 'Petsave@4', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 7, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (47799, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'reward', NULL, NULL, NULL);
+VALUES (47799, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'Petsave@4', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 67 /* Goto */, 0, 1, NULL, 'Rewards', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'Petsave@4', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'Please save my pets.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72980, -1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72980, 3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (47799, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'Rewards', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -204,16 +177,18 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SaveAPetFinished_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 1, 31 /* EraseQuest */, 0, 1, NULL, 'SaveAPetStarted_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 2, 31 /* EraseQuest */, 0, 1, NULL, 'WorkersMotivated', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 3, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 4, 49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 350000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 5, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 38917 /* Braced Mana Forge Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 6, 34 /* AddCharacterTitle */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 776 /* PetSavior */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 7, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have been awarded the title of "Pet Savior".', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 8, 10 /* Tell */, 0, 1, NULL, 'You saved my babies and the workers were not killed in the process?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 9, 10 /* Tell */, 0.5, 1, NULL, 'Thank you! Thank you so much.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 10, 10 /* Tell */, 0.5, 1, NULL, 'My little ones thank you for saving them as well. I don''t know what I would have done if I had lost them!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 11, 10 /* Tell */, 0.5, 1, NULL, 'I will start working with the Mosswarts immediately to ensure things never regress this far again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id, 3, 31 /* EraseQuest */, 0, 1, NULL, 'Petsave', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 350000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 38917 /* Braced Mana Forge Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 34 /* AddCharacterTitle */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 776 /* PetSavior */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have been awarded the title of "Pet Savior".', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 10 /* Tell */, 0, 1, NULL, 'You saved my babies and the workers were not killed in the process?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 0.5, 1, NULL, 'Thank you! Thank you so much.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 10 /* Tell */, 0.5, 1, NULL, 'My little ones thank you for saving them as well. I don''t know what I would have done if I had lost them!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 10 /* Tell */, 0.5, 1, NULL, 'I will start working with the Mosswarts immediately to ensure things never regress this far again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (47799, 2,  5850,  0, 93, 0, False) /* Create Faran War Master Robe (5909) for Wield */
-     , (47799, 2,  31867, -1, 17, 0, False) /* Create Diadem (31867) for Wield */;
+VALUES (47799, 2,  5850,  0,93,    0, False) /* Create Faran War Master Robe (5909) for Wield */
+     , (47799, 2, 31867, -1,17,    0, False) /* Create Diadem (31867) for Wield */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/47799.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/47799.es
@@ -1,0 +1,60 @@
+Use: 
+    - TurnToTarget
+    - InqIntStat: Level, 150 - 999
+        TestSuccess:
+            - InqQuest: SaveAPetFinished_1212
+                QuestSuccess:
+                    - Tell: I will start working with the Mosswarts immediately to ensure things never regress this far again.
+                    - DirectBroadcast: You may complete this quest again in %tqt.
+                QuestFailure:
+                    - InqQuest: SaveAPetStarted_1212
+                        QuestSuccess:
+                            - InqQuestSolves: WorkersMotivated, 10 - 10
+                                QuestSuccess:
+                                    - InqQuest: SavedShady
+                                        QuestSuccess:
+                                            - InqQuest: SavedBubba
+                                                QuestSuccess: 
+                                                    - InqQuest: SavedSpot
+                                                        QuestSuccess:
+                                                            - Goto: reward
+                                                        QuestFailure:
+                                                            - Goto: start
+                                                QuestFailure:
+                                                    - Goto: start
+                                        QuestFailure:
+                                            - Goto: start
+                                QuestFailure:
+                                    - Goto: start
+                        QuestFailure:
+                            - StampQuest: SaveAPetStarted_1212
+                            - Goto: start
+        TestFailure:
+            - Tell: You are not powerful enough to aid me, adventurer.
+
+Gotoset: start
+    - Tell: This can't be happening. No, this CAN'T be happening!
+    - Delay: 0.5, Tell: The workers have all gathered and they are refusing to return to work without another large increase to their wages.
+    - Delay: 0.5, Tell: Not only that, but they are also holding my three little pets hostage to try and force my hand in meeting their demands. My poor babies must be so scared.
+    - Give: 47831
+    - Delay: 0.5,Tell: Please bring this message to them at my sanctuary located around 22.9N, 37.0W. Hopefully they will accept the offer and return my pets. I must prepare you though.
+    - Delay: 0.5,Tell: If they refuse the offer they can be unpredictable and may become violent. They mean well, they are a good group. The pressure of the mob mentality has forced many of the workers to act in such a manner.
+    - Delay: 0.5,Tell: Please do your best not to kill the workers. If they are "roughed up" a bit though, they are sure to come to their senses and stop this nonsense.
+    - Delay: 0.5,Tell: Convince 10 of the workers to return to work. I bet once several see the errors in their way that the others will follow.
+    - Give: 72980, 3
+    - Delay: 0.5,Tell: The victims in all this are my poor little pets. A Tusker, an Armoredillo and an Ursuin.
+    - Delay: 0.5,Tell: They aren't much for strangers but if you feed them this meat it should make them groggy enough to where you can safely place them back in their cages. I have added a special ingredient to the food to tranquilize them very quickly.
+
+Gotoset: reward
+    - StampQuest: SaveAPetFinished_1212
+    - EraseQuest: SaveAPetStarted_1212
+    - EraseQuest: WorkersMotivated
+    - AwardLuminance: 20000
+    - AwardLevelProportionalXP: 100%, 0 - 350,000,000
+    - Give: 38917
+    - AddCharacterTitle: 776
+    - DirectBroadcast: You have been awarded the title of "Pet Savior".
+    - Tell: You saved my babies and the workers were not killed in the process?
+    - Delay: 0.5, Tell: Thank you! Thank you so much.
+    - Delay: 0.5, Tell: My little ones thank you for saving them as well. I don't know what I would have done if I had lost them!
+    - Delay: 0.5, Tell: I will start working with the Mosswarts immediately to ensure things never regress this far again.

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/47799.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/47799.es
@@ -11,44 +11,42 @@ Use:
                         QuestSuccess:
                             - InqQuestSolves: WorkersMotivated, 10 - 10
                                 QuestSuccess:
-                                    - InqQuest: SavedShady
-                                        QuestSuccess:
-                                            - InqQuest: SavedBubba
-                                                QuestSuccess: 
-                                                    - InqQuest: SavedSpot
-                                                        QuestSuccess:
-                                                            - Goto: reward
-                                                        QuestFailure:
-                                                            - Goto: start
-                                                QuestFailure:
-                                                    - Goto: start
-                                        QuestFailure:
-                                            - Goto: start
+                                    - Goto: CheckSaved
                                 QuestFailure:
-                                    - Goto: start
+                                    - Tell: Please convince 10 of the workers to return to work.
+                                    - TakeItems: 47831, -1
+                                    - Give: 47831
+                                    - Goto: CheckSaved
                         QuestFailure:
                             - StampQuest: SaveAPetStarted_1212
-                            - Goto: start
+                            - Tell: This can't be happening. No, this CAN'T be happening!
+                            - Delay: 0.5, Tell: The workers have all gathered and they are refusing to return to work without another large increase to their wages.
+                            - Delay: 0.5, Tell: Not only that, but they are also holding my three little pets hostage to try and force my hand in meeting their demands. My poor babies must be so scared.
+                            - Give: 47831
+                            - Delay: 0.5,Tell: Please bring this message to them at my sanctuary located around 22.9N, 37.0W. Hopefully they will accept the offer and return my pets. I must prepare you though.
+                            - Delay: 0.5,Tell: If they refuse the offer they can be unpredictable and may become violent. They mean well, they are a good group. The pressure of the mob mentality has forced many of the workers to act in such a manner.
+                            - Delay: 0.5,Tell: Please do your best not to kill the workers. If they are "roughed up" a bit though, they are sure to come to their senses and stop this nonsense.
+                            - Delay: 0.5,Tell: Convince 10 of the workers to return to work. I bet once several see the errors in their way that the others will follow.
+                            - Give: 72980, 3
+                            - Delay: 0.5,Tell: The victims in all this are my poor little pets. A Tusker, an Armoredillo and an Ursuin.
+                            - Delay: 0.5,Tell: They aren't much for strangers but if you feed them this meat it should make them groggy enough to where you can safely place them back in their cages. I have added a special ingredient to the food to tranquilize them very quickly.
         TestFailure:
-            - Tell: You are not powerful enough to aid me, adventurer.
+            - Tell: I apologize, but I have no time to talk. There is much on my mind.
 
-Gotoset: start
-    - Tell: This can't be happening. No, this CAN'T be happening!
-    - Delay: 0.5, Tell: The workers have all gathered and they are refusing to return to work without another large increase to their wages.
-    - Delay: 0.5, Tell: Not only that, but they are also holding my three little pets hostage to try and force my hand in meeting their demands. My poor babies must be so scared.
-    - Give: 47831
-    - Delay: 0.5,Tell: Please bring this message to them at my sanctuary located around 22.9N, 37.0W. Hopefully they will accept the offer and return my pets. I must prepare you though.
-    - Delay: 0.5,Tell: If they refuse the offer they can be unpredictable and may become violent. They mean well, they are a good group. The pressure of the mob mentality has forced many of the workers to act in such a manner.
-    - Delay: 0.5,Tell: Please do your best not to kill the workers. If they are "roughed up" a bit though, they are sure to come to their senses and stop this nonsense.
-    - Delay: 0.5,Tell: Convince 10 of the workers to return to work. I bet once several see the errors in their way that the others will follow.
-    - Give: 72980, 3
-    - Delay: 0.5,Tell: The victims in all this are my poor little pets. A Tusker, an Armoredillo and an Ursuin.
-    - Delay: 0.5,Tell: They aren't much for strangers but if you feed them this meat it should make them groggy enough to where you can safely place them back in their cages. I have added a special ingredient to the food to tranquilize them very quickly.
+GotoSet: CheckSaved
+    - InqQuestBitsOn: Petsave, 0x7
+        QuestSuccess:
+            - Goto: Rewards
+        QuestFailure:
+            - Tell: Please save my pets.
+            - TakeItems: 72980, -1
+            - Give: 72980, 3
 
-Gotoset: reward
+GotoSet: Rewards
     - StampQuest: SaveAPetFinished_1212
     - EraseQuest: SaveAPetStarted_1212
     - EraseQuest: WorkersMotivated
+    - EraseQuest: Petsave
     - AwardLuminance: 20000
     - AwardLevelProportionalXP: 100%, 0 - 350,000,000
     - Give: 38917

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970 Mosswart Messenger.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970 Mosswart Messenger.sql
@@ -1,0 +1,203 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72970;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72970, 'ace72970-mosswartmessenger', 10, '2023-03-12 04:10:13') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72970,   1,         16) /* ItemType - Creature */
+     , (72970,   2,          4) /* CreatureType - Mosswart */
+     , (72970,   3,          8) /* PaletteTemplate - Brown */
+     , (72970,   6,         -1) /* ItemsCapacity */
+     , (72970,   7,         -1) /* ContainersCapacity */
+     , (72970,  16,         32) /* ItemUseable - Remote */
+     , (72970,  25,        175) /* Level */
+     , (72970,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72970,  95,          8) /* RadarBlipColor - Yellow */
+     , (72970, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72970, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72970, 146,     800000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72970,   1, True ) /* Stuck */
+     , (72970,   8, True ) /* AllowGive */
+     , (72970,  11, True ) /* IgnoreCollisions */
+     , (72970,  12, True ) /* ReportCollisions */
+     , (72970,  14, True ) /* GravityStatus */
+     , (72970,  19, False) /* Attackable */
+     , (72970,  41, True ) /* ReportCollisionsAsEnvironment */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72970,   1,       5) /* HeartbeatInterval */
+     , (72970,   2,       0) /* HeartbeatTimestamp */
+     , (72970,   3,     0.5) /* HealthRate */
+     , (72970,   4,       5) /* StaminaRate */
+     , (72970,   5,       2) /* ManaRate */
+     , (72970,  12,       1) /* Shade */
+     , (72970,  13,     1.3) /* ArmorModVsSlash */
+     , (72970,  14,     1.5) /* ArmorModVsPierce */
+     , (72970,  15,     1.4) /* ArmorModVsBludgeon */
+     , (72970,  16,       1) /* ArmorModVsCold */
+     , (72970,  17,     0.7) /* ArmorModVsFire */
+     , (72970,  18,     1.3) /* ArmorModVsAcid */
+     , (72970,  19,     0.9) /* ArmorModVsElectric */
+     , (72970,  31,      24) /* VisualAwarenessRange */
+     , (72970,  34,     0.9) /* PowerupTime */
+     , (72970,  36,       1) /* ChargeSpeed */
+     , (72970,  39,     1.1) /* DefaultScale */
+     , (72970,  54,       3) /* UseRadius */
+     , (72970,  64,     0.5) /* ResistSlash */
+     , (72970,  65,     0.8) /* ResistPierce */
+     , (72970,  66,     0.8) /* ResistBludgeon */
+     , (72970,  67,       1) /* ResistFire */
+     , (72970,  68,     0.4) /* ResistCold */
+     , (72970,  69,     0.7) /* ResistAcid */
+     , (72970,  70,     1.1) /* ResistElectric */
+     , (72970,  71,       1) /* ResistHealthBoost */
+     , (72970,  72,       1) /* ResistStaminaDrain */
+     , (72970,  73,       1) /* ResistStaminaBoost */
+     , (72970,  74,       1) /* ResistManaDrain */
+     , (72970,  75,       1) /* ResistManaBoost */
+     , (72970, 104,      10) /* ObviousRadarRange */
+     , (72970, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72970,   1, 'Mosswart Messenger') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72970,   1, 0x02000B4F) /* Setup */
+     , (72970,   2, 0x09000009) /* MotionTable */
+     , (72970,   3, 0x2000002F) /* SoundTable */
+     , (72970,   4, 0x30000005) /* CombatTable */
+     , (72970,   6, 0x040011B8) /* PaletteBase */
+     , (72970,   7, 0x10000346) /* ClothingBase */
+     , (72970,   8, 0x06001039) /* Icon */
+     , (72970,  22, 0x34000020) /* PhysicsEffectTable */
+     , (72970,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (72970,  16, 0x75860003) /* ActivationTarget */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72970,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72970,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72970,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72970,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72970,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72970,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72970,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72970,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72970,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72970,   1, 250, 0, 0) /* Strength */
+     , (72970,   2, 300, 0, 0) /* Endurance */
+     , (72970,   3, 280, 0, 0) /* Quickness */
+     , (72970,   4, 260, 0, 0) /* Coordination */
+     , (72970,   5, 265, 0, 0) /* Focus */
+     , (72970,   6, 300, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72970,   1,  2850, 0, 0, 3000) /* MaxHealth */
+     , (72970,   3,  1790, 0, 0, 2090) /* MaxStamina */
+     , (72970,   5,   500, 0, 0,  800) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72970,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72970,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72970, 14, 0, 3, 0, 250, 0, 0) /* ArcaneLore          Specialized */
+     , (72970, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72970, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72970, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72970, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
+     , (72970, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72970, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72970, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72970, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (72970,  1089,   2.03) /* Lightning Vulnerability Other VI */
+     , (72970,  1108,   2.03) /* Fire Vulnerability Other VI */
+     , (72970,  1161,   2.02) /* Heal Self VI */
+     , (72970,  2128,   2.05) /* Ilservian's Flame */
+     , (72970,  2140,   2.05) /* Alset's Coil */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'You are not welcome here, you should leave before you get hurt!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72970, 6 /* Give */, 1, 47831, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'You have news from Colton?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 1, 1, NULL, 'The Mosswart opens the letter and looks inside.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'Unacceptable! The Directors must be notified of this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'This place is ours now and he will never see his beloved creatures alive again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 8 /* Say */, 1, 20, NULL, 'Kill them slowly, make them suffer!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 15 /* Activate */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 77 /* DeleteSelf */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970.es
@@ -1,0 +1,34 @@
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.045
+    - Motion: Twitch3
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.095
+    - Motion: Twitch2
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch1
+
+HeartBeat: Style: SwordCombat, Substyle: Ready, Probability: 0.05
+    - Motion: Twitch1
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.045
+    - Motion: Twitch3
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.095
+    - Motion: Twitch2
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch1
+
+Use:
+    - TurnToTarget
+    - Tell: You are not welcome here, you should leave before you get hurt!
+
+Give: 47831
+    - TurnToTarget
+    - Tell: You have news from Colton?
+    - Delay: 1, DirectBroadcast: The Mosswart opens the letter and looks inside.
+    - Delay: 1, Tell: Unacceptable! The Directors must be notified of this.
+    - Delay: 1, Tell: This place is ours now and he will never see his beloved creatures alive again.
+    - Delay: 1, Say: Kill them slowly, make them suffer!, Extent: 20
+    - Delay: 1, Activate
+    - Delay: 1, DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72971 Mosswart Director.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72971 Mosswart Director.sql
@@ -1,0 +1,216 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72971;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72971, 'ace72971-mosswartdirector', 10, '2023-03-14 02:38:31') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72971,   1,         16) /* ItemType - Creature */
+     , (72971,   2,          4) /* CreatureType - Mosswart */
+     , (72971,   3,         17) /* PaletteTemplate - Yellow */
+     , (72971,   6,         -1) /* ItemsCapacity */
+     , (72971,   7,         -1) /* ContainersCapacity */
+     , (72971,  16,          1) /* ItemUseable - No */
+     , (72971,  25,        220) /* Level */
+     , (72971,  27,          0) /* ArmorType - None */
+     , (72971,  40,          2) /* CombatMode - Melee */
+     , (72971,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (72971,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72971, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (72971, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72971, 140,          1) /* AiOptions - CanOpenDoors */
+     , (72971, 146,    1400000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72971,   1, True ) /* Stuck */
+     , (72971,   6, True ) /* AiUsesMana */
+     , (72971,  11, False) /* IgnoreCollisions */
+     , (72971,  12, True ) /* ReportCollisions */
+     , (72971,  13, False) /* Ethereal */
+     , (72971,  14, True ) /* GravityStatus */
+     , (72971,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72971,   1,       5) /* HeartbeatInterval */
+     , (72971,   2,       0) /* HeartbeatTimestamp */
+     , (72971,   3,     0.4) /* HealthRate */
+     , (72971,   4,       5) /* StaminaRate */
+     , (72971,   5,       2) /* ManaRate */
+     , (72971,  12,     0.5) /* Shade */
+     , (72971,  13,    0.28) /* ArmorModVsSlash */
+     , (72971,  14,    0.52) /* ArmorModVsPierce */
+     , (72971,  15,    0.52) /* ArmorModVsBludgeon */
+     , (72971,  16,    0.09) /* ArmorModVsCold */
+     , (72971,  17,     0.4) /* ArmorModVsFire */
+     , (72971,  18,    0.03) /* ArmorModVsAcid */
+     , (72971,  19,     0.7) /* ArmorModVsElectric */
+     , (72971,  31,      20) /* VisualAwarenessRange */
+     , (72971,  34,       1) /* PowerupTime */
+     , (72971,  36,       1) /* ChargeSpeed */
+     , (72971,  39,     1.2) /* DefaultScale */
+     , (72971,  64,    0.55) /* ResistSlash */
+     , (72971,  65,     0.8) /* ResistPierce */
+     , (72971,  66,     0.8) /* ResistBludgeon */
+     , (72971,  67,       1) /* ResistFire */
+     , (72971,  68,    0.38) /* ResistCold */
+     , (72971,  69,     0.3) /* ResistAcid */
+     , (72971,  70,       1) /* ResistElectric */
+     , (72971,  71,       1) /* ResistHealthBoost */
+     , (72971,  72,       1) /* ResistStaminaDrain */
+     , (72971,  73,       1) /* ResistStaminaBoost */
+     , (72971,  74,       1) /* ResistManaDrain */
+     , (72971,  75,       1) /* ResistManaBoost */
+     , (72971,  80,       3) /* AiUseMagicDelay */
+     , (72971, 104,      10) /* ObviousRadarRange */
+     , (72971, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72971,   1, 'Mosswart Director') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72971,   1, 0x02000B4F) /* Setup */
+     , (72971,   2, 0x09000009) /* MotionTable */
+     , (72971,   3, 0x2000002F) /* SoundTable */
+     , (72971,   4, 0x30000005) /* CombatTable */
+     , (72971,   6, 0x040011B8) /* PaletteBase */
+     , (72971,   7, 0x10000347) /* ClothingBase */
+     , (72971,   8, 0x06001039) /* Icon */
+     , (72971,  22, 0x34000020) /* PhysicsEffectTable */
+     , (72971,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72971,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72971,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72971,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72971,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72971,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72971,  5,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72971,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72971,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72971,  8,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72971,   1, 340, 0, 0) /* Strength */
+     , (72971,   2, 300, 0, 0) /* Endurance */
+     , (72971,   3, 320, 0, 0) /* Quickness */
+     , (72971,   4, 320, 0, 0) /* Coordination */
+     , (72971,   5, 110, 0, 0) /* Focus */
+     , (72971,   6, 110, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72971,   1,  5850, 0, 0, 6000) /* MaxHealth */
+     , (72971,   3,  3805, 0, 0, 4105) /* MaxStamina */
+     , (72971,   5,  2700, 0, 0, 2810) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72971,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72971,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72971, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72971, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72971, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72971, 34, 0, 3, 0, 310, 0, 0) /* WarMagic            Specialized */
+     , (72971, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72971, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72971, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72971, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (72971,  2162,   2.03) /* Olthoi's Gift */
+     , (72971,  2168,   2.03) /* Gelidite's Gift */
+     , (72971,  2074,   2.02) /* Gossamer Flesh */
+     , (72971,  2136,   2.05) /* Icy Torment */
+     , (72971,  2122,   2.05) /* Disintegration */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 9 /* Generation */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 18 /* Scream */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'CloseDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 19 /* Homesick */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 8 /* Say */, 0, 20, NULL, 'There is freedom in death, only shackles in life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 17 /* LocalBroadcast */, 0, 1, NULL, 'The door along the east wall swings open.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (72971, 2, 32123,  1, 0,  0.5, False) /* Create Acid Spear (32123) for Wield */
+     , (72971, 2, 32124,  1, 0,  0.5, False) /* Create Frost Spear (32124) for Wield */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72971 Mosswart Director.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72971 Mosswart Director.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72971;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72971, 'ace72971-mosswartdirector', 10, '2023-03-14 02:38:31') /* Creature */;
+VALUES (72971, 'ace72971-mosswartdirector', 10, '2023-03-16 11:39:34') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72971,   1,         16) /* ItemType - Creature */
@@ -43,7 +43,7 @@ VALUES (72971,   1,       5) /* HeartbeatInterval */
      , (72971,  17,     0.4) /* ArmorModVsFire */
      , (72971,  18,    0.03) /* ArmorModVsAcid */
      , (72971,  19,     0.7) /* ArmorModVsElectric */
-     , (72971,  31,      20) /* VisualAwarenessRange */
+     , (72971,  31,      18) /* VisualAwarenessRange */
      , (72971,  34,       1) /* PowerupTime */
      , (72971,  36,       1) /* ChargeSpeed */
      , (72971,  39,     1.2) /* DefaultScale */
@@ -76,6 +76,9 @@ VALUES (72971,   1, 0x02000B4F) /* Setup */
      , (72971,   8, 0x06001039) /* Icon */
      , (72971,  22, 0x34000020) /* PhysicsEffectTable */
      , (72971,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (72971,  16, 0x75860017) /* ActivationTarget */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (72971,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -119,6 +122,16 @@ VALUES (72971,  2162,   2.03) /* Olthoi's Gift */
      , (72971,  2074,   2.02) /* Gossamer Flesh */
      , (72971,  2136,   2.05) /* Icy Torment */
      , (72971,  2122,   2.05) /* Disintegration */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72971, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 8 /* Say */, 0, 20, NULL, 'There is freedom in death, only shackles in life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 17 /* LocalBroadcast */, 0, 1, NULL, 'The door along the east wall swings open.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72971, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -177,20 +190,12 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72971, 9 /* Generation */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72971, 18 /* Scream */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'CloseDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72971, 19 /* Homesick */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -198,17 +203,7 @@ VALUES (72971, 19 /* Homesick */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72971, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 8 /* Say */, 0, 20, NULL, 'There is freedom in death, only shackles in life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 2, 17 /* LocalBroadcast */, 0, 1, NULL, 'The door along the east wall swings open.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (72971, 2, 32123,  1, 0,  0.5, False) /* Create Acid Spear (32123) for Wield */

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72971.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72971.es
@@ -1,0 +1,34 @@
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.045
+    - Motion: Twitch3
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.095
+    - Motion: Twitch2
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch1
+
+HeartBeat: Style: SwordCombat, Substyle: Ready, Probability: 0.05
+    - Motion: Twitch1
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.045
+    - Motion: Twitch3
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.095
+    - Motion: Twitch2
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch1
+
+Generation:
+    - LocalSignal: OpenDoor
+
+Scream:
+    - LocalSignal: CloseDoor
+
+Homesick:
+    - LocalSignal: OpenDoor
+
+Death:
+    - LocalSignal: OpenDoor
+    - Say: There is freedom in death, only shackles in life., Extent: 20
+    - LocalBroadcast: The door along the east wall swings open. 

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72972 Mosswart Worker.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72972 Mosswart Worker.sql
@@ -43,7 +43,7 @@ VALUES (72972,   1,       5) /* HeartbeatInterval */
      , (72972,  17,     0.7) /* ArmorModVsFire */
      , (72972,  18,     1.3) /* ArmorModVsAcid */
      , (72972,  19,     0.9) /* ArmorModVsElectric */
-     , (72972,  31,      20) /* VisualAwarenessRange */
+     , (72972,  31,      18) /* VisualAwarenessRange */
      , (72972,  34,     0.9) /* PowerupTime */
      , (72972,  36,       1) /* ChargeSpeed */
      , (72972,  39,     1.2) /* DefaultScale */
@@ -75,17 +75,6 @@ VALUES (72972,   1, 0x02000B4F) /* Setup */
      , (72972,   8, 0x06001039) /* Icon */
      , (72972,  22, 0x34000020) /* PhysicsEffectTable */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (72972,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (72972,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (72972,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (72972,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (72972,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72972,  5,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (72972,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (72972,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72972,  8,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (72972,   1, 230, 0, 0) /* Strength */
      , (72972,   2, 280, 0, 0) /* Endurance */
@@ -97,7 +86,7 @@ VALUES (72972,   1, 230, 0, 0) /* Strength */
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
 VALUES (72972,   1,  3000, 0, 0, 3140) /* MaxHealth */
      , (72972,   3,  2800, 0, 0, 3080) /* MaxStamina */
-     , (72972,   5,   700, 0, 0,  870) /* MaxMana */;
+     , (72972,   5,   700, 0, 0, 870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (72972,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
@@ -112,69 +101,79 @@ VALUES (72972,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72972, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
      , (72972, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72972,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72972,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72972,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72972,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72972,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72972,  5,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72972,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72972,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72972,  8,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (72972,  2172,   2.03) /* Astyrrian's Gift */
-     , (72972,  2168,   2.03) /* Gelidite's Gift */
-     , (72972,  2074,   2.02) /* Gossamer Flesh */
-     , (72972,  2136,   2.05) /* Icy Torment */
-     , (72972,  2140,   2.05) /* Alset's Coil */;
+VALUES (72972,  2172,   2.03)  /* Astyrrian's Gift */
+     , (72972,  2168,   2.03)  /* Gelidite's Gift */
+     , (72972,  2074,   2.02)  /* Gossamer Flesh */
+     , (72972,  2136,   2.05)  /* Icy Torment */
+     , (72972,  2140,   2.05)  /* Alset's Coil */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,  0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72972, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (72972, 9, 72991,  0, 0,    1, False) /* Create Mosswart Worker (72991) for ContainTreasure */;
-
+VALUES (72972, 9, 72991,  0, 0, 1, False) /* Create Mosswart Worker (72991) for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72972 Mosswart Worker.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72972 Mosswart Worker.sql
@@ -1,121 +1,126 @@
-DELETE FROM `weenie` WHERE `class_Id` = 36960;
+DELETE FROM `weenie` WHERE `class_Id` = 72972;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36960, 'ace36960-mosswartprotector', 10, '2023-03-14 02:33:36') /* Creature */;
+VALUES (72972, 'ace72972-mosswartworker', 10, '2023-03-14 02:37:36') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (36960,   1,         16) /* ItemType - Creature */
-     , (36960,   2,          4) /* CreatureType - Mosswart */
-     , (36960,   6,         -1) /* ItemsCapacity */
-     , (36960,   7,         -1) /* ContainersCapacity */
-     , (36960,  16,          1) /* ItemUseable - No */
-     , (36960,  25,        185) /* Level */
-     , (36960,  40,          2) /* CombatMode - Melee */
-     , (36960,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
-     , (36960,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
-     , (36960, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
-     , (36960, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (36960, 146,     800000) /* XpOverride */;
+VALUES (72972,   1,         16) /* ItemType - Creature */
+     , (72972,   2,          4) /* CreatureType - Mosswart */
+     , (72972,   3,         52) /* PaletteTemplate - DarkGrey */
+     , (72972,   6,         -1) /* ItemsCapacity */
+     , (72972,   7,         -1) /* ContainersCapacity */
+     , (72972,  16,          1) /* ItemUseable - No */
+     , (72972,  25,        200) /* Level */
+     , (72972,  27,          0) /* ArmorType - None */
+     , (72972,  40,          2) /* CombatMode - Melee */
+     , (72972,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (72972,  72,         50) /* FriendType - Idol */
+     , (72972,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72972, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (72972, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72972, 140,          1) /* AiOptions - CanOpenDoors */
+     , (72972, 146,    1100000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, True ) /* Stuck */
-     , (36960,   6, False) /* AiUsesMana */
-     , (36960,  11, False) /* IgnoreCollisions */
-     , (36960,  12, True ) /* ReportCollisions */
-     , (36960,  13, False) /* Ethereal */
-     , (36960,  29, True ) /* NoCorpse */
-     , (36960,  65, False) /* IgnoreMagicResist */
-     , (36960,  66, True ) /* IgnoreMagicArmor */;
+VALUES (72972,   1, True ) /* Stuck */
+     , (72972,   6, False) /* AiUsesMana */
+     , (72972,  11, False) /* IgnoreCollisions */
+     , (72972,  12, True ) /* ReportCollisions */
+     , (72972,  13, False) /* Ethereal */
+     , (72972,  29, True ) /* NoCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (36960,   1,       5) /* HeartbeatInterval */
-     , (36960,   2,       0) /* HeartbeatTimestamp */
-     , (36960,   3,     0.5) /* HealthRate */
-     , (36960,   4,       5) /* StaminaRate */
-     , (36960,   5,       2) /* ManaRate */
-     , (36960,  12,       0) /* Shade */
-     , (36960,  13,     1.3) /* ArmorModVsSlash */
-     , (36960,  14,     1.5) /* ArmorModVsPierce */
-     , (36960,  15,     1.4) /* ArmorModVsBludgeon */
-     , (36960,  16,       1) /* ArmorModVsCold */
-     , (36960,  17,     0.7) /* ArmorModVsFire */
-     , (36960,  18,     1.3) /* ArmorModVsAcid */
-     , (36960,  19,     0.9) /* ArmorModVsElectric */
-     , (36960,  31,      24) /* VisualAwarenessRange */
-     , (36960,  34,     0.9) /* PowerupTime */
-     , (36960,  36,       1) /* ChargeSpeed */
-     , (36960,  39,     1.4) /* DefaultScale */
-     , (36960,  64,     0.5) /* ResistSlash */
-     , (36960,  65,     0.8) /* ResistPierce */
-     , (36960,  66,     0.8) /* ResistBludgeon */
-     , (36960,  67,    0.91) /* ResistFire */
-     , (36960,  68,     0.4) /* ResistCold */
-     , (36960,  69,     0.7) /* ResistAcid */
-     , (36960,  70,    0.91) /* ResistElectric */
-     , (36960,  71,       1) /* ResistHealthBoost */
-     , (36960,  72,       1) /* ResistStaminaDrain */
-     , (36960,  73,       1) /* ResistStaminaBoost */
-     , (36960,  74,       1) /* ResistManaDrain */
-     , (36960,  75,       1) /* ResistManaBoost */
-     , (36960, 104,      10) /* ObviousRadarRange */
-     , (36960, 125,       1) /* ResistHealthDrain */;
+VALUES (72972,   1,       5) /* HeartbeatInterval */
+     , (72972,   2,       0) /* HeartbeatTimestamp */
+     , (72972,   3,     0.5) /* HealthRate */
+     , (72972,   4,       5) /* StaminaRate */
+     , (72972,   5,       2) /* ManaRate */
+     , (72972,  12,       1) /* Shade */
+     , (72972,  13,     1.3) /* ArmorModVsSlash */
+     , (72972,  14,     1.5) /* ArmorModVsPierce */
+     , (72972,  15,     1.4) /* ArmorModVsBludgeon */
+     , (72972,  16,       1) /* ArmorModVsCold */
+     , (72972,  17,     0.7) /* ArmorModVsFire */
+     , (72972,  18,     1.3) /* ArmorModVsAcid */
+     , (72972,  19,     0.9) /* ArmorModVsElectric */
+     , (72972,  31,      20) /* VisualAwarenessRange */
+     , (72972,  34,     0.9) /* PowerupTime */
+     , (72972,  36,       1) /* ChargeSpeed */
+     , (72972,  39,     1.2) /* DefaultScale */
+     , (72972,  64,     0.5) /* ResistSlash */
+     , (72972,  65,     0.8) /* ResistPierce */
+     , (72972,  66,     0.8) /* ResistBludgeon */
+     , (72972,  67,       1) /* ResistFire */
+     , (72972,  68,     0.4) /* ResistCold */
+     , (72972,  69,     0.7) /* ResistAcid */
+     , (72972,  70,     1.1) /* ResistElectric */
+     , (72972,  71,       1) /* ResistHealthBoost */
+     , (72972,  72,       1) /* ResistStaminaDrain */
+     , (72972,  73,       1) /* ResistStaminaBoost */
+     , (72972,  74,       1) /* ResistManaDrain */
+     , (72972,  75,       1) /* ResistManaBoost */
+     , (72972, 104,      10) /* ObviousRadarRange */
+     , (72972, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, 'Mosswart Protector') /* Name */;
+VALUES (72972,   1, 'Mosswart Worker') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, 0x020017C9) /* Setup */
-     , (36960,   2, 0x09000009) /* MotionTable */
-     , (36960,   3, 0x2000002F) /* SoundTable */
-     , (36960,   4, 0x30000005) /* CombatTable */
-     , (36960,   8, 0x06001039) /* Icon */
-     , (36960,  22, 0x34000020) /* PhysicsEffectTable */;
+VALUES (72972,   1, 0x02000B4F) /* Setup */
+     , (72972,   2, 0x09000009) /* MotionTable */
+     , (72972,   3, 0x2000002F) /* SoundTable */
+     , (72972,   4, 0x30000005) /* CombatTable */
+     , (72972,   6, 0x040011B8) /* PaletteBase */
+     , (72972,   7, 0x10000347) /* ClothingBase */
+     , (72972,   8, 0x06001039) /* Icon */
+     , (72972,  22, 0x34000020) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (36960,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (36960,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (36960,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (36960,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (36960,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (36960,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (36960,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (36960,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (36960,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72972,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72972,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72972,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72972,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72972,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72972,  5,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72972,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72972,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72972,  8,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (36960,   1, 300, 0, 0) /* Strength */
-     , (36960,   2, 300, 0, 0) /* Endurance */
-     , (36960,   3, 300, 0, 0) /* Quickness */
-     , (36960,   4, 300, 0, 0) /* Coordination */
-     , (36960,   5, 300, 0, 0) /* Focus */
-     , (36960,   6, 300, 0, 0) /* Self */;
+VALUES (72972,   1, 230, 0, 0) /* Strength */
+     , (72972,   2, 280, 0, 0) /* Endurance */
+     , (72972,   3, 250, 0, 0) /* Quickness */
+     , (72972,   4, 230, 0, 0) /* Coordination */
+     , (72972,   5, 200, 0, 0) /* Focus */
+     , (72972,   6, 170, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (36960,   1,  4850, 0, 0, 5000) /* MaxHealth */
-     , (36960,   3,  4700, 0, 0, 5000) /* MaxStamina */
-     , (36960,   5,   700, 0, 0, 1000) /* MaxMana */;
+VALUES (72972,   1,  3000, 0, 0, 3140) /* MaxHealth */
+     , (72972,   3,  2800, 0, 0, 3080) /* MaxStamina */
+     , (72972,   5,   700, 0, 0,  870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36960,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (36960,  7, 0, 3, 0, 320, 0, 0) /* MissileDefense       Specialized */
-     , (36960, 15, 0, 3, 0, 186, 0, 0) /* MagicDefense        Specialized */
-     , (36960, 24, 0, 3, 0, 400, 0, 0) /* Run                 Specialized */
-     , (36960, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
-     , (36960, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (36960, 44, 0, 3, 0, 360, 0, 0) /* HeavyWeapons        Specialized */
-     , (36960, 45, 0, 3, 0, 360, 0, 0) /* LightWeapons        Specialized */
-     , (36960, 46, 0, 3, 0, 360, 0, 0) /* FinesseWeapons      Specialized */;
+VALUES (72972,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72972,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72972, 14, 0, 3, 0, 250, 0, 0) /* ArcaneLore          Specialized */
+     , (72972, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72972, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72972, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72972, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
+     , (72972, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72972, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72972, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72972, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (36960,  2121,   2.04) /* Corrosive Flash */
-     , (36960,  2129,   2.04) /* Sizzling Fury */
-     , (36960,  2176,   2.02) /* Enervation */
-     , (36960,  2128,   2.07) /* Ilservian's Flame */
-     , (36960,  2717,   2.07) /* Acid Arc VII */
-     , (36960,  3061,   2.03) /* Taint Mana */;
+VALUES (72972,  2172,   2.03) /* Astyrrian's Gift */
+     , (72972,  2168,   2.03) /* Gelidite's Gift */
+     , (72972,  2074,   2.02) /* Gossamer Flesh */
+     , (72972,  2136,   2.05) /* Icy Torment */
+     , (72972,  2140,   2.05) /* Alset's Coil */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -123,7 +128,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -131,7 +136,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -139,7 +144,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -147,7 +152,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -155,7 +160,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -163,7 +168,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72972, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -171,6 +176,5 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (36960, 2, 47717,  0, 0,  0.5, False) /* Create Acid Spear (47717) for Wield */
-     , (36960, 2, 47793,  0, 0,  0.5, False) /* Create Frost Spear (47793) for Wield */;
+VALUES (72972, 9, 72991,  0, 0,    1, False) /* Create Mosswart Worker (72991) for ContainTreasure */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72973 Mosswart Grunt.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72973 Mosswart Grunt.sql
@@ -6,7 +6,7 @@ VALUES (72973, 'ace72973-mosswartgrunt', 10, '2023-03-13 06:11:02') /* Creature 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72973,   1,         16) /* ItemType - Creature */
      , (72973,   2,          4) /* CreatureType - Mosswart */
-     , (72973,   3,         51) /* PaletteTemplate - Brown */
+     , (72973,   3,         51) /* PaletteTemplate - MidgGey */
      , (72973,   6,         -1) /* ItemsCapacity */
      , (72973,   7,         -1) /* ContainersCapacity */
      , (72973,  16,          1) /* ItemUseable - No */
@@ -42,7 +42,7 @@ VALUES (72973,   1,       5) /* HeartbeatInterval */
      , (72973,  17,     0.7) /* ArmorModVsFire */
      , (72973,  18,     1.3) /* ArmorModVsAcid */
      , (72973,  19,     0.9) /* ArmorModVsElectric */
-     , (72973,  31,      20) /* VisualAwarenessRange */
+     , (72973,  31,      18) /* VisualAwarenessRange */
      , (72973,  34,     0.9) /* PowerupTime */
      , (72973,  36,       1) /* ChargeSpeed */
      , (72973,  39,     1.2) /* DefaultScale */
@@ -74,17 +74,6 @@ VALUES (72973,   1, 0x02000B4F) /* Setup */
      , (72973,   8, 0x06001039) /* Icon */
      , (72973,  22, 0x34000020) /* PhysicsEffectTable */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (72973,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (72973,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (72973,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (72973,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (72973,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72973,  5,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (72973,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (72973,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72973,  8,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (72973,   1, 230, 0, 0) /* Strength */
      , (72973,   2, 280, 0, 0) /* Endurance */
@@ -96,7 +85,7 @@ VALUES (72973,   1, 230, 0, 0) /* Strength */
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
 VALUES (72973,   1,  3000, 0, 0, 3140) /* MaxHealth */
      , (72973,   3,  2800, 0, 0, 3080) /* MaxStamina */
-     , (72973,   5,   700, 0, 0,  870) /* MaxMana */;
+     , (72973,   5,   700, 0, 0, 870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (72973,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
@@ -110,64 +99,74 @@ VALUES (72973,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72973, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */
      , (72973, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72973,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72973,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72973,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72973,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72973,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72973,  5,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72973,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72973,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72973,  8,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,  0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72973, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (72973, 2, 47717,  1, 0,  0.5, False) /* Create Acid Spear (32123) for Wield */
-     , (72973, 2, 47793,  1, 0,  0.5, False) /* Create Frost Spear (32124) for Wield */
-     , (72973, 9, 72992,  0, 0,    1, False) /* Create Mosswart Grunt (72992) for ContainTreasure */;
-
+VALUES (72973, 2, 47717,  1, 0, 0.5, False) /* Create Acid Spear (47717) for Wield */
+     , (72973, 2, 47793,  1, 0, 0.5, False) /* Create Frost Spear (47793) for Wield */
+     , (72973, 9, 72992,  0, 0, 1, False) /* Create Mosswart Grunt (72992) for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72973 Mosswart Grunt.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72973 Mosswart Grunt.sql
@@ -1,121 +1,117 @@
-DELETE FROM `weenie` WHERE `class_Id` = 36960;
+DELETE FROM `weenie` WHERE `class_Id` = 72973;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36960, 'ace36960-mosswartprotector', 10, '2023-03-14 02:33:36') /* Creature */;
+VALUES (72973, 'ace72973-mosswartgrunt', 10, '2023-03-13 06:11:02') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (36960,   1,         16) /* ItemType - Creature */
-     , (36960,   2,          4) /* CreatureType - Mosswart */
-     , (36960,   6,         -1) /* ItemsCapacity */
-     , (36960,   7,         -1) /* ContainersCapacity */
-     , (36960,  16,          1) /* ItemUseable - No */
-     , (36960,  25,        185) /* Level */
-     , (36960,  40,          2) /* CombatMode - Melee */
-     , (36960,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
-     , (36960,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
-     , (36960, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
-     , (36960, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (36960, 146,     800000) /* XpOverride */;
+VALUES (72973,   1,         16) /* ItemType - Creature */
+     , (72973,   2,          4) /* CreatureType - Mosswart */
+     , (72973,   3,         51) /* PaletteTemplate - Brown */
+     , (72973,   6,         -1) /* ItemsCapacity */
+     , (72973,   7,         -1) /* ContainersCapacity */
+     , (72973,  16,          1) /* ItemUseable - No */
+     , (72973,  25,        200) /* Level */
+     , (72973,  27,          0) /* ArmorType - None */
+     , (72973,  40,          2) /* CombatMode - Melee */
+     , (72973,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (72973,  72,         50) /* FriendType - Idol */
+     , (72973,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72973, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (72973, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72973, 140,          1) /* AiOptions - CanOpenDoors */
+     , (72973, 146,    1100000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, True ) /* Stuck */
-     , (36960,   6, False) /* AiUsesMana */
-     , (36960,  11, False) /* IgnoreCollisions */
-     , (36960,  12, True ) /* ReportCollisions */
-     , (36960,  13, False) /* Ethereal */
-     , (36960,  29, True ) /* NoCorpse */
-     , (36960,  65, False) /* IgnoreMagicResist */
-     , (36960,  66, True ) /* IgnoreMagicArmor */;
+VALUES (72973,   1, True ) /* Stuck */
+     , (72973,  11, False) /* IgnoreCollisions */
+     , (72973,  12, True ) /* ReportCollisions */
+     , (72973,  13, False) /* Ethereal */
+     , (72973,  29, True ) /* NoCorpse */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (36960,   1,       5) /* HeartbeatInterval */
-     , (36960,   2,       0) /* HeartbeatTimestamp */
-     , (36960,   3,     0.5) /* HealthRate */
-     , (36960,   4,       5) /* StaminaRate */
-     , (36960,   5,       2) /* ManaRate */
-     , (36960,  12,       0) /* Shade */
-     , (36960,  13,     1.3) /* ArmorModVsSlash */
-     , (36960,  14,     1.5) /* ArmorModVsPierce */
-     , (36960,  15,     1.4) /* ArmorModVsBludgeon */
-     , (36960,  16,       1) /* ArmorModVsCold */
-     , (36960,  17,     0.7) /* ArmorModVsFire */
-     , (36960,  18,     1.3) /* ArmorModVsAcid */
-     , (36960,  19,     0.9) /* ArmorModVsElectric */
-     , (36960,  31,      24) /* VisualAwarenessRange */
-     , (36960,  34,     0.9) /* PowerupTime */
-     , (36960,  36,       1) /* ChargeSpeed */
-     , (36960,  39,     1.4) /* DefaultScale */
-     , (36960,  64,     0.5) /* ResistSlash */
-     , (36960,  65,     0.8) /* ResistPierce */
-     , (36960,  66,     0.8) /* ResistBludgeon */
-     , (36960,  67,    0.91) /* ResistFire */
-     , (36960,  68,     0.4) /* ResistCold */
-     , (36960,  69,     0.7) /* ResistAcid */
-     , (36960,  70,    0.91) /* ResistElectric */
-     , (36960,  71,       1) /* ResistHealthBoost */
-     , (36960,  72,       1) /* ResistStaminaDrain */
-     , (36960,  73,       1) /* ResistStaminaBoost */
-     , (36960,  74,       1) /* ResistManaDrain */
-     , (36960,  75,       1) /* ResistManaBoost */
-     , (36960, 104,      10) /* ObviousRadarRange */
-     , (36960, 125,       1) /* ResistHealthDrain */;
+VALUES (72973,   1,       5) /* HeartbeatInterval */
+     , (72973,   2,       0) /* HeartbeatTimestamp */
+     , (72973,   3,     0.5) /* HealthRate */
+     , (72973,   4,       5) /* StaminaRate */
+     , (72973,   5,       2) /* ManaRate */
+     , (72973,  12,       0) /* Shade */
+     , (72973,  13,     1.3) /* ArmorModVsSlash */
+     , (72973,  14,     1.5) /* ArmorModVsPierce */
+     , (72973,  15,     1.4) /* ArmorModVsBludgeon */
+     , (72973,  16,       1) /* ArmorModVsCold */
+     , (72973,  17,     0.7) /* ArmorModVsFire */
+     , (72973,  18,     1.3) /* ArmorModVsAcid */
+     , (72973,  19,     0.9) /* ArmorModVsElectric */
+     , (72973,  31,      20) /* VisualAwarenessRange */
+     , (72973,  34,     0.9) /* PowerupTime */
+     , (72973,  36,       1) /* ChargeSpeed */
+     , (72973,  39,     1.2) /* DefaultScale */
+     , (72973,  64,     0.5) /* ResistSlash */
+     , (72973,  65,     0.8) /* ResistPierce */
+     , (72973,  66,     0.8) /* ResistBludgeon */
+     , (72973,  67,       1) /* ResistFire */
+     , (72973,  68,     0.4) /* ResistCold */
+     , (72973,  69,     0.7) /* ResistAcid */
+     , (72973,  70,     1.1) /* ResistElectric */
+     , (72973,  71,       1) /* ResistHealthBoost */
+     , (72973,  72,       1) /* ResistStaminaDrain */
+     , (72973,  73,       1) /* ResistStaminaBoost */
+     , (72973,  74,       1) /* ResistManaDrain */
+     , (72973,  75,       1) /* ResistManaBoost */
+     , (72973, 104,      10) /* ObviousRadarRange */
+     , (72973, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, 'Mosswart Protector') /* Name */;
+VALUES (72973,   1, 'Mosswart Grunt') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, 0x020017C9) /* Setup */
-     , (36960,   2, 0x09000009) /* MotionTable */
-     , (36960,   3, 0x2000002F) /* SoundTable */
-     , (36960,   4, 0x30000005) /* CombatTable */
-     , (36960,   8, 0x06001039) /* Icon */
-     , (36960,  22, 0x34000020) /* PhysicsEffectTable */;
+VALUES (72973,   1, 0x02000B4F) /* Setup */
+     , (72973,   2, 0x09000009) /* MotionTable */
+     , (72973,   3, 0x2000002F) /* SoundTable */
+     , (72973,   4, 0x30000005) /* CombatTable */
+     , (72973,   6, 0x040011B8) /* PaletteBase */
+     , (72973,   7, 0x10000347) /* ClothingBase */
+     , (72973,   8, 0x06001039) /* Icon */
+     , (72973,  22, 0x34000020) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (36960,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (36960,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (36960,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (36960,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (36960,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (36960,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (36960,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (36960,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (36960,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72973,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72973,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72973,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72973,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72973,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72973,  5,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72973,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72973,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72973,  8,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (36960,   1, 300, 0, 0) /* Strength */
-     , (36960,   2, 300, 0, 0) /* Endurance */
-     , (36960,   3, 300, 0, 0) /* Quickness */
-     , (36960,   4, 300, 0, 0) /* Coordination */
-     , (36960,   5, 300, 0, 0) /* Focus */
-     , (36960,   6, 300, 0, 0) /* Self */;
+VALUES (72973,   1, 230, 0, 0) /* Strength */
+     , (72973,   2, 280, 0, 0) /* Endurance */
+     , (72973,   3, 250, 0, 0) /* Quickness */
+     , (72973,   4, 230, 0, 0) /* Coordination */
+     , (72973,   5, 200, 0, 0) /* Focus */
+     , (72973,   6, 170, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (36960,   1,  4850, 0, 0, 5000) /* MaxHealth */
-     , (36960,   3,  4700, 0, 0, 5000) /* MaxStamina */
-     , (36960,   5,   700, 0, 0, 1000) /* MaxMana */;
+VALUES (72973,   1,  3000, 0, 0, 3140) /* MaxHealth */
+     , (72973,   3,  2800, 0, 0, 3080) /* MaxStamina */
+     , (72973,   5,   700, 0, 0,  870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36960,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (36960,  7, 0, 3, 0, 320, 0, 0) /* MissileDefense       Specialized */
-     , (36960, 15, 0, 3, 0, 186, 0, 0) /* MagicDefense        Specialized */
-     , (36960, 24, 0, 3, 0, 400, 0, 0) /* Run                 Specialized */
-     , (36960, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
-     , (36960, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (36960, 44, 0, 3, 0, 360, 0, 0) /* HeavyWeapons        Specialized */
-     , (36960, 45, 0, 3, 0, 360, 0, 0) /* LightWeapons        Specialized */
-     , (36960, 46, 0, 3, 0, 360, 0, 0) /* FinesseWeapons      Specialized */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (36960,  2121,   2.04) /* Corrosive Flash */
-     , (36960,  2129,   2.04) /* Sizzling Fury */
-     , (36960,  2176,   2.02) /* Enervation */
-     , (36960,  2128,   2.07) /* Ilservian's Flame */
-     , (36960,  2717,   2.07) /* Acid Arc VII */
-     , (36960,  3061,   2.03) /* Taint Mana */;
+VALUES (72973,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72973,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72973, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72973, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72973, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72973, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
+     , (72973, 44, 0, 3, 0, 450, 0, 0) /* HeavyWeapons        Specialized */
+     , (72973, 45, 0, 3, 0, 450, 0, 0) /* LightWeapons        Specialized */
+     , (72973, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */
+     , (72973, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -123,7 +119,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -131,7 +127,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -139,7 +135,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -147,7 +143,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -155,7 +151,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -163,7 +159,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72973, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -171,6 +167,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (36960, 2, 47717,  0, 0,  0.5, False) /* Create Acid Spear (47717) for Wield */
-     , (36960, 2, 47793,  0, 0,  0.5, False) /* Create Frost Spear (47793) for Wield */;
+VALUES (72973, 2, 47717,  1, 0,  0.5, False) /* Create Acid Spear (32123) for Wield */
+     , (72973, 2, 47793,  1, 0,  0.5, False) /* Create Frost Spear (32124) for Wield */
+     , (72973, 9, 72992,  0, 0,    1, False) /* Create Mosswart Grunt (72992) for ContainTreasure */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72982 Mosswart Tribesman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72982 Mosswart Tribesman.sql
@@ -1,121 +1,119 @@
-DELETE FROM `weenie` WHERE `class_Id` = 36960;
+DELETE FROM `weenie` WHERE `class_Id` = 72982;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36960, 'ace36960-mosswartprotector', 10, '2023-03-14 02:33:36') /* Creature */;
+VALUES (72982, 'ace72982-mosswarttribesman', 10, '2023-03-14 02:50:14') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (36960,   1,         16) /* ItemType - Creature */
-     , (36960,   2,          4) /* CreatureType - Mosswart */
-     , (36960,   6,         -1) /* ItemsCapacity */
-     , (36960,   7,         -1) /* ContainersCapacity */
-     , (36960,  16,          1) /* ItemUseable - No */
-     , (36960,  25,        185) /* Level */
-     , (36960,  40,          2) /* CombatMode - Melee */
-     , (36960,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
-     , (36960,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
-     , (36960, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
-     , (36960, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (36960, 146,     800000) /* XpOverride */;
+VALUES (72982,   1,         16) /* ItemType - Creature */
+     , (72982,   2,          4) /* CreatureType - Mosswart */
+     , (72982,   3,          7) /* PaletteTemplate - DarkGrey */
+     , (72982,   6,         -1) /* ItemsCapacity */
+     , (72982,   7,         -1) /* ContainersCapacity */
+     , (72982,  16,          1) /* ItemUseable - No */
+     , (72982,  25,        185) /* Level */
+     , (72982,  27,          0) /* ArmorType - None */
+     , (72982,  40,          2) /* CombatMode - Melee */
+     , (72982,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (72982,  72,         50) /* FriendType - Idol */
+     , (72982,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (72982, 101,     524288) /* AiAllowedCombatStyle - StubbornMissile */
+     , (72982, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72982, 140,          1) /* AiOptions - CanOpenDoors */
+     , (72982, 146,     800000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, True ) /* Stuck */
-     , (36960,   6, False) /* AiUsesMana */
-     , (36960,  11, False) /* IgnoreCollisions */
-     , (36960,  12, True ) /* ReportCollisions */
-     , (36960,  13, False) /* Ethereal */
-     , (36960,  29, True ) /* NoCorpse */
-     , (36960,  65, False) /* IgnoreMagicResist */
-     , (36960,  66, True ) /* IgnoreMagicArmor */;
+VALUES (72982,   1, True ) /* Stuck */
+     , (72982,   6, False) /* AiUsesMana */
+     , (72982,  11, False) /* IgnoreCollisions */
+     , (72982,  12, True ) /* ReportCollisions */
+     , (72982,  13, False) /* Ethereal */
+     , (72982,  52, True ) /* AiImmobile */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (36960,   1,       5) /* HeartbeatInterval */
-     , (36960,   2,       0) /* HeartbeatTimestamp */
-     , (36960,   3,     0.5) /* HealthRate */
-     , (36960,   4,       5) /* StaminaRate */
-     , (36960,   5,       2) /* ManaRate */
-     , (36960,  12,       0) /* Shade */
-     , (36960,  13,     1.3) /* ArmorModVsSlash */
-     , (36960,  14,     1.5) /* ArmorModVsPierce */
-     , (36960,  15,     1.4) /* ArmorModVsBludgeon */
-     , (36960,  16,       1) /* ArmorModVsCold */
-     , (36960,  17,     0.7) /* ArmorModVsFire */
-     , (36960,  18,     1.3) /* ArmorModVsAcid */
-     , (36960,  19,     0.9) /* ArmorModVsElectric */
-     , (36960,  31,      24) /* VisualAwarenessRange */
-     , (36960,  34,     0.9) /* PowerupTime */
-     , (36960,  36,       1) /* ChargeSpeed */
-     , (36960,  39,     1.4) /* DefaultScale */
-     , (36960,  64,     0.5) /* ResistSlash */
-     , (36960,  65,     0.8) /* ResistPierce */
-     , (36960,  66,     0.8) /* ResistBludgeon */
-     , (36960,  67,    0.91) /* ResistFire */
-     , (36960,  68,     0.4) /* ResistCold */
-     , (36960,  69,     0.7) /* ResistAcid */
-     , (36960,  70,    0.91) /* ResistElectric */
-     , (36960,  71,       1) /* ResistHealthBoost */
-     , (36960,  72,       1) /* ResistStaminaDrain */
-     , (36960,  73,       1) /* ResistStaminaBoost */
-     , (36960,  74,       1) /* ResistManaDrain */
-     , (36960,  75,       1) /* ResistManaBoost */
-     , (36960, 104,      10) /* ObviousRadarRange */
-     , (36960, 125,       1) /* ResistHealthDrain */;
+VALUES (72982,   1,       5) /* HeartbeatInterval */
+     , (72982,   2,       0) /* HeartbeatTimestamp */
+     , (72982,   3,     0.5) /* HealthRate */
+     , (72982,   4,       5) /* StaminaRate */
+     , (72982,   5,       2) /* ManaRate */
+     , (72982,  12,       1) /* Shade */
+     , (72982,  13,     1.3) /* ArmorModVsSlash */
+     , (72982,  14,     1.5) /* ArmorModVsPierce */
+     , (72982,  15,     1.4) /* ArmorModVsBludgeon */
+     , (72982,  16,       1) /* ArmorModVsCold */
+     , (72982,  17,     0.7) /* ArmorModVsFire */
+     , (72982,  18,     1.3) /* ArmorModVsAcid */
+     , (72982,  19,     0.9) /* ArmorModVsElectric */
+     , (72982,  31,      24) /* VisualAwarenessRange */
+     , (72982,  34,     0.9) /* PowerupTime */
+     , (72982,  36,       1) /* ChargeSpeed */
+     , (72982,  39,     1.2) /* DefaultScale */
+     , (72982,  64,     0.5) /* ResistSlash */
+     , (72982,  65,     0.8) /* ResistPierce */
+     , (72982,  66,     0.8) /* ResistBludgeon */
+     , (72982,  67,       1) /* ResistFire */
+     , (72982,  68,     0.4) /* ResistCold */
+     , (72982,  69,     0.7) /* ResistAcid */
+     , (72982,  70,     1.1) /* ResistElectric */
+     , (72982,  71,       1) /* ResistHealthBoost */
+     , (72982,  72,       1) /* ResistStaminaDrain */
+     , (72982,  73,       1) /* ResistStaminaBoost */
+     , (72982,  74,       1) /* ResistManaDrain */
+     , (72982,  75,       1) /* ResistManaBoost */
+     , (72982, 104,      10) /* ObviousRadarRange */
+     , (72982, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, 'Mosswart Protector') /* Name */;
+VALUES (72982,   1, 'Mosswart Tribesman') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (36960,   1, 0x020017C9) /* Setup */
-     , (36960,   2, 0x09000009) /* MotionTable */
-     , (36960,   3, 0x2000002F) /* SoundTable */
-     , (36960,   4, 0x30000005) /* CombatTable */
-     , (36960,   8, 0x06001039) /* Icon */
-     , (36960,  22, 0x34000020) /* PhysicsEffectTable */;
+VALUES (72982,   1, 0x02000B4F) /* Setup */
+     , (72982,   2, 0x09000009) /* MotionTable */
+     , (72982,   3, 0x2000002F) /* SoundTable */
+     , (72982,   4, 0x30000005) /* CombatTable */
+     , (72982,   6, 0x040011B8) /* PaletteBase */
+     , (72982,   7, 0x10000347) /* ClothingBase */
+     , (72982,   8, 0x06001039) /* Icon */
+     , (72982,  22, 0x34000020) /* PhysicsEffectTable */
+     , (72982,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (36960,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (36960,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (36960,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (36960,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (36960,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (36960,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (36960,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (36960,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (36960,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72982,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72982,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72982,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72982,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72982,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72982,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72982,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72982,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72982,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (36960,   1, 300, 0, 0) /* Strength */
-     , (36960,   2, 300, 0, 0) /* Endurance */
-     , (36960,   3, 300, 0, 0) /* Quickness */
-     , (36960,   4, 300, 0, 0) /* Coordination */
-     , (36960,   5, 300, 0, 0) /* Focus */
-     , (36960,   6, 300, 0, 0) /* Self */;
+VALUES (72982,   1, 230, 0, 0) /* Strength */
+     , (72982,   2, 280, 0, 0) /* Endurance */
+     , (72982,   3, 250, 0, 0) /* Quickness */
+     , (72982,   4, 230, 0, 0) /* Coordination */
+     , (72982,   5, 200, 0, 0) /* Focus */
+     , (72982,   6, 170, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (36960,   1,  4850, 0, 0, 5000) /* MaxHealth */
-     , (36960,   3,  4700, 0, 0, 5000) /* MaxStamina */
-     , (36960,   5,   700, 0, 0, 1000) /* MaxMana */;
+VALUES (72982,   1,  1680, 0, 0, 1820) /* MaxHealth */
+     , (72982,   3,  2800, 0, 0, 3080) /* MaxStamina */
+     , (72982,   5,   700, 0, 0,  870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36960,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (36960,  7, 0, 3, 0, 320, 0, 0) /* MissileDefense       Specialized */
-     , (36960, 15, 0, 3, 0, 186, 0, 0) /* MagicDefense        Specialized */
-     , (36960, 24, 0, 3, 0, 400, 0, 0) /* Run                 Specialized */
-     , (36960, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
-     , (36960, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (36960, 44, 0, 3, 0, 360, 0, 0) /* HeavyWeapons        Specialized */
-     , (36960, 45, 0, 3, 0, 360, 0, 0) /* LightWeapons        Specialized */
-     , (36960, 46, 0, 3, 0, 360, 0, 0) /* FinesseWeapons      Specialized */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (36960,  2121,   2.04) /* Corrosive Flash */
-     , (36960,  2129,   2.04) /* Sizzling Fury */
-     , (36960,  2176,   2.02) /* Enervation */
-     , (36960,  2128,   2.07) /* Ilservian's Flame */
-     , (36960,  2717,   2.07) /* Acid Arc VII */
-     , (36960,  3061,   2.03) /* Taint Mana */;
+VALUES (72982,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72982,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72982, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72982, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72982, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72982, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
+     , (72982, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72982, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72982, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72982, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -123,7 +121,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -131,7 +129,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -139,7 +137,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -147,7 +145,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -155,7 +153,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -163,7 +161,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36960, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (72982, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -171,6 +169,4 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (36960, 2, 47717,  0, 0,  0.5, False) /* Create Acid Spear (47717) for Wield */
-     , (36960, 2, 47793,  0, 0,  0.5, False) /* Create Frost Spear (47793) for Wield */;
-
+VALUES (72982, 2, 72994,  1, 0,    0, False) /* Create Frost Javelin (72982) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72991 Mosswart Worker.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72991 Mosswart Worker.sql
@@ -1,0 +1,189 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72991;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72991, 'ace72991-mosswartworker', 10, '2023-03-13 05:30:45') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72991,   1,         16) /* ItemType - Creature */
+     , (72991,   2,          4) /* CreatureType - Mosswart */
+     , (72991,   3,         52) /* PaletteTemplate - DarkGrey */
+     , (72991,   6,         -1) /* ItemsCapacity */
+     , (72991,   7,         -1) /* ContainersCapacity */
+     , (72991,  16,         32) /* ItemUseable - Remote */
+     , (72991,  25,        175) /* Level */
+     , (72991,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72991,  95,          8) /* RadarBlipColor - Yellow */
+     , (72991, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72991, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72991, 146,     800000) /* XpOverride */
+     , (72991, 267,         60) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72991,   1, True ) /* Stuck */
+     , (72991,  11, True ) /* IgnoreCollisions */
+     , (72991,  12, True ) /* ReportCollisions */
+     , (72991,  14, True ) /* GravityStatus */
+     , (72991,  19, False) /* Attackable */
+     , (72991,  41, True ) /* ReportCollisionsAsEnvironment */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72991,   1,       5) /* HeartbeatInterval */
+     , (72991,   2,       0) /* HeartbeatTimestamp */
+     , (72991,   3,     0.5) /* HealthRate */
+     , (72991,   4,       5) /* StaminaRate */
+     , (72991,   5,       2) /* ManaRate */
+     , (72991,  12,       1) /* Shade */
+     , (72991,  13,     1.3) /* ArmorModVsSlash */
+     , (72991,  14,     1.5) /* ArmorModVsPierce */
+     , (72991,  15,     1.4) /* ArmorModVsBludgeon */
+     , (72991,  16,       1) /* ArmorModVsCold */
+     , (72991,  17,     0.7) /* ArmorModVsFire */
+     , (72991,  18,     1.3) /* ArmorModVsAcid */
+     , (72991,  19,     0.9) /* ArmorModVsElectric */
+     , (72991,  31,      24) /* VisualAwarenessRange */
+     , (72991,  34,     0.9) /* PowerupTime */
+     , (72991,  36,       1) /* ChargeSpeed */
+     , (72991,  39,     1.2) /* DefaultScale */
+     , (72991,  54,       3) /* UseRadius */
+     , (72991,  64,     0.5) /* ResistSlash */
+     , (72991,  65,     0.8) /* ResistPierce */
+     , (72991,  66,     0.8) /* ResistBludgeon */
+     , (72991,  67,       1) /* ResistFire */
+     , (72991,  68,     0.4) /* ResistCold */
+     , (72991,  69,     0.7) /* ResistAcid */
+     , (72991,  70,     1.1) /* ResistElectric */
+     , (72991,  71,       1) /* ResistHealthBoost */
+     , (72991,  72,       1) /* ResistStaminaDrain */
+     , (72991,  73,       1) /* ResistStaminaBoost */
+     , (72991,  74,       1) /* ResistManaDrain */
+     , (72991,  75,       1) /* ResistManaBoost */
+     , (72991, 104,      10) /* ObviousRadarRange */
+     , (72991, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72991,   1, 'Mosswart Worker') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72991,   1, 0x02000B4F) /* Setup */
+     , (72991,   2, 0x09000009) /* MotionTable */
+     , (72991,   3, 0x2000002F) /* SoundTable */
+     , (72991,   4, 0x30000005) /* CombatTable */
+     , (72991,   6, 0x040011B8) /* PaletteBase */
+     , (72991,   7, 0x10000347) /* ClothingBase */
+     , (72991,   8, 0x06001039) /* Icon */
+     , (72991,  22, 0x34000020) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72991,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72991,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72991,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72991,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72991,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72991,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72991,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72991,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72991,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72991,   1, 250, 0, 0) /* Strength */
+     , (72991,   2, 300, 0, 0) /* Endurance */
+     , (72991,   3, 280, 0, 0) /* Quickness */
+     , (72991,   4, 260, 0, 0) /* Coordination */
+     , (72991,   5, 265, 0, 0) /* Focus */
+     , (72991,   6, 300, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72991,   1,  2850, 0, 0, 3000) /* MaxHealth */
+     , (72991,   3,  1790, 0, 0, 2090) /* MaxStamina */
+     , (72991,   5,   500, 0, 0,  800) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72991,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72991,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72991, 14, 0, 3, 0, 250, 0, 0) /* ArcaneLore          Specialized */
+     , (72991, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72991, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72991, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72991, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
+     , (72991, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72991, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72991, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72991, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetStarted_1212', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have returned 10 Mosswarts to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'WorkersMotivated', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'say_stuff', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 32 /* GotoSet */, 0.5, NULL, NULL, NULL, 'say_stuff', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'Stop! I return to work now!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'check_count', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'say_stuff', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'I knew Directors no good. I go work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'check_count', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'check_count', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10_2', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have returned 10 Mosswarts to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72991, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have not yet returned 10 Mosswarts to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72991.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72991.es
@@ -1,0 +1,26 @@
+Use:
+    - InqQuest: SaveAPetStarted_1212
+        QuestSuccess:
+            - InqQuestSolves: WorkersMotivated, 10 - 10 
+                QuestSuccess:
+                    - DirectBroadcast: You have returned 10 Mosswarts to work.
+                QuestFailure:
+                    - StampQuest: WorkersMotivated
+                    - Goto: say_stuff
+
+Gotoset: say_stuff, Probability: 0.5
+    - Tell: Stop! I return to work now!
+    - Goto: check_count
+
+Gotoset: say_stuff, Probability: 1
+    - Tell: I knew Directors no good. I go work.
+    - Goto: check_count
+
+Gotoset: check_count
+    - InqQuestSolves: WorkersMotivated, 10 - 10
+        QuestSuccess:
+            - DirectBroadcast: You have returned 10 Mosswarts to work.
+            - DeleteSelf
+        QuestFailure:
+            - DirectBroadcast: You have not yet returned 10 Mosswarts to work.
+            - DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72992 Mosswart Grunt.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72992 Mosswart Grunt.sql
@@ -1,0 +1,196 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72992;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72992, 'ace72992-mosswartgrunt', 10, '2023-03-13 05:30:52') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72992,   1,         16) /* ItemType - Creature */
+     , (72992,   2,          4) /* CreatureType - Mosswart */
+     , (72992,   3,         51) /* PaletteTemplate - Brown */
+     , (72992,   6,         -1) /* ItemsCapacity */
+     , (72992,   7,         -1) /* ContainersCapacity */
+     , (72992,  16,         32) /* ItemUseable - Remote */
+     , (72992,  25,        200) /* Level */
+     , (72992,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72992,  95,          8) /* RadarBlipColor - Yellow */
+     , (72992, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72992, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72992, 146,     175000) /* XpOverride */
+     , (72992, 267,         60) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72992,   1, True ) /* Stuck */
+     , (72992,  11, True ) /* IgnoreCollisions */
+     , (72992,  12, True ) /* ReportCollisions */
+     , (72992,  14, True ) /* GravityStatus */
+     , (72992,  19, False) /* Attackable */
+     , (72992,  41, True ) /* ReportCollisionsAsEnvironment */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72992,   1,       5) /* HeartbeatInterval */
+     , (72992,   2,       0) /* HeartbeatTimestamp */
+     , (72992,   3,     0.5) /* HealthRate */
+     , (72992,   4,       5) /* StaminaRate */
+     , (72992,   5,       2) /* ManaRate */
+     , (72992,  12,       0) /* Shade */
+     , (72992,  13,     1.3) /* ArmorModVsSlash */
+     , (72992,  14,     1.5) /* ArmorModVsPierce */
+     , (72992,  15,     1.4) /* ArmorModVsBludgeon */
+     , (72992,  16,       1) /* ArmorModVsCold */
+     , (72992,  17,     0.7) /* ArmorModVsFire */
+     , (72992,  18,     1.3) /* ArmorModVsAcid */
+     , (72992,  19,     0.9) /* ArmorModVsElectric */
+     , (72992,  31,      20) /* VisualAwarenessRange */
+     , (72992,  34,     0.9) /* PowerupTime */
+     , (72992,  36,       1) /* ChargeSpeed */
+     , (72992,  39,     1.2) /* DefaultScale */
+     , (72992,  54,       3) /* UseRadius */
+     , (72992,  64,     0.5) /* ResistSlash */
+     , (72992,  65,     0.8) /* ResistPierce */
+     , (72992,  66,     0.8) /* ResistBludgeon */
+     , (72992,  67,       1) /* ResistFire */
+     , (72992,  68,     0.4) /* ResistCold */
+     , (72992,  69,     0.7) /* ResistAcid */
+     , (72992,  70,     1.1) /* ResistElectric */
+     , (72992,  71,       1) /* ResistHealthBoost */
+     , (72992,  72,       1) /* ResistStaminaDrain */
+     , (72992,  73,       1) /* ResistStaminaBoost */
+     , (72992,  74,       1) /* ResistManaDrain */
+     , (72992,  75,       1) /* ResistManaBoost */
+     , (72992, 104,      10) /* ObviousRadarRange */
+     , (72992, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72992,   1, 'Mosswart Grunt') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72992,   1, 0x02000B4F) /* Setup */
+     , (72992,   2, 0x09000009) /* MotionTable */
+     , (72992,   3, 0x2000002F) /* SoundTable */
+     , (72992,   4, 0x30000005) /* CombatTable */
+     , (72992,   6, 0x040011B8) /* PaletteBase */
+     , (72992,   7, 0x10000347) /* ClothingBase */
+     , (72992,   8, 0x06001039) /* Icon */
+     , (72992,  22, 0x34000020) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72992,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72992,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72992,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72992,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72992,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72992,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72992,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72992,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72992,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72992,   1, 230, 0, 0) /* Strength */
+     , (72992,   2, 280, 0, 0) /* Endurance */
+     , (72992,   3, 250, 0, 0) /* Quickness */
+     , (72992,   4, 230, 0, 0) /* Coordination */
+     , (72992,   5, 200, 0, 0) /* Focus */
+     , (72992,   6, 170, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72992,   1,  3000, 0, 0, 3140) /* MaxHealth */
+     , (72992,   3,  2800, 0, 0, 3080) /* MaxStamina */
+     , (72992,   5,   700, 0, 0,  870) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72992,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72992,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72992, 14, 0, 3, 0, 250, 0, 0) /* ArcaneLore          Specialized */
+     , (72992, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72992, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72992, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72992, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72992, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72992, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 21 /* InqQuest */, 0, 1, NULL, 'SaveAPetStarted_1212@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'SaveAPetStarted_1212@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10_3', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have returned 10 Mosswarts to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'WorkersMotivated', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'say_stuff', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 32 /* GotoSet */, 0.33, NULL, NULL, NULL, 'say_stuff', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'No kill me. I no fight, I work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'check_count', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 32 /* GotoSet */, 0.66, NULL, NULL, NULL, 'say_stuff', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'I knew Directors no good. I go work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'check_count', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'say_stuff', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'No! I work! I work!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 67 /* Goto */, 0, 1, NULL, 'check_count', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 32 /* GotoSet */, 1, NULL, NULL, NULL, 'check_count', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 30 /* InqQuestSolves */, 0, 1, NULL, 'WorkersMotivated@10-10_4', NULL, 10, 10, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_4', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have returned 10 Mosswarts to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72992, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'WorkersMotivated@10-10_4', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You have not yet returned 10 Mosswarts to work.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72992.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72992.es
@@ -1,0 +1,30 @@
+Use:
+    - InqQuest: SaveAPetStarted_1212
+        QuestSuccess:
+            - InqQuestSolves: WorkersMotivated, 10 - 10 
+                QuestSuccess:
+                    - DirectBroadcast: You have returned 10 Mosswarts to work.
+                QuestFailure:
+                    - StampQuest: WorkersMotivated
+                    - Goto: say_stuff
+
+Gotoset: say_stuff, Probability: 0.33
+    - Tell: No kill me. I no fight, I work.
+    - Goto: check_count
+
+Gotoset: say_stuff, Probability: 0.66
+    - Tell: I knew Directors no good. I go work.
+    - Goto: check_count
+
+Gotoset: say_stuff, Probability: 1
+    - Tell: No! I work! I work!
+    - Goto: check_count
+
+Gotoset: check_count
+    - InqQuestSolves: WorkersMotivated, 10 - 10
+        QuestSuccess:
+            - DirectBroadcast: You have returned 10 Mosswarts to work.
+            - DeleteSelf
+        QuestFailure:
+            - DirectBroadcast: You have not yet returned 10 Mosswarts to work.
+            - DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72993 Mosswart Director.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72993 Mosswart Director.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72993;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72993, 'ace72993-mosswartdirector', 10, '2023-03-12 09:43:10') /* Creature */;
+VALUES (72993, 'ace72993-mosswartdirector', 10, '2023-03-16 11:46:58') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72993,   1,         16) /* ItemType - Creature */
@@ -43,7 +43,7 @@ VALUES (72993,   1,       5) /* HeartbeatInterval */
      , (72993,  17,     0.4) /* ArmorModVsFire */
      , (72993,  18,    0.03) /* ArmorModVsAcid */
      , (72993,  19,     0.7) /* ArmorModVsElectric */
-     , (72993,  31,      20) /* VisualAwarenessRange */
+     , (72993,  31,      18) /* VisualAwarenessRange */
      , (72993,  34,       1) /* PowerupTime */
      , (72993,  36,       1) /* ChargeSpeed */
      , (72993,  39,     1.2) /* DefaultScale */
@@ -77,16 +77,19 @@ VALUES (72993,   1, 0x02000B4F) /* Setup */
      , (72993,  22, 0x34000020) /* PhysicsEffectTable */
      , (72993,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (72993,  16, 0x7586000C) /* ActivationTarget */;
+
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (72993,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (72993,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
      , (72993,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
      , (72993,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
      , (72993,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72993,  5,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72993,  5,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
      , (72993,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (72993,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72993,  8,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (72993,  8,  4,400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (72993,   1, 340, 0, 0) /* Strength */
@@ -119,6 +122,16 @@ VALUES (72993,  2162,   2.03) /* Olthoi's Gift */
      , (72993,  2074,   2.02) /* Gossamer Flesh */
      , (72993,  2136,   2.05) /* Icy Torment */
      , (72993,  2122,   2.05) /* Disintegration */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 8 /* Say */, 0, 20, NULL, 'There is freedom in death, only shackles in life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 17 /* LocalBroadcast */, 0, 1, NULL, 'The door along the west wall swings open.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72993, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -177,20 +190,12 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72993, 9 /* Generation */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72993, 18 /* Scream */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'CloseDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72993, 19 /* Homesick */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -198,19 +203,9 @@ VALUES (72993, 19 /* Homesick */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72993, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 1, 8 /* Say */, 0, 20, NULL, 'There is freedom in death, only shackles in life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 2, 17 /* LocalBroadcast */, 0, 1, NULL, 'The door along the west wall swings open.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (72993, 2, 32123,  1, 0, 0.5, False) /* Create Acid Spear (32123) for Wield */
-     , (72993, 2, 32124,  1, 0, 0.5, False) /* Create Frost Spear (32124) for Wield */;
+VALUES (72993, 2, 32123,  1, 0,  0.5, False) /* Create Acid Spear (32123) for Wield */
+     , (72993, 2, 32124,  1, 0,  0.5, False) /* Create Frost Spear (32124) for Wield */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72993 Mosswart Director.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72993 Mosswart Director.sql
@@ -1,0 +1,216 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72993;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72993, 'ace72993-mosswartdirector', 10, '2023-03-12 09:43:10') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72993,   1,         16) /* ItemType - Creature */
+     , (72993,   2,          4) /* CreatureType - Mosswart */
+     , (72993,   3,         17) /* PaletteTemplate - Yellow */
+     , (72993,   6,         -1) /* ItemsCapacity */
+     , (72993,   7,         -1) /* ContainersCapacity */
+     , (72993,  16,          1) /* ItemUseable - No */
+     , (72993,  25,        220) /* Level */
+     , (72993,  27,          0) /* ArmorType - None */
+     , (72993,  40,          2) /* CombatMode - Melee */
+     , (72993,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (72993,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72993, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (72993, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72993, 140,          1) /* AiOptions - CanOpenDoors */
+     , (72993, 146,    1400000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72993,   1, True ) /* Stuck */
+     , (72993,   6, True ) /* AiUsesMana */
+     , (72993,  11, False) /* IgnoreCollisions */
+     , (72993,  12, True ) /* ReportCollisions */
+     , (72993,  13, False) /* Ethereal */
+     , (72993,  14, True ) /* GravityStatus */
+     , (72993,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72993,   1,       5) /* HeartbeatInterval */
+     , (72993,   2,       0) /* HeartbeatTimestamp */
+     , (72993,   3,     0.4) /* HealthRate */
+     , (72993,   4,       5) /* StaminaRate */
+     , (72993,   5,       2) /* ManaRate */
+     , (72993,  12,     0.5) /* Shade */
+     , (72993,  13,    0.28) /* ArmorModVsSlash */
+     , (72993,  14,    0.52) /* ArmorModVsPierce */
+     , (72993,  15,    0.52) /* ArmorModVsBludgeon */
+     , (72993,  16,    0.09) /* ArmorModVsCold */
+     , (72993,  17,     0.4) /* ArmorModVsFire */
+     , (72993,  18,    0.03) /* ArmorModVsAcid */
+     , (72993,  19,     0.7) /* ArmorModVsElectric */
+     , (72993,  31,      20) /* VisualAwarenessRange */
+     , (72993,  34,       1) /* PowerupTime */
+     , (72993,  36,       1) /* ChargeSpeed */
+     , (72993,  39,     1.2) /* DefaultScale */
+     , (72993,  64,    0.55) /* ResistSlash */
+     , (72993,  65,     0.8) /* ResistPierce */
+     , (72993,  66,     0.8) /* ResistBludgeon */
+     , (72993,  67,       1) /* ResistFire */
+     , (72993,  68,    0.38) /* ResistCold */
+     , (72993,  69,     0.3) /* ResistAcid */
+     , (72993,  70,       1) /* ResistElectric */
+     , (72993,  71,       1) /* ResistHealthBoost */
+     , (72993,  72,       1) /* ResistStaminaDrain */
+     , (72993,  73,       1) /* ResistStaminaBoost */
+     , (72993,  74,       1) /* ResistManaDrain */
+     , (72993,  75,       1) /* ResistManaBoost */
+     , (72993,  80,       3) /* AiUseMagicDelay */
+     , (72993, 104,      10) /* ObviousRadarRange */
+     , (72993, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72993,   1, 'Mosswart Director') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72993,   1, 0x02000B4F) /* Setup */
+     , (72993,   2, 0x09000009) /* MotionTable */
+     , (72993,   3, 0x2000002F) /* SoundTable */
+     , (72993,   4, 0x30000005) /* CombatTable */
+     , (72993,   6, 0x040011B8) /* PaletteBase */
+     , (72993,   7, 0x10000347) /* ClothingBase */
+     , (72993,   8, 0x06001039) /* Icon */
+     , (72993,  22, 0x34000020) /* PhysicsEffectTable */
+     , (72993,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72993,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72993,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72993,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72993,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72993,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72993,  5,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72993,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72993,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72993,  8,  4, 400, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72993,   1, 340, 0, 0) /* Strength */
+     , (72993,   2, 300, 0, 0) /* Endurance */
+     , (72993,   3, 320, 0, 0) /* Quickness */
+     , (72993,   4, 320, 0, 0) /* Coordination */
+     , (72993,   5, 110, 0, 0) /* Focus */
+     , (72993,   6, 110, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72993,   1,  5850, 0, 0, 6000) /* MaxHealth */
+     , (72993,   3,  3805, 0, 0, 4105) /* MaxStamina */
+     , (72993,   5,  2700, 0, 0, 2810) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72993,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
+     , (72993,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
+     , (72993, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (72993, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
+     , (72993, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72993, 34, 0, 3, 0, 310, 0, 0) /* WarMagic            Specialized */
+     , (72993, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
+     , (72993, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
+     , (72993, 46, 0, 3, 0, 430, 0, 0) /* FinesseWeapons      Specialized */
+     , (72993, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (72993,  2162,   2.03) /* Olthoi's Gift */
+     , (72993,  2168,   2.03) /* Gelidite's Gift */
+     , (72993,  2074,   2.02) /* Gossamer Flesh */
+     , (72993,  2136,   2.05) /* Icy Torment */
+     , (72993,  2122,   2.05) /* Disintegration */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.045, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 9 /* Generation */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 18 /* Scream */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'CloseDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 19 /* Homesick */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72993, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 8 /* Say */, 0, 20, NULL, 'There is freedom in death, only shackles in life.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 17 /* LocalBroadcast */, 0, 1, NULL, 'The door along the west wall swings open.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (72993, 2, 32123,  1, 0, 0.5, False) /* Create Acid Spear (32123) for Wield */
+     , (72993, 2, 32124,  1, 0, 0.5, False) /* Create Frost Spear (32124) for Wield */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72993.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72993.es
@@ -1,7 +1,7 @@
 Death:
     - Activate
     - Extent: 20, Say: There is freedom in death, only shackles in life.
-    - LocalBroadcast: The door along the east wall swings open.
+    - LocalBroadcast: The door along the west wall swings open.
 
 HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.045
     - Motion: Twitch3
@@ -29,4 +29,3 @@ Scream:
 
 Homesick:
     - Activate
-

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/72983 Scavenging Rat.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/72983 Scavenging Rat.sql
@@ -1,0 +1,139 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72983;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72983, 'ace72983-scavengingrat', 10, '2023-03-12 03:45:29') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72983,   1,         16) /* ItemType - Creature */
+     , (72983,   2,         10) /* CreatureType - Rat */
+     , (72983,   3,         10) /* PaletteTemplate - BlueDullSilver */
+     , (72983,   6,         -1) /* ItemsCapacity */
+     , (72983,   7,         -1) /* ContainersCapacity */
+     , (72983,  16,          1) /* ItemUseable - No */
+     , (72983,  25,        200) /* Level */
+     , (72983,  27,          0) /* ArmorType - None */
+     , (72983,  40,          2) /* CombatMode - Melee */
+     , (72983,  68,          3) /* TargetingTactic - Random, Focused */
+     , (72983,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72983, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72983, 146,    1100000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72983,   1, True ) /* Stuck */
+     , (72983,  11, False) /* IgnoreCollisions */
+     , (72983,  12, True ) /* ReportCollisions */
+     , (72983,  13, False) /* Ethereal */
+     , (72983,  14, True ) /* GravityStatus */
+     , (72983,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72983,   1,       5) /* HeartbeatInterval */
+     , (72983,   2,       0) /* HeartbeatTimestamp */
+     , (72983,   3,     0.4) /* HealthRate */
+     , (72983,   4,       5) /* StaminaRate */
+     , (72983,   5,       2) /* ManaRate */
+     , (72983,  12,     0.5) /* Shade */
+     , (72983,  13,     0.4) /* ArmorModVsSlash */
+     , (72983,  14,     0.4) /* ArmorModVsPierce */
+     , (72983,  15,     0.8) /* ArmorModVsBludgeon */
+     , (72983,  16,    0.12) /* ArmorModVsCold */
+     , (72983,  17,     0.7) /* ArmorModVsFire */
+     , (72983,  18,    0.12) /* ArmorModVsAcid */
+     , (72983,  19,     0.8) /* ArmorModVsElectric */
+     , (72983,  31,      22) /* VisualAwarenessRange */
+     , (72983,  34,       2) /* PowerupTime */
+     , (72983,  36,       1) /* ChargeSpeed */
+     , (72983,  39,       2) /* DefaultScale */
+     , (72983,  64,    0.75) /* ResistSlash */
+     , (72983,  65,    0.75) /* ResistPierce */
+     , (72983,  66,       1) /* ResistBludgeon */
+     , (72983,  67,       1) /* ResistFire */
+     , (72983,  68,    0.58) /* ResistCold */
+     , (72983,  69,    0.58) /* ResistAcid */
+     , (72983,  70,       1) /* ResistElectric */
+     , (72983,  71,       1) /* ResistHealthBoost */
+     , (72983,  72,       1) /* ResistStaminaDrain */
+     , (72983,  73,       1) /* ResistStaminaBoost */
+     , (72983,  74,       1) /* ResistManaDrain */
+     , (72983,  75,       1) /* ResistManaBoost */
+     , (72983,  77,       1) /* PhysicsScriptIntensity */
+     , (72983, 104,      10) /* ObviousRadarRange */
+     , (72983, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72983,   1, 'Scavenging Rat') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72983,   1, 0x0200003D) /* Setup */
+     , (72983,   2, 0x0900000E) /* MotionTable */
+     , (72983,   3, 0x2000000F) /* SoundTable */
+     , (72983,   4, 0x30000013) /* CombatTable */
+     , (72983,   6, 0x040001B4) /* PaletteBase */
+     , (72983,   7, 0x10000063) /* ClothingBase */
+     , (72983,   8, 0x0600103B) /* Icon */
+     , (72983,  19, 0x00000056) /* ActivationAnimation */
+     , (72983,  22, 0x34000023) /* PhysicsEffectTable */
+     , (72983,  30,         87) /* PhysicsScript - BreatheLightning */
+     , (72983,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72983,  0,  2, 400, 0.75,  430,  421,  421,  280,  421,  421,  421,  280,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */
+     , (72983, 16,  4, 400, 0.75,  430,  421,  421,  280,  421,  421,  421,  280,    0, 2, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75) /* Torso */
+     , (72983, 17,  4, 400,    0,  430,  421,  421,  280,  421,  421,  421,  280,    0, 3,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25) /* Tail */
+     , (72983, 22, 64, 800,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+     
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72983,   1, 220, 0, 0) /* Strength */
+     , (72983,   2, 280, 0, 0) /* Endurance */
+     , (72983,   3, 260, 0, 0) /* Quickness */
+     , (72983,   4, 245, 0, 0) /* Coordination */
+     , (72983,   5, 200, 0, 0) /* Focus */
+     , (72983,   6, 150, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72983,   1,  1600, 0, 0, 1740) /* MaxHealth */
+     , (72983,   3,  2900, 0, 0, 3180) /* MaxStamina */
+     , (72983,   5,     0, 0, 0,  150) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72983,  6, 0, 2, 0, 522, 0, 0) /* MeleeDefense        Trained */
+     , (72983,  7, 0, 2, 0, 149, 0, 0) /* MissileDefense      Trained */
+     , (72983, 15, 0, 2, 0, 170, 0, 0) /* MagicDefense        Trained */
+     , (72983, 45, 0, 2, 0, 553, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72983, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72983, 5 /* HeartBeat */, 0.175, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72983, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72983, 5 /* HeartBeat */, 0.175, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (72983, 9,  6876,  0, 0, 0.01, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */
+     , (72983, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976 Bubba.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976 Bubba.sql
@@ -1,0 +1,143 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72976;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72976, 'ace72976-bubba', 10, '2023-03-12 06:53:21') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72976,   1,         16) /* ItemType - Creature */
+     , (72976,   2,          8) /* CreatureType - Tusker */
+     , (72976,   6,         -1) /* ItemsCapacity */
+     , (72976,   7,         -1) /* ContainersCapacity */
+     , (72976,  16,         32) /* ItemUseable - Remote */
+     , (72976,  25,         80) /* Level */
+     , (72976,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72976,  95,          8) /* RadarBlipColor - Yellow */
+     , (72976, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (72976, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72976, 146,    1100000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72976,   1, True ) /* Stuck */
+     , (72976,   8, True ) /* AllowGive */
+     , (72976,  11, False) /* IgnoreCollisions */
+     , (72976,  12, True ) /* ReportCollisions */
+     , (72976,  13, False) /* Ethereal */
+     , (72976,  14, True ) /* GravityStatus */
+     , (72976,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72976,   1,       5) /* HeartbeatInterval */
+     , (72976,   2,       0) /* HeartbeatTimestamp */
+     , (72976,   3,     0.8) /* HealthRate */
+     , (72976,   4,     0.8) /* StaminaRate */
+     , (72976,   5,       2) /* ManaRate */
+     , (72976,  12,       0) /* Shade */
+     , (72976,  13,       1) /* ArmorModVsSlash */
+     , (72976,  14,     0.6) /* ArmorModVsPierce */
+     , (72976,  15,       1) /* ArmorModVsBludgeon */
+     , (72976,  16,       1) /* ArmorModVsCold */
+     , (72976,  17,     0.4) /* ArmorModVsFire */
+     , (72976,  18,       1) /* ArmorModVsAcid */
+     , (72976,  19,       1) /* ArmorModVsElectric */
+     , (72976,  31,      22) /* VisualAwarenessRange */
+     , (72976,  34,     2.5) /* PowerupTime */
+     , (72976,  36,       1) /* ChargeSpeed */
+     , (72976,  39,     0.4) /* DefaultScale */
+     , (72976,  54,       3) /* UseRadius */
+     , (72976,  64,     0.5) /* ResistSlash */
+     , (72976,  65,     0.7) /* ResistPierce */
+     , (72976,  66,     0.3) /* ResistBludgeon */
+     , (72976,  67,     0.8) /* ResistFire */
+     , (72976,  68,     0.3) /* ResistCold */
+     , (72976,  69,     0.3) /* ResistAcid */
+     , (72976,  70,     0.4) /* ResistElectric */
+     , (72976,  71,       1) /* ResistHealthBoost */
+     , (72976,  72,       1) /* ResistStaminaDrain */
+     , (72976,  73,       1) /* ResistStaminaBoost */
+     , (72976,  74,       1) /* ResistManaDrain */
+     , (72976, 104,      10) /* ObviousRadarRange */
+     , (72976, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72976,   1, 'Bubba') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72976,   1, 0x02001A33) /* Setup */
+     , (72976,   2, 0x0900000C) /* MotionTable */
+     , (72976,   3, 0x20000011) /* SoundTable */
+     , (72976,   4, 0x3000000B) /* CombatTable */
+     , (72976,   8, 0x06001033) /* Icon */
+     , (72976,  22, 0x34000027) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72976,  0,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72976,  1,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72976,  2,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72976,  3,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72976,  4,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72976,  5,  4,340, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72976,  6,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72976,  7,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72976,  8,  4,340, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72976,   1, 600, 0, 0) /* Strength */
+     , (72976,   2, 410, 0, 0) /* Endurance */
+     , (72976,   3, 290, 0, 0) /* Quickness */
+     , (72976,   4, 375, 0, 0) /* Coordination */
+     , (72976,   5, 200, 0, 0) /* Focus */
+     , (72976,   6, 200, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72976,   1,  1280, 0, 0, 1485) /* MaxHealth */
+     , (72976,   3,  1240, 0, 0, 1650) /* MaxStamina */
+     , (72976,   5,     0, 0, 0,  200) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72976,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
+     , (72976,  7, 0, 3, 0, 405, 0, 0) /* MissileDefense      Specialized */
+     , (72976, 15, 0, 3, 0, 460, 0, 0) /* MagicDefense        Specialized */
+     , (72976, 20, 0, 3, 0,  25, 0, 0) /* Deception           Specialized */
+     , (72976, 22, 0, 3, 0, 120, 0, 0) /* Jump                Specialized */
+     , (72976, 24, 0, 3, 0, 500, 0, 0) /* Run                 Specialized */
+     , (72976, 45, 0, 3, 0, 435, 0, 0) /* LightWeapons        Specialized */
+     , (72976, 46, 0, 3, 0, 435, 0, 0) /* FinesseWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72976, 6 /* Give */, 1, 72980, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Bubba quickly devours the meat.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 2, 1, NULL, 'After several moments, Bubba falls to the ground. The sedative looks to have worked.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 5 /* Motion */, 0, 1, 0x40000011 /* Dead */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 81 /* StampMyQuest */, 0, 1, NULL, 'DruggedMeat', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72976, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat@3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72976, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat@3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SavedBubba', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72977, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72976, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat@3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'This must be one of the pets Colton mentioned.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976 Bubba.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976 Bubba.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72976;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72976, 'ace72976-bubba', 10, '2023-03-12 06:53:21') /* Creature */;
+VALUES (72976, 'ace72976-bubba', 10, '2023-03-16 12:11:43') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72976,   1,         16) /* ItemType - Creature */
@@ -121,20 +121,20 @@ VALUES (72976, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat@3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72976, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat@3', NULL, NULL, NULL);
+VALUES (72976, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat@2', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SavedBubba', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+VALUES (@parent_id, 0, 106 /* SetQuestBitsOn */, 0, 1, NULL, 'Petsave', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72977, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72976, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat@3', NULL, NULL, NULL);
+VALUES (72976, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat@2', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976.es
@@ -8,7 +8,7 @@ Give: 72980
 Use:
     - InqMyQuest: DruggedMeat
         QuestSuccess:
-            - StampQuest: SavedBubba
+            - SetQuestBitsOn: Petsave, 0x2
             - Give: 72977
             - DeleteSelf
         QuestFailure:

--- a/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Tusker/72976.es
@@ -1,0 +1,15 @@
+Give: 72980
+    - DirectBroadcast: Bubba quickly devours the meat.
+    - Motion: Twitch2
+    - Delay: 2, DirectBroadcast: After several moments, Bubba falls to the ground. The sedative looks to have worked.
+    - Motion: Dead
+    - StampMyQuest: DruggedMeat
+
+Use:
+    - InqMyQuest: DruggedMeat
+        QuestSuccess:
+            - StampQuest: SavedBubba
+            - Give: 72977
+            - DeleteSelf
+        QuestFailure:
+            - DirectBroadcast: This must be one of the pets Colton mentioned.

--- a/Database/Patches/9 WeenieDefaults/Creature/Tusker/72987 Bubba.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Tusker/72987 Bubba.sql
@@ -1,0 +1,168 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72987;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72987, 'ace72987-bubba', 10, '2023-03-12 06:53:21') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72987,   1,         16) /* ItemType - Creature */
+     , (72987,   2,          8) /* CreatureType - Tusker */
+     , (72987,   6,         -1) /* ItemsCapacity */
+     , (72987,   7,         -1) /* ContainersCapacity */
+     , (72987,  16,          1) /* ItemUseable - No */
+     , (72987,  25,         80) /* Level */
+     , (72987,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72987,  95,          8) /* RadarBlipColor - Yellow */
+     , (72987, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (72987, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72987, 146,    1100000) /* XpOverride */
+     , (72987, 267,         30) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72987,   1, True ) /* Stuck */
+     , (72987,   8, False ) /* AllowGive */
+     , (72987,  11, False) /* IgnoreCollisions */
+     , (72987,  12, True ) /* ReportCollisions */
+     , (72987,  13, False) /* Ethereal */
+     , (72987,  14, True ) /* GravityStatus */
+     , (72987,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72987,   1,       5) /* HeartbeatInterval */
+     , (72987,   2,       0) /* HeartbeatTimestamp */
+     , (72987,   3,     0.8) /* HealthRate */
+     , (72987,   4,     0.8) /* StaminaRate */
+     , (72987,   5,       2) /* ManaRate */
+     , (72987,  12,       0) /* Shade */
+     , (72987,  13,       1) /* ArmorModVsSlash */
+     , (72987,  14,     0.6) /* ArmorModVsPierce */
+     , (72987,  15,       1) /* ArmorModVsBludgeon */
+     , (72987,  16,       1) /* ArmorModVsCold */
+     , (72987,  17,     0.4) /* ArmorModVsFire */
+     , (72987,  18,       1) /* ArmorModVsAcid */
+     , (72987,  19,       1) /* ArmorModVsElectric */
+     , (72987,  31,      22) /* VisualAwarenessRange */
+     , (72987,  34,     2.5) /* PowerupTime */
+     , (72987,  36,       1) /* ChargeSpeed */
+     , (72987,  39,     0.4) /* DefaultScale */
+     , (72987,  64,     0.5) /* ResistSlash */
+     , (72987,  65,     0.7) /* ResistPierce */
+     , (72987,  66,     0.3) /* ResistBludgeon */
+     , (72987,  67,     0.8) /* ResistFire */
+     , (72987,  68,     0.3) /* ResistCold */
+     , (72987,  69,     0.3) /* ResistAcid */
+     , (72987,  70,     0.4) /* ResistElectric */
+     , (72987,  71,       1) /* ResistHealthBoost */
+     , (72987,  72,       1) /* ResistStaminaDrain */
+     , (72987,  73,       1) /* ResistStaminaBoost */
+     , (72987,  74,       1) /* ResistManaDrain */
+     , (72987, 104,      10) /* ObviousRadarRange */
+     , (72987, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72987,   1, 'Bubba') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72987,   1, 0x02001A33) /* Setup */
+     , (72987,   2, 0x0900000C) /* MotionTable */
+     , (72987,   3, 0x20000011) /* SoundTable */
+     , (72987,   4, 0x3000000B) /* CombatTable */
+     , (72987,   8, 0x06001033) /* Icon */
+     , (72987,  22, 0x34000027) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72987,  0,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72987,  1,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72987,  2,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72987,  3,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72987,  4,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72987,  5,  4,340, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72987,  6,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72987,  7,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72987,  8,  4,340, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72987,   1, 600, 0, 0) /* Strength */
+     , (72987,   2, 410, 0, 0) /* Endurance */
+     , (72987,   3, 290, 0, 0) /* Quickness */
+     , (72987,   4, 375, 0, 0) /* Coordination */
+     , (72987,   5, 200, 0, 0) /* Focus */
+     , (72987,   6, 200, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72987,   1,  1280, 0, 0, 1485) /* MaxHealth */
+     , (72987,   3,  1240, 0, 0, 1650) /* MaxStamina */
+     , (72987,   5,     0, 0, 0,  200) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72987,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
+     , (72987,  7, 0, 3, 0, 405, 0, 0) /* MissileDefense      Specialized */
+     , (72987, 15, 0, 3, 0, 460, 0, 0) /* MagicDefense        Specialized */
+     , (72987, 20, 0, 3, 0,  25, 0, 0) /* Deception           Specialized */
+     , (72987, 22, 0, 3, 0, 120, 0, 0) /* Jump                Specialized */
+     , (72987, 24, 0, 3, 0, 500, 0, 0) /* Run                 Specialized */
+     , (72987, 45, 0, 3, 0, 435, 0, 0) /* LightWeapons        Specialized */
+     , (72987, 46, 0, 3, 0, 435, 0, 0) /* FinesseWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x1300004C /* Cheer */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x1000004D /* ChestBeat */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,  0.125, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x1300004C /* Cheer */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x1000004D /* ChestBeat */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,  0.125, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72987,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978 Spot.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978 Spot.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72978;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72978, 'ace72978-spot', 10, '2023-03-12 07:21:17') /* Creature */;
+VALUES (72978, 'ace72978-spot', 10, '2023-03-16 12:11:51') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72978,   1,         16) /* ItemType - Creature */
@@ -116,20 +116,20 @@ VALUES (72978, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat@3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72978, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, NULL, NULL);
+VALUES (72978, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat@3', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SavedSpot', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+VALUES (@parent_id, 0, 106 /* SetQuestBitsOn */, 0, 1, NULL, 'Petsave', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72979, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72978, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, NULL, NULL);
+VALUES (72978, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat@3', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978 Spot.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978 Spot.sql
@@ -1,0 +1,138 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72978;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72978, 'ace72978-spot', 10, '2023-03-12 07:21:17') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72978,   1,         16) /* ItemType - Creature */
+     , (72978,   2,         46) /* CreatureType - Ursuin */
+     , (72978,   3,         62) /* PaletteTemplate - RedBrown */
+     , (72978,   6,         -1) /* ItemsCapacity */
+     , (72978,   7,         -1) /* ContainersCapacity */
+     , (72978,  16,         32) /* ItemUseable - Remote */
+     , (72978,  25,         95) /* Level */
+     , (72978,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72978,  95,          8) /* RadarBlipColor - Yellow */
+     , (72978, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72978, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72978, 146,      17500) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72978,   1, True ) /* Stuck */
+     , (72978,   8, True ) /* AllowGive */
+     , (72978,  11, False) /* IgnoreCollisions */
+     , (72978,  12, True ) /* ReportCollisions */
+     , (72978,  13, False) /* Ethereal */
+     , (72978,  14, True ) /* GravityStatus */
+     , (72978,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72978,   1,       5) /* HeartbeatInterval */
+     , (72978,   2,       0) /* HeartbeatTimestamp */
+     , (72978,   3,     0.1) /* HealthRate */
+     , (72978,   4,       3) /* StaminaRate */
+     , (72978,   5,       1) /* ManaRate */
+     , (72978,  12,     0.5) /* Shade */
+     , (72978,  13,    0.56) /* ArmorModVsSlash */
+     , (72978,  14,     0.8) /* ArmorModVsPierce */
+     , (72978,  15,    0.56) /* ArmorModVsBludgeon */
+     , (72978,  16,    0.56) /* ArmorModVsCold */
+     , (72978,  17,    0.73) /* ArmorModVsFire */
+     , (72978,  18,    0.56) /* ArmorModVsAcid */
+     , (72978,  19,    0.56) /* ArmorModVsElectric */
+     , (72978,  31,      24) /* VisualAwarenessRange */
+     , (72978,  34,       1) /* PowerupTime */
+     , (72978,  36,       1) /* ChargeSpeed */
+     , (72978,  39,     0.5) /* DefaultScale */
+     , (72978,  54,       3) /* UseRadius */
+     , (72978,  64,    0.58) /* ResistSlash */
+     , (72978,  65,       1) /* ResistPierce */
+     , (72978,  66,    0.58) /* ResistBludgeon */
+     , (72978,  67,    0.86) /* ResistFire */
+     , (72978,  68,    0.58) /* ResistCold */
+     , (72978,  69,    0.58) /* ResistAcid */
+     , (72978,  70,    0.58) /* ResistElectric */
+     , (72978,  71,       1) /* ResistHealthBoost */
+     , (72978,  72,       1) /* ResistStaminaDrain */
+     , (72978,  73,       1) /* ResistStaminaBoost */
+     , (72978,  74,       1) /* ResistManaDrain */
+     , (72978,  75,       1) /* ResistManaBoost */
+     , (72978, 104,      10) /* ObviousRadarRange */
+     , (72978, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72978,   1, 'Spot') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72978,   1, 0x02000925) /* Setup */
+     , (72978,   2, 0x0900009C) /* MotionTable */
+     , (72978,   3, 0x20000063) /* SoundTable */
+     , (72978,   4, 0x30000029) /* CombatTable */
+     , (72978,   6, 0x04000FF0) /* PaletteBase */
+     , (72978,   7, 0x10000248) /* ClothingBase */
+     , (72978,   8, 0x06001DEF) /* Icon */
+     , (72978,  22, 0x34000086) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72978,  0,  2, 30, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1,  0.4,  0.1,    0,  0.4,  0.1,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (72978, 10,  1, 30, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,  0.2,  0.8,    0,  0.2,  0.8,    0,    0,    0,    0,    0,    0) /* FrontLeg */
+     , (72978, 13,  1, 30, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,    0,    0,    0,    0,    0,  0.1,  0.3,  0.7,  0.1,  0.3,  0.7) /* RearLeg */
+     , (72978, 16,  4,  0,    0,  180,   90,   90,   90,   90,   90,   90,   90,    0, 2,  0.6,  0.7,  0.2,  0.6,  0.7,  0.2,  0.9,  0.7,  0.3,  0.9,  0.7,  0.3) /* Torso */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72978,   1, 450, 0, 0) /* Strength */
+     , (72978,   2, 230, 0, 0) /* Endurance */
+     , (72978,   3, 210, 0, 0) /* Quickness */
+     , (72978,   4, 180, 0, 0) /* Coordination */
+     , (72978,   5, 130, 0, 0) /* Focus */
+     , (72978,   6, 100, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72978,   1,  1385, 0, 0, 1500) /* MaxHealth */
+     , (72978,   3,  1420, 0, 0, 1650) /* MaxStamina */
+     , (72978,   5,   400, 0, 0,  500) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72978,  6, 0, 3, 0, 210, 0, 0) /* MeleeDefense        Specialized */
+     , (72978,  7, 0, 3, 0, 335, 0, 0) /* MissileDefense      Specialized */
+     , (72978, 15, 0, 3, 0, 215, 0, 0) /* MagicDefense        Specialized */
+     , (72978, 45, 0, 3, 0, 160, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72978, 6 /* Give */, 1, 72980, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Spot quickly devours the meat.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 2, 1, NULL, 'After several moments, Spot falls to the ground. The sedative looks to have worked.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 5 /* Motion */, 0, 1, 0x40000011 /* Dead */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 81 /* StampMyQuest */, 0, 1, NULL, 'DruggedMeat', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72978, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 80 /* InqMyQuest */, 0, 1, NULL, 'DruggedMeat', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72978, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 22 /* StampQuest */, 0, 1, NULL, 'SavedSpot', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72979, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72978, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'DruggedMeat', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'This must be one of the pets Colton mentioned.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978.es
@@ -1,0 +1,16 @@
+Give: 72980
+    - DirectBroadcast: Spot quickly devours the meat.
+    - Motion: Twitch2
+    - Delay: 2, DirectBroadcast: After several moments, Spot falls to the ground. The sedative looks to have worked.
+    - Motion: Dead
+    - StampMyQuest: DruggedMeat
+
+Use:
+    - InqMyQuest: DruggedMeat
+        QuestSuccess:
+            - StampQuest: SavedSpot
+            - Give: 72979
+            - DeleteSelf
+        QuestFailure:
+            - DirectBroadcast: This must be one of the pets Colton mentioned.
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72978.es
@@ -8,7 +8,7 @@ Give: 72980
 Use:
     - InqMyQuest: DruggedMeat
         QuestSuccess:
-            - StampQuest: SavedSpot
+            - SetQuestBitsOn: Petsave, 0x4
             - Give: 72979
             - DeleteSelf
         QuestFailure:

--- a/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72989 Spot.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ursuin/72989 Spot.sql
@@ -1,0 +1,131 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72989;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72989, 'ace72989-spot', 10, '2023-03-12 07:21:17') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72989,   1,         16) /* ItemType - Creature */
+     , (72989,   2,         46) /* CreatureType - Ursuin */
+     , (72989,   3,         62) /* PaletteTemplate - RedBrown */
+     , (72989,   6,         -1) /* ItemsCapacity */
+     , (72989,   7,         -1) /* ContainersCapacity */
+     , (72989,  16,          1) /* ItemUseable - No */
+     , (72989,  25,         95) /* Level */
+     , (72989,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72989,  95,          8) /* RadarBlipColor - Yellow */
+     , (72989, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (72989, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72989, 146,      17500) /* XpOverride */
+     , (72989, 267,         30) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72989,   1, True ) /* Stuck */
+     , (72989,   8, False ) /* AllowGive */
+     , (72989,  11, False) /* IgnoreCollisions */
+     , (72989,  12, True ) /* ReportCollisions */
+     , (72989,  13, False) /* Ethereal */
+     , (72989,  14, True ) /* GravityStatus */
+     , (72989,  19, False) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72989,   1,       5) /* HeartbeatInterval */
+     , (72989,   2,       0) /* HeartbeatTimestamp */
+     , (72989,   3,     0.1) /* HealthRate */
+     , (72989,   4,       3) /* StaminaRate */
+     , (72989,   5,       1) /* ManaRate */
+     , (72989,  12,     0.5) /* Shade */
+     , (72989,  13,    0.56) /* ArmorModVsSlash */
+     , (72989,  14,     0.8) /* ArmorModVsPierce */
+     , (72989,  15,    0.56) /* ArmorModVsBludgeon */
+     , (72989,  16,    0.56) /* ArmorModVsCold */
+     , (72989,  17,    0.73) /* ArmorModVsFire */
+     , (72989,  18,    0.56) /* ArmorModVsAcid */
+     , (72989,  19,    0.56) /* ArmorModVsElectric */
+     , (72989,  31,      24) /* VisualAwarenessRange */
+     , (72989,  34,       1) /* PowerupTime */
+     , (72989,  36,       1) /* ChargeSpeed */
+     , (72989,  39,     0.5) /* DefaultScale */
+     , (72989,  64,    0.58) /* ResistSlash */
+     , (72989,  65,       1) /* ResistPierce */
+     , (72989,  66,    0.58) /* ResistBludgeon */
+     , (72989,  67,    0.86) /* ResistFire */
+     , (72989,  68,    0.58) /* ResistCold */
+     , (72989,  69,    0.58) /* ResistAcid */
+     , (72989,  70,    0.58) /* ResistElectric */
+     , (72989,  71,       1) /* ResistHealthBoost */
+     , (72989,  72,       1) /* ResistStaminaDrain */
+     , (72989,  73,       1) /* ResistStaminaBoost */
+     , (72989,  74,       1) /* ResistManaDrain */
+     , (72989,  75,       1) /* ResistManaBoost */
+     , (72989, 104,      10) /* ObviousRadarRange */
+     , (72989, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72989,   1, 'Spot') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72989,   1, 0x02000925) /* Setup */
+     , (72989,   2, 0x0900009C) /* MotionTable */
+     , (72989,   3, 0x20000063) /* SoundTable */
+     , (72989,   4, 0x30000029) /* CombatTable */
+     , (72989,   6, 0x04000FF0) /* PaletteBase */
+     , (72989,   7, 0x10000248) /* ClothingBase */
+     , (72989,   8, 0x06001DEF) /* Icon */
+     , (72989,  22, 0x34000086) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72989,  0,  2, 30, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1,  0.4,  0.1,    0,  0.4,  0.1,    0,    0,    0,    0,    0,    0,    0) /* Head */
+     , (72989, 10,  1, 30, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,  0.2,  0.8,    0,  0.2,  0.8,    0,    0,    0,    0,    0,    0) /* FrontLeg */
+     , (72989, 13,  1, 30, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,    0,    0,    0,    0,    0,  0.1,  0.3,  0.7,  0.1,  0.3,  0.7) /* RearLeg */
+     , (72989, 16,  4,  0,    0,  180,   90,   90,   90,   90,   90,   90,   90,    0, 2,  0.6,  0.7,  0.2,  0.6,  0.7,  0.2,  0.9,  0.7,  0.3,  0.9,  0.7,  0.3) /* Torso */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72989,   1, 450, 0, 0) /* Strength */
+     , (72989,   2, 230, 0, 0) /* Endurance */
+     , (72989,   3, 210, 0, 0) /* Quickness */
+     , (72989,   4, 180, 0, 0) /* Coordination */
+     , (72989,   5, 130, 0, 0) /* Focus */
+     , (72989,   6, 100, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72989,   1,  1385, 0, 0, 1500) /* MaxHealth */
+     , (72989,   3,  1420, 0, 0, 1650) /* MaxStamina */
+     , (72989,   5,   400, 0, 0,  500) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72989,  6, 0, 3, 0, 210, 0, 0) /* MeleeDefense        Specialized */
+     , (72989,  7, 0, 3, 0, 335, 0, 0) /* MissileDefense      Specialized */
+     , (72989, 15, 0, 3, 0, 215, 0, 0) /* MagicDefense        Specialized */
+     , (72989, 45, 0, 3, 0, 160, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72989,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72989,  5 /* HeartBeat */,   0.03, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72989,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72989,  5 /* HeartBeat */,   0.03, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Wall/72984 Shady's Cage Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wall/72984 Shady's Cage Door.sql
@@ -1,0 +1,115 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72984;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72984, 'ace72984-cagedoor', 10, '2023-03-12 05:58:43') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72984,   1,         16) /* ItemType - Creature */
+     , (72984,   2,         64) /* CreatureType - Wall */
+     , (72984,   6,         -1) /* ItemsCapacity */
+     , (72984,   7,         -1) /* ContainersCapacity */
+     , (72984,  16,          1) /* ItemUseable - No */
+     , (72984,  19,          0) /* Value */
+     , (72984,  25,        999) /* Level */
+     , (72984,  81,          1) /* MaxGeneratedObjects */
+     , (72984,  82,          0) /* InitGeneratedObjects */
+     , (72984,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72984,  95,          8) /* RadarBlipColor - Yellow */
+     , (72984, 133,          1) /* ShowableOnRadar - ShowNever */
+     , (72984, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72984, 315,       9999) /* CritResistRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72984,   1, True ) /* Stuck */
+     , (72984,   8, True ) /* AllowGive */
+     , (72984,  11, False) /* IgnoreCollisions */
+     , (72984,  12, True ) /* ReportCollisions */
+     , (72984,  13, False) /* Ethereal */
+     , (72984,  19, False) /* Attackable */
+     , (72984,  29, True ) /* NoCorpse */
+     , (72984,  52, True ) /* AiImmobile */
+     , (72984,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (72984,  83, True ) /* NpcLooksLikeObject */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72984,   1,       5) /* HeartbeatInterval */
+     , (72984,   2,       0) /* HeartbeatTimestamp */
+     , (72984,   3,      20) /* HealthRate */
+     , (72984,   4,       0) /* StaminaRate */
+     , (72984,   5,       0) /* ManaRate */
+     , (72984,  13,       1) /* ArmorModVsSlash */
+     , (72984,  14,       1) /* ArmorModVsPierce */
+     , (72984,  15,       1) /* ArmorModVsBludgeon */
+     , (72984,  16,       1) /* ArmorModVsCold */
+     , (72984,  17,       1) /* ArmorModVsFire */
+     , (72984,  18,       1) /* ArmorModVsAcid */
+     , (72984,  19,       1) /* ArmorModVsElectric */
+     , (72984,  31,     0.3) /* VisualAwarenessRange */
+     , (72984,  34,       1) /* PowerupTime */
+     , (72984,  36,       1) /* ChargeSpeed */
+     , (72984,  64,    0.75) /* ResistSlash */
+     , (72984,  65,    0.75) /* ResistPierce */
+     , (72984,  66,    0.75) /* ResistBludgeon */
+     , (72984,  67,    0.75) /* ResistFire */
+     , (72984,  68,    0.75) /* ResistCold */
+     , (72984,  69,    0.75) /* ResistAcid */
+     , (72984,  70,    0.75) /* ResistElectric */
+     , (72984,  71,       1) /* ResistHealthBoost */
+     , (72984,  72,       1) /* ResistStaminaDrain */
+     , (72984,  73,       1) /* ResistStaminaBoost */
+     , (72984,  74,       1) /* ResistManaDrain */
+     , (72984,  75,       1) /* ResistManaBoost */
+     , (72984, 104,      10) /* ObviousRadarRange */
+     , (72984, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72984,   1, 'Shady''s Cage Door') /* Name */
+     , (72984,  15, 'A cage door with the name ''Shady'' engraved on a plate above it.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72984,   1, 0x02000281) /* Setup */
+     , (72984,   2, 0x09000016) /* MotionTable */
+     , (72984,   3, 0x20000022) /* SoundTable */
+     , (72984,   8, 0x06001412) /* Icon */
+     , (72984,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72984,  0,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72984,  1,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72984,  2,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72984,  3,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72984,  4,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72984,  5,  4,  1, 0.75,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72984,  6,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72984,  7,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72984,  8,  4,  1, 0.75,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72984,   1,   1, 0, 0) /* Strength */
+     , (72984,   2,   1, 0, 0) /* Endurance */
+     , (72984,   3,   1, 0, 0) /* Quickness */
+     , (72984,   4,   1, 0, 0) /* Coordination */
+     , (72984,   5,   1, 0, 0) /* Focus */
+     , (72984,   6,   1, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72984,   1,  7999, 0, 0, 8000) /* MaxHealth */
+     , (72984,   3,  1000, 0, 0, 1001) /* MaxStamina */
+     , (72984,   5,     0, 0, 0,    1) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72984,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
+     , (72984,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
+     , (72984, 15, 0, 2, 0,   1, 0, 0) /* MagicDefense        Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72984, 6 /* Give */, 1, 72975, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You place the sleeping Armoredillo inside and close the gate.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72984, -1, 72985, 30, 1, 1, 1, 4, 0, 0, 0, 0x586002E7, 69.980469, -176.884766, 30.000000, 1, 0, 0, 0) /* Generate Shady (72985) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Wall/72984.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wall/72984.es
@@ -1,0 +1,3 @@
+Give: 72975
+    - Generate
+    - DirectBroadcast: You place the sleeping Armoredillo inside and close the gate.

--- a/Database/Patches/9 WeenieDefaults/Creature/Wall/72986 Bubba's Cage Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wall/72986 Bubba's Cage Door.sql
@@ -1,0 +1,115 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72986;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72986, 'ace72986-cagedoor', 10, '2023-03-12 05:58:43') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72986,   1,         16) /* ItemType - Creature */
+     , (72986,   2,         64) /* CreatureType - Wall */
+     , (72986,   6,         -1) /* ItemsCapacity */
+     , (72986,   7,         -1) /* ContainersCapacity */
+     , (72986,  16,          1) /* ItemUseable - No */
+     , (72986,  19,          0) /* Value */
+     , (72986,  25,        999) /* Level */
+     , (72986,  81,          1) /* MaxGeneratedObjects */
+     , (72986,  82,          0) /* InitGeneratedObjects */
+     , (72986,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72986,  95,          8) /* RadarBlipColor - Yellow */
+     , (72986, 133,          1) /* ShowableOnRadar - ShowNever */
+     , (72986, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72986, 315,       9999) /* CritResistRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72986,   1, True ) /* Stuck */
+     , (72986,   8, True ) /* AllowGive */
+     , (72986,  11, False) /* IgnoreCollisions */
+     , (72986,  12, True ) /* ReportCollisions */
+     , (72986,  13, False) /* Ethereal */
+     , (72986,  19, False) /* Attackable */
+     , (72986,  29, True ) /* NoCorpse */
+     , (72986,  52, True ) /* AiImmobile */
+     , (72986,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (72986,  83, True ) /* NpcLooksLikeObject */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72986,   1,       5) /* HeartbeatInterval */
+     , (72986,   2,       0) /* HeartbeatTimestamp */
+     , (72986,   3,      20) /* HealthRate */
+     , (72986,   4,       0) /* StaminaRate */
+     , (72986,   5,       0) /* ManaRate */
+     , (72986,  13,       1) /* ArmorModVsSlash */
+     , (72986,  14,       1) /* ArmorModVsPierce */
+     , (72986,  15,       1) /* ArmorModVsBludgeon */
+     , (72986,  16,       1) /* ArmorModVsCold */
+     , (72986,  17,       1) /* ArmorModVsFire */
+     , (72986,  18,       1) /* ArmorModVsAcid */
+     , (72986,  19,       1) /* ArmorModVsElectric */
+     , (72986,  31,     0.3) /* VisualAwarenessRange */
+     , (72986,  34,       1) /* PowerupTime */
+     , (72986,  36,       1) /* ChargeSpeed */
+     , (72986,  64,    0.75) /* ResistSlash */
+     , (72986,  65,    0.75) /* ResistPierce */
+     , (72986,  66,    0.75) /* ResistBludgeon */
+     , (72986,  67,    0.75) /* ResistFire */
+     , (72986,  68,    0.75) /* ResistCold */
+     , (72986,  69,    0.75) /* ResistAcid */
+     , (72986,  70,    0.75) /* ResistElectric */
+     , (72986,  71,       1) /* ResistHealthBoost */
+     , (72986,  72,       1) /* ResistStaminaDrain */
+     , (72986,  73,       1) /* ResistStaminaBoost */
+     , (72986,  74,       1) /* ResistManaDrain */
+     , (72986,  75,       1) /* ResistManaBoost */
+     , (72986, 104,      10) /* ObviousRadarRange */
+     , (72986, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72986,   1, 'Bubba''s Cage Door') /* Name */
+     , (72986,  15, 'A cage door with the name ''Bubba'' engraved on a plate above it.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72986,   1, 0x02000281) /* Setup */
+     , (72986,   2, 0x09000016) /* MotionTable */
+     , (72986,   3, 0x20000022) /* SoundTable */
+     , (72986,   8, 0x06001412) /* Icon */
+     , (72986,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72986,  0,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72986,  1,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72986,  2,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72986,  3,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72986,  4,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72986,  5,  4,  1, 0.75,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72986,  6,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72986,  7,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72986,  8,  4,  1, 0.75,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72986,   1,   1, 0, 0) /* Strength */
+     , (72986,   2,   1, 0, 0) /* Endurance */
+     , (72986,   3,   1, 0, 0) /* Quickness */
+     , (72986,   4,   1, 0, 0) /* Coordination */
+     , (72986,   5,   1, 0, 0) /* Focus */
+     , (72986,   6,   1, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72986,   1,  7999, 0, 0, 8000) /* MaxHealth */
+     , (72986,   3,  1000, 0, 0, 1001) /* MaxStamina */
+     , (72986,   5,     0, 0, 0,    1) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72986,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
+     , (72986,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
+     , (72986, 15, 0, 2, 0,   1, 0, 0) /* MagicDefense        Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72986, 6 /* Give */, 1, 72977, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You place the sleeping Tusker inside and close the gate.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72986, -1, 72987, 30, 1, 1, 1, 4, 0, 0, 0, 0x5860015C, 103.177734, -0.031250, 0.000000, -0.707107, 0, 0, 0.707107) /* Generate Bubba (72987) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Wall/72988 Spot's Cage Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wall/72988 Spot's Cage Door.sql
@@ -1,0 +1,115 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72988;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72988, 'ace72988-cagedoor', 10, '2023-03-12 05:58:43') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72988,   1,         16) /* ItemType - Creature */
+     , (72988,   2,         64) /* CreatureType - Wall */
+     , (72988,   6,         -1) /* ItemsCapacity */
+     , (72988,   7,         -1) /* ContainersCapacity */
+     , (72988,  16,          1) /* ItemUseable - No */
+     , (72988,  19,          0) /* Value */
+     , (72988,  25,        999) /* Level */
+     , (72988,  81,          1) /* MaxGeneratedObjects */
+     , (72988,  82,          0) /* InitGeneratedObjects */
+     , (72988,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (72988,  95,          8) /* RadarBlipColor - Yellow */
+     , (72988, 133,          1) /* ShowableOnRadar - ShowNever */
+     , (72988, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (72988, 315,       9999) /* CritResistRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72988,   1, True ) /* Stuck */
+     , (72988,   8, True ) /* AllowGive */
+     , (72988,  11, False) /* IgnoreCollisions */
+     , (72988,  12, True ) /* ReportCollisions */
+     , (72988,  13, False) /* Ethereal */
+     , (72988,  19, False) /* Attackable */
+     , (72988,  29, True ) /* NoCorpse */
+     , (72988,  52, True ) /* AiImmobile */
+     , (72988,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (72988,  83, True ) /* NpcLooksLikeObject */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72988,   1,       5) /* HeartbeatInterval */
+     , (72988,   2,       0) /* HeartbeatTimestamp */
+     , (72988,   3,      20) /* HealthRate */
+     , (72988,   4,       0) /* StaminaRate */
+     , (72988,   5,       0) /* ManaRate */
+     , (72988,  13,       1) /* ArmorModVsSlash */
+     , (72988,  14,       1) /* ArmorModVsPierce */
+     , (72988,  15,       1) /* ArmorModVsBludgeon */
+     , (72988,  16,       1) /* ArmorModVsCold */
+     , (72988,  17,       1) /* ArmorModVsFire */
+     , (72988,  18,       1) /* ArmorModVsAcid */
+     , (72988,  19,       1) /* ArmorModVsElectric */
+     , (72988,  31,     0.3) /* VisualAwarenessRange */
+     , (72988,  34,       1) /* PowerupTime */
+     , (72988,  36,       1) /* ChargeSpeed */
+     , (72988,  64,    0.75) /* ResistSlash */
+     , (72988,  65,    0.75) /* ResistPierce */
+     , (72988,  66,    0.75) /* ResistBludgeon */
+     , (72988,  67,    0.75) /* ResistFire */
+     , (72988,  68,    0.75) /* ResistCold */
+     , (72988,  69,    0.75) /* ResistAcid */
+     , (72988,  70,    0.75) /* ResistElectric */
+     , (72988,  71,       1) /* ResistHealthBoost */
+     , (72988,  72,       1) /* ResistStaminaDrain */
+     , (72988,  73,       1) /* ResistStaminaBoost */
+     , (72988,  74,       1) /* ResistManaDrain */
+     , (72988,  75,       1) /* ResistManaBoost */
+     , (72988, 104,      10) /* ObviousRadarRange */
+     , (72988, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72988,   1, 'Spot''s Cage Door') /* Name */
+     , (72988,  15, 'A cage door with the name ''Spot'' engraved on a plate above it.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72988,   1, 0x02000281) /* Setup */
+     , (72988,   2, 0x09000016) /* MotionTable */
+     , (72988,   3, 0x20000022) /* SoundTable */
+     , (72988,   8, 0x06001412) /* Icon */
+     , (72988,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (72988,  0,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72988,  1,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72988,  2,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72988,  3,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72988,  4,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72988,  5,  4,  1, 0.75,  200,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72988,  6,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72988,  7,  4,  0,    0,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72988,  8,  4,  1, 0.75,  200,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (72988,   1,   1, 0, 0) /* Strength */
+     , (72988,   2,   1, 0, 0) /* Endurance */
+     , (72988,   3,   1, 0, 0) /* Quickness */
+     , (72988,   4,   1, 0, 0) /* Coordination */
+     , (72988,   5,   1, 0, 0) /* Focus */
+     , (72988,   6,   1, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (72988,   1,  7999, 0, 0, 8000) /* MaxHealth */
+     , (72988,   3,  1000, 0, 0, 1001) /* MaxStamina */
+     , (72988,   5,     0, 0, 0,    1) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (72988,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
+     , (72988,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
+     , (72988, 15, 0, 2, 0,   1, 0, 0) /* MagicDefense        Trained */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72988, 6 /* Give */, 1, 72979, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 18 /* DirectBroadcast */, 0, 1, NULL, 'You place the sleeping Ursuin inside and close the gate.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72988, -1, 72989, 30, 1, 1, 1, 4, 0, 0, 0, 0x5860031A, 170.009766, -83.130859, 30.000000, 0.000000, 0.000000, 0.000000, -1.000000) /* Generate Spot (72989) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/72990 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/72990 Door.sql
@@ -1,29 +1,32 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72990;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72990, 'ace72990-door', 19, '2021-11-01 00:00:00') /* Door */;
+VALUES (72990, 'ace72990-dooractivated', 19, '2005-02-09 10:00:00') /* Door */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72990,   1,        128) /* ItemType - Misc */
      , (72990,   8,        500) /* Mass */
      , (72990,  16,          1) /* ItemUseable - No */
      , (72990,  19,          0) /* Value */
-     , (72990,  93,         28) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions */
-     , (72990, 119,          0) /* Active */
-     , (72990, 290,          1) /* HearLocalSignals */
-     , (72990, 291,         50) /* HearLocalSignalsRadius */;
+     , (72990,  83,          2) /* ActivationResponse - Use */
+     , (72990,  93,         24) /* PhysicsState - ReportCollisions, IgnoreCollisions */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (72990,   1, True ) /* Stuck */
-     , (72990,   2, True ) /* Open */
-     , (72990,  34, True ) /* DefaultOpen */;
+     , (72990,   2, True) /* Open */
+     , (72990,  12, True ) /* ReportCollisions */
+     , (72990,  13, False) /* Ethereal */
+     , (72990,  14, False) /* GravityStatus */
+     , (72990,  33, False) /* ResetMessagePending */
+     , (72990,  34, True) /* DefaultOpen */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (72990,  11,     300) /* ResetInterval */
      , (72990,  54,       2) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (72990,   1, 'Door') /* Name */;
+VALUES (72990,   1, 'Door') /* Name */
+     , (72990,  14, 'This door cannot be activated from here.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (72990,   1, 0x0200024F) /* Setup */
@@ -31,19 +34,3 @@ VALUES (72990,   1, 0x0200024F) /* Setup */
      , (72990,   3, 0x20000022) /* SoundTable */
      , (72990,   8, 0x06001317) /* Icon */
      , (72990,  22, 0x3400002B) /* PhysicsEffectTable */;
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72990, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'CloseDoor', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0, 117 /* CloseMe */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (72990, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'OpenDoor', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0, 116 /* OpenMe */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/72990 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/72990 Door.sql
@@ -1,0 +1,49 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72990;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72990, 'ace72990-door', 19, '2021-11-01 00:00:00') /* Door */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72990,   1,        128) /* ItemType - Misc */
+     , (72990,   8,        500) /* Mass */
+     , (72990,  16,          1) /* ItemUseable - No */
+     , (72990,  19,          0) /* Value */
+     , (72990,  93,         28) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions */
+     , (72990, 119,          0) /* Active */
+     , (72990, 290,          1) /* HearLocalSignals */
+     , (72990, 291,         50) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72990,   1, True ) /* Stuck */
+     , (72990,   2, True ) /* Open */
+     , (72990,  34, True ) /* DefaultOpen */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72990,  11,     300) /* ResetInterval */
+     , (72990,  54,       2) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72990,   1, 'Door') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72990,   1, 0x0200024F) /* Setup */
+     , (72990,   2, 0x09000016) /* MotionTable */
+     , (72990,   3, 0x20000022) /* SoundTable */
+     , (72990,   8, 0x06001317) /* Icon */
+     , (72990,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72990, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'CloseDoor', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0, 117 /* CloseMe */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72990, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'OpenDoor', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0, 116 /* OpenMe */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Food/Food/72980 Drugged Meat.sql
+++ b/Database/Patches/9 WeenieDefaults/Food/Food/72980 Drugged Meat.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72980;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72980, 'ace72980-druggedmeat', 18, '2005-02-09 10:00:00') /* Food */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72980,   1,      32) /* ItemType - Food */
+     , (72980,   5,      75) /* EncumbranceVal */
+     , (72980,   8,      50) /* Mass */
+     , (72980,   9,       0) /* ValidLocations - None */
+     , (72980,  11,       3) /* MaxStackSize */
+     , (72980,  12,       1) /* StackSize */
+     , (72980,  13,      75) /* StackUnitEncumbrance */
+     , (72980,  14,      50) /* StackUnitMass */
+     , (72980,  15,      20) /* StackUnitValue */
+     , (72980,  16,       1) /* ItemUseable - No */
+     , (72980,  19,       5) /* Value */
+     , (72980,  33,       1) /* Bonded - Bonded*/
+     , (72980,  93,    1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72980, 114,       1) /* Attuned */
+     , (72980, 267,   10800) /* Lifespan */;
+     
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72980, 23,    True) /* DestroyOnSell */
+     , (72980, 69,   False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72980,   1, 'Drugged Meat') /* Name */
+     , (72980,  16, 'A slice of unknown meat that has had a sedative added to it by Colton Reeyan. Give this to Colton''s pets before it starts to rot.') /* LongDesc */
+     , (72980,  20, 'Drugged Meats') /* PluralName */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72980,   1, 0x020000F6) /* Setup */
+     , (72980,   8, 0x06001048) /* Icon */
+     , (72980,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/49570 Contract for Protecting Picketed Pets.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/49570 Contract for Protecting Picketed Pets.sql
@@ -1,0 +1,42 @@
+DELETE FROM `weenie` WHERE `class_Id` = 49570;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (49570, 'ace49570-contractforprotectingpicketedpets', 38, '2019-02-10 00:00:00') /* Gem */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (49570,   1,       2048) /* ItemType - Gem */
+     , (49570,  11,          1) /* MaxStackSize */
+     , (49570,  12,          1) /* StackSize */
+     , (49570,  13,          0) /* StackUnitEncumbrance */
+     , (49570,  15,        100) /* StackUnitValue */
+     , (49570,  16,          8) /* ItemUseable - Contained */
+     , (49570,  18,          2) /* UiEffects - Poisoned */
+     , (49570,  19,        100) /* Value */
+     , (49570,  33,          1) /* Bonded - Bonded */
+     , (49570,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (49570,  94,         16) /* TargetType - Creature */
+     , (49570, 280,        100) /* SharedCooldown */
+     , (49570, 349,        273) /* UseCreatesContractId */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (49570,   1, False) /* Stuck */
+     , (49570,  11, True ) /* IgnoreCollisions */
+     , (49570,  13, True ) /* Ethereal */
+     , (49570,  14, True ) /* GravityStatus */
+     , (49570,  19, True ) /* Attackable */
+     , (49570,  22, True ) /* Inscribable */
+     , (49570,  69, False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (49570, 167,       2) /* CooldownDuration */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (49570,   1, 'Contract for Protecting Picketed Pets') /* Name */
+     , (49570,  14, 'Recommended Level: 150') /* Use */
+     , (49570,  16, 'Rescue Colton''s Pets from the Protestors.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (49570,   1, 0x02000C79) /* Setup */
+     , (49570,   3, 0x20000014) /* SoundTable */
+     , (49570,   8, 0x06006FDA) /* Icon */
+     , (49570,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Food/47831 Sealed Letter.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Food/47831 Sealed Letter.sql
@@ -1,0 +1,26 @@
+DELETE FROM `weenie` WHERE `class_Id` = 47831;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (47831, 'ace47831-sealedletter', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (47831,   1,      32) /* ItemType - Food */
+     , (47831,   5,      50) /* EncumbranceVal */
+     , (47831,  16,       1) /* ItemUseable - No */
+     , (47831,  19,       5) /* Value */
+     , (47831,  33,       1) /* Bonded - Bonded*/
+     , (47831,  93,    1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (47831, 114,       1) /* Attuned */
+     , (47831, 267,    3600) /* Lifespan */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (47831,  1, 'Sealed Letter') /* Name */
+     , (47831, 16, 'A sealed letter given to you by Colton Reeyan to be delivered to ther Mosswart Messenger.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (47831,   1, 0x020000F6) /* Setup */
+     , (47831,   3, 0x20000014) /* SoundTable */
+     , (47831,   8, 0x0600658D) /* Icon */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (47831, 69, False) /* IsSellable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/72975 Sleeping Armoredillo.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/72975 Sleeping Armoredillo.sql
@@ -1,0 +1,28 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72975;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72975, 'ace72975-sleepingarmoredillo', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72975,   1,     128) /* ItemType - Misc */
+     , (72975,   5,     250) /* EncumbranceVal */
+     , (72975,  16,       1) /* ItemUseable - No */
+     , (72975,  19,       0) /* Value */
+     , (72975,  33,       1) /* Bonded - Bonded */
+     , (72975,  93,    1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72975, 114,       1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72975, 22,    True) /* Inscribable */
+     , (72975, 23,    True) /* DestroyOnSell */
+     , (72975, 69,   False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72975,  1, 'Sleeping Armoredillo') /* Name */
+     , (72975, 16, 'Shady is sleeping after eating the drugged meat from Colton Reeyan. You should return it to its cage before it wakes.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72975,   1, 0x0200151F) /* Setup */
+     , (72975,   3, 0x20000014) /* SoundTable */
+     , (72975,   8, 0x0600121F) /* Icon */
+     , (72975,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/72977 Sleeping Tusker.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/72977 Sleeping Tusker.sql
@@ -1,0 +1,28 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72977;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72977, 'ace72977-sleepingtusker', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72977,   1,     128) /* ItemType - Misc */
+     , (72977,   5,     250) /* EncumbranceVal */
+     , (72977,  16,       1) /* ItemUseable - No */
+     , (72977,  19,       0) /* Value */
+     , (72977,  33,       1) /* Bonded - Bonded */
+     , (72977,  93,    1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72977, 114,       1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72977, 22,    True) /* Inscribable */
+     , (72977, 23,    True) /* DestroyOnSell */
+     , (72977, 69,   False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72977,  1, 'Sleeping Tusker') /* Name */
+     , (72977, 16, 'Bubba is sleeping after eating the drugged meat from Colton Reeyan. You should return it to its cage before it wakes.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72977,   1, 0x0200151F) /* Setup */
+     , (72977,   3, 0x20000014) /* SoundTable */
+     , (72977,   8, 0x06001033) /* Icon */
+     , (72977,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/72979 Sleeping Ursuin.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/72979 Sleeping Ursuin.sql
@@ -1,0 +1,28 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72979;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72979, 'ace72979-sleepingursuin', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72979,   1,     128) /* ItemType - Misc */
+     , (72979,   5,     250) /* EncumbranceVal */
+     , (72979,  16,       1) /* ItemUseable - No */
+     , (72979,  19,       0) /* Value */
+     , (72979,  33,       1) /* Bonded - Bonded */
+     , (72979,  93,    1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72979, 114,       1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72979, 22,    True) /* Inscribable */
+     , (72979, 23,    True) /* DestroyOnSell */
+     , (72979, 69,   False) /* IsSellable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72979,  1, 'Sleeping Ursuin') /* Name */
+     , (72979, 16, 'Spot is sleeping after eating the drugged meat from Colton Reeyan. You should return it to its cage before it wakes.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72979,   1, 0x0200151F) /* Setup */
+     , (72979,   3, 0x20000014) /* SoundTable */
+     , (72979,   8, 0x06001DEF) /* Icon */
+     , (72979,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47717 Acid Spear.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47717 Acid Spear.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 47717;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (47717, 'ace47717-acidspear', 6, '2021-11-01 00:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (47717,   1,          1) /* ItemType - MeleeWeapon */
+     , (47717,   3,          4) /* PaletteTemplate - Brown */
+     , (47717,   5,        700) /* EncumbranceVal */
+     , (47717,   8,        140) /* Mass */
+     , (47717,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (47717,  16,          1) /* ItemUseable - No */
+     , (47717,  18,        256) /* UiEffects - Acid */
+     , (47717,  19,        425) /* Value */
+     , (47717,  33,         -2) /* Bonded - Destroy */
+     , (47717,  44,        200) /* Damage */
+     , (47717,  45,         32) /* DamageType - Acid */
+     , (47717,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (47717,  47,          2) /* AttackType - Thrust */
+     , (47717,  48,         45) /* WeaponSkill - LightWeapons */
+     , (47717,  49,          0) /* WeaponTime */
+     , (47717,  51,          1) /* CombatUse - Melee */
+     , (47717,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (47717, 150,        103) /* HookPlacement - Hook */
+     , (47717, 151,          2) /* HookType - Wall */
+     , (47717, 353,          5) /* WeaponType - Spear */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (47717,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (47717,  21,     1.5) /* WeaponLength */
+     , (47717,  22,    0.75) /* DamageVariance */
+     , (47717,  29,       1) /* WeaponDefense */
+     , (47717,  62,       1) /* WeaponOffense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (47717,   1, 'Acid Spear') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (47717,   1, 0x02000544) /* Setup */
+     , (47717,   3, 0x20000014) /* SoundTable */
+     , (47717,   6, 0x04000BEF) /* PaletteBase */
+     , (47717,   7, 0x10000138) /* ClothingBase */
+     , (47717,   8, 0x060010D9) /* Icon */
+     , (47717,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47793 Frost Spear.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47793 Frost Spear.sql
@@ -1,0 +1,46 @@
+DELETE FROM `weenie` WHERE `class_Id` = 47793;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (47793, 'ace47793-frostspear', 6, '2021-11-01 00:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (47793,   1,          1) /* ItemType - MeleeWeapon */
+     , (47793,   3,          4) /* PaletteTemplate - Brown */
+     , (47793,   5,        700) /* EncumbranceVal */
+     , (47793,   8,        140) /* Mass */
+     , (47793,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (47793,  16,          1) /* ItemUseable - No */
+     , (47793,  18,        128) /* UiEffects - Frost */
+     , (47793,  19,        425) /* Value */
+     , (47793,  33,         -2) /* Bonded - Destroy */
+     , (47793,  44,        200) /* Damage */
+     , (47793,  45,          8) /* DamageType - Cold */
+     , (47793,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (47793,  47,          2) /* AttackType - Thrust */
+     , (47793,  48,         45) /* WeaponSkill - LightWeapons */
+     , (47793,  49,          0) /* WeaponTime */
+     , (47793,  51,          1) /* CombatUse - Melee */
+     , (47793,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (47793, 150,        103) /* HookPlacement - Hook */
+     , (47793, 151,          2) /* HookType - Wall */
+     , (47793, 353,          5) /* WeaponType - Spear */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (47793,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (47793,  21,     1.5) /* WeaponLength */
+     , (47793,  22,    0.75) /* DamageVariance */
+     , (47793,  29,       1) /* WeaponDefense */
+     , (47793,  62,       1) /* WeaponOffense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (47793,   1, 'Frost Spear') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (47793,   1, 0x0200056E) /* Setup */
+     , (47793,   3, 0x20000014) /* SoundTable */
+     , (47793,   6, 0x04000BEF) /* PaletteBase */
+     , (47793,   7, 0x10000138) /* ClothingBase */
+     , (47793,   8, 0x060010D9) /* Icon */
+     , (47793,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/72994 Frost Javelin.sql
+++ b/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/72994 Frost Javelin.sql
@@ -1,0 +1,48 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72994;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72994, 'ace72994-javelinfrost', 4, '2005-02-09 10:00:00') /* Missile */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72994,   1,        256) /* ItemType - MissileWeapon */
+     , (72994,   5,         23) /* EncumbranceVal */
+     , (72994,   8,         15) /* Mass */
+     , (72994,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (72994,  11,         40) /* MaxStackSize */
+     , (72994,  12,          1) /* StackSize */
+     , (72994,  13,         23) /* StackUnitEncumbrance */
+     , (72994,  14,         15) /* StackUnitMass */
+     , (72994,  15,         20) /* StackUnitValue */
+     , (72994,  16,          1) /* ItemUseable - No */
+     , (72994,  18,        128) /* UiEffects - Frost */
+     , (72994,  19,         20) /* Value */
+     , (72994,  33,         -2) /* Bonded - Destroy */
+     , (72994,  37,       9999) /* ResistItemAppraisal */
+     , (72994,  44,        400) /* Damage */
+     , (72994,  45,          8) /* DamageType - Cold */
+     , (72994,  46,        128) /* DefaultCombatStyle - ThrownWeapon */
+     , (72994,  48,         12) /* WeaponSkill - ThrownWeapon */
+     , (72994,  49,         20) /* WeaponTime */
+     , (72994,  51,          2) /* CombatUse - Missile */
+     , (72994,  93,     132116) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, Inelastic */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72994,  17, True ) /* Inelastic */
+     , (72994,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72994,  22,     0.3) /* DamageVariance */
+     , (72994,  27,       0) /* RotationSpeed */
+     , (72994,  29,       1) /* WeaponDefense */
+     , (72994,  62,       1) /* WeaponOffense */
+     , (72994,  78,       1) /* Friction */
+     , (72994,  79,       0) /* Elasticity */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72994,   1, 'Frost Javelin') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72994,   1, 0x02000519) /* Setup */
+     , (72994,   3, 0x20000014) /* SoundTable */
+     , (72994,   8, 0x060010C9) /* Icon */
+     , (72994,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/47840 Colton Reeyan's Sanctuary.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/47840 Colton Reeyan's Sanctuary.sql
@@ -29,3 +29,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (47840,   1, 0x020005D5) /* Setup */
      , (47840,   2, 0x09000003) /* MotionTable */
      , (47840,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (47840, 2, 1482686870, 120.000000, -155.800003, 0.010000, 1.000000, 0.000000, 0.000000, 0.000000) /* Destination */
+/* @teleloc 0x58600196 [120.000000 -155.800003 0.010000] 1.000000 0.000000 0.000000 0.000000 */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/72981 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/72981 Surface.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72981;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72981, 'ace72981-surface', 7, '2021-11-08 06:01:47') /* Portal */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72981,   1,   65536) /* ItemType - Portal */
+     , (72981,  16,      32) /* ItemUseable - Remote */
+     , (72981,  93,    3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
+     , (72981, 111,      49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
+     , (72981, 133,       4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72981,   1, True ) /* Stuck */
+     , (72981,  11, False) /* IgnoreCollisions */
+     , (72981,  12, True ) /* ReportCollisions */
+     , (72981,  13, True ) /* Ethereal */
+     , (72981,  15, True ) /* LightsStatus */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72981,  54,    -0.1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72981,   1, 'Surface') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72981,   1, 0x020001B3) /* Setup */
+     , (72981,   2, 0x09000003) /* MotionTable */
+     , (72981,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72981, 2, 1369178121, 27.888454, 10.969747, 0.658076, 0.000000, 0.000000, 0.000000, 1.000000) /* Destination */
+/* @teleloc 0x519C0009 [27.888454 10.969747 0.658076] 0.000000 0.000000 0.000000 1.000000 */;


### PR DESCRIPTION
Adds the On Strike quest (also known as Protecting Picketed Pets).

http://acpedia.org/wiki/On_Strike

Also updates Mosswart Protector weapons and spells found in Aerbax's Citadel to match pcap. This came up because Mosswarts in this quest use the same weapons.

This PR modifies the Danby's Outpost landblock to add the Colton Reeyan NPC.