### PR TITLE
Fix lightning spectral archer gear to match other spectral archer gear

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Ammunition/MissileWeapon/46629 Greater Deadly Lightning Arrow.sql
+++ b/Database/Patches/9 WeenieDefaults/Ammunition/MissileWeapon/46629 Greater Deadly Lightning Arrow.sql
@@ -6,25 +6,35 @@ VALUES (46629, 'ace46629-greaterdeadlylightningarrow', 5, '2021-11-07 08:12:46')
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46629,   1,        256) /* ItemType - MissileWeapon */
      , (46629,   3,         82) /* PaletteTemplate - PinkPurple */
-     , (46629,   5,          1) /* EncumbranceVal */
+     , (46629,   5,          5) /* EncumbranceVal */
+     , (46629,   8,          2) /* Mass */
      , (46629,   9,    8388608) /* ValidLocations - MissileAmmo */
-     , (46629,  11,       2500) /* MaxStackSize */
+     , (46629,  11,       1000) /* MaxStackSize */
      , (46629,  12,          1) /* StackSize */
-     , (46629,  13,          1) /* StackUnitEncumbrance */
-     , (46629,  15,          1) /* StackUnitValue */
+     , (46629,  13,          5) /* StackUnitEncumbrance */
+     , (46629,  14,          2) /* StackUnitMass */
+     , (46629,  15,         11) /* StackUnitValue */
      , (46629,  16,          1) /* ItemUseable - No */
      , (46629,  18,         64) /* UiEffects - Lightning */
-     , (46629,  19,          1) /* Value */
-     , (46629,  33,         -2) /* Bonded - Destroy */
-     , (46629,  44,         40) /* Damage */
+     , (46629,  19,         11) /* Value */
+     , (46629,  44,        400) /* Damage */
      , (46629,  45,         64) /* DamageType - Electric */
      , (46629,  50,          1) /* AmmoType - Arrow */
      , (46629,  51,          3) /* CombatUse - Ammo */
      , (46629,  93,     132116) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, Inelastic */
-     , (46629, 151,          2) /* HookType - Wall */;
+     , (46629, 150,        103) /* HookPlacement - Hook */
+     , (46629, 151,          2) /* HookType - Wall */
+     , (46629, 158,          2) /* WieldRequirements - RawSkill */
+     , (46629, 159,         47) /* WieldSkillType - MissileWeapons */
+     , (46629, 160,        230) /* WieldDifficulty */;
+     
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46629,  17, True ) /* Inelastic */
+     , (46629,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46629,  22,     0.3) /* DamageVariance */
+     , (46629,  29,       1) /* WeaponDefense */
      , (46629,  39,     1.1) /* DefaultScale */
      , (46629,  76,     0.8) /* Translucency */
      , (46629,  78,       1) /* Friction */

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/46633 Lightning Longbow.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/46633 Lightning Longbow.sql
@@ -10,35 +10,31 @@ VALUES (46633,   1,        256) /* ItemType - MissileWeapon */
      , (46633,   9,    4194304) /* ValidLocations - MissileWeapon */
      , (46633,  16,          1) /* ItemUseable - No */
      , (46633,  18,         64) /* UiEffects - Lightning */
+     , (46633,  19,          0) /* Value */
      , (46633,  33,         -2) /* Bonded - Destroy */
-     , (46633,  37,       9999) /* ResistItemAppraisal */
      , (46633,  45,         64) /* DamageType - Electric */
      , (46633,  46,         16) /* DefaultCombatStyle - Bow */
-     , (46633,  48,          2) /* WeaponSkill - Bow */
-     , (46633,  49,         45) /* WeaponTime */
+     , (46633,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (46633,  49,         -1) /* WeaponTime */
      , (46633,  50,          1) /* AmmoType - Arrow */
      , (46633,  51,          2) /* CombatUse - Missile */
      , (46633,  52,          2) /* ParentLocation - LeftHand */
      , (46633,  53,          3) /* PlacementPosition - LeftHand */
-     , (46633,  60,        192) /* WeaponRange */
      , (46633,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-     , (46633, 114,          1) /* Attuned - Attuned */
      , (46633, 151,          2) /* HookType - Wall */
-     , (46633, 158,          2) /* WieldRequirements - RawSkill */
-     , (46633, 159,          2) /* WieldSkillType - Bow */
-     , (46633, 204,         16) /* ElementalDamageBonus */;
+     , (46633, 204,         16) /* ElementalDamageBonus */
+     , (46633, 353,          8) /* WeaponType - Bow */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (46633,  22, True ) /* Inscribable */
-     , (46633,  69, False) /* IsSellable */;
+VALUES (46633,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46633,   5,       0) /* ManaRate */
-     , (46633,  26,    27.3) /* MaximumVelocity */
-     , (46633,  29,    1.37) /* WeaponDefense */
+     , (46633,  26,    26.3) /* MaximumVelocity */
+     , (46633,  29,       1) /* WeaponDefense */
      , (46633,  39,     1.1) /* DefaultScale */
      , (46633,  62,       1) /* WeaponOffense */
-     , (46633,  63,    2.66) /* DamageMod */;
+     , (46633,  63,       1) /* DamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46633,   1, 'Lightning Longbow') /* Name */;


### PR DESCRIPTION
Most of the changes are completely useless for monster-only items, just made to be consistent with the others. The main changes are: 
1. Removal of the melee defense mod that only shows up on the lightning bow. Guessing they took it from the wiki page for the Master Archer version of the weapon?
2. Changing weapon mod and arrow damage to match other versions, making them equally as dangerous as other spectral archers.