### PR TITLE
Graveyard Misc Fixes

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/472C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/472C.sql
@@ -73,7 +73,7 @@ VALUES (0x7472C1E2, 72227, 0x472C0024, 113.682, 74.1627, 3.28829, 0.922628, 0, 0
 /* @teleloc 0x472C0024 [113.681999 74.162697 3.288290] 0.922628 0.000000 0.000000 -0.385690 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7472C1E3, 72210, 0x472C0035, 158.506, 113.967, 8.34349, 0.996349, 0, 0, -0.085372, False, '2021-11-01 00:00:00'); /* Linkable Night Monster Generator ( 5 Min.) */
+VALUES (0x7472C1E3, 72998, 0x472C0035, 158.506, 113.967, 8.34349, 0.996349, 0, 0, -0.085372, False, '2021-11-01 00:00:00'); /* Linkable Night Monster Generator ( 10 Min.) */
 /* @teleloc 0x472C0035 [158.505997 113.967003 8.343490] 0.996349 0.000000 0.000000 -0.085372 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/482D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/482D.sql
@@ -180,7 +180,7 @@ VALUES (0x7482D4AC, 72227, 0x482D0006, 19.5705, 140.833, 2.31894, -0.666313, 0, 
 /* @teleloc 0x482D0006 [19.570499 140.832993 2.318940] -0.666313 0.000000 0.000000 0.745672 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7482D4AE, 72210, 0x482D0025, 106.072, 108.445, 6.055, 0.676416, 0, 0, -0.73652, False, '2021-11-01 00:00:00'); /* Linkable Night Monster Generator ( 5 Min.) */
+VALUES (0x7482D4AE, 72998, 0x482D0025, 106.072, 108.445, 6.055, 0.676416, 0, 0, -0.73652, False, '2021-11-01 00:00:00'); /* Linkable Night Monster Generator ( 10 Min.) */
 /* @teleloc 0x482D0025 [106.071999 108.445000 6.055000] 0.676416 0.000000 0.000000 -0.736520 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/482E.sql
+++ b/Database/Patches/6 LandBlockExtendedData/482E.sql
@@ -233,7 +233,7 @@ VALUES (0x7482E3EC, 72223, 0x482E002F, 136.187, 156.909, 6.055, 0.983239, 0, 0, 
 /* @teleloc 0x482E002F [136.186996 156.908997 6.055000] 0.983239 0.000000 0.000000 -0.182323 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7482E3ED, 72210, 0x482E0014, 49.7876, 76.1596, 10.055, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Night Monster Generator ( 5 Min.) */
+VALUES (0x7482E3ED, 72998, 0x482E0014, 49.7876, 76.1596, 10.055, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Night Monster Generator ( 10 Min.) */
 /* @teleloc 0x482E0014 [49.787601 76.159599 10.055000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/8C03.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8C03.sql
@@ -493,7 +493,7 @@ VALUES (0x78C032DD, 48766, 0x8C0303E2, 123.255, -206.72, 0, 0.924074, 0, 0, -0.3
 /* @teleloc 0x8C0303E2 [123.254997 -206.720001 0.000000] 0.924074 0.000000 0.000000 -0.382213 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78C032DE,  7923, 0x8C0307DA, 203.253, -195.997, 24.003, 0.918523, 0, 0, 0.395368, False, '2021-11-29 06:19:28'); /* Linkable Monster Generator ( 3 Min.) */
+VALUES (0x78C032DE,  7924, 0x8C0307DA, 203.253, -195.997, 24.003, 0.918523, 0, 0, 0.395368, False, '2021-11-29 06:19:28'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x8C0307DA [203.253006 -195.996994 24.003000] 0.918523 0.000000 0.000000 0.395368 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/35268 Spectral Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/35268 Spectral Dread.sql
@@ -95,14 +95,12 @@ VALUES (35268,   1,     0, 20000, 0, 20250) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (35268,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (35268,  7, 0, 3, 0, 520, 0, 0) /* MissileDefense      Specialized */
-     , (35268, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (35268, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (35268, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (35268, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (35268, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (35268, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (35268, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (35268, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (35268, 31, 0, 3, 0, 220, 0, 0) /* CreatureEnchantment Specialized */
+     , (35268, 33, 0, 3, 0, 220, 0, 0) /* LifeMagic           Specialized */
+     , (35268, 34, 0, 3, 0, 240, 0, 0) /* WarMagic            Specialized */
+     , (35268, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35268,  0,  1,  0,    0,  500,  320,  480,  480,  500,  320,  485,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -201,7 +199,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35268,  5 /* HeartBeat */,  0.032, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35268,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/35270 Spectral Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/35270 Spectral Dread.sql
@@ -94,14 +94,12 @@ VALUES (35270,   1,     0, 20000, 0, 20250) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (35270,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (35270,  7, 0, 3, 0, 520, 0, 0) /* MissileDefense      Specialized */
-     , (35270, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (35270, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (35270, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (35270, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (35270, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (35270, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (35270, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (35270, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (35270, 31, 0, 3, 0, 220, 0, 0) /* CreatureEnchantment Specialized */
+     , (35270, 33, 0, 3, 0, 220, 0, 0) /* LifeMagic           Specialized */
+     , (35270, 34, 0, 3, 0, 240, 0, 0) /* WarMagic            Specialized */
+     , (35270, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35270,  0,  1,  0,    0,  500,  320,  480,  480,  500,  320,  485,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -200,7 +198,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35270,  5 /* HeartBeat */,  0.032, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35270,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/35400 Corrupted Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/35400 Corrupted Dread.sql
@@ -97,11 +97,10 @@ VALUES (35400,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (35400, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (35400, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (35400, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (35400, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (35400, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (35400, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (35400, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (35400, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (35400, 31, 0, 3, 0, 265, 0, 0) /* CreatureEnchantment Specialized */
+     , (35400, 33, 0, 3, 0, 265, 0, 0) /* LifeMagic           Specialized */
+     , (35400, 34, 0, 3, 0, 285, 0, 0) /* WarMagic            Specialized */
+     , (35400, 45, 0, 3, 0, 380, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35400,  0,  1,  0,    0,  250,  160,  240,  240,  250,  160,  243,  188,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/37146 Laylana.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/37146 Laylana.sql
@@ -100,12 +100,12 @@ VALUES (37146,  0,  4,  0,    0,  400,  400,  400,  400,  400,  400,  400,  400,
      , (37146,  8,  4, 600, 0.75,  400,  400,  400,  400,  400,  400,  400,  400,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37146,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (37146,  5 /* HeartBeat */,  0.022, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'My Love, where have you gone?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'My Love, where have you gone?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (37146,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/37146.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/37146.es
@@ -1,5 +1,5 @@
-HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.042
-    - Say: My Love, where have you gone?, Extent: 20
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.022
+    - Say: My Love, where have you gone?, Extent: 0
     
 Use:
     - TurnToTarget

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/37452 Corrupted Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/37452 Corrupted Dread.sql
@@ -98,11 +98,10 @@ VALUES (37452,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (37452, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (37452, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (37452, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (37452, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (37452, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (37452, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (37452, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (37452, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (37452, 31, 0, 3, 0, 265, 0, 0) /* CreatureEnchantment Specialized */
+     , (37452, 33, 0, 3, 0, 265, 0, 0) /* LifeMagic           Specialized */
+     , (37452, 34, 0, 3, 0, 285, 0, 0) /* WarMagic            Specialized */
+     , (37452, 45, 0, 3, 0, 380, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (37452,  0,  1,  0,    0,  250,  160,  240,  240,  250,  160,  243,  188,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/37454 Spectral Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/37454 Spectral Dread.sql
@@ -94,14 +94,12 @@ VALUES (37454,   1,     0, 20000, 0, 20250) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (37454,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (37454,  7, 0, 3, 0, 520, 0, 0) /* MissileDefense      Specialized */
-     , (37454, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (37454, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (37454, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (37454, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (37454, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (37454, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (37454, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (37454, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (37454, 31, 0, 3, 0, 220, 0, 0) /* CreatureEnchantment Specialized */
+     , (37454, 33, 0, 3, 0, 220, 0, 0) /* LifeMagic           Specialized */
+     , (37454, 34, 0, 3, 0, 240, 0, 0) /* WarMagic            Specialized */
+     , (37454, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (37454,  0,  1,  0,    0,  500,  320,  480,  480,  500,  320,  485,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -200,7 +198,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37454,  5 /* HeartBeat */,  0.032, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (37454,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/41961 Corrupted Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/41961 Corrupted Dread.sql
@@ -97,11 +97,10 @@ VALUES (41961,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (41961, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (41961, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (41961, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (41961, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (41961, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (41961, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (41961, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (41961, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (41961, 31, 0, 3, 0, 265, 0, 0) /* CreatureEnchantment Specialized */
+     , (41961, 33, 0, 3, 0, 265, 0, 0) /* LifeMagic           Specialized */
+     , (41961, 34, 0, 3, 0, 285, 0, 0) /* WarMagic            Specialized */
+     , (41961, 45, 0, 3, 0, 380, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (41961,  0,  1,  0,    0,  250,  160,  240,  240,  250,  160,  243,  188,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/45165 Corrupted Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/45165 Corrupted Dread.sql
@@ -97,11 +97,10 @@ VALUES (45165,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (45165, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (45165, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (45165, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (45165, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (45165, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (45165, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (45165, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (45165, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (45165, 31, 0, 3, 0, 265, 0, 0) /* CreatureEnchantment Specialized */
+     , (45165, 33, 0, 3, 0, 265, 0, 0) /* LifeMagic           Specialized */
+     , (45165, 34, 0, 3, 0, 285, 0, 0) /* WarMagic            Specialized */
+     , (45165, 45, 0, 3, 0, 380, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (45165,  0,  1,  0,    0,  250,  160,  240,  240,  250,  160,  243,  188,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/45182 Corrupted Dread.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/45182 Corrupted Dread.sql
@@ -97,11 +97,10 @@ VALUES (45182,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (45182, 14, 0, 3, 0, 263, 0, 0) /* ArcaneLore          Specialized */
      , (45182, 15, 0, 3, 0, 340, 0, 0) /* MagicDefense        Specialized */
      , (45182, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (45182, 24, 0, 3, 0, 600, 0, 0) /* Run                 Specialized */
-     , (45182, 31, 0, 3, 0, 300, 0, 0) /* CreatureEnchantment Specialized */
-     , (45182, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (45182, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (45182, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */;
+     , (45182, 31, 0, 3, 0, 265, 0, 0) /* CreatureEnchantment Specialized */
+     , (45182, 33, 0, 3, 0, 265, 0, 0) /* LifeMagic           Specialized */
+     , (45182, 34, 0, 3, 0, 285, 0, 0) /* WarMagic            Specialized */
+     , (45182, 45, 0, 3, 0, 380, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (45182,  0,  1,  0,    0,  250,  160,  240,  240,  250,  160,  243,  188,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/35091 Wight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/35091 Wight.sql
@@ -69,31 +69,7 @@ VALUES (35091,   1, 0x020016A1) /* Setup */
      , (35091,   7, 0x10000066) /* ClothingBase */
      , (35091,   8, 0x06001226) /* Icon */
      , (35091,  22, 0x34000028) /* PhysicsEffectTable */
-     , (35091,  32,       2020) /* WieldedTreasureType - 
-                                   Wield Electric Crossbow (47856) | Probability: 5.7999997%
-                                   Wield 30x Lightning Quarrel (48067) | Probability: 100%
-                                   Wield Acid Crossbow (47854) | Probability: 5.7999997%
-                                   Wield 30x Acid Quarrel (48066) | Probability: 100%
-                                   Wield Heavy Crossbow (47858) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Arbalest (47852) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Lightning Silifi (48076) | Probability: 7.5000005%
-                                   Wield Lightning Nekode (48073) | Probability: 7.5000005%
-                                   Wield Acid Ono (48078) | Probability: 7.5000005%
-                                   Wield Silifi (48074) | Probability: 7.5000005%
-                                   Wield Nekode (48071) | Probability: 7.5000005%
-                                   Wield Katar (48069) | Probability: 7.5000005%
-                                   Wield Acid Silifi (48075) | Probability: 7.5000005%
-                                   Wield Lightning Ono (48079) | Probability: 7.5000005%
-                                   Wield Ono (48077) | Probability: 7.5000005%
-                                   Wield Lightning Katar (48070) | Probability: 7.5000005%
-                                   Wield Acid Nekode (48072) | Probability: 7.5000005%
-                                   Wield Acid Quarrel (48066) | Probability: 7.5000005%
-                                   Wield Acid Katar (48068) | Probability: 7.5000005%
-                                   Wield Kite Shield (91) | Probability: 30.000002%
-                                   Wield Round Shield (93) | Probability: 30.000002%
-                                   Wield Buckler (44) | Probability: 30.000002% */
+     , (35091,  32,       2020) /* WieldedTreasureType */
      , (35091,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -110,17 +86,15 @@ VALUES (35091,   1,  2885, 0, 0, 3000) /* MaxHealth */
      , (35091,   5,  2000, 0, 0, 2255) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35091,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (35091,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (35091,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (35091,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (35091, 15, 0, 3, 0, 345, 0, 0) /* MagicDefense        Specialized */
-     , (35091, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (35091, 33, 0, 3, 0, 375, 0, 0) /* LifeMagic           Specialized */
-     , (35091, 34, 0, 3, 0, 375, 0, 0) /* WarMagic            Specialized */
-     , (35091, 41, 0, 3, 0, 445, 0, 0) /* TwoHandedCombat     Specialized */
-     , (35091, 44, 0, 3, 0, 445, 0, 0) /* HeavyWeapons        Specialized */
-     , (35091, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (35091, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */
-     , (35091, 47, 0, 3, 0, 445, 0, 0) /* MissileWeapons      Specialized */;
+     , (35091, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (35091, 41, 0, 3, 0, 560, 0, 0) /* TwoHandedCombat     Specialized */
+     , (35091, 44, 0, 3, 0, 560, 0, 0) /* HeavyWeapons        Specialized */
+     , (35091, 45, 0, 3, 0, 560, 0, 0) /* LightWeapons        Specialized */
+     , (35091, 46, 0, 3, 0, 560, 0, 0) /* FinesseWeapons      Specialized */
+     , (35091, 47, 0, 3, 0, 440, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35091,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/35092 Wight Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/35092 Wight Captain.sql
@@ -68,31 +68,7 @@ VALUES (35092,   1, 0x020016A1) /* Setup */
      , (35092,   7, 0x10000066) /* ClothingBase */
      , (35092,   8, 0x06001226) /* Icon */
      , (35092,  22, 0x34000028) /* PhysicsEffectTable */
-     , (35092,  32,       2020) /* WieldedTreasureType - 
-                                   Wield Electric Crossbow (47856) | Probability: 5.7999997%
-                                   Wield 30x Lightning Quarrel (48067) | Probability: 100%
-                                   Wield Acid Crossbow (47854) | Probability: 5.7999997%
-                                   Wield 30x Acid Quarrel (48066) | Probability: 100%
-                                   Wield Heavy Crossbow (47858) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Arbalest (47852) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Lightning Silifi (48076) | Probability: 7.5000005%
-                                   Wield Lightning Nekode (48073) | Probability: 7.5000005%
-                                   Wield Acid Ono (48078) | Probability: 7.5000005%
-                                   Wield Silifi (48074) | Probability: 7.5000005%
-                                   Wield Nekode (48071) | Probability: 7.5000005%
-                                   Wield Katar (48069) | Probability: 7.5000005%
-                                   Wield Acid Silifi (48075) | Probability: 7.5000005%
-                                   Wield Lightning Ono (48079) | Probability: 7.5000005%
-                                   Wield Ono (48077) | Probability: 7.5000005%
-                                   Wield Lightning Katar (48070) | Probability: 7.5000005%
-                                   Wield Acid Nekode (48072) | Probability: 7.5000005%
-                                   Wield Acid Quarrel (48066) | Probability: 7.5000005%
-                                   Wield Acid Katar (48068) | Probability: 7.5000005%
-                                   Wield Kite Shield (91) | Probability: 30.000002%
-                                   Wield Round Shield (93) | Probability: 30.000002%
-                                   Wield Buckler (44) | Probability: 30.000002% */
+     , (35092,  32,       2020) /* WieldedTreasureType */
      , (35092,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -109,17 +85,17 @@ VALUES (35092,   1,  4000, 0, 0, 4120) /* MaxHealth */
      , (35092,   5,  2000, 0, 0, 2285) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35092,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (35092,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
-     , (35092, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (35092, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (35092, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (35092, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (35092, 41, 0, 3, 0, 445, 0, 0) /* TwoHandedCombat     Specialized */
-     , (35092, 44, 0, 3, 0, 445, 0, 0) /* HeavyWeapons        Specialized */
-     , (35092, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (35092, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */
-     , (35092, 47, 0, 3, 0, 445, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (35092,  6, 0, 3, 0, 540, 0, 0) /* MeleeDefense        Specialized */
+     , (35092,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
+     , (35092, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Specialized */
+     , (35092, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (35092, 33, 0, 3, 0, 245, 0, 0) /* LifeMagic           Specialized */
+     , (35092, 34, 0, 3, 0, 265, 0, 0) /* WarMagic            Specialized */
+     , (35092, 41, 0, 3, 0, 580, 0, 0) /* TwoHandedCombat     Specialized */
+     , (35092, 44, 0, 3, 0, 580, 0, 0) /* HeavyWeapons        Specialized */
+     , (35092, 45, 0, 3, 0, 580, 0, 0) /* LightWeapons        Specialized */
+     , (35092, 46, 0, 3, 0, 580, 0, 0) /* FinesseWeapons      Specialized */
+     , (35092, 47, 0, 3, 0, 380, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35092,  0,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/35093 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/35093 Wight Blade Sorcerer.sql
@@ -86,34 +86,33 @@ VALUES (35093,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (35093,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35093,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (35093,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (35093,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (35093,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (35093, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (35093, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (35093, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (35093, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (35093, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (35093, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */;
+     , (35093, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (35093, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (35093, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (35093, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35093,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (35093,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (35093,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (35093,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (35093,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (35093,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (35093,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (35093,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (35093,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (35093,  0,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (35093,  1,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (35093,  2,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (35093,  3,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (35093,  4,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (35093,  5,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (35093,  6,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (35093,  7,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (35093,  8,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35093,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (35093,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (35093,  4424,    2.2)  /* Incantation of Force Arc */
-     , (35093,  4442,   2.25)  /* Incantation of Force Blast */
-     , (35093,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (35093,  4489,  2.501)  /* Incantation of Fester Other */
-     , (35093,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (35093,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (35093,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (35093,  4424,   2.12)  /* Incantation of Force Arc */
+     , (35093,  4442,   2.15)  /* Incantation of Force Blast */
+     , (35093,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (35093,  4489,    2.1)  /* Incantation of Fester Other */
+     , (35093,  2166,   2.11)  /* Tusker's Gift */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35093,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/37460 Wight Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/37460 Wight Captain.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37460;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37460, 'ace37460-wightcaptain', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (37460, 'ace37460-wightcaptain', 10, '2023-03-18 02:12:25') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37460,   1,         16) /* ItemType - Creature */
@@ -73,6 +73,7 @@ VALUES (37460,   1, 0x020016A1) /* Setup */
      , (37460,   6, 0x04000742) /* PaletteBase */
      , (37460,   8, 0x06001226) /* Icon */
      , (37460,  22, 0x34000028) /* PhysicsEffectTable */
+     , (37460,  32,       2020) /* WieldedTreasureType */
      , (37460,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -89,28 +90,28 @@ VALUES (37460,   1,  4000, 0, 0, 4120) /* MaxHealth */
      , (37460,   5,  2000, 0, 0, 2285) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (37460,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (37460,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
-     , (37460, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (37460, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (37460, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (37460, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (37460, 41, 0, 3, 0, 445, 0, 0) /* TwoHandedCombat     Specialized */
-     , (37460, 44, 0, 3, 0, 445, 0, 0) /* HeavyWeapons        Specialized */
-     , (37460, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (37460, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */
-     , (37460, 47, 0, 3, 0, 445, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (37460,  6, 0, 3, 0, 540, 0, 0) /* MeleeDefense        Specialized */
+     , (37460,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
+     , (37460, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Specialized */
+     , (37460, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (37460, 33, 0, 3, 0, 245, 0, 0) /* LifeMagic           Specialized */
+     , (37460, 34, 0, 3, 0, 265, 0, 0) /* WarMagic            Specialized */
+     , (37460, 41, 0, 3, 0, 580, 0, 0) /* TwoHandedCombat     Specialized */
+     , (37460, 44, 0, 3, 0, 580, 0, 0) /* HeavyWeapons        Specialized */
+     , (37460, 45, 0, 3, 0, 580, 0, 0) /* LightWeapons        Specialized */
+     , (37460, 46, 0, 3, 0, 580, 0, 0) /* FinesseWeapons      Specialized */
+     , (37460, 47, 0, 3, 0, 380, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (37460,  0,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (37460,  1,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (37460,  2,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (37460,  3,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (37460,  4,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (37460,  5,  4, 250, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (37460,  6,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (37460,  7,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (37460,  8,  4, 255, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (37460,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (37460,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (37460,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (37460,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (37460,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (37460,  5,  4, 250, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (37460,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (37460,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (37460,  8,  4, 255, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (37460,  1784,   2.05)  /* Horizon's Blades */
@@ -119,7 +120,7 @@ VALUES (37460,  1784,   2.05)  /* Horizon's Blades */
      , (37460,  4475,  2.059)  /* Incantation of Blade Vulnerability Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37460,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (37460,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -127,36 +128,44 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37460, 32 /* GotoSet */,    0.2, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (37460, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37460, 32 /* GotoSet */,    0.4, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (37460, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37460, 32 /* GotoSet */,    0.6, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (37460, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37460, 32 /* GotoSet */,    0.8, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (37460, 32 /* GotoSet */,   0.33, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37460, 32 /* GotoSet */,   0.66, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (37460, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
@@ -164,7 +173,7 @@ VALUES (37460, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (37460, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/37461 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/37461 Wight Blade Sorcerer.sql
@@ -91,34 +91,49 @@ VALUES (37461,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (37461,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (37461,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (37461,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (37461,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (37461,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (37461, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (37461, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (37461, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (37461, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (37461, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (37461, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */;
+     , (37461, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (37461, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (37461, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (37461, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (37461,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (37461,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (37461,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (37461,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (37461,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (37461,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (37461,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (37461,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (37461,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (37461,  0,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (37461,  1,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (37461,  2,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (37461,  3,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (37461,  4,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (37461,  5,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (37461,  6,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (37461,  7,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (37461,  8,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (37461,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (37461,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (37461,  4424,    2.2)  /* Incantation of Force Arc */
-     , (37461,  4442,   2.25)  /* Incantation of Force Blast */
-     , (37461,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (37461,  4489,  2.501)  /* Incantation of Fester Other */
-     , (37461,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (37461,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (37461,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (37461,  4424,   2.12)  /* Incantation of Force Arc */
+     , (37461,  4442,   2.15)  /* Incantation of Force Blast */
+     , (37461,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (37461,  4489,    2.1)  /* Incantation of Fester Other */
+     , (37461,  2166,   2.11)  /* Tusker's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37461,  3 /* Death */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'At last, freed from my cursed existence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37461,  5 /* HeartBeat */,   0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We must prepare for the onslaught of the Archmage.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (37461, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/37462 Wight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/37462 Wight.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37462;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37462, 'ace37462-wight', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (37462, 'ace37462-wight', 10, '2023-03-18 02:52:48') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37462,   1,         16) /* ItemType - Creature */
@@ -69,31 +69,7 @@ VALUES (37462,   1, 0x020016A1) /* Setup */
      , (37462,   7, 0x10000066) /* ClothingBase */
      , (37462,   8, 0x06001226) /* Icon */
      , (37462,  22, 0x34000028) /* PhysicsEffectTable */
-     , (37462,  32,       2020) /* WieldedTreasureType - 
-                                   Wield Electric Crossbow (47856) | Probability: 5.7999997%
-                                   Wield 30x Lightning Quarrel (48067) | Probability: 100%
-                                   Wield Acid Crossbow (47854) | Probability: 5.7999997%
-                                   Wield 30x Acid Quarrel (48066) | Probability: 100%
-                                   Wield Heavy Crossbow (47858) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Arbalest (47852) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Lightning Silifi (48076) | Probability: 7.5000005%
-                                   Wield Lightning Nekode (48073) | Probability: 7.5000005%
-                                   Wield Acid Ono (48078) | Probability: 7.5000005%
-                                   Wield Silifi (48074) | Probability: 7.5000005%
-                                   Wield Nekode (48071) | Probability: 7.5000005%
-                                   Wield Katar (48069) | Probability: 7.5000005%
-                                   Wield Acid Silifi (48075) | Probability: 7.5000005%
-                                   Wield Lightning Ono (48079) | Probability: 7.5000005%
-                                   Wield Ono (48077) | Probability: 7.5000005%
-                                   Wield Lightning Katar (48070) | Probability: 7.5000005%
-                                   Wield Acid Nekode (48072) | Probability: 7.5000005%
-                                   Wield Acid Quarrel (48066) | Probability: 7.5000005%
-                                   Wield Acid Katar (48068) | Probability: 7.5000005%
-                                   Wield Kite Shield (91) | Probability: 30.000002%
-                                   Wield Round Shield (93) | Probability: 30.000002%
-                                   Wield Buckler (44) | Probability: 30.000002% */
+     , (37462,  32,       2020) /* WieldedTreasureType */
      , (37462,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -110,25 +86,63 @@ VALUES (37462,   1,  2885, 0, 0, 3000) /* MaxHealth */
      , (37462,   5,  2000, 0, 0, 2255) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (37462,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (37462,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (37462,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (37462,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (37462, 15, 0, 3, 0, 345, 0, 0) /* MagicDefense        Specialized */
-     , (37462, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (37462, 33, 0, 3, 0, 375, 0, 0) /* LifeMagic           Specialized */
-     , (37462, 34, 0, 3, 0, 375, 0, 0) /* WarMagic            Specialized */
-     , (37462, 41, 0, 3, 0, 445, 0, 0) /* TwoHandedCombat     Specialized */
-     , (37462, 44, 0, 3, 0, 445, 0, 0) /* HeavyWeapons        Specialized */
-     , (37462, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (37462, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */
-     , (37462, 47, 0, 3, 0, 445, 0, 0) /* MissileWeapons      Specialized */;
+     , (37462, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (37462, 41, 0, 3, 0, 560, 0, 0) /* TwoHandedCombat     Specialized */
+     , (37462, 44, 0, 3, 0, 560, 0, 0) /* HeavyWeapons        Specialized */
+     , (37462, 45, 0, 3, 0, 560, 0, 0) /* LightWeapons        Specialized */
+     , (37462, 46, 0, 3, 0, 560, 0, 0) /* FinesseWeapons      Specialized */
+     , (37462, 47, 0, 3, 0, 440, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (37462,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (37462,  1,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (37462,  2,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (37462,  3,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (37462,  4,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (37462,  5,  4, 150, 0.75,  275,  234,  261,  234,  261,  234,  248,  261,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (37462,  6,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (37462,  7,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (37462,  8,  4, 155, 0.75,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (37462,  0,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (37462,  1,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (37462,  2,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (37462,  3,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (37462,  4,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (37462,  5,  4, 150, 0.75,  275,  137,  137,  137,  137,  137,  137,  137,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (37462,  6,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (37462,  7,  4,  0,    0,  275,  137,  137,  137,  137,  137,  137,  137,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (37462,  8,  4, 155, 0.75,  275,  137,  137,  137,  137,  137,  137,  137,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37462, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'You should not be here!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37462, 18 /* Scream */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37462, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37462, 18 /* Scream */,   0.25, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'I smell blood!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37462, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Intruders in our city!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/38713 Shambling Archivist.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/38713 Shambling Archivist.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 38713;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (38713, 'ace38713-shamblingarchivist', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (38713, 'ace38713-shamblingarchivist', 10, '2023-03-18 03:12:56') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (38713,   1,         16) /* ItemType - Creature */
@@ -76,6 +76,17 @@ VALUES (38713,   1, 0x020014C0) /* Setup */
      , (38713,  22, 0x34000028) /* PhysicsEffectTable */
      , (38713,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (38713,  0,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (38713,  1,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (38713,  2,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (38713,  3,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (38713,  4,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (38713,  5,  4,400, 0.75,  425,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (38713,  6,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (38713,  7,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (38713,  8,  4,400, 0.75,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (38713,   1, 350, 0, 0) /* Strength */
      , (38713,   2, 350, 0, 0) /* Endurance */
@@ -96,66 +107,53 @@ VALUES (38713,  6, 0, 3, 0, 490, 0, 0) /* MeleeDefense        Specialized */
      , (38713, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
      , (38713, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
      , (38713, 34, 0, 3, 0, 200, 0, 0) /* WarMagic            Specialized */
-     , (38713, 41, 0, 3, 0, 343, 0, 0) /* TwoHandedCombat     Specialized */
-     , (38713, 44, 0, 3, 0, 343, 0, 0) /* HeavyWeapons        Specialized */
-     , (38713, 45, 0, 3, 0, 343, 0, 0) /* LightWeapons        Specialized */
-     , (38713, 46, 0, 3, 0, 333, 0, 0) /* FinesseWeapons      Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (38713,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (38713,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (38713,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (38713,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (38713,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (38713,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (38713,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (38713,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (38713,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (38713, 45, 0, 3, 0, 343, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (38713,  2074,   2.05)  /* Gossamer Flesh */
-     , (38713,  2168,   2.12)  /* Gelidite's Gift */
-     , (38713,  1787,   2.15)  /* Halo of Frost */
-     , (38713,  2135,   2.02)  /* Winter's Embrace */
-     , (38713,  2178,   2.02)  /* Decrepitude's Grasp */
-     , (38713,  2136,      3)  /* Icy Torment */;
+VALUES (38713,  2074,   2.08) /* Gossamer Flesh */
+     , (38713,  2168,   2.09) /* Gelidite's Gift */
+     , (38713,  1787,   2.14) /* Halo of Frost */
+     , (38713,  2135,   2.17) /* Winter's Embrace */
+     , (38713,  2178,   2.13) /* Decrepitude's Grasp */
+     , (38713,  2136,   2.23) /* Icy Torment */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (38713,  5 /* HeartBeat */,  0.032, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (38713, 5 /* HeartBeat */, 0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Records... must be kept... even in the face of apocalypse.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 8 /* Say */, 0, 0, NULL, 'Records... must be kept... even in the face of apocalypse.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (38713,  5 /* HeartBeat */,  0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (38713, 5 /* HeartBeat */, 0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (38713,  5 /* HeartBeat */,  0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (38713, 5 /* HeartBeat */, 0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (38713,  5 /* HeartBeat */,  0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (38713, 5 /* HeartBeat */, 0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (38713,  5 /* HeartBeat */,  0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (38713, 5 /* HeartBeat */, 0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/38713.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/38713.es
@@ -1,0 +1,15 @@
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.042
+    - Extent: 0, Say: Records... must be kept... even in the face of apocalypse.
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.172
+    - Move: 0x00000000 [6 6 0] 1 0 0 0
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.272
+    - Move: 0x00000000 [0 12 0] 1 0 0 0
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.372
+    - Move: 0x00000000 [-6 6 0] 1 0 0 0
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.472
+    - Move: 0x00000000 [0 0 0] 1 0 0 0
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/41966 Wight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/41966 Wight.sql
@@ -71,31 +71,7 @@ VALUES (41966,   1, 0x020016A1) /* Setup */
      , (41966,   7, 0x10000066) /* ClothingBase */
      , (41966,   8, 0x06001226) /* Icon */
      , (41966,  22, 0x34000028) /* PhysicsEffectTable */
-     , (41966,  32,       2020) /* WieldedTreasureType - 
-                                   Wield Electric Crossbow (47856) | Probability: 5.7999997%
-                                   Wield 30x Lightning Quarrel (48067) | Probability: 100%
-                                   Wield Acid Crossbow (47854) | Probability: 5.7999997%
-                                   Wield 30x Acid Quarrel (48066) | Probability: 100%
-                                   Wield Heavy Crossbow (47858) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Arbalest (47852) | Probability: 5.7999997%
-                                   Wield 30x Quarrel (48065) | Probability: 100%
-                                   Wield Lightning Silifi (48076) | Probability: 7.5000005%
-                                   Wield Lightning Nekode (48073) | Probability: 7.5000005%
-                                   Wield Acid Ono (48078) | Probability: 7.5000005%
-                                   Wield Silifi (48074) | Probability: 7.5000005%
-                                   Wield Nekode (48071) | Probability: 7.5000005%
-                                   Wield Katar (48069) | Probability: 7.5000005%
-                                   Wield Acid Silifi (48075) | Probability: 7.5000005%
-                                   Wield Lightning Ono (48079) | Probability: 7.5000005%
-                                   Wield Ono (48077) | Probability: 7.5000005%
-                                   Wield Lightning Katar (48070) | Probability: 7.5000005%
-                                   Wield Acid Nekode (48072) | Probability: 7.5000005%
-                                   Wield Acid Quarrel (48066) | Probability: 7.5000005%
-                                   Wield Acid Katar (48068) | Probability: 7.5000005%
-                                   Wield Kite Shield (91) | Probability: 30.000002%
-                                   Wield Round Shield (93) | Probability: 30.000002%
-                                   Wield Buckler (44) | Probability: 30.000002% */
+     , (41966,  32,       2020) /* WieldedTreasureType */
      , (41966,  35,       2101) /* DeathTreasureType - Loot Tier: 8 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -112,17 +88,15 @@ VALUES (41966,   1,  2885, 0, 0, 3000) /* MaxHealth */
      , (41966,   5,  2000, 0, 0, 2255) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (41966,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
-     , (41966,  7, 0, 3, 0, 387, 0, 0) /* MissileDefense      Specialized */
-     , (41966, 15, 0, 3, 0, 365, 0, 0) /* MagicDefense        Specialized */
-     , (41966, 20, 0, 3, 0, 440, 0, 0) /* Deception           Specialized */
-     , (41966, 33, 0, 3, 0, 395, 0, 0) /* LifeMagic           Specialized */
-     , (41966, 34, 0, 3, 0, 400, 0, 0) /* WarMagic            Specialized */
-     , (41966, 41, 0, 3, 0, 465, 0, 0) /* TwoHandedCombat     Specialized */
-     , (41966, 44, 0, 3, 0, 465, 0, 0) /* HeavyWeapons        Specialized */
-     , (41966, 45, 0, 3, 0, 465, 0, 0) /* LightWeapons        Specialized */
-     , (41966, 46, 0, 3, 0, 465, 0, 0) /* FinesseWeapons      Specialized */
-     , (41966, 47, 0, 3, 0, 465, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (41966,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (41966,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
+     , (41966, 15, 0, 3, 0, 345, 0, 0) /* MagicDefense        Specialized */
+     , (41966, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (41966, 41, 0, 3, 0, 560, 0, 0) /* TwoHandedCombat     Specialized */
+     , (41966, 44, 0, 3, 0, 560, 0, 0) /* HeavyWeapons        Specialized */
+     , (41966, 45, 0, 3, 0, 560, 0, 0) /* LightWeapons        Specialized */
+     , (41966, 46, 0, 3, 0, 560, 0, 0) /* FinesseWeapons      Specialized */
+     , (41966, 47, 0, 3, 0, 440, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (41966,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -134,6 +108,46 @@ VALUES (41966,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,
      , (41966,  6,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (41966,  7,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (41966,  8,  4, 155, 0.75,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41966, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'You should not be here!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41966, 18 /* Scream */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41966, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41966, 18 /* Scream */,   0.25, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'I smell blood!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41966, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Intruders in our city!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (41966, 9, 35105,  1, 0, 0.5, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/41967 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/41967 Wight Blade Sorcerer.sql
@@ -92,34 +92,49 @@ VALUES (41967,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (41967,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (41967,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (41967,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (41967,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (41967,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (41967, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (41967, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (41967, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (41967, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (41967, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (41967, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */;
+     , (41967, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (41967, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (41967, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (41967, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (41967,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (41967,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (41967,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (41967,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (41967,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (41967,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (41967,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (41967,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (41967,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (41967,  0,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (41967,  1,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (41967,  2,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (41967,  3,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (41967,  4,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (41967,  5,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (41967,  6,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (41967,  7,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (41967,  8,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (41967,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (41967,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (41967,  4424,    2.2)  /* Incantation of Force Arc */
-     , (41967,  4442,   2.25)  /* Incantation of Force Blast */
-     , (41967,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (41967,  4489,  2.501)  /* Incantation of Fester Other */
-     , (41967,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (41967,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (41967,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (41967,  4424,   2.12)  /* Incantation of Force Arc */
+     , (41967,  4442,   2.15)  /* Incantation of Force Blast */
+     , (41967,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (41967,  4489,    2.1)  /* Incantation of Fester Other */
+     , (41967,  2166,   2.11)  /* Tusker's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41967,  3 /* Death */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'At last, freed from my cursed existence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41967,  5 /* HeartBeat */,   0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We must prepare for the onslaught of the Archmage.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (41967, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/41968 Wight Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/41968 Wight Captain.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 41968;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (41968, 'ace41968-wightcaptain', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (41968, 'ace41968-wightcaptain', 10, '2023-03-18 02:12:35') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (41968,   1,         16) /* ItemType - Creature */
@@ -69,6 +69,7 @@ VALUES (41968,   1, 0x020016A1) /* Setup */
      , (41968,   7, 0x10000066) /* ClothingBase */
      , (41968,   8, 0x06001226) /* Icon */
      , (41968,  22, 0x34000028) /* PhysicsEffectTable */
+     , (41968,  32,       2020) /* WieldedTreasureType */
      , (41968,  35,       2105) /* DeathTreasureType - Loot Tier: 8 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -85,28 +86,28 @@ VALUES (41968,   1,  4000, 0, 0, 4120) /* MaxHealth */
      , (41968,   5,  2000, 0, 0, 2285) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (41968,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (41968,  7, 0, 3, 0, 387, 0, 0) /* MissileDefense      Specialized */
+VALUES (41968,  6, 0, 3, 0, 540, 0, 0) /* MeleeDefense        Specialized */
+     , (41968,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
      , (41968, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Specialized */
-     , (41968, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (41968, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (41968, 34, 0, 3, 0, 415, 0, 0) /* WarMagic            Specialized */
-     , (41968, 41, 0, 3, 0, 460, 0, 0) /* TwoHandedCombat     Specialized */
-     , (41968, 44, 0, 3, 0, 460, 0, 0) /* HeavyWeapons        Specialized */
-     , (41968, 45, 0, 3, 0, 460, 0, 0) /* LightWeapons        Specialized */
-     , (41968, 46, 0, 3, 0, 460, 0, 0) /* FinesseWeapons      Specialized */
-     , (41968, 47, 0, 3, 0, 460, 0, 0) /* MissileWeapons      Specialized */;
+     , (41968, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (41968, 33, 0, 3, 0, 245, 0, 0) /* LifeMagic           Specialized */
+     , (41968, 34, 0, 3, 0, 265, 0, 0) /* WarMagic            Specialized */
+     , (41968, 41, 0, 3, 0, 580, 0, 0) /* TwoHandedCombat     Specialized */
+     , (41968, 44, 0, 3, 0, 580, 0, 0) /* HeavyWeapons        Specialized */
+     , (41968, 45, 0, 3, 0, 580, 0, 0) /* LightWeapons        Specialized */
+     , (41968, 46, 0, 3, 0, 580, 0, 0) /* FinesseWeapons      Specialized */
+     , (41968, 47, 0, 3, 0, 380, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (41968,  0,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (41968,  1,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (41968,  2,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (41968,  3,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (41968,  4,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (41968,  5,  4, 250, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (41968,  6,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (41968,  7,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (41968,  8,  4, 255, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (41968,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (41968,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (41968,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (41968,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (41968,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (41968,  5,  4, 250, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (41968,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (41968,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (41968,  8,  4, 255, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (41968,  1784,   2.05)  /* Horizon's Blades */
@@ -115,7 +116,7 @@ VALUES (41968,  1784,   2.05)  /* Horizon's Blades */
      , (41968,  4475,  2.059)  /* Incantation of Blade Vulnerability Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (41968,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (41968,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -123,36 +124,44 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (41968, 32 /* GotoSet */,    0.2, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (41968, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (41968, 32 /* GotoSet */,    0.4, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (41968, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (41968, 32 /* GotoSet */,    0.6, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (41968, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (41968, 32 /* GotoSet */,    0.8, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (41968, 32 /* GotoSet */,   0.33, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (41968, 32 /* GotoSet */,   0.66, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (41968, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
@@ -160,7 +169,7 @@ VALUES (41968, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (41968, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/42025 Wight Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/42025 Wight Captain.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42025;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42025, 'ace42025-wightcaptain', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (42025, 'ace42025-wightcaptain', 10, '2023-03-18 02:12:46') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42025,   1,         16) /* ItemType - Creature */
@@ -68,6 +68,7 @@ VALUES (42025,   1, 0x020016A1) /* Setup */
      , (42025,   7, 0x10000066) /* ClothingBase */
      , (42025,   8, 0x06001226) /* Icon */
      , (42025,  22, 0x34000028) /* PhysicsEffectTable */
+     , (42025,  32,       2020) /* WieldedTreasureType */
      , (42025,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -84,31 +85,87 @@ VALUES (42025,   1,  4000, 0, 0, 4120) /* MaxHealth */
      , (42025,   5,  2000, 0, 0, 2285) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (42025,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (42025,  7, 0, 3, 0, 387, 0, 0) /* MissileDefense      Specialized */
+VALUES (42025,  6, 0, 3, 0, 540, 0, 0) /* MeleeDefense        Specialized */
+     , (42025,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
      , (42025, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Specialized */
-     , (42025, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (42025, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (42025, 34, 0, 3, 0, 415, 0, 0) /* WarMagic            Specialized */
-     , (42025, 41, 0, 3, 0, 460, 0, 0) /* TwoHandedCombat     Specialized */
-     , (42025, 44, 0, 3, 0, 460, 0, 0) /* HeavyWeapons        Specialized */
-     , (42025, 45, 0, 3, 0, 460, 0, 0) /* LightWeapons        Specialized */
-     , (42025, 46, 0, 3, 0, 460, 0, 0) /* FinesseWeapons      Specialized */
-     , (42025, 47, 0, 3, 0, 460, 0, 0) /* MissileWeapons      Specialized */;
+     , (42025, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (42025, 33, 0, 3, 0, 245, 0, 0) /* LifeMagic           Specialized */
+     , (42025, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (42025, 41, 0, 3, 0, 580, 0, 0) /* TwoHandedCombat     Specialized */
+     , (42025, 44, 0, 3, 0, 580, 0, 0) /* HeavyWeapons        Specialized */
+     , (42025, 45, 0, 3, 0, 580, 0, 0) /* LightWeapons        Specialized */
+     , (42025, 46, 0, 3, 0, 580, 0, 0) /* FinesseWeapons      Specialized */
+     , (42025, 47, 0, 3, 0, 380, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (42025,  0,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (42025,  1,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (42025,  2,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (42025,  3,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (42025,  4,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (42025,  5,  4, 250, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (42025,  6,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (42025,  7,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (42025,  8,  4, 255, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (42025,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (42025,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (42025,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (42025,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (42025,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (42025,  5,  4, 250, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (42025,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (42025,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (42025,  8,  4, 255, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (42025,  1784,   2.05)  /* Horizon's Blades */
      , (42025,  4312,  2.053)  /* Incantation of Imperil Other */
      , (42025,  4422,  2.056)  /* Incantation of Blade Arc */
      , (42025,  4475,  2.059)  /* Incantation of Blade Vulnerability Other */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025, 32 /* GotoSet */,   0.33, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025, 32 /* GotoSet */,   0.66, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42025, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/42026 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/42026 Wight Blade Sorcerer.sql
@@ -91,31 +91,46 @@ VALUES (42026,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (42026,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (42026,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (42026,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (42026,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (42026,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (42026, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (42026, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (42026, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (42026, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (42026, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (42026, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */;
+     , (42026, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (42026, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (42026, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (42026, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (42026,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (42026,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (42026,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (42026,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (42026,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (42026,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (42026,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (42026,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (42026,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (42026,  0,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (42026,  1,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (42026,  2,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (42026,  3,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (42026,  4,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (42026,  5,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (42026,  6,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (42026,  7,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (42026,  8,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (42026,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (42026,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (42026,  4424,    2.2)  /* Incantation of Force Arc */
-     , (42026,  4442,   2.25)  /* Incantation of Force Blast */
-     , (42026,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (42026,  4489,  2.501)  /* Incantation of Fester Other */
-     , (42026,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (42026,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (42026,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (42026,  4424,   2.12)  /* Incantation of Force Arc */
+     , (42026,  4442,   2.15)  /* Incantation of Force Blast */
+     , (42026,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (42026,  4489,    2.1)  /* Incantation of Fester Other */
+     , (42026,  2166,   2.11)  /* Tusker's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42026,  3 /* Death */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'At last, freed from my cursed existence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (42026,  5 /* HeartBeat */,   0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We must prepare for the onslaught of the Archmage.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45160 Wight Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45160 Wight Captain.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45160;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45160, 'ace45160-wightcaptain', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (45160, 'ace45160-wightcaptain', 10, '2023-03-18 02:12:54') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45160,   1,         16) /* ItemType - Creature */
@@ -68,6 +68,7 @@ VALUES (45160,   1, 0x020016A1) /* Setup */
      , (45160,   7, 0x10000066) /* ClothingBase */
      , (45160,   8, 0x06001226) /* Icon */
      , (45160,  22, 0x34000028) /* PhysicsEffectTable */
+     , (45160,  32,       2020) /* WieldedTreasureType */
      , (45160,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -84,28 +85,28 @@ VALUES (45160,   1,  4000, 0, 0, 4120) /* MaxHealth */
      , (45160,   5,  2000, 0, 0, 2285) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45160,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (45160,  7, 0, 3, 0, 387, 0, 0) /* MissileDefense      Specialized */
+VALUES (45160,  6, 0, 3, 0, 540, 0, 0) /* MeleeDefense        Specialized */
+     , (45160,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
      , (45160, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Specialized */
-     , (45160, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (45160, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (45160, 34, 0, 3, 0, 415, 0, 0) /* WarMagic            Specialized */
-     , (45160, 41, 0, 3, 0, 460, 0, 0) /* TwoHandedCombat     Specialized */
-     , (45160, 44, 0, 3, 0, 460, 0, 0) /* HeavyWeapons        Specialized */
-     , (45160, 45, 0, 3, 0, 460, 0, 0) /* LightWeapons        Specialized */
-     , (45160, 46, 0, 3, 0, 460, 0, 0) /* FinesseWeapons      Specialized */
-     , (45160, 47, 0, 3, 0, 460, 0, 0) /* MissileWeapons      Specialized */;
+     , (45160, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (45160, 33, 0, 3, 0, 245, 0, 0) /* LifeMagic           Specialized */
+     , (45160, 34, 0, 3, 0, 265, 0, 0) /* WarMagic            Specialized */
+     , (45160, 41, 0, 3, 0, 580, 0, 0) /* TwoHandedCombat     Specialized */
+     , (45160, 44, 0, 3, 0, 580, 0, 0) /* HeavyWeapons        Specialized */
+     , (45160, 45, 0, 3, 0, 580, 0, 0) /* LightWeapons        Specialized */
+     , (45160, 46, 0, 3, 0, 580, 0, 0) /* FinesseWeapons      Specialized */
+     , (45160, 47, 0, 3, 0, 380, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (45160,  0,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (45160,  1,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (45160,  2,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (45160,  3,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (45160,  4,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (45160,  5,  4, 250, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (45160,  6,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (45160,  7,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (45160,  8,  4, 255, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (45160,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (45160,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (45160,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (45160,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (45160,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (45160,  5,  4, 250, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (45160,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (45160,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (45160,  8,  4, 255, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (45160,  1784,   2.05)  /* Horizon's Blades */
@@ -114,7 +115,7 @@ VALUES (45160,  1784,   2.05)  /* Horizon's Blades */
      , (45160,  4475,  2.059)  /* Incantation of Blade Vulnerability Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45160,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (45160,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -122,36 +123,44 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45160, 32 /* GotoSet */,    0.2, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45160, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45160, 32 /* GotoSet */,    0.4, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45160, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45160, 32 /* GotoSet */,    0.6, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45160, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45160, 32 /* GotoSet */,    0.8, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45160, 32 /* GotoSet */,   0.33, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45160, 32 /* GotoSet */,   0.66, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (45160, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
@@ -159,7 +168,7 @@ VALUES (45160, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (45160, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45161 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45161 Wight Blade Sorcerer.sql
@@ -91,34 +91,49 @@ VALUES (45161,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (45161,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45161,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (45161,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (45161,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (45161,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (45161, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (45161, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (45161, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (45161, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (45161, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (45161, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */;
+     , (45161, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (45161, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (45161, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (45161, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (45161,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (45161,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (45161,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (45161,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (45161,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (45161,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (45161,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (45161,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (45161,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (45161,  0,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (45161,  1,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (45161,  2,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (45161,  3,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (45161,  4,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (45161,  5,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (45161,  6,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (45161,  7,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (45161,  8,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (45161,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (45161,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (45161,  4424,    2.2)  /* Incantation of Force Arc */
-     , (45161,  4442,   2.25)  /* Incantation of Force Blast */
-     , (45161,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (45161,  4489,  2.501)  /* Incantation of Fester Other */
-     , (45161,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (45161,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (45161,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (45161,  4424,   2.12)  /* Incantation of Force Arc */
+     , (45161,  4442,   2.15)  /* Incantation of Force Blast */
+     , (45161,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (45161,  4489,    2.1)  /* Incantation of Fester Other */
+     , (45161,  2166,   2.11)  /* Tusker's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45161,  3 /* Death */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'At last, freed from my cursed existence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45161,  5 /* HeartBeat */,   0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We must prepare for the onslaught of the Archmage.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (45161, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45162 Wight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45162 Wight.sql
@@ -69,6 +69,7 @@ VALUES (45162,   1, 0x020016A1) /* Setup */
      , (45162,   7, 0x10000066) /* ClothingBase */
      , (45162,   8, 0x06001226) /* Icon */
      , (45162,  22, 0x34000028) /* PhysicsEffectTable */
+     , (45162,  32,       2020) /* WieldedTreasureType */
      , (45162,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -85,17 +86,15 @@ VALUES (45162,   1,  2885, 0, 0, 3000) /* MaxHealth */
      , (45162,   5,  2000, 0, 0, 2255) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45162,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (45162,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (45162,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (45162,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (45162, 15, 0, 3, 0, 345, 0, 0) /* MagicDefense        Specialized */
-     , (45162, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (45162, 33, 0, 3, 0, 375, 0, 0) /* LifeMagic           Specialized */
-     , (45162, 34, 0, 3, 0, 375, 0, 0) /* WarMagic            Specialized */
-     , (45162, 41, 0, 3, 0, 445, 0, 0) /* TwoHandedCombat     Specialized */
-     , (45162, 44, 0, 3, 0, 445, 0, 0) /* HeavyWeapons        Specialized */
-     , (45162, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (45162, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */
-     , (45162, 47, 0, 3, 0, 445, 0, 0) /* MissileWeapons      Specialized */;
+     , (45162, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (45162, 41, 0, 3, 0, 560, 0, 0) /* TwoHandedCombat     Specialized */
+     , (45162, 44, 0, 3, 0, 560, 0, 0) /* HeavyWeapons        Specialized */
+     , (45162, 45, 0, 3, 0, 560, 0, 0) /* LightWeapons        Specialized */
+     , (45162, 46, 0, 3, 0, 560, 0, 0) /* FinesseWeapons      Specialized */
+     , (45162, 47, 0, 3, 0, 440, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (45162,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -109,44 +108,44 @@ VALUES (45162,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,
      , (45162,  8,  4, 155, 0.75,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45162,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (45162, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'You should not be here!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45162, 32 /* GotoSet */,   0.25, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45162, 18 /* Scream */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'You should not be here!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45162, 32 /* GotoSet */,    0.5, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45162, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Intruders in our city!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45162, 32 /* GotoSet */,   0.75, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45162, 18 /* Scream */,   0.25, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'I smell blood!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45162, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45162, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'I smell blood!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Intruders in our city!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (45162, 9, 35105,  1, 0, 0.5, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45178 Wight Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45178 Wight Captain.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45178;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45178, 'ace45178-wightcaptain', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (45178, 'ace45178-wightcaptain', 10, '2023-03-18 02:13:09') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45178,   1,         16) /* ItemType - Creature */
@@ -68,6 +68,7 @@ VALUES (45178,   1, 0x020016A1) /* Setup */
      , (45178,   7, 0x10000066) /* ClothingBase */
      , (45178,   8, 0x06001226) /* Icon */
      , (45178,  22, 0x34000028) /* PhysicsEffectTable */
+     , (45178,  32,       2020) /* WieldedTreasureType */
      , (45178,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -84,28 +85,28 @@ VALUES (45178,   1,  4000, 0, 0, 4120) /* MaxHealth */
      , (45178,   5,  2000, 0, 0, 2285) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45178,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (45178,  7, 0, 3, 0, 387, 0, 0) /* MissileDefense      Specialized */
+VALUES (45178,  6, 0, 3, 0, 540, 0, 0) /* MeleeDefense        Specialized */
+     , (45178,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
      , (45178, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Specialized */
-     , (45178, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (45178, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (45178, 34, 0, 3, 0, 415, 0, 0) /* WarMagic            Specialized */
-     , (45178, 41, 0, 3, 0, 460, 0, 0) /* TwoHandedCombat     Specialized */
-     , (45178, 44, 0, 3, 0, 460, 0, 0) /* HeavyWeapons        Specialized */
-     , (45178, 45, 0, 3, 0, 460, 0, 0) /* LightWeapons        Specialized */
-     , (45178, 46, 0, 3, 0, 460, 0, 0) /* FinesseWeapons      Specialized */
-     , (45178, 47, 0, 3, 0, 460, 0, 0) /* MissileWeapons      Specialized */;
+     , (45178, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (45178, 33, 0, 3, 0, 245, 0, 0) /* LifeMagic           Specialized */
+     , (45178, 34, 0, 3, 0, 265, 0, 0) /* WarMagic            Specialized */
+     , (45178, 41, 0, 3, 0, 580, 0, 0) /* TwoHandedCombat     Specialized */
+     , (45178, 44, 0, 3, 0, 580, 0, 0) /* HeavyWeapons        Specialized */
+     , (45178, 45, 0, 3, 0, 580, 0, 0) /* LightWeapons        Specialized */
+     , (45178, 46, 0, 3, 0, 580, 0, 0) /* FinesseWeapons      Specialized */
+     , (45178, 47, 0, 3, 0, 380, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (45178,  0,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (45178,  1,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (45178,  2,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (45178,  3,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (45178,  4,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (45178,  5,  4, 250, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (45178,  6,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (45178,  7,  4,  0,    0,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (45178,  8,  4, 255, 0.75,  350,  298,  333,  298,  333,  298,  315,  333,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (45178,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (45178,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (45178,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (45178,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (45178,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (45178,  5,  4, 250, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (45178,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (45178,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (45178,  8,  4, 255, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (45178,  1784,   2.05)  /* Horizon's Blades */
@@ -114,7 +115,7 @@ VALUES (45178,  1784,   2.05)  /* Horizon's Blades */
      , (45178,  4475,  2.059)  /* Incantation of Blade Vulnerability Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45178,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (45178,  5 /* HeartBeat */,  0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -122,36 +123,44 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45178, 32 /* GotoSet */,    0.2, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45178, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45178, 32 /* GotoSet */,    0.4, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45178, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45178, 32 /* GotoSet */,    0.6, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45178, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'An intruder in our midst!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45178, 32 /* GotoSet */,    0.8, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45178, 32 /* GotoSet */,   0.33, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Keep your weapons at the ready.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45178, 32 /* GotoSet */,   0.66, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Be watchful for the living.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (45178, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
@@ -159,7 +168,7 @@ VALUES (45178, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Stand your ground.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (45178, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45179 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45179 Wight Blade Sorcerer.sql
@@ -91,34 +91,49 @@ VALUES (45179,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (45179,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45179,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
-     , (45179,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (45179,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (45179,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (45179, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
-     , (45179, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (45179, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (45179, 34, 0, 3, 0, 395, 0, 0) /* WarMagic            Specialized */
-     , (45179, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (45179, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */;
+     , (45179, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (45179, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (45179, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (45179, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (45179,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (45179,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (45179,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (45179,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (45179,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (45179,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (45179,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (45179,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (45179,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (45179,  0,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (45179,  1,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (45179,  2,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (45179,  3,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (45179,  4,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (45179,  5,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (45179,  6,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (45179,  7,  4,  0,    0,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (45179,  8,  4, 400, 0.75,  425,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (45179,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (45179,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (45179,  4424,    2.2)  /* Incantation of Force Arc */
-     , (45179,  4442,   2.25)  /* Incantation of Force Blast */
-     , (45179,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (45179,  4489,  2.501)  /* Incantation of Fester Other */
-     , (45179,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (45179,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (45179,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (45179,  4424,   2.12)  /* Incantation of Force Arc */
+     , (45179,  4442,   2.15)  /* Incantation of Force Blast */
+     , (45179,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (45179,  4489,    2.1)  /* Incantation of Fester Other */
+     , (45179,  2166,   2.11)  /* Tusker's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45179,  3 /* Death */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'At last, freed from my cursed existence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45179,  5 /* HeartBeat */,   0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We must prepare for the onslaught of the Archmage.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (45179, 9, 35105,  0, 0, 1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45187 Wight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45187 Wight.sql
@@ -69,6 +69,7 @@ VALUES (45187,   1, 0x020016A1) /* Setup */
      , (45187,   7, 0x10000066) /* ClothingBase */
      , (45187,   8, 0x06001226) /* Icon */
      , (45187,  22, 0x34000028) /* PhysicsEffectTable */
+     , (45187,  32,       2020) /* WieldedTreasureType */
      , (45187,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -85,17 +86,15 @@ VALUES (45187,   1,  2885, 0, 0, 3000) /* MaxHealth */
      , (45187,   5,  2000, 0, 0, 2255) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45187,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (45187,  7, 0, 3, 0, 367, 0, 0) /* MissileDefense      Specialized */
+VALUES (45187,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (45187,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
      , (45187, 15, 0, 3, 0, 345, 0, 0) /* MagicDefense        Specialized */
-     , (45187, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (45187, 33, 0, 3, 0, 375, 0, 0) /* LifeMagic           Specialized */
-     , (45187, 34, 0, 3, 0, 375, 0, 0) /* WarMagic            Specialized */
-     , (45187, 41, 0, 3, 0, 445, 0, 0) /* TwoHandedCombat     Specialized */
-     , (45187, 44, 0, 3, 0, 445, 0, 0) /* HeavyWeapons        Specialized */
-     , (45187, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (45187, 46, 0, 3, 0, 445, 0, 0) /* FinesseWeapons      Specialized */
-     , (45187, 47, 0, 3, 0, 445, 0, 0) /* MissileWeapons      Specialized */;
+     , (45187, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (45187, 41, 0, 3, 0, 560, 0, 0) /* TwoHandedCombat     Specialized */
+     , (45187, 44, 0, 3, 0, 560, 0, 0) /* HeavyWeapons        Specialized */
+     , (45187, 45, 0, 3, 0, 560, 0, 0) /* LightWeapons        Specialized */
+     , (45187, 46, 0, 3, 0, 560, 0, 0) /* FinesseWeapons      Specialized */
+     , (45187, 47, 0, 3, 0, 440, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (45187,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -109,44 +108,44 @@ VALUES (45187,  0,  4,  0,    0,  275,  234,  261,  234,  261,  234,  248,  261,
      , (45187,  8,  4, 155, 0.75,  275,  234,  261,  234,  261,  234,  248,  261,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45187,  5 /* HeartBeat */,  0.042, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (45187, 18 /* Scream */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'PickSay', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'You should not be here!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45187, 32 /* GotoSet */,   0.25, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45187, 18 /* Scream */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'You should not be here!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'The lich took our lives, we shall take yours!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45187, 32 /* GotoSet */,    0.5, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45187, 18 /* Scream */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'Intruders in our city!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45187, 32 /* GotoSet */,   0.75, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45187, 18 /* Scream */,   0.25, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'We shall brook no living presence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'I smell blood!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45187, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'PickSay', NULL, NULL, NULL);
+VALUES (45187, 18 /* Scream */,    0.3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   8 /* Say */, 0, 20, NULL, 'I smell blood!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Intruders in our city!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (45187, 9, 35105,  1, 0, 0.5, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/46815 Wight Blade Sorcerer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/46815 Wight Blade Sorcerer.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46815;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46815, 'ace46815-wightbladesorcerer', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (46815, 'ace46815-wightbladesorcerer', 10, '2023-03-18 01:40:09') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46815,   1,         16) /* ItemType - Creature */
@@ -88,34 +88,49 @@ VALUES (46815,   1,  3390, 0, 0, 3500) /* MaxHealth */
      , (46815,   5,  2000, 0, 0, 2305) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (46815,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (46815,  7, 0, 3, 0, 380, 0, 0) /* MissileDefense      Specialized */
-     , (46815, 15, 0, 3, 0, 425, 0, 0) /* MagicDefense        Specialized */
-     , (46815, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (46815, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (46815, 34, 0, 3, 0, 460, 0, 0) /* WarMagic            Specialized */
-     , (46815, 45, 0, 3, 0, 445, 0, 0) /* LightWeapons        Specialized */
-     , (46815, 46, 0, 3, 0, 460, 0, 0) /* FinesseWeapons      Specialized */;
+VALUES (46815,  6, 0, 3, 0, 520, 0, 0) /* MeleeDefense        Specialized */
+     , (46815,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
+     , (46815, 15, 0, 3, 0, 395, 0, 0) /* MagicDefense        Specialized */
+     , (46815, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (46815, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (46815, 34, 0, 3, 0, 260, 0, 0) /* WarMagic            Specialized */
+     , (46815, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (46815,  0,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (46815,  1,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (46815,  2,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (46815,  3,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (46815,  4,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (46815,  5,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (46815,  6,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (46815,  7,  4,  0,    0,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (46815,  8,  4, 400, 0.75,  225,  191,  214,  191,  214,  191,  203,  214,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (46815,  0,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (46815,  1,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (46815,  2,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (46815,  3,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (46815,  4,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (46815,  5,  4, 400, 0.75,  425,  112,  112,  112,  112,  112,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (46815,  6,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (46815,  7,  4,  0,    0,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (46815,  8,  4, 400, 0.75,  425,  112,  112,  112,  112,  112,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (46815,  1786,  2.143)  /* Nuhmudira's Spines */
-     , (46815,  5531,  2.167)  /* Bloodstone Bolt VII */
-     , (46815,  4424,    2.2)  /* Incantation of Force Arc */
-     , (46815,  4442,   2.25)  /* Incantation of Force Blast */
-     , (46815,  4443,  2.334)  /* Incantation of Force Bolt */
-     , (46815,  4489,  2.501)  /* Incantation of Fester Other */
-     , (46815,  2166,  3.002)  /* Tusker's Gift */;
+VALUES (46815,  1786,    2.1)  /* Nuhmudira's Spines */
+     , (46815,  5531,   2.11)  /* Bloodstone Bolt VII */
+     , (46815,  4424,   2.12)  /* Incantation of Force Arc */
+     , (46815,  4442,   2.15)  /* Incantation of Force Blast */
+     , (46815,  4443,   2.17)  /* Incantation of Force Bolt */
+     , (46815,  4489,    2.1)  /* Incantation of Fester Other */
+     , (46815,  2166,   2.11)  /* Tusker's Gift */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46815,  3 /* Death */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'At last, freed from my cursed existence!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46815,  5 /* HeartBeat */,   0.012, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'We must prepare for the onslaught of the Archmage.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (46815, 9, 35105,  1, 0, 0.1, False) /* Create Pyre Shroud (35105) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/72216 Shade of Lord Rytheran.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/72216 Shade of Lord Rytheran.sql
@@ -47,7 +47,7 @@ VALUES (72216,   1,       5) /* HeartbeatInterval */
      , (72216,  34,       2) /* PowerupTime */
      , (72216,  36,       1) /* ChargeSpeed */
      , (72216,  39,     1.3) /* DefaultScale */
-     , (72216,  41,     180) /* RegenerationInterval */
+     , (72216,  41,      60) /* RegenerationInterval */
      , (72216,  43,      10) /* GeneratorRadius */
      , (72216,  64,    0.89) /* ResistSlash */
      , (72216,  65,     0.5) /* ResistPierce */
@@ -141,5 +141,9 @@ VALUES (72216, 2, 72284,  1, 0, 0, False) /* Create Invisible Staff (72284) for 
      , (72216, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72216, -1, 42026, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (42026) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72216, -1, 42025, 0, 4, 4, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (42025) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72216, -1, 42026, 300, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (42026) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72216, -1, 42026, 300, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (42026) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72216, -1, 42025, 300, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (42025) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72216, -1, 42025, 300, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (42025) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72216, -1, 42025, 300, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (42025) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72216, -1, 42025, 300, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (42025) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/52305 Corrupted Gravestone.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/52305 Corrupted Gravestone.sql
@@ -17,7 +17,6 @@ VALUES (52305,   1,         16) /* ItemType - Creature */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (52305,   1, True ) /* Stuck */
-     , (52305,  19, True ) /* Attackable */
      , (52305,  29, True ) /* NoCorpse */
      , (52305,  52, True ) /* AiImmobile */
      , (52305,  82, True ) /* DontTurnOrMoveWhenGiving */
@@ -26,9 +25,39 @@ VALUES (52305,   1, True ) /* Stuck */
      , (52305, 118, True ) /* NeverAttack */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (52305,  31,       2) /* VisualAwarenessRange */
+VALUES (52305,   1,       5) /* HeartbeatInterval */
+     , (52305,   2,       0) /* HeartbeatTimestamp */
+     , (52305,   3,       0) /* HealthRate */
+     , (52305,   4,       0) /* StaminaRate */
+     , (52305,   5,       0) /* ManaRate */
+     , (52305,  12,       0) /* Shade */
+     , (52305,  13,       1) /* ArmorModVsSlash */
+     , (52305,  14,       1) /* ArmorModVsPierce */
+     , (52305,  15,       1) /* ArmorModVsBludgeon */
+     , (52305,  16,       1) /* ArmorModVsCold */
+     , (52305,  17,       1) /* ArmorModVsFire */
+     , (52305,  18,       1) /* ArmorModVsAcid */
+     , (52305,  19,       1) /* ArmorModVsElectric */
+     , (52305,  31,       5) /* VisualAwarenessRange */
+     , (52305,  34,       1) /* PowerupTime */
+     , (52305,  36,       1) /* ChargeSpeed */
      , (52305,  39,     1.5) /* DefaultScale */
-     , (52305,  43,       0) /* GeneratorRadius */;
+     , (52305,  41,       5) /* RegenerationInterval */
+     , (52305,  43,       0) /* GeneratorRadius */
+     , (52305,  64,    0.75) /* ResistSlash */
+     , (52305,  65,    0.75) /* ResistPierce */
+     , (52305,  66,    0.75) /* ResistBludgeon */
+     , (52305,  67,    0.75) /* ResistFire */
+     , (52305,  68,    0.75) /* ResistCold */
+     , (52305,  69,    0.75) /* ResistAcid */
+     , (52305,  70,    0.75) /* ResistElectric */
+     , (52305,  71,       1) /* ResistHealthBoost */
+     , (52305,  72,       1) /* ResistStaminaDrain */
+     , (52305,  73,       1) /* ResistStaminaBoost */
+     , (52305,  74,       1) /* ResistManaDrain */
+     , (52305,  75,       1) /* ResistManaBoost */
+     , (52305, 104,      10) /* ObviousRadarRange */
+     , (52305, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (52305,   1, 'Corrupted Gravestone') /* Name */
@@ -52,9 +81,9 @@ VALUES (52305,   1, 400, 0, 0) /* Strength */
      , (52305,   6, 490, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (52305,   1,     0, 0, 0, 1000) /* MaxHealth */
-     , (52305,   3,  5000, 0, 0, 5500) /* MaxStamina */
-     , (52305,   5,  5000, 0, 0, 5490) /* MaxMana */;
+VALUES (52305, 1, 7750, 0, 0, 8000) /* MaxHealth */
+     , (52305, 3, 5500, 0, 0, 5000) /* MaxStamina */
+     , (52305, 5, 5490, 0, 0, 5000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (52305,  6, 0, 3, 0, 385, 0, 0) /* MeleeDefense        Specialized */
@@ -82,5 +111,5 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  88 /* LocalSignal */, 0, 1, NULL, 'SpawnGuards', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (52305, -1, 52307, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Unknown (52307) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (52305, -1, 72218, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gravestone Guards Gen (72218) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+VALUES (52305, -1, 52307, 60, 1, 1, 1, 4,  0, 0, 0, 0, 0, 0, 2, 1, 0, 0, 0) /* Generate Uknown (52307) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (52305, -1, 72218, 60, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gravestone Guards Gen (72218) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/35059 Hatred Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/35059 Hatred Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 35059;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (35059, 'ace35059-hatredwisp', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (35059, 'ace35059-hatredwisp', 10, '2023-03-25 05:53:59') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (35059,   1,         16) /* ItemType - Creature */
@@ -32,36 +32,35 @@ VALUES (35059,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35059,   1,       5) /* HeartbeatInterval */
      , (35059,   2,       0) /* HeartbeatTimestamp */
-     , (35059,   3,       3) /* HealthRate */
+     , (35059,   3,       5) /* HealthRate */
      , (35059,   4,       5) /* StaminaRate */
-     , (35059,   5,       5) /* ManaRate */
-     , (35059,  13,       1) /* ArmorModVsSlash */
+     , (35059,   5,       1) /* ManaRate */
+     , (35059,  13,     0.9) /* ArmorModVsSlash */
      , (35059,  14,       1) /* ArmorModVsPierce */
-     , (35059,  15,     0.5) /* ArmorModVsBludgeon */
-     , (35059,  16,     0.5) /* ArmorModVsCold */
+     , (35059,  15,     0.9) /* ArmorModVsBludgeon */
+     , (35059,  16,     0.9) /* ArmorModVsCold */
      , (35059,  17,      10) /* ArmorModVsFire */
-     , (35059,  18,    0.64) /* ArmorModVsAcid */
-     , (35059,  19,     0.5) /* ArmorModVsElectric */
+     , (35059,  18,       1) /* ArmorModVsAcid */
+     , (35059,  19,       1) /* ArmorModVsElectric */
      , (35059,  31,      30) /* VisualAwarenessRange */
      , (35059,  34,       1) /* PowerupTime */
      , (35059,  36,       1) /* ChargeSpeed */
      , (35059,  39,     1.3) /* DefaultScale */
-     , (35059,  64,       1) /* ResistSlash */
+     , (35059,  64,     0.6) /* ResistSlash */
      , (35059,  65,       1) /* ResistPierce */
-     , (35059,  66,     0.7) /* ResistBludgeon */
-     , (35059,  67,     0.1) /* ResistFire */
-     , (35059,  68,     0.7) /* ResistCold */
-     , (35059,  69,    0.75) /* ResistAcid */
-     , (35059,  70,     0.7) /* ResistElectric */
+     , (35059,  66,     0.6) /* ResistBludgeon */
+     , (35059,  67,       0) /* ResistFire */
+     , (35059,  68,     0.6) /* ResistCold */
+     , (35059,  69,     0.4) /* ResistAcid */
+     , (35059,  70,     0.4) /* ResistElectric */
      , (35059,  71,       1) /* ResistHealthBoost */
-     , (35059,  72,       0) /* ResistStaminaDrain */
+     , (35059,  72,       1) /* ResistStaminaDrain */
      , (35059,  73,       1) /* ResistStaminaBoost */
-     , (35059,  74,       0) /* ResistManaDrain */
+     , (35059,  74,       1) /* ResistManaDrain */
      , (35059,  75,       1) /* ResistManaBoost */
      , (35059,  80,       3) /* AiUseMagicDelay */
      , (35059, 104,      10) /* ObviousRadarRange */
-     , (35059, 122,       2) /* AiAcquireHealth */
-     , (35059, 125,       0) /* ResistHealthDrain */;
+     , (35059, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35059,   1, 'Hatred Wisp') /* Name */
@@ -75,6 +74,12 @@ VALUES (35059,   1, 0x020009DB) /* Setup */
      , (35059,   8, 0x06001F64) /* Icon */
      , (35059,  35,       2105) /* DeathTreasureType - Loot Tier: 8 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (35059,  0, 32,150,  0.5,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (35059, 16, 32,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
+     , (35059, 17, 32,150, 0.75,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
+     , (35059, 21, 32,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (35059,   1, 400, 0, 0) /* Strength */
      , (35059,   2, 500, 0, 0) /* Endurance */
@@ -84,116 +89,110 @@ VALUES (35059,   1, 400, 0, 0) /* Strength */
      , (35059,   6, 490, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (35059,   1, 20000, 0, 0, 20250) /* MaxHealth */
+VALUES (35059,   1, 20000, 0, 0,20250) /* MaxHealth */
      , (35059,   3,  5000, 0, 0, 5500) /* MaxStamina */
      , (35059,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35059,  6, 0, 3, 0, 385, 0, 0) /* MeleeDefense        Specialized */
-     , (35059,  7, 0, 3, 0, 285, 0, 0) /* MissileDefense      Specialized */
-     , (35059, 15, 0, 3, 0, 245, 0, 0) /* MagicDefense        Specialized */
+VALUES (35059,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (35059,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (35059, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense        Specialized */
      , (35059, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (35059, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (35059, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (35059, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (35059, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (35059, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (35059, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (35059, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (35059, 45, 0, 3, 0, 390, 0, 0) /* LightWeapons        Specialized */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35059,  0, 32, 150,  0.5,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (35059, 16, 32,  0,    0,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
-     , (35059, 17, 32, 150, 0.75,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
-     , (35059, 21, 32,  0,    0,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
-
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35059,  1785,   2.01)  /* Cassius' Ring of Fire */
-     , (35059,  2127,  2.067)  /* Silencia's Scorn */
-     , (35059,  2128,    2.3)  /* Ilservian's Flame */
-     , (35059,  2129,  2.067)  /* Sizzling Fury */
-     , (35059,  2745,    2.3)  /* Flame Arc VII */;
+VALUES (35059,  1785,   2.01) /* Cassius' Ring of Fire */
+     , (35059,  2127,  2.067) /* Silencia's Scorn */
+     , (35059,  2128,    2.3) /* Ilservian's Flame */
+     , (35059,  2129,  2.067) /* Sizzling Fury */
+     , (35059,  2745,    2.3) /* Flame Arc VII */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,  0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,  0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,  0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35059,  5 /* HeartBeat */,  0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35059, 5 /* HeartBeat */, 0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35059, 9, 48908,  0, 0, 0.06, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
      , (35059, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
      , (35059, 9, 35504,  0, 0, 0.06, False) /* Create Ornate Bone Key (35504) for ContainTreasure */
      , (35059, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/35089 Despair Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/35089 Despair Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 35089;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (35089, 'ace35089-despairwisp', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (35089, 'ace35089-despairwisp', 10, '2023-03-25 05:57:04') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (35089,   1,         16) /* ItemType - Creature */
@@ -32,35 +32,35 @@ VALUES (35089,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35089,   1,       5) /* HeartbeatInterval */
      , (35089,   2,       0) /* HeartbeatTimestamp */
-     , (35089,   3,       3) /* HealthRate */
+     , (35089,   3,       5) /* HealthRate */
      , (35089,   4,       5) /* StaminaRate */
-     , (35089,   5,       5) /* ManaRate */
-     , (35089,  13,       1) /* ArmorModVsSlash */
+     , (35089,   5,       1) /* ManaRate */
+     , (35089,  13,     0.9) /* ArmorModVsSlash */
      , (35089,  14,       1) /* ArmorModVsPierce */
-     , (35089,  15,     0.5) /* ArmorModVsBludgeon */
-     , (35089,  16,     0.5) /* ArmorModVsCold */
-     , (35089,  17,      10) /* ArmorModVsFire */
-     , (35089,  18,    0.64) /* ArmorModVsAcid */
-     , (35089,  19,     0.5) /* ArmorModVsElectric */
+     , (35089,  15,     0.9) /* ArmorModVsBludgeon */
+     , (35089,  16,       1) /* ArmorModVsCold */
+     , (35089,  17,       1) /* ArmorModVsFire */
+     , (35089,  18,      10) /* ArmorModVsAcid */
+     , (35089,  19,     0.9) /* ArmorModVsElectric */
      , (35089,  31,      30) /* VisualAwarenessRange */
      , (35089,  34,       1) /* PowerupTime */
      , (35089,  36,       1) /* ChargeSpeed */
      , (35089,  39,     1.3) /* DefaultScale */
-     , (35089,  64,       1) /* ResistSlash */
+     , (35089,  64,     0.6) /* ResistSlash */
      , (35089,  65,       1) /* ResistPierce */
-     , (35089,  66,     0.7) /* ResistBludgeon */
-     , (35089,  67,     0.1) /* ResistFire */
-     , (35089,  68,     0.7) /* ResistCold */
-     , (35089,  69,    0.75) /* ResistAcid */
-     , (35089,  70,     0.7) /* ResistElectric */
+     , (35089,  66,     0.6) /* ResistBludgeon */
+     , (35089,  67,     0.4) /* ResistFire */
+     , (35089,  68,     0.4) /* ResistCold */
+     , (35089,  69,       0) /* ResistAcid */
+     , (35089,  70,     0.6) /* ResistElectric */
      , (35089,  71,       1) /* ResistHealthBoost */
-     , (35089,  72,       0) /* ResistStaminaDrain */
+     , (35089,  72,       1) /* ResistStaminaDrain */
      , (35089,  73,       1) /* ResistStaminaBoost */
-     , (35089,  74,       0) /* ResistManaDrain */
+     , (35089,  74,       1) /* ResistManaDrain */
      , (35089,  75,       1) /* ResistManaBoost */
+     , (35089,  80,       3) /* AiUseMagicDelay */
      , (35089, 104,      10) /* ObviousRadarRange */
-     , (35089, 122,       2) /* AiAcquireHealth */
-     , (35089, 125,       0) /* ResistHealthDrain */;
+     , (35089, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35089,   1, 'Despair Wisp') /* Name */
@@ -74,6 +74,12 @@ VALUES (35089,   1, 0x02000A4C) /* Setup */
      , (35089,   8, 0x060020C3) /* Icon */
      , (35089,  35,       2105) /* DeathTreasureType - Loot Tier: 8 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (35089,  0, 32,150,  0.5,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (35089, 16, 32,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
+     , (35089, 17, 32,150, 0.75,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
+     , (35089, 21, 32,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (35089,   1, 220, 0, 0) /* Strength */
      , (35089,   2, 250, 0, 0) /* Endurance */
@@ -83,117 +89,111 @@ VALUES (35089,   1, 220, 0, 0) /* Strength */
      , (35089,   6, 490, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (35089,   1, 20000, 0, 0, 20125) /* MaxHealth */
+VALUES (35089,   1, 20000, 0, 0,20125) /* MaxHealth */
      , (35089,   3,  5000, 0, 0, 5250) /* MaxStamina */
      , (35089,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35089,  6, 0, 3, 0, 383, 0, 0) /* MeleeDefense        Specialized */
-     , (35089,  7, 0, 3, 0, 270, 0, 0) /* MissileDefense      Specialized */
-     , (35089, 15, 0, 3, 0, 240, 0, 0) /* MagicDefense        Specialized */
+VALUES (35089,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (35089,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (35089, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense         Specialized */
      , (35089, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (35089, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (35089, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (35089, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (35089, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (35089, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (35089, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (35089, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (35089, 45, 0, 3, 0, 390, 0, 0) /* LightWeapons        Specialized */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35089,  0, 32, 150,  0.5,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (35089, 16, 32,  0,    0,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
-     , (35089, 17, 32, 150, 0.75,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
-     , (35089, 21, 32,  0,    0,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
-
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35089,  1161,      2)  /* Heal Self VI */
-     , (35089,  2162,    2.3)  /* Olthoi's Gift */
-     , (35089,  2328,  2.067)  /* Vitality Siphon */
-     , (35089,  2329,  2.067)  /* Essence Void */
-     , (35089,  3877,  2.067)  /* Corrosive Strike */
-     , (35089,  3881,    2.3)  /* Corrosive Ring */;
+VALUES (35089,  1161,      2) /* Heal Self VI */
+     , (35089,  2162,    2.3) /* Olthoi's Gift */
+     , (35089,  2328,  2.067) /* Vitality Siphon */
+     , (35089,  2329,  2.067) /* Essence Void */
+     , (35089,  3877,  2.067) /* Corrosive Strike */
+     , (35089,  3881,    2.3) /* Corrosive Ring */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,  0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,  0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,  0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35089,  5 /* HeartBeat */,  0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35089, 5 /* HeartBeat */, 0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35089, 9, 48908,  0, 0, 0.06, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
      , (35089, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
      , (35089, 9, 35504,  0, 0, 0.06, False) /* Create Ornate Bone Key (35504) for ContainTreasure */
      , (35089, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/35090 Sorrow Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/35090 Sorrow Wisp.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 35090;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (35090, 'ace35090-sorrowwisp', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (35090, 'ace35090-sorrowwisp', 10, '2023-03-25 05:41:36') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (35090,   1,         16) /* ItemType - Creature */
@@ -32,35 +32,35 @@ VALUES (35090,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35090,   1,       5) /* HeartbeatInterval */
      , (35090,   2,       0) /* HeartbeatTimestamp */
-     , (35090,   3,       3) /* HealthRate */
+     , (35090,   3,       5) /* HealthRate */
      , (35090,   4,       5) /* StaminaRate */
-     , (35090,   5,       5) /* ManaRate */
-     , (35090,  13,       1) /* ArmorModVsSlash */
+     , (35090,   5,       1) /* ManaRate */
+     , (35090,  13,     0.9) /* ArmorModVsSlash */
      , (35090,  14,       1) /* ArmorModVsPierce */
-     , (35090,  15,     0.5) /* ArmorModVsBludgeon */
-     , (35090,  16,     0.5) /* ArmorModVsCold */
-     , (35090,  17,      10) /* ArmorModVsFire */
-     , (35090,  18,    0.64) /* ArmorModVsAcid */
-     , (35090,  19,     0.5) /* ArmorModVsElectric */
+     , (35090,  15,     0.9) /* ArmorModVsBludgeon */
+     , (35090,  16,      10) /* ArmorModVsCold */
+     , (35090,  17,     0.9) /* ArmorModVsFire */
+     , (35090,  18,       1) /* ArmorModVsAcid */
+     , (35090,  19,       1) /* ArmorModVsElectric */
      , (35090,  31,      30) /* VisualAwarenessRange */
      , (35090,  34,       1) /* PowerupTime */
      , (35090,  36,       1) /* ChargeSpeed */
      , (35090,  39,     1.3) /* DefaultScale */
-     , (35090,  64,       1) /* ResistSlash */
-     , (35090,  65,       1) /* ResistPierce */
-     , (35090,  66,     0.7) /* ResistBludgeon */
-     , (35090,  67,     0.1) /* ResistFire */
-     , (35090,  68,     0.7) /* ResistCold */
-     , (35090,  69,    0.75) /* ResistAcid */
-     , (35090,  70,     0.7) /* ResistElectric */
+     , (35090,  64,     0.6) /* ResistSlash */
+     , (35090,  65,     0.4) /* ResistPierce */
+     , (35090,  66,     0.6) /* ResistBludgeon */
+     , (35090,  67,     0.6) /* ResistFire */
+     , (35090,  68,       0) /* ResistCold */
+     , (35090,  69,     0.4) /* ResistAcid */
+     , (35090,  70,     0.4) /* ResistElectric */
      , (35090,  71,       1) /* ResistHealthBoost */
-     , (35090,  72,       0) /* ResistStaminaDrain */
+     , (35090,  72,       1) /* ResistStaminaDrain */
      , (35090,  73,       1) /* ResistStaminaBoost */
-     , (35090,  74,       0) /* ResistManaDrain */
+     , (35090,  74,       1) /* ResistManaDrain */
      , (35090,  75,       1) /* ResistManaBoost */
+     , (35090,  80,       3) /* AiUseMagicDelay */
      , (35090, 104,      10) /* ObviousRadarRange */
-     , (35090, 122,       2) /* AiAcquireHealth */
-     , (35090, 125,       0) /* ResistHealthDrain */;
+     , (35090, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (35090,   1, 'Sorrow Wisp') /* Name */
@@ -74,6 +74,12 @@ VALUES (35090,   1, 0x02000A29) /* Setup */
      , (35090,   8, 0x0600207C) /* Icon */
      , (35090,  35,       2105) /* DeathTreasureType - Loot Tier: 8 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (35090,  0, 32,150,  0.5,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (35090, 16, 32,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
+     , (35090, 17, 32,150, 0.75,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
+     , (35090, 21, 32,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (35090,   1, 220, 0, 0) /* Strength */
      , (35090,   2, 250, 0, 0) /* Endurance */
@@ -83,120 +89,114 @@ VALUES (35090,   1, 220, 0, 0) /* Strength */
      , (35090,   6, 490, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (35090,   1, 20000, 0, 0, 20125) /* MaxHealth */
+VALUES (35090,   1, 20000, 0, 0,20125) /* MaxHealth */
      , (35090,   3,  5000, 0, 0, 5250) /* MaxStamina */
      , (35090,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35090,  6, 0, 3, 0, 383, 0, 0) /* MeleeDefense        Specialized */
-     , (35090,  7, 0, 3, 0, 270, 0, 0) /* MissileDefense      Specialized */
-     , (35090, 15, 0, 3, 0, 240, 0, 0) /* MagicDefense        Specialized */
+VALUES (35090,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (35090,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (35090, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense         Specialized */
      , (35090, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (35090, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (35090, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (35090, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (35090, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (35090, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (35090, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (35090, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (35090, 45, 0, 3, 0, 450, 0, 0) /* LightWeapons        Specialized */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35090,  0, 32, 150,  0.5,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (35090, 16, 32,  0,    0,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Torso */
-     , (35090, 17, 32, 150, 0.75,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
-     , (35090, 21, 32,  0,    0,  300,  300,  300,  150,  150, 3000,  192,  150,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
-
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35090,  2070,  2.067)  /* Heart Rend */
-     , (35090,  2073,  2.067)  /* Adja's Intervention */
-     , (35090,  2078,  2.067)  /* Void's Call */
-     , (35090,  2084,  2.067)  /* Belly of Lead */
-     , (35090,  2136,  2.067)  /* Icy Torment */
-     , (35090,  2328,      2)  /* Vitality Siphon */
-     , (35090,  3879,    2.3)  /* Glacial Strike */
-     , (35090,  3909,  2.067)  /* Mana Syphon */
-     , (35090,  3916,    2.3)  /* Flayed Flesh */;
+VALUES (35090,  2070,  2.067) /* Heart Rend */
+     , (35090,  2073,  2.067) /* Adja's Intervention */
+     , (35090,  2078,  2.067) /* Void's Call */
+     , (35090,  2084,  2.067) /* Belly of Lead */
+     , (35090,  2136,  2.067) /* Icy Torment */
+     , (35090,  2328,      2) /* Vitality Siphon */
+     , (35090,  3879,    2.3) /* Glacial Strike */
+     , (35090,  3909,  2.067) /* Mana Syphon */
+     , (35090,  3916,    2.3) /* Flayed Flesh */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,  0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,  0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,  0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (35090,  5 /* HeartBeat */,  0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (35090, 5 /* HeartBeat */, 0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
+VALUES (@parent_id, 0, 6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35090, 9, 48908,  0, 0, 0.06, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
      , (35090, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */
      , (35090, 9, 35504,  0, 0, 0.06, False) /* Create Ornate Bone Key (35504) for ContainTreasure */
      , (35090, 9,     0,  0, 0, 0.94, False) /* Create nothing for ContainTreasure */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/41970 Hatred Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/41970 Hatred Wisp.sql
@@ -32,36 +32,35 @@ VALUES (41970,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (41970,   1,       5) /* HeartbeatInterval */
      , (41970,   2,       0) /* HeartbeatTimestamp */
-     , (41970,   3,       3) /* HealthRate */
+     , (41970,   3,       5) /* HealthRate */
      , (41970,   4,       5) /* StaminaRate */
-     , (41970,   5,       5) /* ManaRate */
-     , (41970,  13,       1) /* ArmorModVsSlash */
+     , (41970,   5,       1) /* ManaRate */
+     , (41970,  13,     0.9) /* ArmorModVsSlash */
      , (41970,  14,       1) /* ArmorModVsPierce */
-     , (41970,  15,     0.5) /* ArmorModVsBludgeon */
-     , (41970,  16,     0.5) /* ArmorModVsCold */
+     , (41970,  15,     0.9) /* ArmorModVsBludgeon */
+     , (41970,  16,     0.9) /* ArmorModVsCold */
      , (41970,  17,      10) /* ArmorModVsFire */
-     , (41970,  18,    0.64) /* ArmorModVsAcid */
-     , (41970,  19,     0.5) /* ArmorModVsElectric */
+     , (41970,  18,       1) /* ArmorModVsAcid */
+     , (41970,  19,       1) /* ArmorModVsElectric */
      , (41970,  31,      30) /* VisualAwarenessRange */
      , (41970,  34,       1) /* PowerupTime */
      , (41970,  36,       1) /* ChargeSpeed */
      , (41970,  39,     1.3) /* DefaultScale */
-     , (41970,  64,       1) /* ResistSlash */
+     , (41970,  64,     0.6) /* ResistSlash */
      , (41970,  65,       1) /* ResistPierce */
-     , (41970,  66,     0.7) /* ResistBludgeon */
-     , (41970,  67,     0.1) /* ResistFire */
-     , (41970,  68,     0.7) /* ResistCold */
-     , (41970,  69,    0.75) /* ResistAcid */
-     , (41970,  70,     0.7) /* ResistElectric */
+     , (41970,  66,     0.6) /* ResistBludgeon */
+     , (41970,  67,       0) /* ResistFire */
+     , (41970,  68,     0.6) /* ResistCold */
+     , (41970,  69,     0.4) /* ResistAcid */
+     , (41970,  70,     0.4) /* ResistElectric */
      , (41970,  71,       1) /* ResistHealthBoost */
-     , (41970,  72,       0) /* ResistStaminaDrain */
+     , (41970,  72,       1) /* ResistStaminaDrain */
      , (41970,  73,       1) /* ResistStaminaBoost */
-     , (41970,  74,       0) /* ResistManaDrain */
+     , (41970,  74,       1) /* ResistManaDrain */
      , (41970,  75,       1) /* ResistManaBoost */
      , (41970,  80,       3) /* AiUseMagicDelay */
      , (41970, 104,      10) /* ObviousRadarRange */
-     , (41970, 122,       2) /* AiAcquireHealth */
-     , (41970, 125,       0) /* ResistHealthDrain */;
+     , (41970, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (41970,   1, 'Hatred Wisp') /* Name */
@@ -89,14 +88,13 @@ VALUES (41970,   1, 20000, 0, 0, 20250) /* MaxHealth */
      , (41970,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (41970,  6, 0, 3, 0, 385, 0, 0) /* MeleeDefense        Specialized */
-     , (41970,  7, 0, 3, 0, 285, 0, 0) /* MissileDefense      Specialized */
-     , (41970, 15, 0, 3, 0, 245, 0, 0) /* MagicDefense        Specialized */
+VALUES (41970,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (41970,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (41970, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense        Specialized */
      , (41970, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (41970, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (41970, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (41970, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (41970, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (41970, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (41970, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (41970, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (41970, 45, 0, 3, 0, 390, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/41971 Sorrow Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/41971 Sorrow Wisp.sql
@@ -32,35 +32,35 @@ VALUES (41971,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (41971,   1,       5) /* HeartbeatInterval */
      , (41971,   2,       0) /* HeartbeatTimestamp */
-     , (41971,   3,       3) /* HealthRate */
+     , (41971,   3,       5) /* HealthRate */
      , (41971,   4,       5) /* StaminaRate */
-     , (41971,   5,       5) /* ManaRate */
-     , (41971,  13,       1) /* ArmorModVsSlash */
+     , (41971,   5,       1) /* ManaRate */
+     , (41971,  13,     0.9) /* ArmorModVsSlash */
      , (41971,  14,       1) /* ArmorModVsPierce */
-     , (41971,  15,     0.5) /* ArmorModVsBludgeon */
-     , (41971,  16,     0.5) /* ArmorModVsCold */
-     , (41971,  17,      10) /* ArmorModVsFire */
-     , (41971,  18,    0.64) /* ArmorModVsAcid */
-     , (41971,  19,     0.5) /* ArmorModVsElectric */
+     , (41971,  15,     0.9) /* ArmorModVsBludgeon */
+     , (41971,  16,      10) /* ArmorModVsCold */
+     , (41971,  17,     0.9) /* ArmorModVsFire */
+     , (41971,  18,       1) /* ArmorModVsAcid */
+     , (41971,  19,       1) /* ArmorModVsElectric */
      , (41971,  31,      30) /* VisualAwarenessRange */
      , (41971,  34,       1) /* PowerupTime */
      , (41971,  36,       1) /* ChargeSpeed */
      , (41971,  39,     1.3) /* DefaultScale */
-     , (41971,  64,       1) /* ResistSlash */
-     , (41971,  65,       1) /* ResistPierce */
-     , (41971,  66,     0.7) /* ResistBludgeon */
-     , (41971,  67,     0.1) /* ResistFire */
-     , (41971,  68,     0.7) /* ResistCold */
-     , (41971,  69,    0.75) /* ResistAcid */
-     , (41971,  70,     0.7) /* ResistElectric */
+     , (41971,  64,     0.6) /* ResistSlash */
+     , (41971,  65,     0.4) /* ResistPierce */
+     , (41971,  66,     0.6) /* ResistBludgeon */
+     , (41971,  67,     0.6) /* ResistFire */
+     , (41971,  68,       0) /* ResistCold */
+     , (41971,  69,     0.4) /* ResistAcid */
+     , (41971,  70,     0.4) /* ResistElectric */
      , (41971,  71,       1) /* ResistHealthBoost */
-     , (41971,  72,       0) /* ResistStaminaDrain */
+     , (41971,  72,       1) /* ResistStaminaDrain */
      , (41971,  73,       1) /* ResistStaminaBoost */
-     , (41971,  74,       0) /* ResistManaDrain */
+     , (41971,  74,       1) /* ResistManaDrain */
      , (41971,  75,       1) /* ResistManaBoost */
+     , (41971,  80,       3) /* AiUseMagicDelay */
      , (41971, 104,      10) /* ObviousRadarRange */
-     , (41971, 122,       2) /* AiAcquireHealth */
-     , (41971, 125,       0) /* ResistHealthDrain */;
+     , (41971, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (41971,   1, 'Sorrow Wisp') /* Name */
@@ -88,14 +88,13 @@ VALUES (41971,   1, 20000, 0, 0, 20125) /* MaxHealth */
      , (41971,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (41971,  6, 0, 3, 0, 383, 0, 0) /* MeleeDefense        Specialized */
-     , (41971,  7, 0, 3, 0, 270, 0, 0) /* MissileDefense      Specialized */
-     , (41971, 15, 0, 3, 0, 240, 0, 0) /* MagicDefense        Specialized */
+VALUES (41971,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (41971,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (41971, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense         Specialized */
      , (41971, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (41971, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (41971, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (41971, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (41971, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (41971, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (41971, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (41971, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (41971, 45, 0, 3, 0, 450, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/45183 Sorrow Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/45183 Sorrow Wisp.sql
@@ -31,35 +31,35 @@ VALUES (45183,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (45183,   1,       5) /* HeartbeatInterval */
      , (45183,   2,       0) /* HeartbeatTimestamp */
-     , (45183,   3,       3) /* HealthRate */
+     , (45183,   3,       5) /* HealthRate */
      , (45183,   4,       5) /* StaminaRate */
-     , (45183,   5,       5) /* ManaRate */
-     , (45183,  13,       1) /* ArmorModVsSlash */
+     , (45183,   5,       1) /* ManaRate */
+     , (45183,  13,     0.9) /* ArmorModVsSlash */
      , (45183,  14,       1) /* ArmorModVsPierce */
-     , (45183,  15,     0.5) /* ArmorModVsBludgeon */
-     , (45183,  16,     0.5) /* ArmorModVsCold */
-     , (45183,  17,      10) /* ArmorModVsFire */
-     , (45183,  18,    0.64) /* ArmorModVsAcid */
-     , (45183,  19,     0.5) /* ArmorModVsElectric */
+     , (45183,  15,     0.9) /* ArmorModVsBludgeon */
+     , (45183,  16,      10) /* ArmorModVsCold */
+     , (45183,  17,     0.9) /* ArmorModVsFire */
+     , (45183,  18,       1) /* ArmorModVsAcid */
+     , (45183,  19,       1) /* ArmorModVsElectric */
      , (45183,  31,      30) /* VisualAwarenessRange */
      , (45183,  34,       1) /* PowerupTime */
      , (45183,  36,       1) /* ChargeSpeed */
      , (45183,  39,     1.3) /* DefaultScale */
-     , (45183,  64,       1) /* ResistSlash */
-     , (45183,  65,       1) /* ResistPierce */
-     , (45183,  66,     0.7) /* ResistBludgeon */
-     , (45183,  67,     0.1) /* ResistFire */
-     , (45183,  68,     0.7) /* ResistCold */
-     , (45183,  69,    0.75) /* ResistAcid */
-     , (45183,  70,     0.7) /* ResistElectric */
+     , (45183,  64,     0.6) /* ResistSlash */
+     , (45183,  65,     0.4) /* ResistPierce */
+     , (45183,  66,     0.6) /* ResistBludgeon */
+     , (45183,  67,     0.6) /* ResistFire */
+     , (45183,  68,       0) /* ResistCold */
+     , (45183,  69,     0.4) /* ResistAcid */
+     , (45183,  70,     0.4) /* ResistElectric */
      , (45183,  71,       1) /* ResistHealthBoost */
-     , (45183,  72,       0) /* ResistStaminaDrain */
+     , (45183,  72,       1) /* ResistStaminaDrain */
      , (45183,  73,       1) /* ResistStaminaBoost */
-     , (45183,  74,       0) /* ResistManaDrain */
+     , (45183,  74,       1) /* ResistManaDrain */
      , (45183,  75,       1) /* ResistManaBoost */
+     , (45183,  80,       3) /* AiUseMagicDelay */
      , (45183, 104,      10) /* ObviousRadarRange */
-     , (45183, 122,       2) /* AiAcquireHealth */
-     , (45183, 125,       0) /* ResistHealthDrain */;
+     , (45183, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (45183,   1, 'Sorrow Wisp') /* Name */
@@ -87,14 +87,13 @@ VALUES (45183,   1, 20000, 0, 0, 20125) /* MaxHealth */
      , (45183,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45183,  6, 0, 3, 0, 383, 0, 0) /* MeleeDefense        Specialized */
-     , (45183,  7, 0, 3, 0, 270, 0, 0) /* MissileDefense      Specialized */
-     , (45183, 15, 0, 3, 0, 240, 0, 0) /* MagicDefense        Specialized */
+VALUES (45183,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (45183,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (45183, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense         Specialized */
      , (45183, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (45183, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (45183, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (45183, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (45183, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (45183, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (45183, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (45183, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (45183, 45, 0, 3, 0, 450, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Wisp/45184 Hatred Wisp.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wisp/45184 Hatred Wisp.sql
@@ -31,36 +31,35 @@ VALUES (45184,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (45184,   1,       5) /* HeartbeatInterval */
      , (45184,   2,       0) /* HeartbeatTimestamp */
-     , (45184,   3,       3) /* HealthRate */
+     , (45184,   3,       5) /* HealthRate */
      , (45184,   4,       5) /* StaminaRate */
-     , (45184,   5,       5) /* ManaRate */
-     , (45184,  13,       1) /* ArmorModVsSlash */
+     , (45184,   5,       1) /* ManaRate */
+     , (45184,  13,     0.9) /* ArmorModVsSlash */
      , (45184,  14,       1) /* ArmorModVsPierce */
-     , (45184,  15,     0.5) /* ArmorModVsBludgeon */
-     , (45184,  16,     0.5) /* ArmorModVsCold */
+     , (45184,  15,     0.9) /* ArmorModVsBludgeon */
+     , (45184,  16,     0.9) /* ArmorModVsCold */
      , (45184,  17,      10) /* ArmorModVsFire */
-     , (45184,  18,    0.64) /* ArmorModVsAcid */
-     , (45184,  19,     0.5) /* ArmorModVsElectric */
+     , (45184,  18,       1) /* ArmorModVsAcid */
+     , (45184,  19,       1) /* ArmorModVsElectric */
      , (45184,  31,      30) /* VisualAwarenessRange */
      , (45184,  34,       1) /* PowerupTime */
      , (45184,  36,       1) /* ChargeSpeed */
      , (45184,  39,     1.3) /* DefaultScale */
-     , (45184,  64,       1) /* ResistSlash */
+     , (45184,  64,     0.6) /* ResistSlash */
      , (45184,  65,       1) /* ResistPierce */
-     , (45184,  66,     0.7) /* ResistBludgeon */
-     , (45184,  67,     0.1) /* ResistFire */
-     , (45184,  68,     0.7) /* ResistCold */
-     , (45184,  69,    0.75) /* ResistAcid */
-     , (45184,  70,     0.7) /* ResistElectric */
+     , (45184,  66,     0.6) /* ResistBludgeon */
+     , (45184,  67,       0) /* ResistFire */
+     , (45184,  68,     0.6) /* ResistCold */
+     , (45184,  69,     0.4) /* ResistAcid */
+     , (45184,  70,     0.4) /* ResistElectric */
      , (45184,  71,       1) /* ResistHealthBoost */
-     , (45184,  72,       0) /* ResistStaminaDrain */
+     , (45184,  72,       1) /* ResistStaminaDrain */
      , (45184,  73,       1) /* ResistStaminaBoost */
-     , (45184,  74,       0) /* ResistManaDrain */
+     , (45184,  74,       1) /* ResistManaDrain */
      , (45184,  75,       1) /* ResistManaBoost */
      , (45184,  80,       3) /* AiUseMagicDelay */
      , (45184, 104,      10) /* ObviousRadarRange */
-     , (45184, 122,       2) /* AiAcquireHealth */
-     , (45184, 125,       0) /* ResistHealthDrain */;
+     , (45184, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (45184,   1, 'Hatred Wisp') /* Name */
@@ -88,14 +87,13 @@ VALUES (45184,   1, 20000, 0, 0, 20250) /* MaxHealth */
      , (45184,   5,  5000, 0, 0, 5490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (45184,  6, 0, 3, 0, 385, 0, 0) /* MeleeDefense        Specialized */
-     , (45184,  7, 0, 3, 0, 285, 0, 0) /* MissileDefense      Specialized */
-     , (45184, 15, 0, 3, 0, 245, 0, 0) /* MagicDefense        Specialized */
+VALUES (45184,  6, 0, 3, 0, 398, 0, 0) /* MeleeDefense         Specialized */
+     , (45184,  7, 0, 3, 0, 500, 0, 0) /* MissileDefense      Specialized */
+     , (45184, 15, 0, 3, 0, 280, 0, 0) /* MagicDefense        Specialized */
      , (45184, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (45184, 24, 0, 2, 0, 600, 0, 0) /* Run                 Trained */
-     , (45184, 31, 0, 3, 0, 345, 0, 0) /* CreatureEnchantment Specialized */
-     , (45184, 33, 0, 3, 0, 345, 0, 0) /* LifeMagic           Specialized */
-     , (45184, 34, 0, 3, 0, 345, 0, 0) /* WarMagic            Specialized */
+     , (45184, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment  Specialized */
+     , (45184, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic            Specialized */
+     , (45184, 34, 0, 3, 0, 220, 0, 0) /* WarMagic             Specialized */
      , (45184, 45, 0, 3, 0, 390, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72217 GY Corrupted Gravestone Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72217 GY Corrupted Gravestone Gen.sql
@@ -14,7 +14,7 @@ VALUES (72217,   1, True ) /* Stuck */
      , (72217,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72217,  41,     120) /* RegenerationInterval */
+VALUES (72217,  41,      60) /* RegenerationInterval */
      , (72217,  43,      50) /* GeneratorRadius */
      , (72217, 121,       1) /* GeneratorInitialDelay */;
 
@@ -26,4 +26,5 @@ VALUES (72217,   1, 0x0200026B) /* Setup */
      , (72217,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72217, -1, 52305, 60, 4, 4, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Gravestone (52305) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72217, -1, 52305, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Gravestone (52305) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72217, -1, 52305, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Gravestone (52305) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72219 GY Night Exhumed Bones Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72219 GY Night Exhumed Bones Gen.sql
@@ -17,7 +17,7 @@ VALUES (72219,   1, True ) /* Stuck */
      , (72219,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72219,  41,     120) /* RegenerationInterval */
+VALUES (72219,  41,      60) /* RegenerationInterval */
      , (72219,  43,      40) /* GeneratorRadius */
      , (72219, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,4 +29,7 @@ VALUES (72219,   1, 0x0200026B) /* Setup */
      , (72219,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72219, -1, 35251, 60, 4, 4, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x4 up to max of 4) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72219, -1, 35251, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72219, -1, 35251, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72219, -1, 35251, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72219, -1, 35251, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Exhumed Bones Piles (35251) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72220 GY Day Rat Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72220 GY Day Rat Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72220,   1, True ) /* Stuck */
      , (72220,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72220,  41,     180) /* RegenerationInterval */
+VALUES (72220,  41,      60) /* RegenerationInterval */
      , (72220,  43,       8) /* GeneratorRadius */
      , (72220, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,4 +29,9 @@ VALUES (72220,   1, 0x0200026B) /* Setup */
      , (72220,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72220, -1, 35100, 120, 6, 6, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x6 up to max of 6) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72220, -1, 35100, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72220, -1, 35100, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72220, -1, 35100, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72220, -1, 35100, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72220, -1, 35100, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72220, -1, 35100, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Grave Rat (35100) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72221 GY Day Pyre Skeleton Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72221 GY Day Pyre Skeleton Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72221,   1, True ) /* Stuck */
      , (72221,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72221,  41,     180) /* RegenerationInterval */
+VALUES (72221,  41,      60) /* RegenerationInterval */
      , (72221,  43,       8) /* GeneratorRadius */
      , (72221, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,5 +29,7 @@ VALUES (72221,   1, 0x0200026B) /* Setup */
      , (72221,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72221, -1, 35097, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72221, -1, 35099, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72221, -1, 35097, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72221, -1, 35099, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72221, -1, 35099, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72221, -1, 35099, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72222 GY Day Pyre Champion Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72222 GY Day Pyre Champion Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72222,   1, True ) /* Stuck */
      , (72222,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72222,  41,     180) /* RegenerationInterval */
+VALUES (72222,  41,      60) /* RegenerationInterval */
      , (72222,  43,       8) /* GeneratorRadius */
      , (72222, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,6 +29,8 @@ VALUES (72222,   1, 0x0200026B) /* Setup */
      , (72222,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72222, -1, 35097, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72222, -1, 35099, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72222, -1, 35098, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (35098) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72222, -1, 35097, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (35097) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72222, -1, 35099, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72222, -1, 35099, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72222, -1, 35099, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (35099) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72222, -1, 35098, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (35098) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72223 GY Night Pyre Skeleton Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72223 GY Night Pyre Skeleton Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72223,   1, True ) /* Stuck */
      , (72223,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72223,  41,     180) /* RegenerationInterval */
+VALUES (72223,  41,      60) /* RegenerationInterval */
      , (72223,  43,       8) /* GeneratorRadius */
      , (72223, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,5 +29,7 @@ VALUES (72223,   1, 0x0200026B) /* Setup */
      , (72223,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72223, -1, 41963, 0, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72223, -1, 52308, 0, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72223, -1, 41963, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72223, -1, 52308, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72223, -1, 52308, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72223, -1, 52308, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72224 GY Night Pyre Champion Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72224 GY Night Pyre Champion Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72224,   1, True ) /* Stuck */
      , (72224,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72224,  41,     180) /* RegenerationInterval */
+VALUES (72224,  41,      60) /* RegenerationInterval */
      , (72224,  43,       8) /* GeneratorRadius */
      , (72224, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,6 +29,8 @@ VALUES (72224,   1, 0x0200026B) /* Setup */
      , (72224,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72224, -1, 41963, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72224, -1, 52308, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72224, -1, 46816, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72224, -1, 41963, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72224, -1, 52308, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72224, -1, 52308, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72224, -1, 52308, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (52308) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72224, -1, 46816, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72225 GY Night Undead Camp Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72225 GY Night Undead Camp Gen.sql
@@ -17,7 +17,7 @@ VALUES (72225,   1, True ) /* Stuck */
      , (72225,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72225,  41,     180) /* RegenerationInterval */
+VALUES (72225,  41,      60) /* RegenerationInterval */
      , (72225,  43,       8) /* GeneratorRadius */
      , (72225, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,6 +29,8 @@ VALUES (72225,   1, 0x0200026B) /* Setup */
      , (72225,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72225, -1, 46815, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72225, -1, 41968, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (41968) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72225, -1, 41966, 120, 3, 3, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x3 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72225, -1, 46815, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72225, -1, 41968, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (41968) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72225, -1, 41966, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72225, -1, 41966, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72225, -1, 41966, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72226 GY Night Ghost Wanderer Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72226 GY Night Ghost Wanderer Gen.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (72226, 'ace72226-gynightghostwanderergen', 1, '2022-07-22 16:06:17') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (72226,  81,          5) /* MaxGeneratedObjects */
-     , (72226,  82,          5) /* InitGeneratedObjects */
+VALUES (72226,  81,          1) /* MaxGeneratedObjects */
+     , (72226,  82,          1) /* InitGeneratedObjects */
      , (72226,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (72226, 103,          2) /* GeneratorDestructionType - Destroy */
      , (72226, 142,          4) /* GeneratorTimeType - Night */
@@ -17,7 +17,7 @@ VALUES (72226,   1, True ) /* Stuck */
      , (72226,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72226,  41,     180) /* RegenerationInterval */
+VALUES (72226,  41,      60) /* RegenerationInterval */
      , (72226,  43,       8) /* GeneratorRadius */
      , (72226, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,4 +29,4 @@ VALUES (72226,   1, 0x0200026B) /* Setup */
      , (72226,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72226, -1, 35268, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Dread (35268) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72226, -1, 35268, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Dread (35268) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72227 GY Night Wisp Wanderer Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72227 GY Night Wisp Wanderer Gen.sql
@@ -17,7 +17,7 @@ VALUES (72227,   1, True ) /* Stuck */
      , (72227,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72227,  41,     180) /* RegenerationInterval */
+VALUES (72227,  41,     600) /* RegenerationInterval */
      , (72227,  43,       8) /* GeneratorRadius */
      , (72227, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,6 +29,6 @@ VALUES (72227,   1, 0x0200026B) /* Setup */
      , (72227,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72227, 0.33, 35059, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (35059) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72227, 0.66, 35089, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Despair Wisp (35089) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72227, 1, 35090, 120, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (35090) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72227, 0.33, 35059, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (35059) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72227, 0.66, 35089, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Despair Wisp (35089) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72227, 1, 35090, 300, 1, 1, 1, 2, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (35090) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72235 Mhoire Castle Master Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72235 Mhoire Castle Master Gen.sql
@@ -14,7 +14,7 @@ VALUES (72235,   1, True ) /* Stuck */
      , (72235,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72235,  41,     120) /* RegenerationInterval */
+VALUES (72235,  41,     300) /* RegenerationInterval */
      , (72235,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72240 Mhoire Oubliette Glyph Master Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72240 Mhoire Oubliette Glyph Master Gen.sql
@@ -14,7 +14,7 @@ VALUES (72240,   1, True ) /* Stuck */
      , (72240,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72240,  41,     180) /* RegenerationInterval */
+VALUES (72240,  41,     300) /* RegenerationInterval */
      , (72240,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72241 Mhoire Oubliette Master Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72241 Mhoire Oubliette Master Gen.sql
@@ -14,7 +14,7 @@ VALUES (72241,   1, True ) /* Stuck */
      , (72241,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72241,  41,     120) /* RegenerationInterval */
+VALUES (72241,  41,     300) /* RegenerationInterval */
      , (72241,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72242 Mhoire Oubliette Glyph Pyre Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72242 Mhoire Oubliette Glyph Pyre Gen.sql
@@ -27,6 +27,8 @@ VALUES (72242,   1, 0x0200026B) /* Setup */
      , (72242,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72242, 0.33, 45173, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (45173) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72242, 0.66, 45174, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (45174) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72242, 1, 45175, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45175) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72242, 0.2, 45173, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (45173) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72242, 0.4, 45174, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (45174) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72242, 0.6, 45175, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45175) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72242, 0.8, 45175, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45175) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72242, 1, 45175, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45175) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72243 Mhoire Oubliette Glyph Wight Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72243 Mhoire Oubliette Glyph Wight Gen.sql
@@ -27,6 +27,8 @@ VALUES (72243,   1, 0x0200026B) /* Setup */
      , (72243,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72243, 0.33, 45178, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (45178) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72243, 0.66, 45179, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (45179) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72243, 1, 45187, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45187) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72243, 0.2, 45178, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (45178) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72243, 0.4, 45179, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (45179) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72243, 0.6, 45187, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45187) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72243, 0.8, 45187, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45187) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72243, 1, 45187, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45187) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72244 Mhoire Oubliette Glyph Single Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72244 Mhoire Oubliette Glyph Single Gen.sql
@@ -16,7 +16,7 @@ VALUES (72244,   1, True ) /* Stuck */
      , (72244,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72244,  41,     180) /* RegenerationInterval */
+VALUES (72244,  41,     300) /* RegenerationInterval */
      , (72244,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,7 +27,7 @@ VALUES (72244,   1, 0x0200026B) /* Setup */
      , (72244,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72244, 0.33, 45182, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Dread (45182) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72244, 0.66, 45171, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guardian Statue (45171) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72244, 0.82, 45183, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (45183) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72244, 1, 45184, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (45184) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+VALUES (72244, 0.33, 45182, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Dread (45182) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72244, 0.66, 45171, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guardian Statue (45171) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72244, 0.82, 45183, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (45183) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72244, 1, 45184, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (45184) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72245 Mhoire Oubliette Pyre Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72245 Mhoire Oubliette Pyre Gen.sql
@@ -16,7 +16,7 @@ VALUES (72245,   1, True ) /* Stuck */
      , (72245,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72245,  41,     180) /* RegenerationInterval */
+VALUES (72245,  41,     300) /* RegenerationInterval */
      , (72245,  43,       3) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,6 +27,8 @@ VALUES (72245,   1, 0x0200026B) /* Setup */
      , (72245,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72245, 0.33, 45155, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (45155) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72245, 0.66, 45156, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (45156) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72245, 1, 45157, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45157) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72245, 0.2, 45155, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (45155) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72245, 0.4, 45156, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (45156) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72245, 0.6, 45157, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45157) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72245, 0.8, 45157, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45157) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72245, 1, 45157, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (45157) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72246 Mhoire Oubliette Wight Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72246 Mhoire Oubliette Wight Gen.sql
@@ -16,7 +16,7 @@ VALUES (72246,   1, True ) /* Stuck */
      , (72246,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72246,  41,     180) /* RegenerationInterval */
+VALUES (72246,  41,     300) /* RegenerationInterval */
      , (72246,  43,       3) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,6 +27,8 @@ VALUES (72246,   1, 0x0200026B) /* Setup */
      , (72246,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72246, 0.33, 45160, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (45160) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72246, 0.66, 45161, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (45161) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72246, 1, 45162, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45162) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72246, 0.2, 45160, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (45160) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72246, 0.4, 45161, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (45161) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72246, 0.6, 45162, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45162) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72246, 0.8, 45162, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45162) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72246, 1, 45162, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (45162) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72247 Mhoire Oubliette Single Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72247 Mhoire Oubliette Single Gen.sql
@@ -16,7 +16,7 @@ VALUES (72247,   1, True ) /* Stuck */
      , (72247,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72247,  41,     180) /* RegenerationInterval */
+VALUES (72247,  41,     300) /* RegenerationInterval */
      , (72247,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,5 +27,5 @@ VALUES (72247,   1, 0x0200026B) /* Setup */
      , (72247,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72247, 0.5, 45165, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Dread (45165) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72247, 1, 45153, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guardian Statue (45153) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+VALUES (72247, 0.5, 45165, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Dread (45165) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72247, 1, 45153, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guardian Statue (45153) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72248 Mhoire Castle Pyre Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72248 Mhoire Castle Pyre Gen.sql
@@ -16,7 +16,7 @@ VALUES (72248,   1, True ) /* Stuck */
      , (72248,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72248,  41,     180) /* RegenerationInterval */
+VALUES (72248,  41,     300) /* RegenerationInterval */
      , (72248,  43,       3) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,6 +27,7 @@ VALUES (72248,   1, 0x0200026B) /* Setup */
      , (72248,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72248, 0.33, 41964, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (41964) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72248, 0.66, 41963, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72248, 1, 41965, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (41965) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72248, 0.25, 41964, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (41964) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72248, 0.5, 41963, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Skeleton (41963) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72248, 0.75, 41965, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (41965) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72248, 1, 41965, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Minion (41965) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72249 Mhoire Castle Wight Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72249 Mhoire Castle Wight Gen.sql
@@ -16,7 +16,7 @@ VALUES (72249,   1, True ) /* Stuck */
      , (72249,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72249,  41,     180) /* RegenerationInterval */
+VALUES (72249,  41,     300) /* RegenerationInterval */
      , (72249,  43,       3) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,6 +27,8 @@ VALUES (72249,   1, 0x0200026B) /* Setup */
      , (72249,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72249, 0.33, 41968, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (41968) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72249, 0.66, 41967, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (41967) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (72249, 1, 41966, 0, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (72249, 0.2, 41968, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Captain (41968) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72249, 0.4, 41967, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (41967) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72249, 0.6, 41966, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72249, 0.8, 41966, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72249, 1, 41966, 180, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight (41966) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72250 Mhoire Castle Single Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72250 Mhoire Castle Single Gen.sql
@@ -16,7 +16,7 @@ VALUES (72250,   1, True ) /* Stuck */
      , (72250,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72250,  41,     180) /* RegenerationInterval */
+VALUES (72250,  41,     300) /* RegenerationInterval */
      , (72250,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
@@ -27,8 +27,8 @@ VALUES (72250,   1, 0x0200026B) /* Setup */
      , (72250,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (72250, 0.3, 41961, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Dread (41961) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72250, 0.6, 41959, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guardian Statue (41959) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72250, 0.75, 41970, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (41970) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72250, 0.9, 41971, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (41971) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (72250, 1, 42063, 20, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Fountain (42063) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+VALUES (72250, 0.3, 41961, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Corrupted Dread (41961) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72250, 0.6, 41959, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guardian Statue (41959) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72250, 0.75, 41970, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Hatred Wisp (41970) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72250, 0.9, 41971, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sorrow Wisp (41971) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (72250, 1, 42063, 180, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spectral Fountain (42063) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72998 Linkable Night Monster Gen (10 min.).sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72998 Linkable Night Monster Gen (10 min.).sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 72998;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (72998, 'ace72998-linknightmonstergen10min', 1, '2005-02-09 10:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (72998,  66,          1) /* CheckpointStatus */
+     , (72998,  81,          0) /* MaxGeneratedObjects */
+     , (72998,  82,          0) /* InitGeneratedObjects */
+     , (72998,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (72998, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (72998, 142,          4) /* GeneratorTimeType - Night */
+     , (72998, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (72998,   1, True ) /* Stuck */
+     , (72998,  11, True ) /* IgnoreCollisions */
+     , (72998,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (72998,  41,      60) /* RegenerationInterval */
+     , (72998,  43,       1) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (72998,   1, 'Linkable Night Monster Gen (10 min.)') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (72998,   1, 0x0200026B) /* Setup */
+     , (72998,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72998, -1, 3666, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Place Holder Object (3666) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87012 GY Night Bunker Top Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87012 GY Night Bunker Top Gen.sql
@@ -17,7 +17,7 @@ VALUES (87012,   1, True ) /* Stuck */
      , (87012,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (87012,  41,     180) /* RegenerationInterval */
+VALUES (87012,  41,      60) /* RegenerationInterval */
      , (87012,  43,       2) /* GeneratorRadius */
      , (87012, 121,       1) /* GeneratorInitialDelay */;
 
@@ -29,5 +29,5 @@ VALUES (87012,   1, 0x0200026B) /* Setup */
      , (87012,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87012, -1, 46816, 120, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
-     , (87012, -1, 46815, 120, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;
+VALUES (87012, -1, 46816, 600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Pyre Champion (46816) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (87012, -1, 46815, 600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wight Blade Sorcerer (46815) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;


### PR DESCRIPTION
Revised generators to correct spawn rates - bunker tops and perches are now 10 min (based on retail video showing no faster than 10 min), ground spawns are now 5 min and mhoire castle and oubliette are 5 min (previously by mistake 2 and 3 min). Outdoor roamers (wisps, ghosts) are now 10 min. The Shade of Lord Rytheran's generator has also been corrected to respawn adds every 5 min.

Fixed gravestones - added missing smoke effect, fixed broken generator, and added missing properties to match other similar mobs (e.g., Rynthid Crystals).

Added missing wield profile to Wights and Wight Captains.

Corrected Wight Blade Sorcerers so they are no longer 100% casters and can go melee (as seen in retail video).

Adjusted skills for most creatures based on pcap estimated values when available. For example, Wight Blade Sorcerers had magic skills that were too high, and defense skills that were too low. Retail video also confirms that a top tier player could resist them at a high rate.

Adjusted resistances on wisps based on vulnerabilities listed on the wiki.

Added missing say emotes to undead (on scream, on death, and heartbeat).

Increased say emote range on Laylana which was too short, in effect resulting in it never heard.