### PR TITLE
Eastham Sewer

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/01CF.sql
+++ b/Database/Patches/6 LandBlockExtendedData/01CF.sql
@@ -1,0 +1,527 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x01CF;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF000,  1316, 0x01CF0103, 17.5729, -104.434, -18, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF0103 [17.572901 -104.433998 -18.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF001,  1610, 0x01CF0103, 18.3508, -99.5622, -17.9967, 0.895178, 0, 0, -0.44571,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0103 [18.350800 -99.562202 -17.996700] 0.895178 0.000000 0.000000 -0.445710 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF002,  1610, 0x01CF0103, 19.9707, -101.324, -17.9967, 0.767794, 0, 0, -0.640696,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0103 [19.970699 -101.323997 -17.996700] 0.767794 0.000000 0.000000 -0.640696 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF003,  1316, 0x01CF010B, 34.3203, -90.7495, -18, 0.703627, 0, 0, -0.710569, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF010B [34.320301 -90.749496 -18.000000] 0.703627 0.000000 0.000000 -0.710569 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF004,  4018, 0x01CF010B, 25.6244, -85.8036, -18, 0.695286, 0, 0, -0.718733, False, '2005-02-09 10:00:00'); /* Cheap Thief Generator */
+/* @teleloc 0x01CF010B [25.624399 -85.803596 -18.000000] 0.695286 0.000000 0.000000 -0.718733 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF005,  1610, 0x01CF010B, 30, -90, -17.9958, -0.2685, 0, 0, -0.96328,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF010B [30.000000 -90.000000 -17.995800] -0.268500 0.000000 0.000000 -0.963280 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF006,  5625, 0x01CF0111, 30, -104.75, -18, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0111 [30.000000 -104.750000 -18.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF007,  1290, 0x01CF0115, 25.25, -120, -18, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0115 [25.250000 -120.000000 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF008,  5624, 0x01CF0116, 30, -115.25, -18, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0116 [30.000000 -115.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF009,   568, 0x01CF0117, 28.5824, -130.023, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0117 [28.582399 -130.022995 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF00A,  4255, 0x01CF011F, 40, -80, -17.989, -0.086504, 0, 0, -0.996252,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF011F [40.000000 -80.000000 -17.989000] -0.086504 0.000000 0.000000 -0.996252 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF00B,   278, 0x01CF0122, 40, -75.25, -18, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0122 [40.000000 -75.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF00C,   152, 0x01CF0124, 44.0552, -99.2246, -18, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Font */
+/* @teleloc 0x01CF0124 [44.055199 -99.224602 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF00D,  4012, 0x01CF012F, 12.7594, -86.936, -12, -0.31958, 0, 0, -0.947559, False, '2005-02-09 10:00:00'); /* Cheap Glitter Generator */
+/* @teleloc 0x01CF012F [12.759400 -86.935997 -12.000000] -0.319580 0.000000 0.000000 -0.947559 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF00E,  1610, 0x01CF012F, 9.01374, -89.0918, -11.9958, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF012F [9.013740 -89.091797 -11.995800] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF00F,  1610, 0x01CF012F, 8.61842, -92.5499, -11.9958, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF012F [8.618420 -92.549896 -11.995800] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF010,  1610, 0x01CF012F, 9.79903, -91.1905, -11.9958, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF012F [9.799030 -91.190498 -11.995800] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF011,   278, 0x01CF0131, 5.25, -90, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0131 [5.250000 -90.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF012,   278, 0x01CF0132, 14.75, -90, -12, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0132 [14.750000 -90.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF013,  1610, 0x01CF0133, 20.1345, -84.709, -11.9965, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0133 [20.134501 -84.709000 -11.996500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF014,  1610, 0x01CF0134, 20.4902, -91.0929, -11.9958, 0.192308, 0, 0, -0.981335,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0134 [20.490200 -91.092903 -11.995800] 0.192308 0.000000 0.000000 -0.981335 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF015,  4255, 0x01CF0139, 42.4141, -53.9157, -11.995, 0.899673, 0, 0, -0.436565,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF0139 [42.414101 -53.915699 -11.995000] 0.899673 0.000000 0.000000 -0.436565 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF016,  4255, 0x01CF013A, 43.2271, -56.9868, -11.989, -0.514384, 0, 0, -0.85756,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF013A [43.227100 -56.986801 -11.989000] -0.514384 0.000000 0.000000 -0.857560 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF017,  4452, 0x01CF013F, 50.0271, -45.051, -12, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF013F [50.027100 -45.050999 -12.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF018,  4255, 0x01CF0141, 46.2146, -57.459, -11.995, 0.978911, 0, 0, -0.204288,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF0141 [46.214600 -57.459000 -11.995000] 0.978911 0.000000 0.000000 -0.204288 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF019,  4019, 0x01CF0142, 53.6506, -73.6967, -12, -0.895177, 0, 0, -0.44571, False, '2005-02-09 10:00:00'); /* Cheap Utility Generator */
+/* @teleloc 0x01CF0142 [53.650600 -73.696701 -12.000000] -0.895177 0.000000 0.000000 -0.445710 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF01A,  1610, 0x01CF0142, 47.8387, -70.5036, -11.9958, 0.429132, 0, 0, -0.903242,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0142 [47.838699 -70.503601 -11.995800] 0.429132 0.000000 0.000000 -0.903242 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF01B,  1608, 0x01CF0142, 49.6855, -67.0434, -11.9967, 0.491284, 0, 0, -0.870999,  True, '2005-02-09 10:00:00'); /* Drudge Lurker */
+/* @teleloc 0x01CF0142 [49.685501 -67.043404 -11.996700] 0.491284 0.000000 0.000000 -0.870999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF01C,   298, 0x01CF0142, 53.1825, -72.7803, -11.995, 0.625347, 0, 0, -0.780347,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01CF0142 [53.182499 -72.780296 -11.995000] 0.625347 0.000000 0.000000 -0.780347 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF01D,  1610, 0x01CF0149, 58.5128, -21.3711, -11.9967, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0149 [58.512798 -21.371099 -11.996700] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF01E,  1610, 0x01CF0149, 58.7899, -18.2906, -11.9967, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0149 [58.789902 -18.290600 -11.996700] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF01F,   568, 0x01CF014B, 64.75, -20, -12, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF014B [64.750000 -20.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF020,   420, 0x01CF016B, 72.518, -12.3896, -12, -0.903896, 0, 0, -0.427753, False, '2005-02-09 10:00:00'); /* Item Food Generator */
+/* @teleloc 0x01CF016B [72.517998 -12.389600 -12.000000] -0.903896 0.000000 0.000000 -0.427753 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF021,  4255, 0x01CF016B, 67.6892, -8.87783, -11.989, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF016B [67.689201 -8.877830 -11.989000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF022,  3978, 0x01CF016B, 70.6102, -5.93412, -12, -1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF016B [70.610199 -5.934120 -12.000000] -1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF023,   568, 0x01CF016D, 74.755, -10, -12, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF016D [74.754997 -10.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF024,  1610, 0x01CF0170, 70.0434, -22.3542, -11.995, 0.997294, 0, 0, 0.073514, False, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0170 [70.043404 -22.354200 -11.995000] 0.997294 0.000000 0.000000 0.073514 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF025,  1610, 0x01CF0187, 71.9209, -90.4061, -11.9967, -0.303514, 0, 0, -0.952827,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0187 [71.920898 -90.406097 -11.996700] -0.303514 0.000000 0.000000 -0.952827 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF026,  1610, 0x01CF0190, 71.294, -129.074, -11.9967, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0190 [71.293999 -129.074005 -11.996700] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF027,  1610, 0x01CF0191, 74.3279, -130.514, -11.9967, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0191 [74.327904 -130.514008 -11.996700] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF028,  1321, 0x01CF0193, 80.4514, 1.56932, -11.9965, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Matted Drudge Ravener */
+/* @teleloc 0x01CF0193 [80.451401 1.569320 -11.996500] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF029,  1610, 0x01CF0193, 79.8915, -1.91029, -11.9958, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0193 [79.891502 -1.910290 -11.995800] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF02A,   298, 0x01CF0193, 79.6745, 0.478784, -11.995, 0.639217, 0, 0, -0.769026,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01CF0193 [79.674500 0.478784 -11.995000] 0.639217 0.000000 0.000000 -0.769026 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF02B,   568, 0x01CF0195, 84.75, 0, -12, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0195 [84.750000 0.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF02C,  2131, 0x01CF019F, 80, -40, -12, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01CF019F [80.000000 -40.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF02D,  2179, 0x01CF01A2, 83.0071, -39.9645, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF01A2 [83.007103 -39.964500 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701CF02D, 0x701CF01C, '2005-02-09 10:00:00') /* Pressure Plate (298) */
+     , (0x701CF02D, 0x701CF02C, '2005-02-09 10:00:00') /* Pressure Plate (2131) */
+     , (0x701CF02D, 0x701CF038, '2005-02-09 10:00:00') /* Lever (285) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF02E,  2131, 0x01CF01A4, 80, -50, -12, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01CF01A4 [80.000000 -50.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF02F,  2179, 0x01CF01A7, 81.7755, -49.978, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF01A7 [81.775497 -49.978001 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701CF02F, 0x701CF02A, '2005-02-09 10:00:00') /* Pressure Plate (298) */
+     , (0x701CF02F, 0x701CF02E, '2005-02-09 10:00:00') /* Pressure Plate (2131) */
+     , (0x701CF02F, 0x701CF03C, '2005-02-09 10:00:00') /* Lever (285) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF030,   420, 0x01CF01A9, 78.7157, -67.2038, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Item Food Generator */
+/* @teleloc 0x01CF01A9 [78.715698 -67.203796 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF031,  1610, 0x01CF01A9, 81.4157, -69.4755, -11.995, -0.985944, 0, 0, 0.167077, False, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01A9 [81.415703 -69.475502 -11.995000] -0.985944 0.000000 0.000000 0.167077 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF032,   420, 0x01CF01AC, 80.1619, -77.0751, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Item Food Generator */
+/* @teleloc 0x01CF01AC [80.161903 -77.075104 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF033,  4255, 0x01CF01AC, 82.8083, -79.2361, -11.989, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF01AC [82.808296 -79.236099 -11.989000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF034,  1610, 0x01CF01AF, 78.2636, -91.9929, -11.9967, -0.786733, 0, 0, -0.617293,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01AF [78.263603 -91.992897 -11.996700] -0.786733 0.000000 0.000000 -0.617293 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF035,  1610, 0x01CF01B3, 80.8616, -95.4932, -11.9465, 0.018434, 0, 0, -0.99983,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01B3 [80.861603 -95.493202 -11.946500] 0.018434 0.000000 0.000000 -0.999830 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF036,   553, 0x01CF01B5, 84.4089, -114.492, -12, 0.538678, 0, 0, -0.842512, False, '2005-02-09 10:00:00'); /* Mushroom Circle Generator */
+/* @teleloc 0x01CF01B5 [84.408897 -114.491997 -12.000000] 0.538678 0.000000 0.000000 -0.842512 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF037,  1610, 0x01CF01C0, 89.053, -11.05, -12, 0.786733, 0, 0, -0.617293, False, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C0 [89.053001 -11.050000 -12.000000] 0.786733 0.000000 0.000000 -0.617293 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF038,   285, 0x01CF01C4, 87.7341, -38.4481, -10.602, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01CF01C4 [87.734100 -38.448101 -10.602000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF039,  1610, 0x01CF01C4, 87.2736, -41.0022, -11.9958, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C4 [87.273598 -41.002201 -11.995800] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF03A,  1610, 0x01CF01C4, 87.3077, -39.2872, -11.9958, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C4 [87.307701 -39.287201 -11.995800] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF03B,  4009, 0x01CF01C5, 87.7106, -50.2677, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Cheap Alu. Warrior Generator */
+/* @teleloc 0x01CF01C5 [87.710602 -50.267700 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF03C,   285, 0x01CF01C5, 87.7409, -48.438, -10.655, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01CF01C5 [87.740898 -48.438000 -10.655000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF03D,  1610, 0x01CF01C5, 87.422, -49.1789, -11.9967, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C5 [87.421997 -49.178902 -11.996700] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF03E,  1610, 0x01CF01C5, 87.6388, -51.1799, -11.9967, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C5 [87.638802 -51.179901 -11.996700] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF03F,   420, 0x01CF01C9, 101.109, 1.8898, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Item Food Generator */
+/* @teleloc 0x01CF01C9 [101.109001 1.889800 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF040,  1610, 0x01CF01C9, 103.598, 2.1189, -11.9967, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C9 [103.598000 2.118900 -11.996700] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF041,  1316, 0x01CF01D0, 12.9436, -70.971, -6, 0.043291, 0, 0, -0.999062, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF01D0 [12.943600 -70.971001 -6.000000] 0.043291 0.000000 0.000000 -0.999062 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF042,  1317, 0x01CF01D0, 12.4209, -66.0354, -6, 0.99778, 0, 0, -0.066601, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF01D0 [12.420900 -66.035400 -6.000000] 0.997780 0.000000 0.000000 -0.066601 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF043,   143, 0x01CF01D0, 8.72819, -66.0341, -6, 0.99778, 0, 0, -0.066601, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF01D0 [8.728190 -66.034103 -6.000000] 0.997780 0.000000 0.000000 -0.066601 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF044,  1610, 0x01CF01D0, 10.6785, -70.0754, -5.9958, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01D0 [10.678500 -70.075401 -5.995800] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF045,   278, 0x01CF01D3, 5.25002, -70, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF01D3 [5.250020 -70.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF046,  1610, 0x01CF01D8, 62.2371, -134.157, -5.99668, 0.760264, 0, 0, -0.649614,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01D8 [62.237099 -134.156998 -5.996680] 0.760264 0.000000 0.000000 -0.649614 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF047,  1610, 0x01CF01D8, 56.0438, -133.966, -5.99668, 0.760264, 0, 0, -0.649614,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01D8 [56.043800 -133.966003 -5.996680] 0.760264 0.000000 0.000000 -0.649614 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF048,  1610, 0x01CF01DA, 69.2753, -129.057, -5.9958, 0.401748, 0, 0, -0.91575,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01DA [69.275299 -129.057007 -5.995800] 0.401748 0.000000 0.000000 -0.915750 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF049,  1610, 0x01CF01DD, 80, -130, -5.9958, -0.018434, 0, 0, -0.99983,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01DD [80.000000 -130.000000 -5.995800] -0.018434 0.000000 0.000000 -0.999830 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF04A,  1610, 0x01CF01DD, 80.7661, -127.987, -5.99668, 0.327424, 0, 0, -0.944878,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF01DD [80.766098 -127.987000 -5.996680] 0.327424 0.000000 0.000000 -0.944878 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF04B,  4255, 0x01CF01EA, 103.758, -133.13, -5.989, -0.737056, 0, 0, -0.675831,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF01EA [103.758003 -133.130005 -5.989000] -0.737056 0.000000 0.000000 -0.675831 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF04C,  4255, 0x01CF01EB, 96.2981, -142.721, -5.989, 0.867657, 0, 0, -0.497163,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF01EB [96.298103 -142.720993 -5.989000] 0.867657 0.000000 0.000000 -0.497163 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF04D,  1610, 0x01CF0205, 11.4667, -88.1706, 0.0042, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0205 [11.466700 -88.170601 0.004200] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF04E,  1610, 0x01CF0206, 21.869, -87.8071, 0.0042, -0.653338, 0, 0, -0.757066,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0206 [21.868999 -87.807098 0.004200] -0.653338 0.000000 0.000000 -0.757066 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF04F,  5625, 0x01CF0208, 24.75, -90, 0, -0.707107, 0, 0, 0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0208 [24.750000 -90.000000 0.000000] -0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF050,  5625, 0x01CF0209, 15.25, -90, 0, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF0209 [15.250000 -90.000000 0.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF051,  1610, 0x01CF020B, 19.8693, -96.2865, 0.0042, -0.999977, 0, 0, -0.006764,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF020B [19.869301 -96.286499 0.004200] -0.999977 0.000000 0.000000 -0.006764 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF052,  4255, 0x01CF021A, 109.67, -120.195, 0.011, 0.876674, 0, 0, -0.481084,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF021A [109.669998 -120.195000 0.011000] 0.876674 0.000000 0.000000 -0.481084 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF053,  4255, 0x01CF021F, 115.156, -128.527, 0.011, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF021F [115.155998 -128.526993 0.011000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF054,  4255, 0x01CF0221, 131.41, -119.155, 0.011, -0.34939, 0, 0, -0.936977,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF0221 [131.410004 -119.154999 0.011000] -0.349390 0.000000 0.000000 -0.936977 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF055,  7923, 0x01CF0237, 119.809, -162.411, 6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x01CF0237 [119.808998 -162.410995 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701CF055, 0x701CF001, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF002, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF005, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF00A, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF00E, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF00F, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF010, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF013, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF014, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF015, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF016, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF018, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF01A, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF01B, '2005-02-09 10:00:00') /* Drudge Lurker (1608) */
+     , (0x701CF055, 0x701CF01D, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF01E, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF021, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF025, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF026, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF027, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF028, '2005-02-09 10:00:00') /* Matted Drudge Ravener (1321) */
+     , (0x701CF055, 0x701CF029, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF033, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF034, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF035, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF039, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF03A, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF03D, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF03E, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF040, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF044, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF046, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF047, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF048, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF049, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF04A, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF04B, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF04C, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF04D, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF04E, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF051, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF052, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF053, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF054, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF057, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF059, '2005-02-09 10:00:00') /* Drudge Stalker Pack Rat (1322) */
+     , (0x701CF055, 0x701CF05C, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF05F, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF060, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF061, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF063, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF064, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF065, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF066, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF067, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF068, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF069, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF06F, '2005-02-09 10:00:00') /* Malus Shreth (4255) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF056,  1324, 0x01CF023C, 128.078, -166.807, 6.19004, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01CF023C [128.078003 -166.807007 6.190040] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF057,  1610, 0x01CF024B, 0, -100, 18.0042, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF024B [0.000000 -100.000000 18.004200] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF058,  1314, 0x01CF024F, 8.86336, -63.8305, 18, 0.403446, 0, 0, -0.915004, False, '2005-02-09 10:00:00'); /* Book Shelf */
+/* @teleloc 0x01CF024F [8.863360 -63.830502 18.000000] 0.403446 0.000000 0.000000 -0.915004 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF059,  1322, 0x01CF0260, 11.07, -99.4784, 18.0035, -0.360302, 0, 0, -0.932836,  True, '2005-02-09 10:00:00'); /* Drudge Stalker Pack Rat */
+/* @teleloc 0x01CF0260 [11.070000 -99.478401 18.003500] -0.360302 0.000000 0.000000 -0.932836 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF05A,  1316, 0x01CF0263, 5.34062, -105.389, 18, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF0263 [5.340620 -105.389000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF05B,   420, 0x01CF0267, 18.0085, -58.792, 18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Item Food Generator */
+/* @teleloc 0x01CF0267 [18.008499 -58.792000 18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF05C,  1610, 0x01CF0268, 20, -70, 18.0042, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0268 [20.000000 -70.000000 18.004200] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF05D,  1913, 0x01CF0269, 23.6299, -83.8598, 18, -0.01658, 0, 0, -0.999863, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF0269 [23.629900 -83.859802 18.000000] -0.016580 0.000000 0.000000 -0.999863 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF05E,  1317, 0x01CF026D, 15.3205, -97.6902, 18, -0.136255, 0, 0, -0.990674, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF026D [15.320500 -97.690201 18.000000] -0.136255 0.000000 0.000000 -0.990674 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF05F,  1610, 0x01CF0270, 24.0292, -111.289, 18.0042, -0.560729, 0, 0, -0.827999,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0270 [24.029200 -111.289001 18.004200] -0.560729 0.000000 0.000000 -0.827999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF060,  1610, 0x01CF0270, 20, -110, 18.0042, -0.803857, 0, 0, -0.594823,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0270 [20.000000 -110.000000 18.004200] -0.803857 0.000000 0.000000 -0.594823 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF061,  1610, 0x01CF0277, 28.1459, -68.0791, 18.0042, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0277 [28.145901 -68.079102 18.004200] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF062,  1609, 0x01CF0279, 10.7238, -69.9457, 24.2335, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Drudge Stalker */
+/* @teleloc 0x01CF0279 [10.723800 -69.945702 24.233500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF063,  1610, 0x01CF027F, 19.4378, -49.3027, 21.0042, 0.658444, 0, 0, -0.75263,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF027F [19.437799 -49.302700 21.004200] 0.658444 0.000000 0.000000 -0.752630 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF064,  1610, 0x01CF027F, 19.8092, -50.8082, 21.0042, 0.658444, 0, 0, -0.75263,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF027F [19.809200 -50.808201 21.004200] 0.658444 0.000000 0.000000 -0.752630 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF065,  1610, 0x01CF0281, 18.0312, -57.0268, 24.0042, 0.658444, 0, 0, -0.75263,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0281 [18.031200 -57.026798 24.004200] 0.658444 0.000000 0.000000 -0.752630 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF066,  1610, 0x01CF0284, 21.9064, -99.8537, 24.048, -0.750399, 0, 0, -0.660985,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0284 [21.906401 -99.853699 24.048000] -0.750399 0.000000 0.000000 -0.660985 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF067,  1610, 0x01CF0286, 28.9069, -51.3112, 24.0042, 0.448735, 0, 0, -0.893665,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0286 [28.906900 -51.311199 24.004200] 0.448735 0.000000 0.000000 -0.893665 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF068,  1610, 0x01CF0286, 28.7893, -47.541, 24.0042, 0.448735, 0, 0, -0.893665,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0286 [28.789301 -47.541000 24.004200] 0.448735 0.000000 0.000000 -0.893665 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF069,  1610, 0x01CF0286, 32.6579, -48.1129, 24.0042, 0.448735, 0, 0, -0.893665,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
+/* @teleloc 0x01CF0286 [32.657902 -48.112900 24.004200] 0.448735 0.000000 0.000000 -0.893665 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF06A,  1314, 0x01CF0287, 27.9826, -64.8974, 24, -0.001526, 0, 0, -0.999999, False, '2005-02-09 10:00:00'); /* Book Shelf */
+/* @teleloc 0x01CF0287 [27.982599 -64.897400 24.000000] -0.001526 0.000000 0.000000 -0.999999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF06B,  1324, 0x01CF0291, 40.2194, -38.2247, 24, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01CF0291 [40.219398 -38.224701 24.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF06C,  1932, 0x01CF0297, 43.7345, -64.4172, 24, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF0297 [43.734501 -64.417198 24.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF06D,  4129, 0x01CF029B, 39.8449, -89.9254, 24, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Fountain */
+/* @teleloc 0x01CF029B [39.844898 -89.925400 24.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF06E,  1315, 0x01CF02A4, 53.2353, -53.8723, 30, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF02A4 [53.235298 -53.872299 30.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF06F,  4255, 0x01CF02A4, 49.863, -49.7409, 30.011, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Malus Shreth */
+/* @teleloc 0x01CF02A4 [49.862999 -49.740898 30.011000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF070,  1931, 0x01CF02A4, 53.9112, -51.1205, 30, 0.654742, 0, 0, -0.755852, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x01CF02A4 [53.911201 -51.120499 30.000000] 0.654742 0.000000 0.000000 -0.755852 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF071,  1318, 0x01CF02A6, 50, -54.75, 30, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01CF02A6 [50.000000 -54.750000 30.000000] 0.000000 0.000000 0.000000 -1.000000 */

--- a/Database/Patches/6 LandBlockExtendedData/01CF.sql
+++ b/Database/Patches/6 LandBlockExtendedData/01CF.sql
@@ -203,7 +203,7 @@ VALUES (0x701CF030,   420, 0x01CF01A9, 78.7157, -67.2038, -12, -0.707107, 0, 0, 
 /* @teleloc 0x01CF01A9 [78.715698 -67.203796 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701CF031,  1610, 0x01CF01A9, 81.4157, -69.4755, -11.995, -0.985944, 0, 0, 0.167077, False, '2005-02-09 10:00:00'); /* Drudge Ravener */
+VALUES (0x701CF031,  1610, 0x01CF01A9, 81.4157, -69.4755, -11.995, -0.985944, 0, 0, 0.167077,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
 /* @teleloc 0x01CF01A9 [81.415703 -69.475502 -11.995000] -0.985944 0.000000 0.000000 0.167077 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -227,7 +227,7 @@ VALUES (0x701CF036,   553, 0x01CF01B5, 84.4089, -114.492, -12, 0.538678, 0, 0, -
 /* @teleloc 0x01CF01B5 [84.408897 -114.491997 -12.000000] 0.538678 0.000000 0.000000 -0.842512 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701CF037,  1610, 0x01CF01C0, 89.053, -11.05, -12, 0.786733, 0, 0, -0.617293, False, '2005-02-09 10:00:00'); /* Drudge Ravener */
+VALUES (0x701CF037,  1610, 0x01CF01C0, 89.053, -11.05, -12, 0.786733, 0, 0, -0.617293,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
 /* @teleloc 0x01CF01C0 [89.053001 -11.050000 -12.000000] 0.786733 0.000000 0.000000 -0.617293 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -373,9 +373,11 @@ VALUES (0x701CF055, 0x701CF001, '2005-02-09 10:00:00') /* Drudge Ravener (1610) 
      , (0x701CF055, 0x701CF027, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF028, '2005-02-09 10:00:00') /* Matted Drudge Ravener (1321) */
      , (0x701CF055, 0x701CF029, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF031, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF033, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
      , (0x701CF055, 0x701CF034, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF035, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF037, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF039, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF03A, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF03D, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
@@ -401,6 +403,7 @@ VALUES (0x701CF055, 0x701CF001, '2005-02-09 10:00:00') /* Drudge Ravener (1610) 
      , (0x701CF055, 0x701CF05F, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF060, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF061, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF062, '2005-02-09 10:00:00') /* Drudge Stalker (1609) */
      , (0x701CF055, 0x701CF063, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF064, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF065, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
@@ -465,7 +468,7 @@ VALUES (0x701CF061,  1610, 0x01CF0277, 28.1459, -68.0791, 18.0042, 0, 0, 0, -1, 
 /* @teleloc 0x01CF0277 [28.145901 -68.079102 18.004200] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701CF062,  1609, 0x01CF0279, 10.7238, -69.9457, 24.2335, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Drudge Stalker */
+VALUES (0x701CF062,  1609, 0x01CF0279, 10.7238, -69.9457, 24.2335, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Drudge Stalker */
 /* @teleloc 0x01CF0279 [10.723800 -69.945702 24.233500] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/01CF.sql
+++ b/Database/Patches/6 LandBlockExtendedData/01CF.sql
@@ -145,10 +145,6 @@ VALUES (0x701CF023,   568, 0x01CF016D, 74.755, -10, -12, 0.707107, 0, 0, -0.7071
 /* @teleloc 0x01CF016D [74.754997 -10.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701CF024,  1610, 0x01CF0170, 70.0434, -22.3542, -11.995, 0.997294, 0, 0, 0.073514, False, '2005-02-09 10:00:00'); /* Drudge Ravener */
-/* @teleloc 0x01CF0170 [70.043404 -22.354200 -11.995000] 0.997294 0.000000 0.000000 0.073514 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x701CF025,  1610, 0x01CF0187, 71.9209, -90.4061, -11.9967, -0.303514, 0, 0, -0.952827,  True, '2005-02-09 10:00:00'); /* Drudge Ravener */
 /* @teleloc 0x01CF0187 [71.920898 -90.406097 -11.996700] -0.303514 0.000000 0.000000 -0.952827 */
 
@@ -412,7 +408,13 @@ VALUES (0x701CF055, 0x701CF001, '2005-02-09 10:00:00') /* Drudge Ravener (1610) 
      , (0x701CF055, 0x701CF067, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF068, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
      , (0x701CF055, 0x701CF069, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
-     , (0x701CF055, 0x701CF06F, '2005-02-09 10:00:00') /* Malus Shreth (4255) */;
+     , (0x701CF055, 0x701CF06F, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF072, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF073, '2005-02-09 10:00:00') /* Drudge Stalker (1609) */
+     , (0x701CF055, 0x701CF074, '2005-02-09 10:00:00') /* Malus Shreth (4255) */
+     , (0x701CF055, 0x701CF075, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF076, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */
+     , (0x701CF055, 0x701CF077, '2005-02-09 10:00:00') /* Drudge Ravener (1610) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x701CF056,  1324, 0x01CF023C, 128.078, -166.807, 6.19004, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Surface Portal */
@@ -525,3 +527,27 @@ VALUES (0x701CF070,  1931, 0x01CF02A4, 53.9112, -51.1205, 30, 0.654742, 0, 0, -0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x701CF071,  1318, 0x01CF02A6, 50, -54.75, 30, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
 /* @teleloc 0x01CF02A6 [50.000000 -54.750000 30.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF072,  1610, 0x01CF01C9, 101.869, 0.026606, -11.9955, -0.723865, 0, 0, -0.689942,  True, '2023-03-24 11:22:15'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C9 [101.869003 0.026606 -11.995500] -0.723865 0.000000 0.000000 -0.689942 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF073,  1609, 0x01CF01C9, 101.341, -1.89575, -11.9955, 0.699375, 0, 0, 0.714755,  True, '2023-03-24 11:22:46'); /* Drudge Stalker */
+/* @teleloc 0x01CF01C9 [101.341003 -1.895750 -11.995500] 0.699375 0.000000 0.000000 0.714755 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF074,  4255, 0x01CF016B, 69.7255, -9.73308, -12.0218, -0.7288, 0, 0, 0.684727,  True, '2023-03-24 11:23:25'); /* Malus Shreth */
+/* @teleloc 0x01CF016B [69.725502 -9.733080 -12.021800] -0.728800 0.000000 0.000000 0.684727 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF075,  1610, 0x01CF01C5, 85.8511, -50.5, -11.9955, -0.668969, 0, 0, -0.743291,  True, '2023-03-24 11:23:55'); /* Drudge Ravener */
+/* @teleloc 0x01CF01C5 [85.851097 -50.500000 -11.995500] -0.668969 0.000000 0.000000 -0.743291 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF076,  1610, 0x01CF0124, 39.7234, -100.179, -17.9954, 0.701542, 0, 0, 0.712628,  True, '2023-03-24 11:26:24'); /* Drudge Ravener */
+/* @teleloc 0x01CF0124 [39.723400 -100.179001 -17.995399] 0.701542 0.000000 0.000000 0.712628 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701CF077,  1610, 0x01CF010C, 30.2474, -99.3987, -17.9954, -0.009941, 0, 0, 0.999951,  True, '2023-03-24 11:26:43'); /* Drudge Ravener */
+/* @teleloc 0x01CF010C [30.247400 -99.398697 -17.995399] -0.009941 0.000000 0.000000 0.999951 */

--- a/Database/Patches/8 QuestDefDB/EasthamSewerSwordPickup1110.sql
+++ b/Database/Patches/8 QuestDefDB/EasthamSewerSwordPickup1110.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'EasthamSewerSwordPickup1110';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('EasthamSewerSwordPickup1110', 72000, -1, 'Player has picked up the Slimy Broad Sword from the Eastham Sewer', '2023-03-23 20:13:04');

--- a/Database/Patches/9 WeenieDefaults/Chest/Container/01315 Chest.sql
+++ b/Database/Patches/9 WeenieDefaults/Chest/Container/01315 Chest.sql
@@ -1,0 +1,54 @@
+DELETE FROM `weenie` WHERE `class_Id` = 1315;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (1315, 'chestsewershield', 20, '2005-02-09 10:00:00') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (1315,   1,        512) /* ItemType - Container */
+     , (1315,   5,       9000) /* EncumbranceVal */
+     , (1315,   6,         -1) /* ItemsCapacity */
+     , (1315,   7,         -1) /* ContainersCapacity */
+     , (1315,   8,       3000) /* Mass */
+     , (1315,  16,         48) /* ItemUseable - ViewedRemote */
+     , (1315,  19,       3000) /* Value */
+     , (1315,  37,         40) /* ResistItemAppraisal */
+     , (1315,  38,        350) /* ResistLockpick */
+     , (1315,  81,          2) /* MaxGeneratedObjects */
+     , (1315,  82,          2) /* InitGeneratedObjects */
+     , (1315,  83,          2) /* ActivationResponse - Use */
+     , (1315,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (1315,  96,        500) /* EncumbranceCapacity */
+     , (1315, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (1315,   1, True ) /* Stuck */
+     , (1315,   2, False) /* Open */
+     , (1315,   3, True ) /* Locked */
+     , (1315,  12, True ) /* ReportCollisions */
+     , (1315,  13, False) /* Ethereal */
+     , (1315,  33, False) /* ResetMessagePending */
+     , (1315,  34, False) /* DefaultOpen */
+     , (1315,  35, True ) /* DefaultLocked */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (1315,  11,     300) /* ResetInterval */
+     , (1315,  39,     0.9) /* DefaultScale */
+     , (1315,  41,      60) /* RegenerationInterval */
+     , (1315,  43,       1) /* GeneratorRadius */
+     , (1315,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (1315,   1, 'Chest') /* Name */
+     , (1315,  12, 'keyeasthamsewerchest') /* LockCode */
+     , (1315,  14, 'Use this item to open it and see its contents.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (1315,   1, 0x0200007C) /* Setup */
+     , (1315,   2, 0x09000004) /* MotionTable */
+     , (1315,   3, 0x20000021) /* SoundTable */
+     , (1315,   8, 0x06001020) /* Icon */
+     , (1315,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (1315, -1, 43417, 1800, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Slimy Broad Sword (43417) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */
+     , (1315, -1, 1313, 1800, 1, 1, 2, 8, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Metal Round Shield (1313) (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: Contain */;

--- a/Database/Patches/9 WeenieDefaults/Chest/Container/01316 Chest.sql
+++ b/Database/Patches/9 WeenieDefaults/Chest/Container/01316 Chest.sql
@@ -1,0 +1,54 @@
+DELETE FROM `weenie` WHERE `class_Id` = 1316;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (1316, 'chestsewertreasure', 20, '2005-02-09 10:00:00') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (1316,   1,        512) /* ItemType - Container */
+     , (1316,   5,       9000) /* EncumbranceVal */
+     , (1316,   6,         -1) /* ItemsCapacity */
+     , (1316,   7,         -1) /* ContainersCapacity */
+     , (1316,   8,       3000) /* Mass */
+     , (1316,  16,         48) /* ItemUseable - ViewedRemote */
+     , (1316,  19,       3000) /* Value */
+     , (1316,  37,         35) /* ResistItemAppraisal */
+     , (1316,  38,        400) /* ResistLockpick */
+     , (1316,  81,          1) /* MaxGeneratedObjects */
+     , (1316,  82,          1) /* InitGeneratedObjects */
+     , (1316,  83,          2) /* ActivationResponse - Use */
+     , (1316,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (1316,  96,        500) /* EncumbranceCapacity */
+     , (1316, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (1316,   1, True ) /* Stuck */
+     , (1316,   2, False) /* Open */
+     , (1316,   3, True ) /* Locked */
+     , (1316,  12, True ) /* ReportCollisions */
+     , (1316,  13, False) /* Ethereal */
+     , (1316,  33, False) /* ResetMessagePending */
+     , (1316,  34, False) /* DefaultOpen */
+     , (1316,  35, True ) /* DefaultLocked */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (1316,  11,     300) /* ResetInterval */
+     , (1316,  41,      60) /* RegenerationInterval */
+     , (1316,  43,       1) /* GeneratorRadius */
+     , (1316,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (1316,   1, 'Chest') /* Name */
+     , (1316,  12, 'keyeasthamsewer') /* LockCode */
+     , (1316,  14, 'Use this item to open it and see its contents.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (1316,   1, 0x0200007C) /* Setup */
+     , (1316,   2, 0x09000004) /* MotionTable */
+     , (1316,   3, 0x20000021) /* SoundTable */
+     , (1316,   8, 0x06001020) /* Icon */
+     , (1316,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (1316, 0.5, 459, 1000, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 1 from Death Treasure Table id: 459 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */
+     , (1316, 0.8, 16, 1000, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 2 from Death Treasure Table id: 16 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */
+     , (1316, 1, 463, 1000, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 2 from Death Treasure Table id: 463 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.es
@@ -17,8 +17,8 @@ Give: Slimy Broad Sword (43417)
     - TurnToTarget
     - Tell: My God! It couldn't be, where did you find it?
 	- Tell: This brings me back, back to a better time when I was a young naive warrior who thought he could take on the world.
-    - Delay: 1, Tell: Thank you for bringing this back to me, it is rare to find something to smile about these days.
     - AwardNoShareXP: 8,800,000
+    - Delay: 1, Tell: Thank you for bringing this back to me, it is rare to find something to smile about these days.
 
 Use: Probability: 0.2
     - Motion: Ready

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.es
@@ -1,0 +1,77 @@
+Refuse: Black Marrow Tea (30798)
+    - TurnToTarget
+    - Tell: No! You keep that! I made it for you.
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.06
+    - Motion: Shiver
+
+Give: Broken Black Marrow Key (30823)
+    - TurnToTarget
+    - Tell: Yes! This is the stuff! I have more than enough to keep my calm for months to come, but I can make some tea for you out of this!
+    - Delay: 1, DirectBroadcast: Samuel produces a mortar and pestle and quickly crushes the charred bits of marrow and then stirs the powder into a mug of heated rum.
+    - Delay: 1, Tell: There you go! One sip of this stuff and you'll forget about all those things that trouble your dreams!
+    - AwardNoShareXP: 80,000
+    - Give: Black Marrow Tea (30798)
+
+Give: Slimy Broad Sword (43417)
+    - TurnToTarget
+    - Tell: My God! It couldn't be, where did you find it?
+	- Tell: This brings me back, back to a better time when I was a young naive warrior who thought he could take on the world.
+    - Delay: 1, Tell: Thank you for bringing this back to me, it is rare to find something to smile about these days.
+    - AwardNoShareXP: 8,800,000
+
+Use: Probability: 0.2
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: If only...if only I had resigned before this. But now, those things, that place...the things I saw. They'll stay with me forever.
+    - Motion: Cry
+    - Delay: 3, Motion: MimeDrink
+    - Delay: 1, Tell: I'll drown them out! I swear I will.
+
+Use: Probability: 0.4
+    - Delay: 1, Tell: I'm not a coward. You hear me!?
+    - Motion: ShakeFist
+    - Delay: 1.5, Tell: The horror...the horror...
+    - Motion: MimeDrink
+
+Use: Probability: 0.59
+    - Delay: 1, Tell: The island - the Virindi came there. They took it over, drove the shadows away, for the most part. They reconstructed the island in their image.
+    - Motion: Shiver
+    - Delay: 2, Tell: Or so they thought.
+    - Delay: 1, DirectBroadcast: Samuel manages a meek smile.
+    - Motion: MimeDrink
+    - Delay: 1.5, Tell: Sit?
+    - Motion: HaveASeat
+    - Delay: 1, ForceMotion: SitState
+    - Delay: 1, Tell: You see. The Virindi thought that they could take the island over and cleanse it. They thought that they were more powerful than whatever force controls that place.  But they weren't, you see?
+    - Delay: 2.5, Motion: MimeDrink
+    - Delay: 1, Tell: They've been there quite a while now, or they were. They're not there anymore, not the normal Virindi. The twisted ones...they're still there.
+    - Motion: Shiver
+    - Delay: 1, DirectBroadcast: Samuel's voice becomes low and takes on a surreal quality.
+    - Delay: 1, Tell: ...and so are his spawn. The spawn of the -
+    - Delay: 0.5, Motion: Cry
+    - Delay: 0.5, Motion: MimeDrink
+
+Use: Probability: 0.69
+    - Delay: 1, Tell: No, no. I don't serve as a Royal Guard anymore. If the High Queen wants the uniform back she can come pry it off of my cold corpse. I'm owed! I saw those things. Those horrific creatures.
+    - Motion: MimeDrink
+
+Use: Probability: 0.79
+    - Tell: It has been so many months since that nightmare of an island changed. So many months, but the horrors are still fresh in my mind. I see the shadow in everything now. More than once has a hen stirred me to fright.
+    - Delay: 1, Motion: Cry
+    - Delay: 1, Tell: Fortunately, I have found something to help me cope with my fears. Oddly enough, this remedy came directly from the Singularity Caul itself.
+    - Delay: 1, Tell: Before I left that place, I came across some odd things, maybe mineral deposits, maybe the bones of some long dead creature, I do not know. All I know is steeping the stuff in hot water and cutting with rum has done wonders for my nerves.
+    - Delay: 1, Tell: If you find anything like that on the Caul, you know - charred bones of some sort - bring them to me and I'll brew you up some of this wonder drink as well!
+
+Use: Probability: 0.99
+    - Delay: 1, Tell: A few years back - you see? A few years back, this island was found. Apparently, Monarchs had gone there before Bael'zharon walked the world, as a test. Something like that-
+    - Delay: 2, Tell: This island...it was the home of nothing, but that was not the truth. Beneath the land, shadows lived, multiplied and schemed to take the world for their own. With their master destroyed, driven away and imprisoned by our forces and Asheron -
+    - Delay: 1, Motion: MimeDrink
+    - Delay: 1, Tell: But he's gone now - you see? He's gone and she drove him off...and now - these things.
+    - Delay: 1, Motion: Cry
+
+Use:
+    - Delay: 1, DirectBroadcast: Samuel seems to slur his words.
+    - Delay: 0.5, Tell: I was once Sam the brave, Sam the Cruel...now look at me. I'm Sam the can't even keep his gruel down.
+    - Motion: Cry
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 25896;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (25896, 'drunkguardcaul', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (25896, 'drunkguardcaul', 10, '2023-03-23 09:48:31') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (25896,   1,         16) /* ItemType - Creature */
@@ -129,8 +129,20 @@ VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NU
      , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Yes! This is the stuff! I have more than enough to keep my calm for months to come, but I can make some tea for you out of this!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel produces a mortar and pestle and quickly crushes the charred bits of marrow and then stirs the powder into a mug of heated rum.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'There you go! One sip of this stuff and you''ll forget about all those things that trouble your dreams!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 80000, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 30798 /* Black Marrow Tea */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  4,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 80000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30798 /* Black Marrow Tea */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (25896,  6 /* Give */,      1, 43417 /* Slimy Broad Sword */, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'My God! It couldn''t be, where did you find it?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'This brings me back, back to a better time when I was a young naive warrior who thought he could take on the world.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'Thank you for bringing this back to me, it is rare to find something to smile about these days.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8800000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (25896,  7 /* Use */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/25896 Samuel, Former Guardian.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 25896;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (25896, 'drunkguardcaul', 10, '2023-03-23 09:48:31') /* Creature */;
+VALUES (25896, 'drunkguardcaul', 10, '2023-03-24 01:04:43') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (25896,   1,         16) /* ItemType - Creature */
@@ -70,27 +70,6 @@ VALUES (25896,   1, 0x02000001) /* Setup */
      , (25896,   4, 0x30000000) /* CombatTable */
      , (25896,   8, 0x06001036) /* Icon */;
 
-INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (25896,   1, 200, 0, 0) /* Strength */
-     , (25896,   2, 140, 0, 0) /* Endurance */
-     , (25896,   3, 180, 0, 0) /* Quickness */
-     , (25896,   4, 200, 0, 0) /* Coordination */
-     , (25896,   5,  90, 0, 0) /* Focus */
-     , (25896,   6,  90, 0, 0) /* Self */;
-
-INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (25896,   1,   125, 0, 0, 195) /* MaxHealth */
-     , (25896,   3,   110, 0, 0, 250) /* MaxStamina */
-     , (25896,   5,    55, 0, 0, 145) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (25896,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
-     , (25896,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
-     , (25896, 31, 0, 3, 0, 400, 0, 0) /* CreatureEnchantment Specialized */
-     , (25896, 32, 0, 3, 0, 400, 0, 0) /* ItemEnchantment     Specialized */
-     , (25896, 33, 0, 3, 0, 400, 0, 0) /* LifeMagic           Specialized */
-     , (25896, 45, 0, 2, 0,   1, 0, 0) /* LightWeapons        Trained */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (25896,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (25896,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
@@ -102,138 +81,160 @@ VALUES (25896,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
      , (25896,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (25896,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (25896,   1, 200, 0, 0) /* Strength */
+     , (25896,   2, 140, 0, 0) /* Endurance */
+     , (25896,   3, 180, 0, 0) /* Quickness */
+     , (25896,   4, 200, 0, 0) /* Coordination */
+     , (25896,   5,  90, 0, 0) /* Focus */
+     , (25896,   6,  90, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (25896,   1,   125, 0, 0,  195) /* MaxHealth */
+     , (25896,   3,   110, 0, 0,  250) /* MaxStamina */
+     , (25896,   5,    55, 0, 0,  145) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (25896,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
+     , (25896,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
+     , (25896, 31, 0, 3, 0, 400, 0, 0) /* CreatureEnchantment Specialized */
+     , (25896, 32, 0, 3, 0, 400, 0, 0) /* ItemEnchantment     Specialized */
+     , (25896, 33, 0, 3, 0, 400, 0, 0) /* LifeMagic           Specialized */
+     , (25896, 45, 0, 2, 0,   1, 0, 0) /* LightWeapons        Trained */;
+
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  1 /* Refuse */,      1, 30798 /* Black Marrow Tea */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 1 /* Refuse */, 1, 30798 /* Black Marrow Tea */, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'No! You keep that! I made it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'No! You keep that! I made it for you.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  5 /* HeartBeat */,   0.06, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (25896, 5 /* HeartBeat */, 0.06, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x13000094 /* Shiver */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x13000094 /* Shiver */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  6 /* Give */,      1, 30823 /* Broken Black Marrow Key */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 6 /* Give */, 1, 30823 /* Broken Black Marrow Key */, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Yes! This is the stuff! I have more than enough to keep my calm for months to come, but I can make some tea for you out of this!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel produces a mortar and pestle and quickly crushes the charred bits of marrow and then stirs the powder into a mug of heated rum.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'There you go! One sip of this stuff and you''ll forget about all those things that trouble your dreams!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 80000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30798 /* Black Marrow Tea */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'Yes! This is the stuff! I have more than enough to keep my calm for months to come, but I can make some tea for you out of this!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel produces a mortar and pestle and quickly crushes the charred bits of marrow and then stirs the powder into a mug of heated rum.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'There you go! One sip of this stuff and you''ll forget about all those things that trouble your dreams!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 80000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 30798 /* Black Marrow Tea */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  6 /* Give */,      1, 43417 /* Slimy Broad Sword */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 6 /* Give */, 1, 43417, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'My God! It couldn''t be, where did you find it?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'This brings me back, back to a better time when I was a young naive warrior who thought he could take on the world.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'Thank you for bringing this back to me, it is rare to find something to smile about these days.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8800000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0, 1, NULL, 'My God! It couldn''t be, where did you find it?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0, 1, NULL, 'This brings me back, back to a better time when I was a young naive warrior who thought he could take on the world.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8800000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'Thank you for bringing this back to me, it is rare to find something to smile about these days.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  10 /* Tell */, 0, 1, NULL, 'If only...if only I had resigned before this. But now, those things, that place...the things I saw. They''ll stay with me forever.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   5 /* Motion */, 0, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,   5 /* Motion */, 3, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  10 /* Tell */, 1, 1, NULL, 'I''ll drown them out! I swear I will.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 0, 1, NULL, 'If only...if only I had resigned before this. But now, those things, that place...the things I saw. They''ll stay with me forever.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 5 /* Motion */, 0, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 5 /* Motion */, 3, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1, 1, NULL, 'I''ll drown them out! I swear I will.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,    0.4, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 0.4, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  10 /* Tell */, 1, 1, NULL, 'I''m not a coward. You hear me!?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x13000079 /* ShakeFist */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  10 /* Tell */, 1.5, 1, NULL, 'The horror...the horror...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,   5 /* Motion */, 0, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 1, 1, NULL, 'I''m not a coward. You hear me!?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x13000079 /* ShakeFist */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 1.5, 1, NULL, 'The horror...the horror...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 5 /* Motion */, 0, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,   0.59, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 0.59, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  10 /* Tell */, 1, 1, NULL, 'The island - the Virindi came there. They took it over, drove the shadows away, for the most part. They reconstructed the island in their image.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x13000094 /* Shiver */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  10 /* Tell */, 2, 1, NULL, 'Or so they thought.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel manages a meek smile.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,   5 /* Motion */, 0, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5,  10 /* Tell */, 1.5, 1, NULL, 'Sit?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  6,   5 /* Motion */, 0, 1, 0x13000152 /* HaveASeat */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  7,  52 /* ForceMotion */, 1, 1, 0x4300013D /* SitState */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  8,  10 /* Tell */, 1, 1, NULL, 'You see. The Virindi thought that they could take the island over and cleanse it. They thought that they were more powerful than whatever force controls that place.  But they weren''t, you see?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  9,   5 /* Motion */, 2.5, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 10,  10 /* Tell */, 1, 1, NULL, 'They''ve been there quite a while now, or they were. They''re not there anymore, not the normal Virindi. The twisted ones...they''re still there.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 11,   5 /* Motion */, 0, 1, 0x13000094 /* Shiver */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 12,  18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel''s voice becomes low and takes on a surreal quality.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 13,  10 /* Tell */, 1, 1, NULL, '...and so are his spawn. The spawn of the -', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 14,   5 /* Motion */, 0.5, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 15,   5 /* Motion */, 0.5, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 1, 1, NULL, 'The island - the Virindi came there. They took it over, drove the shadows away, for the most part. They reconstructed the island in their image.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x13000094 /* Shiver */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 2, 1, NULL, 'Or so they thought.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel manages a meek smile.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 5 /* Motion */, 0, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 5, 10 /* Tell */, 1.5, 1, NULL, 'Sit?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 6, 5 /* Motion */, 0, 1, 0x13000152 /* HaveASeat */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 7, 52 /* ForceMotion */, 1, 1, 0x4300013D /* SitState */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 8, 10 /* Tell */, 1, 1, NULL, 'You see. The Virindi thought that they could take the island over and cleanse it. They thought that they were more powerful than whatever force controls that place.  But they weren''t, you see?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 9, 5 /* Motion */, 2.5, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 10, 10 /* Tell */, 1, 1, NULL, 'They''ve been there quite a while now, or they were. They''re not there anymore, not the normal Virindi. The twisted ones...they''re still there.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11, 5 /* Motion */, 0, 1, 0x13000094 /* Shiver */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 12, 18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel''s voice becomes low and takes on a surreal quality.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 13, 10 /* Tell */, 1, 1, NULL, '...and so are his spawn. The spawn of the -', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 14, 5 /* Motion */, 0.5, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 15, 5 /* Motion */, 0.5, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,   0.69, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 0.69, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  10 /* Tell */, 1, 1, NULL, 'No, no. I don''t serve as a Royal Guard anymore. If the High Queen wants the uniform back she can come pry it off of my cold corpse. I''m owed! I saw those things. Those horrific creatures.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 1, 1, NULL, 'No, no. I don''t serve as a Royal Guard anymore. If the High Queen wants the uniform back she can come pry it off of my cold corpse. I''m owed! I saw those things. Those horrific creatures.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,   0.79, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 0.79, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'It has been so many months since that nightmare of an island changed. So many months, but the horrors are still fresh in my mind. I see the shadow in everything now. More than once has a hen stirred me to fright.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   5 /* Motion */, 1, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  10 /* Tell */, 1, 1, NULL, 'Fortunately, I have found something to help me cope with my fears. Oddly enough, this remedy came directly from the Singularity Caul itself.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'Before I left that place, I came across some odd things, maybe mineral deposits, maybe the bones of some long dead creature, I do not know. All I know is steeping the stuff in hot water and cutting with rum has done wonders for my nerves.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  10 /* Tell */, 1, 1, NULL, 'If you find anything like that on the Caul, you know - charred bones of some sort - bring them to me and I''ll brew you up some of this wonder drink as well!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 0, 1, NULL, 'It has been so many months since that nightmare of an island changed. So many months, but the horrors are still fresh in my mind. I see the shadow in everything now. More than once has a hen stirred me to fright.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 1, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 10 /* Tell */, 1, 1, NULL, 'Fortunately, I have found something to help me cope with my fears. Oddly enough, this remedy came directly from the Singularity Caul itself.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'Before I left that place, I came across some odd things, maybe mineral deposits, maybe the bones of some long dead creature, I do not know. All I know is steeping the stuff in hot water and cutting with rum has done wonders for my nerves.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 10 /* Tell */, 1, 1, NULL, 'If you find anything like that on the Caul, you know - charred bones of some sort - bring them to me and I''ll brew you up some of this wonder drink as well!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,   0.99, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 0.99, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  10 /* Tell */, 1, 1, NULL, 'A few years back - you see? A few years back, this island was found. Apparently, Monarchs had gone there before Bael''zharon walked the world, as a test. Something like that-', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 2, 1, NULL, 'This island...it was the home of nothing, but that was not the truth. Beneath the land, shadows lived, multiplied and schemed to take the world for their own. With their master destroyed, driven away and imprisoned by our forces and Asheron -', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,   5 /* Motion */, 1, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'But he''s gone now - you see? He''s gone and she drove him off...and now - these things.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,   5 /* Motion */, 1, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 10 /* Tell */, 1, 1, NULL, 'A few years back - you see? A few years back, this island was found. Apparently, Monarchs had gone there before Bael''zharon walked the world, as a test. Something like that-', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 2, 1, NULL, 'This island...it was the home of nothing, but that was not the truth. Beneath the land, shadows lived, multiplied and schemed to take the world for their own. With their master destroyed, driven away and imprisoned by our forces and Asheron -', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 5 /* Motion */, 1, 1, 0x13000082 /* MimeDrink */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 10 /* Tell */, 1, 1, NULL, 'But he''s gone now - you see? He''s gone and she drove him off...and now - these things.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 4, 5 /* Motion */, 1, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (25896,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (25896, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel seems to slur his words.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0.5, 1, NULL, 'I was once Sam the brave, Sam the Cruel...now look at me. I''m Sam the can''t even keep his gruel down.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,   5 /* Motion */, 0, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 1, 1, NULL, 'Samuel seems to slur his words.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 10 /* Tell */, 0.5, 1, NULL, 'I was once Sam the brave, Sam the Cruel...now look at me. I''m Sam the can''t even keep his gruel down.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 5 /* Motion */, 0, 1, 0x1300007F /* Cry */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (25896, 2, 10870,  0, 17, 0.7, False) /* Create Canescent Mattekar Robe (10870) for Wield */
-     , (25896, 2,   118,  0, 14, 1, False) /* Create Cap (118) for Wield */;
+VALUES (25896, 2, 10870,  0,17,  0.7, False) /* Create Canescent Mattekar Robe (10870) for Wield */
+     , (25896, 2,   118,  0,14,    1, False) /* Create Cap (118) for Wield */;
+

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/01318 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/01318 Door.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 1318;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (1318, 'dooreasthamsewer', 19, '2005-02-09 10:00:00') /* Door */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (1318,   1,        128) /* ItemType - Misc */
+     , (1318,   8,        500) /* Mass */
+     , (1318,  16,         32) /* ItemUseable - Remote */
+     , (1318,  19,          0) /* Value */
+     , (1318,  38,        350) /* ResistLockpick */
+     , (1318,  93,         24) /* PhysicsState - ReportCollisions, IgnoreCollisions */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (1318,   1, True ) /* Stuck */
+     , (1318,   2, False) /* Open */
+     , (1318,   3, True ) /* Locked */
+     , (1318,  12, True ) /* ReportCollisions */
+     , (1318,  13, False) /* Ethereal */
+     , (1318,  14, False) /* GravityStatus */
+     , (1318,  33, False) /* ResetMessagePending */
+     , (1318,  34, False) /* DefaultOpen */
+     , (1318,  35, True ) /* DefaultLocked */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (1318,  11,     300) /* ResetInterval */
+     , (1318,  54,       2) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (1318,   1, 'Door') /* Name */
+     , (1318,  12, 'keyeasthamsewer') /* LockCode */
+     , (1318,  14, 'Use this item to open it.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (1318,   1, 0x0200024F) /* Setup */
+     , (1318,   2, 0x09000016) /* MotionTable */
+     , (1318,   3, 0x20000022) /* SoundTable */
+     , (1318,   8, 0x06001317) /* Icon */
+     , (1318,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Armor/01313 Metal Round Shield.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Armor/01313 Metal Round Shield.sql
@@ -26,7 +26,7 @@ INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (1313,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (1313,   5,  -0.017) /* ManaRate */
+VALUES (1313,   5, -0.0166) /* ManaRate */
      , (1313,  13,    0.76) /* ArmorModVsSlash */
      , (1313,  14,     0.8) /* ArmorModVsPierce */
      , (1313,  15,    0.72) /* ArmorModVsBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Generic/Armor/01313 Metal Round Shield.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Armor/01313 Metal Round Shield.sql
@@ -1,0 +1,56 @@
+DELETE FROM `weenie` WHERE `class_Id` = 1313;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (1313, 'shieldroundmetal', 1, '2023-03-23 08:20:54') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (1313,   1,          2) /* ItemType - Armor */
+     , (1313,   3,          4) /* PaletteTemplate - Brown */
+     , (1313,   5,        690) /* EncumbranceVal */
+     , (1313,   8,        230) /* Mass */
+     , (1313,   9,    2097152) /* ValidLocations - Shield */
+     , (1313,  16,          1) /* ItemUseable - No */
+     , (1313,  19,        300) /* Value */
+     , (1313,  27,          2) /* ArmorType - Leather */
+     , (1313,  28,        165) /* ArmorLevel */
+     , (1313,  51,          4) /* CombatUse - Shield */
+     , (1313,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (1313, 106,         60) /* ItemSpellcraft */
+     , (1313, 107,        800) /* ItemCurMana */
+     , (1313, 108,        800) /* ItemMaxMana */
+     , (1313, 109,         10) /* ItemDifficulty */
+     , (1313, 150,        103) /* HookPlacement - Hook */
+     , (1313, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (1313,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (1313,   5,  -0.017) /* ManaRate */
+     , (1313,  13,    0.76) /* ArmorModVsSlash */
+     , (1313,  14,     0.8) /* ArmorModVsPierce */
+     , (1313,  15,    0.72) /* ArmorModVsBludgeon */
+     , (1313,  16,    0.81) /* ArmorModVsCold */
+     , (1313,  17,     1.1) /* ArmorModVsFire */
+     , (1313,  18,    0.91) /* ArmorModVsAcid */
+     , (1313,  19,     0.6) /* ArmorModVsElectric */
+     , (1313,  39,       1) /* DefaultScale */
+     , (1313, 110,       1) /* BulkMod */
+     , (1313, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (1313,   1, 'Metal Round Shield') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (1313,   1, 0x02000162) /* Setup */
+     , (1313,   3, 0x20000014) /* SoundTable */
+     , (1313,   6, 0x04000BEF) /* PaletteBase */
+     , (1313,   7, 0x10000094) /* ClothingBase */
+     , (1313,   8, 0x06000FE1) /* Icon */
+     , (1313,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (1313,   320,      2)  /* Finesse Weapon Mastery Other V */
+     , (1313,  1484,      2)  /* Impenetrability IV */
+     , (1313,   416,      2)  /* Heavy Weapon Mastery Other V */
+     , (1313,   296,      2)  /* Light Weapon Mastery Other V */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/43417 Slimy Broad Sword.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/43417 Slimy Broad Sword.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 43417;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (43417, 'ace43417-slimybroadsword', 1, '2023-03-23 08:12:14') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (43417,   1,        128) /* ItemType - Misc */
+     , (43417,   5,        500) /* EncumbranceVal */
+     , (43417,  16,          1) /* ItemUseable - No */
+     , (43417,  19,        500) /* Value */
+     , (43417,  33,          1) /* Bonded - Bonded */
+     , (43417,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (43417, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (43417,  22, True ) /* Inscribable */
+     , (43417,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (43417,   1, 'Slimy Broad Sword') /* Name */
+     , (43417,  16, 'This sword seems well worn and is covered with slime from the sewers. You notice an engraving on the hilt that looks like it says "Samuel".') /* LongDesc */
+     , (43417,  33, 'EasthamSewerSwordPickup1110') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (43417,   1, 0x02000146) /* Setup */
+     , (43417,   3, 0x20000014) /* SoundTable */
+     , (43417,   6, 0x04000BEF) /* PaletteBase */
+     , (43417,   8, 0x06001658) /* Icon */
+     , (43417,  22, 0x3400002B) /* PhysicsEffectTable */;


### PR DESCRIPTION
Updates Eastham Sewer to end of retail.

- Upgraded Spawns in dungeon
  - mostly Drudge Raveners and Maulus Shreth, with a couple of random lesser drudges and key-droppers. Compared with PCAPs + PcapPlayer
- Updated lockpick difficulty on some doors and chests
- Added Slimy Broad Sword reward to final chest on a 20 hour pickup timer
- Updated Shield found in same chest.
- Updated Samuel, Former Guardian to reward for returning the sword.