### PR TITLE
Fix Modified Taulandoi Crit Freq

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/46941 Modified Taulandoi.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/46941 Modified Taulandoi.sql
@@ -40,7 +40,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46941,   5,      -1) /* ManaRate */
      , (46941,  29,    1.15) /* WeaponDefense */
      , (46941, 144,     0.1) /* ManaConversionMod */
-     , (46941, 147,       1) /* CriticalFrequency */
+     , (46941, 147,    0.25) /* CriticalFrequency */
      , (46941, 152,     1.1) /* ElementalDamageMod */
      , (46941, 157,       1) /* ResistanceModifier */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/46942 Modified Taulandoi.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/46942 Modified Taulandoi.sql
@@ -40,7 +40,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46942,   5,      -1) /* ManaRate */
      , (46942,  29,    1.15) /* WeaponDefense */
      , (46942, 144,     0.1) /* ManaConversionMod */
-     , (46942, 147,       1) /* CriticalFrequency */
+     , (46942, 147,    0.25) /* CriticalFrequency */
      , (46942, 152,     1.1) /* ElementalDamageMod */
      , (46942, 157,       1) /* ResistanceModifier */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/46943 Modified Taulandoi.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/46943 Modified Taulandoi.sql
@@ -40,7 +40,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46943,   5,      -1) /* ManaRate */
      , (46943,  29,    1.15) /* WeaponDefense */
      , (46943, 144,     0.1) /* ManaConversionMod */
-     , (46943, 147,       1) /* CriticalFrequency */
+     , (46943, 147,    0.25) /* CriticalFrequency */
      , (46943, 152,     1.1) /* ElementalDamageMod */
      , (46943, 157,       1) /* ResistanceModifier */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/46944 Modified Taulandoi.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/46944 Modified Taulandoi.sql
@@ -40,7 +40,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46944,   5,      -1) /* ManaRate */
      , (46944,  29,    1.15) /* WeaponDefense */
      , (46944, 144,     0.1) /* ManaConversionMod */
-     , (46944, 147,       1) /* CriticalFrequency */
+     , (46944, 147,    0.25) /* CriticalFrequency */
      , (46944, 152,     1.1) /* ElementalDamageMod */
      , (46944, 157,       1) /* ResistanceModifier */;
 


### PR DESCRIPTION
Sets the critical frequency of the 4 Modified Taulandoi to 0.25. Previously, was set to 1 by mistake.