### PR TITLE
Flavor Text and Other Updates

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/37455 Forge Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/37455 Forge Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37455;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37455, 'ace37455-forgegolem', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (37455, 'ace37455-forgegolem', 10, '2023-04-06 10:43:17') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37455,   1,         16) /* ItemType - Creature */
@@ -80,35 +80,40 @@ VALUES (37455,   1,  3000, 0, 0, 3500) /* MaxHealth */
      , (37455,   5,  3500, 0, 0, 4100) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (37455,  6, 0, 2, 0, 577, 0, 0) /* MeleeDefense        Trained */
-     , (37455,  7, 0, 2, 0, 149, 0, 0) /* MissileDefense      Trained */
-     , (37455, 15, 0, 2, 0, 170, 0, 0) /* MagicDefense        Trained */
-     , (37455, 16, 0, 2, 0, 527, 0, 0) /* ManaConversion      Trained */
-     , (37455, 31, 0, 2, 0, 527, 0, 0) /* CreatureEnchantment Trained */
-     , (37455, 33, 0, 2, 0, 527, 0, 0) /* LifeMagic           Trained */
-     , (37455, 34, 0, 2, 0, 527, 0, 0) /* WarMagic            Trained */
-     , (37455, 41, 0, 2, 0, 132, 0, 0) /* TwoHandedCombat     Trained */
-     , (37455, 43, 0, 2, 0, 527, 0, 0) /* VoidMagic           Trained */
-     , (37455, 44, 0, 2, 0, 132, 0, 0) /* HeavyWeapons        Trained */
-     , (37455, 45, 0, 2, 0, 132, 0, 0) /* LightWeapons        Trained */
-     , (37455, 46, 0, 2, 0, 132, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (37455,  6, 0, 2, 0, 266, 0, 0) /* MeleeDefense        Trained */
+     , (37455,  7, 0, 2, 0, 249, 0, 0) /* MissileDefense      Trained */
+     , (37455, 15, 0, 2, 0, 284, 0, 0) /* MagicDefense        Trained */
+     , (37455, 16, 0, 2, 0, 100, 0, 0) /* ManaConversion      Trained */
+     , (37455, 31, 0, 2, 0, 130, 0, 0) /* CreatureEnchantment Trained */
+     , (37455, 33, 0, 2, 0, 130, 0, 0) /* LifeMagic           Trained */
+     , (37455, 34, 0, 2, 0, 130, 0, 0) /* WarMagic            Trained */
+     , (37455, 43, 0, 2, 0, 130, 0, 0) /* VoidMagic           Trained */
+     , (37455, 45, 0, 2, 0, 132, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (37455,  0,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (37455,  1,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (37455,  2,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (37455,  3,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (37455,  4,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (37455,  5,  4, 90, 0.75,  350,  168,  161,  175,   84,  298,  112,  112,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (37455,  6,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (37455,  7,  4,  0,    0,  350,  168,  161,  175,   84,  298,  112,  112,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (37455,  8,  4, 90, 0.75,  350,  168,  161,  175,   84,  298,  112,  112,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (37455,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (37455,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (37455,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (37455,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (37455,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (37455,  5,  4, 90, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (37455,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (37455,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (37455,  8,  4, 90, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (37455,  3463,   2.02)  /* Char Flesh */
-     , (37455,  3878,   2.02)  /* Incendiary Strike */
-     , (37455,  3882,   2.02)  /* Incendiary Ring */
-     , (37455,  4716,   2.02)  /* Burning Curse */;
+VALUES (37455,  3463,   2.05)  /* Char Flesh */
+     , (37455,  3878,   2.05)  /* Incendiary Strike */
+     , (37455,  3882,   2.06)  /* Incendiary Ring */
+     , (37455,  4716,   2.06)  /* Burning Curse */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37455,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 1, NULL, '%s strikes the final blow and the Forge Golem crumbles. Bits of ghostly blue metal can be seen in its remains.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (37455, 9, 37589,  0, 0, 1, False) /* Create Forge Vault Key (37589) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/37455.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/37455.es
@@ -1,0 +1,2 @@
+Death:
+    - LocalBroadcast: %s strikes the final blow and the Forge Golem crumbles. Bits of ghostly blue metal can be seen in its remains.

--- a/Database/Patches/9 WeenieDefaults/Creature/Moarsman/40306 Verdant Moarsman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Moarsman/40306 Verdant Moarsman.sql
@@ -70,7 +70,8 @@ VALUES (40306,   1, 0x02000992) /* Setup */
      , (40306,   7, 0x10000276) /* ClothingBase */
      , (40306,   8, 0x06001ED1) /* Icon */
      , (40306,  22, 0x34000069) /* PhysicsEffectTable */
-     , (40306,  30,         86) /* PhysicsScript - BreatheAcid */;
+     , (40306,  30,         86) /* PhysicsScript - BreatheAcid */
+     , (40306,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (40306,   1, 230, 0, 0) /* Strength */

--- a/Database/Patches/9 WeenieDefaults/Creature/Moarsman/41181 Verdant Moarsman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Moarsman/41181 Verdant Moarsman.sql
@@ -71,7 +71,8 @@ VALUES (41181,   1, 0x02000992) /* Setup */
      , (41181,   7, 0x10000276) /* ClothingBase */
      , (41181,   8, 0x06001ED1) /* Icon */
      , (41181,  22, 0x34000069) /* PhysicsEffectTable */
-     , (41181,  30,         86) /* PhysicsScript - BreatheAcid */;
+     , (41181,  30,         86) /* PhysicsScript - BreatheAcid */
+     , (41181,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (41181,   1, 230, 0, 0) /* Strength */

--- a/Database/Patches/9 WeenieDefaults/Creature/Penguin/45853 Mouf.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Penguin/45853 Mouf.sql
@@ -1,11 +1,12 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45853;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45853, 'ace45853-mouf', 10, '2022-08-22 03:09:27') /* Creature */;
+VALUES (45853, 'ace45853-mouf', 10, '2023-04-05 12:11:31') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45853,   1,         16) /* ItemType - Creature */
      , (45853,   2,         80) /* CreatureType - Penguin */
+     , (45853,   3,         61) /* PaletteTemplate - White */
      , (45853,   6,         -1) /* ItemsCapacity */
      , (45853,   7,         -1) /* ContainersCapacity */
      , (45853,  16,         32) /* ItemUseable - Remote */
@@ -31,36 +32,48 @@ VALUES (45853,   1, 0x02001252) /* Setup */
      , (45853,   2, 0x0900017B) /* MotionTable */
      , (45853,   3, 0x200000BA) /* SoundTable */
      , (45853,   6, 0x0400197C) /* PaletteBase */
+     , (45853,   7, 0x10000599) /* ClothingBase */
      , (45853,   8, 0x060036F6) /* Icon */;
 
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (45853,   1,  20, 0, 0) /* Strength */
+     , (45853,   2,  30, 0, 0) /* Endurance */
+     , (45853,   3,  55, 0, 0) /* Quickness */
+     , (45853,   4,  50, 0, 0) /* Coordination */
+     , (45853,   5,  25, 0, 0) /* Focus */
+     , (45853,   6,  15, 0, 0) /* Self */;
+
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (45853,   1,     0, 0, 0, 30) /* MaxHealth */;
+VALUES (45853,   1,    15, 0, 0,   30) /* MaxHealth */
+     , (45853,   3,   110, 0, 0,  140) /* MaxStamina */
+     , (45853,   5,     0, 0, 0,   15) /* MaxMana */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45853,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (45853, 7 /* Use */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  21 /* InqQuest */, 0, 1, NULL, 'moufreward', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 21 /* InqQuest */, 0, 1, NULL, 'moufreward', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45853, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'moufreward', NULL, NULL, NULL);
+VALUES (45853, 12 /* QuestSuccess */, 1, NULL, NULL, NULL, 'moufreward', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Mouf appears to be busy gathering his belongings. He looks like he is preparing to leave.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Mouf appears to be busy gathering his belongings. He looks like he is preparing to leave.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (45853, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'moufreward', NULL, NULL, NULL);
+VALUES (45853, 13 /* QuestFailure */, 1, NULL, NULL, NULL, 'moufreward', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Mouf cowers as you approach. He draws a large "P" in the snow and slips a piece of paper into your pack.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 46021 /* Letter from Mouf */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 48748 /* Legendary Key */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  22 /* StampQuest */, 0, 1, NULL, 'moufreward', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'Mouf cowers as you approach. He draws a large "P" in the snow and slips a piece of paper into your pack.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 46021 /* Letter from Mouf */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 48748 /* Legendary Key */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 3, 22 /* StampQuest */, 0, 1, NULL, 'moufreward', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/44061 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/44061 Door.sql
@@ -15,7 +15,8 @@ VALUES (44061,   1, True ) /* Stuck */
      , (44061,  34, False) /* DefaultOpen */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (44061,  54,       2) /* UseRadius */;
+VALUES (44061,  11,     300) /* ResetInterval */
+     , (44061,  54,       2) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (44061,   1, 'Door') /* Name */

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88125 Rynthid Test 4 Portal Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88125 Rynthid Test 4 Portal Generator.sql
@@ -14,7 +14,7 @@ VALUES (88125,   1, True ) /* Stuck */
      , (88125,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (88125,  41,     600) /* RegenerationInterval */
+VALUES (88125,  41,       5) /* RegenerationInterval */
      , (88125,  43,       0) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/37513 Armory.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/37513 Armory.sql
@@ -15,7 +15,7 @@ VALUES (37513,   1, True ) /* Stuck */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (37513,  39,     1.2) /* DefaultScale */
-     , (37513,  54,     0.5) /* UseRadius */;
+     , (37513,  54,       1) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37513,   1, 'Armory') /* Name */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/37513 Armory.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/37513 Armory.sql
@@ -15,7 +15,7 @@ VALUES (37513,   1, True ) /* Stuck */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (37513,  39,     1.2) /* DefaultScale */
-     , (37513,  54,       1) /* UseRadius */;
+     , (37513,  54,     0.5) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37513,   1, 'Armory') /* Name */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/37514 Forges.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/37514 Forges.sql
@@ -15,7 +15,7 @@ VALUES (37514,   1, True ) /* Stuck */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (37514,  39,     1.2) /* DefaultScale */
-     , (37514,  54,     0.5) /* UseRadius */;
+     , (37514,  54,       1) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37514,   1, 'Forges') /* Name */;
@@ -28,3 +28,11 @@ VALUES (37514,   1, 0x02000EFC) /* Setup */
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (37514, 2, 0x00EA01E5, 90, -90, -53.4467, 1, 0, 0, 0) /* Destination */
 /* @teleloc 0x00EA01E5 [90.000000 -90.000000 -53.446701] 1.000000 0.000000 0.000000 0.000000 */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (37514,  4 /* Portal */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'A blast of heat washes over you from below. Then you arrive on the Forge levels.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/37514 Forges.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/37514 Forges.sql
@@ -15,7 +15,7 @@ VALUES (37514,   1, True ) /* Stuck */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (37514,  39,     1.2) /* DefaultScale */
-     , (37514,  54,       1) /* UseRadius */;
+     , (37514,  54,     0.5) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37514,   1, 'Forges') /* Name */;


### PR DESCRIPTION
Adds on death local broadcast to Forge Golem seen in retail video by Xeo, and updates the golem's skills and casting probability. Some of its base skills were set to what should be its effective skills. 

Adds flavor text to Forges portal seen in the retail video. 

Adds a regular door reset interval of 300 seconds to regular (not lever activated) Neftet-style door. This was not set, and doors closed too quickly  (in under a min). In retail video, these doors stay open for much longer. 

Updated one of the Rynthid Testing portal generators to match the other portal generators. The others are set to 5 sec regen interval, this one was left at 600 seconds, forcing players to wait around for 10 min for a new color portal to spawn. 

Added missing T7 loot profile to Verdant Moarsman.

Corrects art and stats of NPC Mouf to match retail.