### PR TITLE
Fix landblock spawns with incorrect cellblock locations

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/001A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/001A.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x001A;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A000,  7923, 0x001A0180, 190, -100, 0.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 3 Min.) */
-/* @teleloc 0x001A0180 [190.000000 -100.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A000,  7923, 0x001A017D, 190, -100, 0.005, 1, 0, 0, 0, False, '2023-04-10 10:34:27'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x001A017D [190.000000 -100.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7001A000, 0x7001A037, '2021-11-01 00:00:00') /* Platinum Legion Quartermaster (29424) */
@@ -12,22 +12,22 @@ VALUES (0x7001A000, 0x7001A037, '2021-11-01 00:00:00') /* Platinum Legion Quarte
      , (0x7001A000, 0x7001A058, '2021-11-01 00:00:00') /* Platinum Legion Bodyguard (29398) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A001, 30287, 0x001A01E9, 130, -313, 6.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x001A01E9 [130.000000 -313.000000 6.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A001, 30287, 0x001A01EA, 130, -313, 6.005, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x001A01EA [130.000000 -313.000000 6.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7001A001, 0x7001A00A, '2021-11-01 00:00:00') /* Lever (286) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A002, 30287, 0x001A01FA, 130, -434.5, 6.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x001A01FA [130.000000 -434.500000 6.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A002, 30287, 0x001A01FB, 130, -434.5, 6.005, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x001A01FB [130.000000 -434.500000 6.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7001A002, 0x7001A00C, '2021-11-01 00:00:00') /* Lever (2609) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A003, 30287, 0x001A02AE, 130, -250, 12.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x001A02AE [130.000000 -250.000000 12.005000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A003, 30287, 0x001A02AC, 130, -250, 12.005, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x001A02AC [130.000000 -250.000000 12.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7001A003, 0x7001A00B, '2021-11-01 00:00:00') /* Torch (7323) */;
@@ -57,16 +57,16 @@ VALUES (0x7001A009, 29385, 0x001A01BA, 30.0049, -266.82, 6.005, -0.000304, 0, 0,
 /* @teleloc 0x001A01BA [30.004900 -266.820007 6.005000] -0.000304 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A00A,   286, 0x001A0205, 136.5, -335, 7.954, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Lever */
-/* @teleloc 0x001A0205 [136.500000 -335.000000 7.954000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A00A,   286, 0x001A0206, 136.5, -335, 7.954, 1, 0, 0, 0,  True, '2023-04-10 10:36:12'); /* Lever */
+/* @teleloc 0x001A0206 [136.500000 -335.000000 7.954000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A00B,  7323, 0x001A029D, 123.35, -328.42, 13.825, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Torch */
-/* @teleloc 0x001A029D [123.349998 -328.420013 13.825000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A00B,  7323, 0x001A029E, 123.35, -328.42, 13.825, 1, 0, 0, 0,  True, '2023-04-10 10:36:12'); /* Torch */
+/* @teleloc 0x001A029E [123.349998 -328.420013 13.825000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7001A00C,  2609, 0x001A02CE, 140, -426.5, 12.059, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Lever */
-/* @teleloc 0x001A02CE [140.000000 -426.500000 12.059000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7001A00C,  2609, 0x001A02CF, 140, -426.5, 12.059, 1, 0, 0, 0,  True, '2023-04-10 10:36:12'); /* Lever */
+/* @teleloc 0x001A02CF [140.000000 -426.500000 12.059000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7001A00D, 28656, 0x001A0103, 230.305, -278.496, -11.995, 0.995004, 0, 0, -0.099833,  True, '2021-11-01 00:00:00'); /* Viamontian Lord */

--- a/Database/Patches/6 LandBlockExtendedData/002D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/002D.sql
@@ -173,8 +173,8 @@ VALUES (0x7002D3ED,  6122, 0x002D0103, 90, -220.051, -41.995, 1, 0, 0, 0, False,
 /* @teleloc 0x002D0103 [90.000000 -220.050995 -41.994999] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7002D3EE,  6122, 0x002D0101, 80, -230.051, -41.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x002D0101 [80.000000 -230.050995 -41.994999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7002D3EE,  6122, 0x002D0102, 80, -230.051, -41.995, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x002D0102 [80.000000 -230.050995 -41.994999] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7002D3EF, 31009, 0x002D034F, 159.578, 0.060317, 0.005, 0.458137, 0, 0, -0.888881,  True, '2021-11-01 00:00:00'); /* Mosswart Worshipper */

--- a/Database/Patches/6 LandBlockExtendedData/0044.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0044.sql
@@ -51,8 +51,8 @@ VALUES (0x700443EA, 0x700443EC, '2023-03-23 00:00:00') /* Insatiable Eater (2863
      , (0x700443EA, 0x70044429, '2023-03-23 00:00:00') /* Royal Thaumaturge (29303) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700443EB, 32283, 0x00440201, 70.113, -149.918, 0.308, 0.031422, 0, 0, 0.999506, False, '2023-03-23 00:00:00'); /* Exit */
-/* @teleloc 0x00440201 [70.112999 -149.917999 0.308000] 0.031422 0.000000 0.000000 0.999506 */
+VALUES (0x700443EB, 32283, 0x004401FE, 70.113, -149.918, 0.308, 0.031422, 0, 0, 0.999506, False, '2023-04-10 10:36:12'); /* Exit */
+/* @teleloc 0x004401FE [70.112999 -149.917999 0.308000] 0.031422 0.000000 0.000000 0.999506 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700443EC, 28635, 0x004401DB, 16.0529, -200.483, 0.000185, 0.821896, 0, 0, -0.569638,  True, '2023-03-23 00:00:00'); /* Insatiable Eater */

--- a/Database/Patches/6 LandBlockExtendedData/0045.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0045.sql
@@ -544,48 +544,48 @@ VALUES (0x70045455, 32507, 0x00450285, 470.643, -419.851, -5.98994, 0.707107, 0,
 /* @teleloc 0x00450285 [470.643005 -419.851013 -5.989940] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70045456,  6122, 0x0045014A, 320, -410, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045014A [320.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70045456,  6122, 0x00450127, 320, -410, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00450127 [320.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70045457,  6122, 0x00450127, 320, -420, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00450127 [320.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70045457,  6122, 0x0045012D, 320, -420, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x0045012D [320.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70045458,  6122, 0x0045012D, 320, -430, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045012D [320.000000 -430.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70045458,  6122, 0x0045012E, 320, -430, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x0045012E [320.000000 -430.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70045459,  6122, 0x0045012E, 330, -410, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045012E [330.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70045459,  6122, 0x00450134, 330, -410, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00450134 [330.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004545A,  6122, 0x00450144, 330, -420, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00450144 [330.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7004545A,  6122, 0x0045013C, 330, -420, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x0045013C [330.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004545B,  6122, 0x0045013C, 330, -430, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045013C [330.000000 -430.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7004545B,  6122, 0x00450144, 330, -430, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00450144 [330.000000 -430.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004545C,  6122, 0x00450152, 340, -410, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00450152 [340.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7004545C,  6122, 0x0045014A, 340, -410, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x0045014A [340.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004545D,  6122, 0x0045015A, 340, -420, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045015A [340.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7004545D,  6122, 0x00450152, 340, -420, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00450152 [340.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004545E,  6122, 0x0045015B, 340, -430, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045015B [340.000000 -430.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7004545E,  6122, 0x0045015A, 340, -430, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x0045015A [340.000000 -430.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004545F,  6122, 0x00450161, 350, -410, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00450161 [350.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7004545F,  6122, 0x0045015B, 350, -410, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x0045015B [350.000000 -410.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70045460,  6122, 0x0045015A, 350, -420, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0045015A [350.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70045460,  6122, 0x00450161, 350, -420, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00450161 [350.000000 -420.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x70045461,  6122, 0x00450162, 350, -430, -12, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Acid */

--- a/Database/Patches/6 LandBlockExtendedData/004D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/004D.sql
@@ -742,8 +742,8 @@ INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modifi
 VALUES (0x7004D15E, 0x7004D15F, '2021-11-01 00:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004D15F,  2131, 0x004D0590, 89.7738, -370.225, -12, -0.039774, 0, 0, -0.999209,  True, '2021-11-01 00:00:00'); /* Pressure Plate */
-/* @teleloc 0x004D0590 [89.773804 -370.225006 -12.000000] -0.039774 0.000000 0.000000 -0.999209 */
+VALUES (0x7004D15F,  2131, 0x004D04A1, 89.7738, -370.225, -12, -0.039774, 0, 0, -0.999209,  True, '2023-04-10 10:36:12'); /* Pressure Plate */
+/* @teleloc 0x004D04A1 [89.773804 -370.225006 -12.000000] -0.039774 0.000000 0.000000 -0.999209 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7004D160, 24170, 0x004D0584, 75.132, -357.213, -9.476, -0.989997, 0, 0, -0.141087, False, '2021-11-01 00:00:00'); /* Lightning Trap */
@@ -760,8 +760,8 @@ INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modifi
 VALUES (0x7004D161, 0x7004D162, '2021-11-01 00:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004D162,  2131, 0x004D0584, 80.4911, -359.963, -12, -0.728916, 0, 0, -0.684603,  True, '2021-11-01 00:00:00'); /* Pressure Plate */
-/* @teleloc 0x004D0584 [80.491096 -359.963013 -12.000000] -0.728916 0.000000 0.000000 -0.684603 */
+VALUES (0x7004D162,  2131, 0x004D0445, 80.4911, -359.963, -12, -0.728916, 0, 0, -0.684603,  True, '2023-04-10 10:36:12'); /* Pressure Plate */
+/* @teleloc 0x004D0445 [80.491096 -359.963013 -12.000000] -0.728916 0.000000 0.000000 -0.684603 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7004D163, 24170, 0x004D058E, 87.0993, -345.142, -9.47599, -0.787444, 0, 0, -0.616386,  True, '2021-11-01 00:00:00'); /* Lightning Trap */
@@ -778,8 +778,8 @@ INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modifi
 VALUES (0x7004D164, 0x7004D163, '2021-11-01 00:00:00') /* Lightning Trap (24170) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004D165,  2131, 0x004D058E, 90.1124, -350.825, -12, -0.999924, 0, 0, 0.012294,  True, '2021-11-01 00:00:00'); /* Pressure Plate */
-/* @teleloc 0x004D058E [90.112396 -350.825012 -12.000000] -0.999924 0.000000 0.000000 0.012294 */
+VALUES (0x7004D165,  2131, 0x004D0491, 90.1124, -350.825, -12, -0.999924, 0, 0, 0.012294,  True, '2023-04-10 10:36:12'); /* Pressure Plate */
+/* @teleloc 0x004D0491 [90.112396 -350.825012 -12.000000] -0.999924 0.000000 0.000000 0.012294 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7004D166, 24170, 0x004D059B, 104.799, -356.945, -9.44499, -0.937115, 0, 0, 0.349021,  True, '2021-11-01 00:00:00'); /* Lightning Trap */
@@ -796,8 +796,8 @@ INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modifi
 VALUES (0x7004D167, 0x7004D166, '2021-11-01 00:00:00') /* Lightning Trap (24170) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7004D168,  2131, 0x004D059B, 99.186, -360.112, -12, -0.718588, 0, 0, 0.695436,  True, '2021-11-01 00:00:00'); /* Pressure Plate */
-/* @teleloc 0x004D059B [99.185997 -360.112000 -12.000000] -0.718588 0.000000 0.000000 0.695436 */
+VALUES (0x7004D168,  2131, 0x004D04D7, 99.186, -360.112, -12, -0.718588, 0, 0, 0.695436,  True, '2023-04-10 10:36:12'); /* Pressure Plate */
+/* @teleloc 0x004D04D7 [99.185997 -360.112000 -12.000000] -0.718588 0.000000 0.000000 0.695436 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7004D169, 25572, 0x004D0379, 98.5974, -359.851, -24, 0.72742, 0, 0, 0.686193, False, '2021-11-01 00:00:00'); /* Dispel All Trap */

--- a/Database/Patches/6 LandBlockExtendedData/005D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/005D.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x005D;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7005D3E8,  1154, 0x005D0101, 16.7485, -2.75706, -35.9955, -0.305701, 0, 0, -0.952128, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
-/* @teleloc 0x005D0101 [16.748501 -2.757060 -35.995499] -0.305701 0.000000 0.000000 -0.952128 */
+VALUES (0x7005D3E8,  1154, 0x005D0106, 16.7485, -2.75706, -35.9955, -0.305701, 0, 0, -0.952128, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator */
+/* @teleloc 0x005D0106 [16.748501 -2.757060 -35.995499] -0.305701 0.000000 0.000000 -0.952128 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7005D3E8, 0x7005D3E9, '2021-11-01 00:00:00') /* Harbinger (71239) */;

--- a/Database/Patches/6 LandBlockExtendedData/005F.sql
+++ b/Database/Patches/6 LandBlockExtendedData/005F.sql
@@ -324,8 +324,8 @@ VALUES (0x7005F043, 80089, 0x005F0216, 43.1135, -97.2422, 1.554, 1, 0, 0, 0, Fal
 /* @teleloc 0x005F0216 [43.113499 -97.242203 1.554000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7005F044, 80090, 0x005F01C8, 11.9422, -84.8439, 1.554, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Empty Plate */
-/* @teleloc 0x005F01C8 [11.942200 -84.843903 1.554000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7005F044, 80090, 0x005F01C4, 11.9422, -84.8439, 1.554, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Empty Plate */
+/* @teleloc 0x005F01C4 [11.942200 -84.843903 1.554000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7005F045, 80091, 0x005F020E, 43.0111, -82.2335, 1.554, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Empty Plate */

--- a/Database/Patches/6 LandBlockExtendedData/0096.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0096.sql
@@ -86,8 +86,8 @@ VALUES (0x70096000, 0x70096005, '2021-11-01 00:00:00') /* Insatiable Eater (2863
      , (0x70096000, 0x70096053, '2021-11-01 00:00:00') /* Insatiable Eater (28635) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70096001, 24129, 0x00960309, 83.105, -36.2565, -23.995, 0.004128, 0, 0, 0.999992, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 2 Min.) */
-/* @teleloc 0x00960309 [83.105003 -36.256500 -23.995001] 0.004128 0.000000 0.000000 0.999992 */
+VALUES (0x70096001, 24129, 0x00960308, 83.105, -36.2565, -23.995, 0.004128, 0, 0, 0.999992, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 2 Min.) */
+/* @teleloc 0x00960308 [83.105003 -36.256500 -23.995001] 0.004128 0.000000 0.000000 0.999992 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70096001, 0x70096054, '2021-11-01 00:00:00') /* Insatiable Eater (28848) */

--- a/Database/Patches/6 LandBlockExtendedData/00CB.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00CB.sql
@@ -109,8 +109,8 @@ VALUES (0x700CB0EB, 88308, 0x00CB01CA, 240, -310, -30, 0.707107, 0, 0, -0.707107
 /* @teleloc 0x00CB01CA [240.000000 -310.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700CB0EC, 88308, 0x00CB01CA, 180, -310, -30, 0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
-/* @teleloc 0x00CB01CA [180.000000 -310.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700CB0EC, 88308, 0x00CB0186, 180, -310, -30, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Falatacot Patrol Trap */
+/* @teleloc 0x00CB0186 [180.000000 -310.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700CB0ED, 88308, 0x00CB01D4, 260, -260, -30, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
@@ -121,8 +121,8 @@ VALUES (0x700CB0EE, 88308, 0x00CB01D1, 260, -230, -30, 0, 0, 0, -1, False, '2022
 /* @teleloc 0x00CB01D1 [260.000000 -230.000000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700CB0EF, 88308, 0x00CB01D9, 260, -290, -30, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
-/* @teleloc 0x00CB01D9 [260.000000 -290.000000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700CB0EF, 88308, 0x00CB01D8, 260, -290, -30, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Falatacot Patrol Trap */
+/* @teleloc 0x00CB01D8 [260.000000 -290.000000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700CB0F0, 88308, 0x00CB019B, 210, -210, -30, 0.707107, 0, 0, 0.707107, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
@@ -177,8 +177,8 @@ VALUES (0x700CB0FC, 88308, 0x00CB016A, 100, -80, -30, 1, 0, 0, 0, False, '2022-0
 /* @teleloc 0x00CB016A [100.000000 -80.000000 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700CB0FD, 88308, 0x00CB0162, 100, -20, -30, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
-/* @teleloc 0x00CB0162 [100.000000 -20.000000 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700CB0FD, 88308, 0x00CB0163, 100, -20, -30, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Falatacot Patrol Trap */
+/* @teleloc 0x00CB0163 [100.000000 -20.000000 -30.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700CB0FE, 88308, 0x00CB012D, 50, 0, -30, 0.707107, 0, 0, 0.707107, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
@@ -349,12 +349,12 @@ VALUES (0x700CB127, 88308, 0x00CB0242, 390, -60, -30, -1, 0, 0, 0, False, '2022-
 /* @teleloc 0x00CB0242 [390.000000 -60.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700CB128, 88308, 0x00CB0245, 390, -90, -30, -1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
-/* @teleloc 0x00CB0245 [390.000000 -90.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700CB128, 88308, 0x00CB0246, 390, -90, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Falatacot Patrol Trap */
+/* @teleloc 0x00CB0246 [390.000000 -90.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700CB129, 88308, 0x00CB023E, 390, -30, -30, -1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
-/* @teleloc 0x00CB023E [390.000000 -30.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700CB129, 88308, 0x00CB023F, 390, -30, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Falatacot Patrol Trap */
+/* @teleloc 0x00CB023F [390.000000 -30.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700CB12A, 88308, 0x00CB0209, 340, -10, -30, 0.707107, 0, 0, 0.707107, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
@@ -377,8 +377,8 @@ VALUES (0x700CB12E, 88308, 0x00CB0385, 340, -100, -12, 0.707107, 0, 0, -0.707107
 /* @teleloc 0x00CB0385 [340.000000 -100.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700CB12F, 88308, 0x00CB036C, 310, -100, -12, 0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */
-/* @teleloc 0x00CB036C [310.000000 -100.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700CB12F, 88308, 0x00CB0366, 310, -100, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Falatacot Patrol Trap */
+/* @teleloc 0x00CB0366 [310.000000 -100.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700CB130, 88308, 0x00CB0399, 370, -100, -12, 0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Falatacot Patrol Trap */

--- a/Database/Patches/6 LandBlockExtendedData/00E3.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00E3.sql
@@ -341,32 +341,32 @@ VALUES (0x700E3425,  6122, 0x00E3011B, 150, -220, -30, -1, 0, 0, 0, False, '2021
 /* @teleloc 0x00E3011B [150.000000 -220.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E3426,  6122, 0x00E3011B, 140, -220, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [140.000000 -220.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E3426,  6122, 0x00E30113, 140, -220, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E30113 [140.000000 -220.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E3427,  6122, 0x00E3011B, 130, -220, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [130.000000 -220.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E3427,  6122, 0x00E30107, 130, -220, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E30107 [130.000000 -220.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E3428,  6122, 0x00E3011B, 150, -210, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [150.000000 -210.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E3428,  6122, 0x00E3011A, 150, -210, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E3011A [150.000000 -210.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E3429,  6122, 0x00E3011B, 150, -200, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [150.000000 -200.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E3429,  6122, 0x00E30114, 150, -200, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E30114 [150.000000 -200.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E342A,  6122, 0x00E3011B, 140, -200, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [140.000000 -200.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E342A,  6122, 0x00E3010D, 140, -200, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E3010D [140.000000 -200.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E342B,  6122, 0x00E3011B, 130, -200, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [130.000000 -200.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E342B,  6122, 0x00E30100, 130, -200, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E30100 [130.000000 -200.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700E342C,  6122, 0x00E3011B, 130, -210, -30, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x00E3011B [130.000000 -210.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700E342C,  6122, 0x00E30106, 130, -210, -30, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Acid */
+/* @teleloc 0x00E30106 [130.000000 -210.000000 -30.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700E342D, 71274, 0x00E30198, 50, 1.8, -18, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Aste Soul Renderer's Chest */

--- a/Database/Patches/6 LandBlockExtendedData/00EA.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00EA.sql
@@ -783,16 +783,16 @@ VALUES (0x700EA1AE,  5625, 0x00EA0593, 20, -84.75, -6, 0, 0, 0, -1, False, '2021
 /* @teleloc 0x00EA0593 [20.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1AF,  5625, 0x00EA059C, 30, -84.75, -6, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA059C [30.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700EA1AF,  5625, 0x00EA059B, 30, -84.75, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA059B [30.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700EA1B0,  5625, 0x00EA042C, 84.75, -20, -30, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
 /* @teleloc 0x00EA042C [84.750000 -20.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1B1,  5625, 0x00EA042D, 84.75, -30, -30, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA042D [84.750000 -30.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1B1,  5625, 0x00EA042F, 84.75, -30, -30, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA042F [84.750000 -30.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700EA1B2,  5625, 0x00EA0450, 95.25, -30, -30, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
@@ -831,88 +831,88 @@ VALUES (0x700EA1BA,  5625, 0x00EA047C, 150, -84.75, -30, 0, 0, 0, -1, False, '20
 /* @teleloc 0x00EA047C [150.000000 -84.750000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1BB,  5625, 0x00EA0481, 160, -84.75, -30, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0481 [160.000000 -84.750000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700EA1BB,  5625, 0x00EA0483, 160, -84.75, -30, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0483 [160.000000 -84.750000 -30.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1BC,  5625, 0x00EA053A, 150, -84.75, -18, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA053A [150.000000 -84.750000 -18.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700EA1BC,  5625, 0x00EA053C, 150, -84.75, -18, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA053C [150.000000 -84.750000 -18.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1BD,  5625, 0x00EA053E, 150, -95.25, -18, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA053E [150.000000 -95.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700EA1BD,  5625, 0x00EA0540, 150, -95.25, -18, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0540 [150.000000 -95.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1BE,  5625, 0x00EA0546, 160, -95.25, -18, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0546 [160.000000 -95.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700EA1BE,  5625, 0x00EA0548, 160, -95.25, -18, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0548 [160.000000 -95.250000 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1BF,  5625, 0x00EA0542, 160, -84.75, -18, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0542 [160.000000 -84.750000 -18.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700EA1BF,  5625, 0x00EA0544, 160, -84.75, -18, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0544 [160.000000 -84.750000 -18.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C0,  5625, 0x00EA0602, 160, -84.75, -6, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0602 [160.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700EA1C0,  5625, 0x00EA0604, 160, -84.75, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0604 [160.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C1, 87108, 0x00EA05FA, 150, -84.75, -6, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Armory Door */
-/* @teleloc 0x00EA05FA [150.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x700EA1C1, 87108, 0x00EA05FC, 150, -84.75, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Armory Door */
+/* @teleloc 0x00EA05FC [150.000000 -84.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C2,  5625, 0x00EA05FE, 150, -95.25, -6, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA05FE [150.000000 -95.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700EA1C2,  5625, 0x00EA0600, 150, -95.25, -6, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0600 [150.000000 -95.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C3,  5625, 0x00EA0606, 160, -95.25, -6, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0606 [160.000000 -95.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700EA1C3,  5625, 0x00EA0608, 160, -95.25, -6, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0608 [160.000000 -95.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700EA1C4,  5625, 0x00EA0458, 95.25, -150, -30, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Door */
 /* @teleloc 0x00EA0458 [95.250000 -150.000000 -30.000000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C5, 87109, 0x00EA0448, 95.25, -160, -30, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Armory Door */
-/* @teleloc 0x00EA0448 [95.250000 -160.000000 -30.000000] 0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x700EA1C5, 87109, 0x00EA045B, 95.25, -160, -30, 0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Armory Door */
+/* @teleloc 0x00EA045B [95.250000 -160.000000 -30.000000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C6,  5625, 0x00EA0438, 84.75, -160, -30, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0438 [84.750000 -160.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1C6,  5625, 0x00EA043A, 84.75, -160, -30, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA043A [84.750000 -160.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C7,  5625, 0x00EA0435, 84.75, -150, -30, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0435 [84.750000 -150.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1C7,  5625, 0x00EA0437, 84.75, -150, -30, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0437 [84.750000 -150.000000 -30.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C8,  5625, 0x00EA051E, 95.25, -160, -18, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA051E [95.250000 -160.000000 -18.000000] 0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x700EA1C8,  5625, 0x00EA0520, 95.25, -160, -18, 0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0520 [95.250000 -160.000000 -18.000000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1C9,  5625, 0x00EA051B, 95.25, -150, -18, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA051B [95.250000 -150.000000 -18.000000] 0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x700EA1C9,  5625, 0x00EA051D, 95.25, -150, -18, 0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA051D [95.250000 -150.000000 -18.000000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1CA,  5625, 0x00EA0501, 84.75, -150, -18, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0501 [84.750000 -150.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1CA,  5625, 0x00EA0503, 84.75, -150, -18, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0503 [84.750000 -150.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1CB,  5625, 0x00EA0504, 84.75, -160, -18, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA0504 [84.750000 -160.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1CB,  5625, 0x00EA0506, 84.75, -160, -18, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA0506 [84.750000 -160.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1CC,  5625, 0x00EA05BF, 84.75, -150, -6, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA05BF [84.750000 -150.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1CC,  5625, 0x00EA05C1, 84.75, -150, -6, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA05C1 [84.750000 -150.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1CD,  5625, 0x00EA05C2, 84.75, -160, -6, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA05C2 [84.750000 -160.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x700EA1CD,  5625, 0x00EA05C4, 84.75, -160, -6, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA05C4 [84.750000 -160.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700EA1CE,  5625, 0x00EA05E6, 95.25, -160, -6, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */
 /* @teleloc 0x00EA05E6 [95.250000 -160.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1CF,  5625, 0x00EA05E1, 95.25, -150, -6, 0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA05E1 [95.250000 -150.000000 -6.000000] 0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x700EA1CF,  5625, 0x00EA05E3, 95.25, -150, -6, 0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA05E3 [95.250000 -150.000000 -6.000000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700EA1D0, 37452, 0x00EA058B, 11.2474, -92.5505, -5.971, -0.152224, 0, 0, -0.988346,  True, '2021-11-01 00:00:00'); /* Corrupted Dread */
@@ -963,8 +963,8 @@ VALUES (0x700EA1DB,  5625, 0x00EA05B8, 84.75, -30, -6, -0.707107, 0, 0, 0.707107
 /* @teleloc 0x00EA05B8 [84.750000 -30.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EA1DC,  5625, 0x00EA05B3, 84.75, -20, -6, -0.707107, 0, 0, 0.707107, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x00EA05B3 [84.750000 -20.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x700EA1DC,  5625, 0x00EA05B5, 84.75, -20, -6, -0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x00EA05B5 [84.750000 -20.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700EA1DD,  5625, 0x00EA05D7, 95.25, -20, -6, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */

--- a/Database/Patches/6 LandBlockExtendedData/00F1.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00F1.sql
@@ -400,12 +400,12 @@ VALUES (0x700F1431,  5624, 0x00F10457, 110, -105.162, -12, 1, 0, 0, 0, False, '2
 /* @teleloc 0x00F10457 [110.000000 -105.162003 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700F1432, 29935, 0x00F10495, 120, -90, -12, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Platform */
-/* @teleloc 0x00F10495 [120.000000 -90.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700F1432, 29935, 0x00F10358, 120, -90, -12, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Platform */
+/* @teleloc 0x00F10358 [120.000000 -90.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700F1433, 29935, 0x00F103EF, 100, -90, -12, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Platform */
-/* @teleloc 0x00F103EF [100.000000 -90.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700F1433, 29935, 0x00F10345, 100, -90, -12, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Platform */
+/* @teleloc 0x00F10345 [100.000000 -90.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700F1434,  5624, 0x00F103FD, 98.0581, -150, -12, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Door */

--- a/Database/Patches/6 LandBlockExtendedData/0139.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0139.sql
@@ -952,12 +952,12 @@ VALUES (0x701390DD,  5668, 0x0139038C, 129.91, -116.863, -17.5239, 0, 0, 0, -1, 
 /* @teleloc 0x0139038C [129.910004 -116.862999 -17.523899] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701390DE,   285, 0x01390399, 36.584, -63.0517, 1.266, -0.461749, 0, 0, -0.887011,  True, '2023-03-23 00:00:00'); /* Lever */
-/* @teleloc 0x01390399 [36.584000 -63.051701 1.266000] -0.461749 0.000000 0.000000 -0.887011 */
+VALUES (0x701390DE,   285, 0x01390398, 36.584, -63.0517, 1.266, -0.461749, 0, 0, -0.887011,  True, '2023-04-10 10:36:12'); /* Lever */
+/* @teleloc 0x01390398 [36.584000 -63.051701 1.266000] -0.461749 0.000000 0.000000 -0.887011 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701390DF,  7924, 0x01390399, 36.2867, -61.0705, 0, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x01390399 [36.286701 -61.070499 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x701390DF,  7924, 0x01390398, 36.2867, -61.0705, 0, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x01390398 [36.286701 -61.070499 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x701390DF, 0x70139005, '2023-03-23 00:00:00') /* Grave Rat (43166) */
@@ -1047,8 +1047,8 @@ VALUES (0x701390DF, 0x70139005, '2023-03-23 00:00:00') /* Grave Rat (43166) */
      , (0x701390DF, 0x701390D7, '2023-03-23 00:00:00') /* Banderling Smasher (43488) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701390E0,  7924, 0x01390399, 40.1373, -63.6676, 0, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x01390399 [40.137299 -63.667599 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x701390E0,  7924, 0x01390398, 40.1373, -63.6676, 0, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x01390398 [40.137299 -63.667599 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x701390E0, 0x70139000, '2023-03-23 00:00:00') /* Depraved Shadow (33634) */
@@ -1065,16 +1065,16 @@ VALUES (0x701390E0, 0x70139000, '2023-03-23 00:00:00') /* Depraved Shadow (33634
      , (0x701390E0, 0x701390DC, '2023-03-23 00:00:00') /* Zombie Mage (43162) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701390E1,  7924, 0x01390399, 43.6571, -60.9424, 0, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x01390399 [43.657101 -60.942402 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x701390E1,  7924, 0x01390398, 43.6571, -60.9424, 0, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x01390398 [43.657101 -60.942402 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701390E2,  5668, 0x01390399, 40, -57, 0, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Surface Portal */
-/* @teleloc 0x01390399 [40.000000 -57.000000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x701390E2,  5668, 0x01390398, 40, -57, 0, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Surface Portal */
+/* @teleloc 0x01390398 [40.000000 -57.000000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x701390E3,  7924, 0x01390399, 37.1457, -59.2867, 0.005, 0.62161, 0, 0, -0.783327, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x01390399 [37.145699 -59.286701 0.005000] 0.621610 0.000000 0.000000 -0.783327 */
+VALUES (0x701390E3,  7924, 0x01390398, 37.1457, -59.2867, 0.005, 0.62161, 0, 0, -0.783327, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x01390398 [37.145699 -59.286701 0.005000] 0.621610 0.000000 0.000000 -0.783327 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x701390E3, 0x70139046, '2023-03-23 00:00:00') /* Black Coral Golem (40144) */

--- a/Database/Patches/6 LandBlockExtendedData/013E.sql
+++ b/Database/Patches/6 LandBlockExtendedData/013E.sql
@@ -1,100 +1,100 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x013E;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E000,  5516, 0x013E0100, 30, -200, -18, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Surface Portal */
-/* @teleloc 0x013E0100 [30.000000 -200.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E000,  5516, 0x013E0278, 30, -200, -18, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Surface Portal */
+/* @teleloc 0x013E0278 [30.000000 -200.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E001,   568, 0x013E0102, 34.75, -200, -18, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E0102 [34.750000 -200.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E001,   568, 0x013E027A, 34.75, -200, -18, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E027A [34.750000 -200.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E002,  4139, 0x013E0106, 50, -202.162, -18, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E0106 [50.000000 -202.162003 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7013E002,  4139, 0x013E027E, 50, -202.162, -18, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E027E [50.000000 -202.162003 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7013E002, 0x7013E009, '2023-03-23 00:00:00') /* Lever (285) */
      , (0x7013E002, 0x7013E00E, '2023-03-23 00:00:00') /* Lever (2609) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E006,  4829, 0x013E0108, 53.638, -222.044, -18, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Sarcophagus */
-/* @teleloc 0x013E0108 [53.638000 -222.044006 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E006,  4829, 0x013E0280, 53.638, -222.044, -18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Sarcophagus */
+/* @teleloc 0x013E0280 [53.638000 -222.044006 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E009,   285, 0x013E0108, 49.526, -224.872, -16.4084, 0, 0, 0, -1,  True, '2023-03-23 00:00:00'); /* Lever */
-/* @teleloc 0x013E0108 [49.526001 -224.871994 -16.408400] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x7013E009,   285, 0x013E0280, 49.526, -224.872, -16.4084, 0, 0, 0, -1,  True, '2023-04-10 10:36:12'); /* Lever */
+/* @teleloc 0x013E0280 [49.526001 -224.871994 -16.408400] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E00A,   278, 0x013E010A, 55.25, -190, -18, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E010A [55.250000 -190.000000 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E00A,   278, 0x013E0282, 55.25, -190, -18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E0282 [55.250000 -190.000000 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E00E,  2609, 0x013E0146, 23.8778, -261.348, -12, 1, 0, 0, 0,  True, '2023-03-23 00:00:00'); /* Lever */
-/* @teleloc 0x013E0146 [23.877800 -261.347992 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7013E00E,  2609, 0x013E02C9, 23.8778, -261.348, -12, 1, 0, 0, 0,  True, '2023-04-10 10:36:12'); /* Lever */
+/* @teleloc 0x013E02C9 [23.877800 -261.347992 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E00F,   269, 0x013E0148, 34.8944, -127.468, -10.63, 0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Button */
-/* @teleloc 0x013E0148 [34.894402 -127.468002 -10.630000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E00F,   269, 0x013E02CB, 34.8944, -127.468, -10.63, 0.707107, 0, 0, -0.707107,  True, '2023-04-10 10:36:12'); /* Button */
+/* @teleloc 0x013E02CB [34.894402 -127.468002 -10.630000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E014,   269, 0x013E016A, 36.1457, -128.24, -10.629, -0.997549, 0, 0, -0.069973,  True, '2023-03-23 00:00:00'); /* Button */
-/* @teleloc 0x013E016A [36.145699 -128.240005 -10.629000] -0.997549 0.000000 0.000000 -0.069973 */
+VALUES (0x7013E014,   269, 0x013E02ED, 36.1457, -128.24, -10.629, -0.997549, 0, 0, -0.069973,  True, '2023-04-10 10:36:12'); /* Button */
+/* @teleloc 0x013E02ED [36.145699 -128.240005 -10.629000] -0.997549 0.000000 0.000000 -0.069973 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E015,  2179, 0x013E016A, 35.2978, -130.003, -12, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E016A [35.297798 -130.003006 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E015,  2179, 0x013E02ED, 35.2978, -130.003, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E02ED [35.297798 -130.003006 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7013E015, 0x7013E00F, '2023-03-23 00:00:00') /* Button (269) */
      , (0x7013E015, 0x7013E014, '2023-03-23 00:00:00') /* Button (269) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E017,   278, 0x013E0185, 39.9974, -185.207, -12, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E0185 [39.997398 -185.207001 -12.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x7013E017,   278, 0x013E0308, 39.9974, -185.207, -12, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E0308 [39.997398 -185.207001 -12.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E01E,  2131, 0x013E01F7, 70.1785, -266.754, -12, 0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Pressure Plate */
-/* @teleloc 0x013E01F7 [70.178497 -266.753998 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E01E,  2131, 0x013E037A, 70.1785, -266.754, -12, 0.707107, 0, 0, -0.707107,  True, '2023-04-10 10:36:12'); /* Pressure Plate */
+/* @teleloc 0x013E037A [70.178497 -266.753998 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E01F,  2131, 0x013E01FA, 69.9456, -278.16, -12, -0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Pressure Plate */
-/* @teleloc 0x013E01FA [69.945602 -278.160004 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E01F,  2131, 0x013E037D, 69.9456, -278.16, -12, -0.707107, 0, 0, -0.707107,  True, '2023-04-10 10:36:12'); /* Pressure Plate */
+/* @teleloc 0x013E037D [69.945602 -278.160004 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7013E026, 72956, 0x013E0201, 80, -200, -11.9975, -0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Skeleton Noble */
 /* @teleloc 0x013E0201 [80.000000 -200.000000 -11.997500] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E027,   146, 0x013E0201, 83.1811, -202.27, -12, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Coffin */
-/* @teleloc 0x013E0201 [83.181099 -202.270004 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E027,   146, 0x013E0387, 83.1811, -202.27, -12, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Coffin */
+/* @teleloc 0x013E0387 [83.181099 -202.270004 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E028,  4832, 0x013E0201, 83.2476, -197.304, -12, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Sarcophagus */
-/* @teleloc 0x013E0201 [83.247597 -197.304001 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E028,  4832, 0x013E0387, 83.2476, -197.304, -12, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Sarcophagus */
+/* @teleloc 0x013E0387 [83.247597 -197.304001 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7013E029, 72956, 0x013E0249, 69.1479, -159.854, -5.9975, -0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Skeleton Noble */
 /* @teleloc 0x013E0249 [69.147903 -159.854004 -5.997500] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E02B,   278, 0x013E024B, 65.25, -160, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E024B [65.250000 -160.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E02B,   278, 0x013E03D5, 65.25, -160, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E03D5 [65.250000 -160.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E02C,   278, 0x013E024E, 65.25, -170, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E024E [65.250000 -170.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E02C,   278, 0x013E03D8, 65.25, -170, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E03D8 [65.250000 -170.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E02E,   278, 0x013E0251, 65.25, -180, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x013E0251 [65.250000 -180.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E02E,   278, 0x013E03DB, 65.25, -180, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x013E03DB [65.250000 -180.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E032,  5516, 0x013E028B, 42.7385, -162.713, 0, -0.923879, 0, 0, -0.382684, False, '2023-03-23 00:00:00'); /* Surface Portal */
-/* @teleloc 0x013E028B [42.738499 -162.712997 0.000000] -0.923879 0.000000 0.000000 -0.382684 */
+VALUES (0x7013E032,  5516, 0x013E0415, 42.7385, -162.713, 0, -0.923879, 0, 0, -0.382684, False, '2023-04-10 10:36:12'); /* Surface Portal */
+/* @teleloc 0x013E0415 [42.738499 -162.712997 0.000000] -0.923879 0.000000 0.000000 -0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E033,  4873, 0x013E0108, 46.4045, -222.651, -18, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Sarcophagus */
-/* @teleloc 0x013E0108 [46.404499 -222.651001 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E033,  4873, 0x013E0280, 46.4045, -222.651, -18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Sarcophagus */
+/* @teleloc 0x013E0280 [46.404499 -222.651001 -18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7013E034,  5656, 0x013E0108, 51.8302, -222.537, -17.995, -0.996703, 0, 0, -0.081131,  True, '2023-03-23 00:00:00'); /* Lord Kelannik */
@@ -233,16 +233,16 @@ VALUES (0x7013E055, 72956, 0x013E01F1, 73.7229, -223.785, -11.995, -0.470868, 0,
 /* @teleloc 0x013E01F1 [73.722900 -223.785004 -11.995000] -0.470868 0.000000 0.000000 -0.882204 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E056, 72962, 0x013E01FA, 69.9225, -279.747, -10.9194, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Lightning Trap */
-/* @teleloc 0x013E01FA [69.922501 -279.747009 -10.919400] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E056, 72962, 0x013E037D, 69.9225, -279.747, -10.9194, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Lightning Trap */
+/* @teleloc 0x013E037D [69.922501 -279.747009 -10.919400] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7013E056, 0x7013E01E, '2023-03-23 00:00:00') /* Pressure Plate (2131) */
      , (0x7013E056, 0x7013E01F, '2023-03-23 00:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E057,  4867, 0x013E01FA, 70.0011, -283.14, -12, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Sarcophagus */
-/* @teleloc 0x013E01FA [70.001099 -283.140015 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7013E057,  4867, 0x013E037D, 70.0011, -283.14, -12, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Sarcophagus */
+/* @teleloc 0x013E037D [70.001099 -283.140015 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7013E058, 72956, 0x013E01FA, 72.0775, -276.783, -11.9975, -0.995644, 0, 0, -0.09324,  True, '2023-03-23 00:00:00'); /* Skeleton Noble */
@@ -257,8 +257,8 @@ VALUES (0x7013E05A, 43162, 0x013E01FF, 83.026, -126.491, -11.9925, 0, 0, 0, -1, 
 /* @teleloc 0x013E01FF [83.026001 -126.490997 -11.992500] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E05B,  4812, 0x013E0200, 82.7181, -129.863, -12, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Sarcophagus */
-/* @teleloc 0x013E0200 [82.718102 -129.863007 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7013E05B,  4812, 0x013E0383, 82.7181, -129.863, -12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Sarcophagus */
+/* @teleloc 0x013E0383 [82.718102 -129.863007 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7013E05C, 72956, 0x013E0200, 80.5274, -129.615, -11.995, 0.732476, 0, 0, 0.680793,  True, '2023-03-23 00:00:00'); /* Skeleton Noble */
@@ -317,8 +317,8 @@ VALUES (0x7013E069, 72956, 0x013E026E, 30.001, -125.213, 0.005, -0.004204, 0, 0,
 /* @teleloc 0x013E026E [30.000999 -125.212997 0.005000] -0.004204 0.000000 0.000000 -0.999991 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E06A,  7924, 0x013E0275, 28.4986, -149.635, 0, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x013E0275 [28.498600 -149.634995 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7013E06A,  7924, 0x013E03FF, 28.4986, -149.635, 0, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x013E03FF [28.498600 -149.634995 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7013E06A, 0x7013E026, '2023-03-23 00:00:00') /* Skeleton Noble (72956) */
@@ -379,8 +379,8 @@ VALUES (0x7013E06A, 0x7013E026, '2023-03-23 00:00:00') /* Skeleton Noble (72956)
      , (0x7013E06A, 0x7013E075, '2023-03-23 00:00:00') /* Skeleton Noble (72956) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7013E06B,  7923, 0x013E0275, 31.6303, -149.398, 0.005, 0.026424, 0, 0, 0.999651, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 3 Min.) */
-/* @teleloc 0x013E0275 [31.630301 -149.397995 0.005000] 0.026424 0.000000 0.000000 0.999651 */
+VALUES (0x7013E06B,  7923, 0x013E03FF, 31.6303, -149.398, 0.005, 0.026424, 0, 0, 0.999651, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x013E03FF [31.630301 -149.397995 0.005000] 0.026424 0.000000 0.000000 0.999651 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7013E06B, 0x7013E034, '2023-03-23 00:00:00') /* Lord Kelannik (5656) */

--- a/Database/Patches/6 LandBlockExtendedData/018E.sql
+++ b/Database/Patches/6 LandBlockExtendedData/018E.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x018E;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7018E000, 24129, 0x018E037A, 26.721, -149.887, -5.995, 0.713819, 0, 0, -0.70033, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 2 Min.) */
-/* @teleloc 0x018E037A [26.721001 -149.886993 -5.995000] 0.713819 0.000000 0.000000 -0.700330 */
+VALUES (0x7018E000, 24129, 0x018E024C, 26.721, -149.887, -5.995, 0.713819, 0, 0, -0.70033, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 2 Min.) */
+/* @teleloc 0x018E024C [26.721001 -149.886993 -5.995000] 0.713819 0.000000 0.000000 -0.700330 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7018E000, 0x7018E021, '2021-11-01 00:00:00') /* Frenzied Fiun (28644) */

--- a/Database/Patches/6 LandBlockExtendedData/0193.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0193.sql
@@ -277,8 +277,8 @@ VALUES (0x7019302F,  2571, 0x01930141, 0.090277, -49.9466, 0.005, 0.706652, 0, 0
 /* @teleloc 0x01930141 [0.090277 -49.946602 0.005000] 0.706652 0.000000 0.000000 -0.707562 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70193030,  1350, 0x01930119, 1.88466, -38.3127, 0, 0.72575, 0, 0, -0.687958, False, '2021-11-01 00:00:00'); /* Granite Golem Generator */
-/* @teleloc 0x01930119 [1.884660 -38.312698 0.000000] 0.725750 0.000000 0.000000 -0.687958 */
+VALUES (0x70193030,  1350, 0x01930140, 1.88466, -38.3127, 0, 0.72575, 0, 0, -0.687958, False, '2023-04-10 10:36:12'); /* Granite Golem Generator */
+/* @teleloc 0x01930140 [1.884660 -38.312698 0.000000] 0.725750 0.000000 0.000000 -0.687958 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x70193031,  2572, 0x01930102, 60.0376, -39.9981, -11.995, -0.689373, 0, 0, -0.724406,  True, '2021-11-01 00:00:00'); /* K'nath D'Nob */
@@ -353,8 +353,8 @@ VALUES (0x70193042,  2571, 0x01930161, 60.2732, -20.0641, 0.005, -0.701877, 0, 0
 /* @teleloc 0x01930161 [60.273201 -20.064100 0.005000] -0.701877 0.000000 0.000000 -0.712298 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70193043,  1350, 0x01930146, 75.25, -20, 0, -0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Granite Golem Generator */
-/* @teleloc 0x01930146 [75.250000 -20.000000 0.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70193043,  1350, 0x0193016D, 75.25, -20, 0, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Granite Golem Generator */
+/* @teleloc 0x0193016D [75.250000 -20.000000 0.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x70193044, 31226, 0x01930119, 371.763, -30.0863, -11.995, -0.719537, 0, 0, 0.694454,  True, '2021-11-01 00:00:00'); /* Runic Skull */

--- a/Database/Patches/6 LandBlockExtendedData/0284.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0284.sql
@@ -1,0 +1,283 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x0284;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284000, 11480, 0x02840100, 240.973, -143.718, -23.995, 0.674841, 0, 0, 0.737963,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840100 [240.973007 -143.718002 -23.995001] 0.674841 0.000000 0.000000 0.737963 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284001, 11727, 0x02840103, 254.932, -135.605, -23.995, -0.559649, 0, 0, -0.82873,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840103 [254.932007 -135.604996 -23.995001] -0.559649 0.000000 0.000000 -0.828730 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284002, 11480, 0x0284010D, 126.388, -120.581, -17.995, -0.56367, 0, 0, -0.826,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284010D [126.388000 -120.581001 -17.995001] -0.563670 0.000000 0.000000 -0.826000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284003,  5627, 0x02840116, 135.003, -120.005, -17.995, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x02840116 [135.003006 -120.004997 -17.995001] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284004, 11480, 0x0284010F, 132.91, -140.728, -17.9729, 0.825336, 0, 0, -0.564642,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284010F [132.910004 -140.727997 -17.972900] 0.825336 0.000000 0.000000 -0.564642 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284005,  5627, 0x0284010F, 134.972, -140.101, -17.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284010F [134.972000 -140.100998 -17.995001] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284006, 11480, 0x02840112, 143.602, -108.816, -17.995, -0.462927, 0, 0, -0.886396,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840112 [143.602005 -108.816002 -17.995001] -0.462927 0.000000 0.000000 -0.886396 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284007, 11480, 0x02840118, 141.935, -137.983, -17.995, 0.941027, 0, 0, 0.338332,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840118 [141.934998 -137.983002 -17.995001] 0.941027 0.000000 0.000000 0.338332 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284008,  5627, 0x02840121, 154.018, -120.068, -17.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840121 [154.018005 -120.068001 -17.995001] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284009,  5627, 0x02840125, 154.958, -130.105, -17.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840125 [154.957993 -130.104996 -17.995001] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028400A,  5627, 0x02840128, 154.943, -139.89, -17.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840128 [154.942993 -139.889999 -17.995001] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028400B,  5627, 0x0284012B, 155.294, -109.986, -17.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284012B [155.294006 -109.986000 -17.995001] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028400C, 11480, 0x02840131, 159.656, -129.502, -17.995, -0.739283, 0, 0, -0.673395,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840131 [159.656006 -129.501999 -17.995001] -0.739283 0.000000 0.000000 -0.673395 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028400D,  5627, 0x0284013C, 160.065, -155.4, -17.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284013C [160.065002 -155.399994 -17.995001] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028400E, 11480, 0x0284013C, 160.054, -157.072, -17.995, 0.999687, 0, 0, 0.024997,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284013C [160.054001 -157.072006 -17.995001] 0.999687 0.000000 0.000000 0.024997 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028400F,  4219, 0x0284013C, 158.815, -157.048, -17.995, -0.999965, 0, 0, 0.008408, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+/* @teleloc 0x0284013C [158.815002 -157.048004 -17.995001] -0.999965 0.000000 0.000000 0.008408 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7028400F, 0x70284004, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x7028400F, 0x7028400E, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284010, 11480, 0x02840140, 171.377, -140.705, -17.995, -0.992516, 0, 0, -0.122118,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840140 [171.376999 -140.705002 -17.995001] -0.992516 0.000000 0.000000 -0.122118 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284011,  5627, 0x02840149, 184.014, -129.994, -17.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840149 [184.014008 -129.994003 -17.995001] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284012, 11480, 0x0284014D, 192.896, -118.744, -17.1378, -0.323361, 0, 0, -0.946276,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284014D [192.895996 -118.744003 -17.137800] -0.323361 0.000000 0.000000 -0.946276 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284013, 11480, 0x0284014F, 188.489, -130.325, -17.995, -0.795518, 0, 0, -0.60593,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284014F [188.488998 -130.324997 -17.995001] -0.795518 0.000000 0.000000 -0.605930 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284014, 11480, 0x02840151, 202.98, -125.648, -17.995, -0.665775, 0, 0, -0.746153,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840151 [202.979996 -125.648003 -17.995001] -0.665775 0.000000 0.000000 -0.746153 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284015, 11480, 0x02840151, 201.443, -132.776, -16.2254, -0.897814, 0, 0, -0.440375,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840151 [201.442993 -132.776001 -16.225401] -0.897814 0.000000 0.000000 -0.440375 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284016, 11480, 0x02840153, 212.726, -132.105, -17.995, 0.789135, 0, 0, 0.61422,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840153 [212.725998 -132.104996 -17.995001] 0.789135 0.000000 0.000000 0.614220 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284017, 11480, 0x02840156, 221.388, -139.851, -17.995, -0.710619, 0, 0, -0.703577,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840156 [221.388000 -139.850998 -17.995001] -0.710619 0.000000 0.000000 -0.703577 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284018,  5624, 0x02840162, 89.9865, -84.6815, -11.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840162 [89.986504 -84.681503 -11.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284019, 11480, 0x02840164, 89.5934, -90.0676, -11.995, -0.997759, 0, 0, 0.066915,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840164 [89.593399 -90.067596 -11.995000] -0.997759 0.000000 0.000000 0.066915 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028401A, 11480, 0x02840164, 92.5697, -92.4834, -11.995, -0.999665, 0, 0, -0.025895,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840164 [92.569702 -92.483398 -11.995000] -0.999665 0.000000 0.000000 -0.025895 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028401B,  5624, 0x0284016C, 105.263, -89.9947, -11.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284016C [105.263000 -89.994698 -11.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028401C,  5624, 0x0284016E, 124.704, -59.9811, -11.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284016E [124.704002 -59.981098 -11.995000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028401D, 11480, 0x0284017E, 121.859, -110.238, -11.995, -0.967378, 0, 0, -0.253337,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284017E [121.859001 -110.237999 -11.995000] -0.967378 0.000000 0.000000 -0.253337 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028401E, 11480, 0x02840188, 129.92, -56.2884, -11.995, 0.52849, 0, 0, 0.848939,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840188 [129.919998 -56.288399 -11.995000] 0.528490 0.000000 0.000000 0.848939 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028401F, 11480, 0x02840189, 130.04, -65.7903, -11.995, 0.989658, 0, 0, 0.143449,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840189 [130.039993 -65.790298 -11.995000] 0.989658 0.000000 0.000000 0.143449 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284020,  5624, 0x0284018A, 129.966, -75.2823, -11.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284018A [129.966003 -75.282303 -11.995000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284021, 10852, 0x02840193, 130.184, -109.085, -11.995, 0.174347, 0, 0, -0.984684, False, '2005-02-09 10:00:00'); /* Surface Exit */
+/* @teleloc 0x02840193 [130.184006 -109.084999 -11.995000] 0.174347 0.000000 0.000000 -0.984684 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284022,  5625, 0x02840195, 129.982, -114.78, -11.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840195 [129.981995 -114.779999 -11.995000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284023,  5625, 0x02840196, 125.275, -109.911, -11.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840196 [125.275002 -109.911003 -11.995000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284024,  5625, 0x02840197, 134.645, -109.96, -11.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840197 [134.645004 -109.959999 -11.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284025,  5625, 0x02840198, 130.073, -105.254, -11.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840198 [130.072998 -105.253998 -11.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284026, 11480, 0x0284019F, 136.682, -49.8841, -11.995, -0.13988, 0, 0, -0.990168,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284019F [136.682007 -49.884102 -11.995000] -0.139880 0.000000 0.000000 -0.990168 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284027, 11480, 0x028401A5, 138.411, -108.573, -11.995, -0.044699, 0, 0, 0.999,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x028401A5 [138.410995 -108.572998 -11.995000] -0.044699 0.000000 0.000000 0.999000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284028,  5624, 0x028401BC, 54.7263, -30.0021, -5.995, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x028401BC [54.726299 -30.002100 -5.995000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284029,  5624, 0x028401BE, 54.7749, -50.015, -5.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x028401BE [54.774899 -50.014999 -5.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028402A, 11480, 0x028401C1, 59.1551, -29.0628, -5.995, -0.746041, 0, 0, -0.665901,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x028401C1 [59.155102 -29.062799 -5.995000] -0.746041 0.000000 0.000000 -0.665901 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028402B, 11480, 0x028401C3, 59.4115, -48.9821, -5.995, -0.680623, 0, 0, -0.732634,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x028401C3 [59.411499 -48.982101 -5.995000] -0.680623 0.000000 0.000000 -0.732634 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028402C, 11480, 0x028401DA, 78.8004, -39.1087, -5.995, -0.677744, 0, 0, -0.735298,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x028401DA [78.800400 -39.108700 -5.995000] -0.677744 0.000000 0.000000 -0.735298 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028402D, 11480, 0x028401DF, 80.9507, -61.5055, -5.995, -0.995793, 0, 0, 0.091628,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x028401DF [80.950699 -61.505501 -5.995000] -0.995793 0.000000 0.000000 0.091628 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028402E,  5624, 0x028401E0, 79.9952, -65.3029, -5.995, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x028401E0 [79.995201 -65.302902 -5.995000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028402F, 11480, 0x028401F8, 102.251, -41.6397, -5.995, -0.407786, 0, 0, -0.913078,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x028401F8 [102.250999 -41.639702 -5.995000] -0.407786 0.000000 0.000000 -0.913078 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284030,  5624, 0x028401FC, 105.28, -40.0055, -5.995, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x028401FC [105.279999 -40.005501 -5.995000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284031, 10852, 0x0284020B, 1.92769, -18.5332, 0.005, -0.608528, 0, 0, -0.793533, False, '2005-02-09 10:00:00'); /* Surface Exit */
+/* @teleloc 0x0284020B [1.927690 -18.533199 0.005000] -0.608528 0.000000 0.000000 -0.793533 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284032,  5625, 0x0284020D, 4.74832, -20.0148, 0.005, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0284020D [4.748320 -20.014799 0.005000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284033,  5625, 0x02840213, 19.9666, -4.66261, 0.005, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840213 [19.966600 -4.662610 0.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284034,  7924, 0x02840215, 19.6033, -18.6585, 0.005, -0.65779, 0, 0, -0.753201, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x02840215 [19.603300 -18.658501 0.005000] -0.657790 0.000000 0.000000 -0.753201 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70284034, 0x70284019, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028401A, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028401E, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028401F, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x70284026, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028402A, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028402B, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028402C, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028402D, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028402F, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x70284035, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x70284038, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028403A, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284034, 0x7028403B, '2005-02-09 10:00:00') /* Olthoi Harvester (11727) */
+     , (0x70284034, 0x7028403C, '2005-02-09 10:00:00') /* Olthoi Harvester (11727) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284035, 11480, 0x0284022F, 49.7621, -27.3995, 0.005, -0.938369, 0, 0, -0.345635,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284022F [49.762100 -27.399500 0.005000] -0.938369 0.000000 0.000000 -0.345635 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284036,  7932, 0x02840215, 21.2405, -17.977, 0.005, 0.057536, 0, 0, -0.998343, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 4 Min.) */
+/* @teleloc 0x02840215 [21.240499 -17.976999 0.005000] 0.057536 0.000000 0.000000 -0.998343 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70284036, 0x70284000, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284001, '2005-02-09 10:00:00') /* Olthoi Harvester (11727) */
+     , (0x70284036, 0x70284002, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284006, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284007, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x7028400C, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284010, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284012, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284013, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284014, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284015, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284016, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284017, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x7028401D, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */
+     , (0x70284036, 0x70284027, '2005-02-09 10:00:00') /* Olthoi Harvester (11480) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284037,  5624, 0x02840217, 20.0221, -35.2487, 0.005, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840217 [20.022100 -35.248699 0.005000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284038, 11480, 0x02840222, 27.8, -48.0974, 0.005, -0.915378, 0, 0, 0.402596,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840222 [27.799999 -48.097401 0.005000] -0.915378 0.000000 0.000000 0.402596 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70284039,  5624, 0x02840223, 35.243, -19.9811, 0.005, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x02840223 [35.243000 -19.981100 0.005000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028403A, 11480, 0x0284022D, 50.6088, -24.7961, 0.005, 0.546983, 0, 0, 0.837144,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x0284022D [50.608799 -24.796101 0.005000] 0.546983 0.000000 0.000000 0.837144 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028403B, 11727, 0x02840101, 244.443, -147.629, -23.995, -0.731546, 0, 0, -0.681792,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840101 [244.442993 -147.628998 -23.995001] -0.731546 0.000000 0.000000 -0.681792 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7028403C, 11727, 0x02840101, 239.174, -148.78, -23.995, -0.889197, 0, 0, -0.457524,  True, '2005-02-09 10:00:00'); /* Olthoi Harvester */
+/* @teleloc 0x02840101 [239.173996 -148.779999 -23.995001] -0.889197 0.000000 0.000000 -0.457524 */

--- a/Database/Patches/6 LandBlockExtendedData/039D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/039D.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x039D;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7039D000,  7924, 0x039D02A2, 110, -35, 47.937, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x039D02A2 [110.000000 -35.000000 47.937000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7039D000,  7924, 0x039D029C, 110, -35, 47.937, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x039D029C [110.000000 -35.000000 47.937000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7039D000, 0x7039D004, '2021-11-01 00:00:00') /* Ravenous Eater (28637) */

--- a/Database/Patches/6 LandBlockExtendedData/536D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/536D.sql
@@ -60,24 +60,24 @@ VALUES (0x7536D00D,   278, 0x536D0143, 130, -154.755, -42, 0, 0, 0, -1, False, '
 /* @teleloc 0x536D0143 [130.000000 -154.755005 -42.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D00E,   278, 0x536D01BF, 105.25, -100, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01BF [105.250000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D00E,   278, 0x536D023F, 105.25, -100, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D023F [105.250000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D00F, 15301, 0x536D01C4, 110, -134.3, -6, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Bookcase */
-/* @teleloc 0x536D01C4 [110.000000 -134.300003 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x7536D00F, 15301, 0x536D0244, 110, -134.3, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Bookcase */
+/* @teleloc 0x536D0244 [110.000000 -134.300003 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7536D00F, 0x7536D010, '2023-03-23 00:00:00') /* Tome (15302) */
      , (0x7536D00F, 0x7536D021, '2023-03-23 00:00:00') /* Candle (14468) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D010, 15302, 0x536D01C4, 106, -129, -6, 0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Tome */
-/* @teleloc 0x536D01C4 [106.000000 -129.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D010, 15302, 0x536D0244, 106, -129, -6, 0.707107, 0, 0, -0.707107,  True, '2023-04-10 10:36:12'); /* Tome */
+/* @teleloc 0x536D0244 [106.000000 -129.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D011,  7925, 0x536D01C4, 109.996, -130.155, -5.995, -0.054177, 0, 0, -0.998531, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 10 Min.) */
-/* @teleloc 0x536D01C4 [109.996002 -130.154999 -5.995000] -0.054177 0.000000 0.000000 -0.998531 */
+VALUES (0x7536D011,  7925, 0x536D0244, 109.996, -130.155, -5.995, -0.054177, 0, 0, -0.998531, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 10 Min.) */
+/* @teleloc 0x536D0244 [109.996002 -130.154999 -5.995000] -0.054177 0.000000 0.000000 -0.998531 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7536D011, 0x7536D001, '2023-03-23 00:00:00') /* Essa Sclavus (2585) */
@@ -97,68 +97,68 @@ VALUES (0x7536D011, 0x7536D001, '2023-03-23 00:00:00') /* Essa Sclavus (2585) */
      , (0x7536D011, 0x7536D028, '2023-03-23 00:00:00') /* Aste Sclavus (2584) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D012,   278, 0x536D01CB, 124.75, -100, -6, -0.707107, 0, 0, 0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01CB [124.750000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x7536D012,   278, 0x536D024B, 124.75, -100, -6, -0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D024B [124.750000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D013,   278, 0x536D01CC, 115.25, -100, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01CC [115.250000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D013,   278, 0x536D024C, 115.25, -100, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D024C [115.250000 -100.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D014,   278, 0x536D01CD, 120, -104.75, -6, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01CD [120.000000 -104.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x7536D014,   278, 0x536D024D, 120, -104.75, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D024D [120.000000 -104.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D015,   278, 0x536D01DE, 130, -85.25, -6, -1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01DE [130.000000 -85.250000 -6.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7536D015,   278, 0x536D025E, 130, -85.25, -6, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D025E [130.000000 -85.250000 -6.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D016,   278, 0x536D01E5, 130, -134.75, -6, 0, 0, 0, 1, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01E5 [130.000000 -134.750000 -6.000000] 0.000000 0.000000 0.000000 1.000000 */
+VALUES (0x7536D016,   278, 0x536D0265, 130, -134.75, -6, 0, 0, 0, 1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D0265 [130.000000 -134.750000 -6.000000] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D017,   278, 0x536D01EC, 144.75, -90, -6, -0.707107, 0, 0, 0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01EC [144.750000 -90.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x7536D017,   278, 0x536D026C, 144.75, -90, -6, -0.707107, 0, 0, 0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D026C [144.750000 -90.000000 -6.000000] -0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D018,   278, 0x536D01ED, 135.25, -90, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01ED [135.250000 -90.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D018,   278, 0x536D026D, 135.25, -90, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D026D [135.250000 -90.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D019,   278, 0x536D01EE, 140, -94.75, -6, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01EE [140.000000 -94.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x7536D019,   278, 0x536D026E, 140, -94.75, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D026E [140.000000 -94.750000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D01A,   278, 0x536D01F8, 135.25, -120, -6, -0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01F8 [135.250000 -120.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D01A,   278, 0x536D0278, 135.25, -120, -6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D0278 [135.250000 -120.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D01B,   278, 0x536D01F9, 144.75, -120, -6, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01F9 [144.750000 -120.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D01B,   278, 0x536D0279, 144.75, -120, -6, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D0279 [144.750000 -120.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D01C,   278, 0x536D01FA, 140, -115.25, -6, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D01FA [140.000000 -115.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7536D01C,   278, 0x536D027A, 140, -115.25, -6, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D027A [140.000000 -115.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D01D,  5624, 0x536D0203, 150, -115, -6, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D0203 [150.000000 -115.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x7536D01D,  5624, 0x536D0283, 150, -115, -6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D0283 [150.000000 -115.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D01E,   278, 0x536D0207, 154.75, -120, -6, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D0207 [154.750000 -120.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D01E,   278, 0x536D0287, 154.75, -120, -6, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D0287 [154.750000 -120.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D01F, 15276, 0x536D0209, 152.454, -130.038, -5.995, -0.684709, 0, 0, 0.728817, False, '2023-03-23 00:00:00'); /* Nuhmudira's Mansion */
-/* @teleloc 0x536D0209 [152.453995 -130.037994 -5.995000] -0.684709 0.000000 0.000000 0.728817 */
+VALUES (0x7536D01F, 15276, 0x536D0289, 152.454, -130.038, -5.995, -0.684709, 0, 0, 0.728817, False, '2023-04-10 10:36:12'); /* Nuhmudira's Mansion */
+/* @teleloc 0x536D0289 [152.453995 -130.037994 -5.995000] -0.684709 0.000000 0.000000 0.728817 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D020,   568, 0x536D020B, 145.25, -130.013, -6, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x536D020B [145.250000 -130.013000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7536D020,   568, 0x536D028B, 145.25, -130.013, -6, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x536D028B [145.250000 -130.013000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7536D021, 14468, 0x536D01B8, 109.486, -151.562, -13.5, 1, 0, 0, 0,  True, '2023-03-23 00:00:00'); /* Candle */
-/* @teleloc 0x536D01B8 [109.486000 -151.561996 -13.500000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7536D021, 14468, 0x536D0236, 109.486, -151.562, -13.5, 1, 0, 0, 0,  True, '2023-04-10 10:36:12'); /* Candle */
+/* @teleloc 0x536D0236 [109.486000 -151.561996 -13.500000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7536D022,  2583, 0x536D0105, 104.125, -160.604, -41.995, 0.666333, 0, 0, -0.745655,  True, '2023-03-23 00:00:00'); /* Se Sclavus */

--- a/Database/Patches/6 LandBlockExtendedData/576F.sql
+++ b/Database/Patches/6 LandBlockExtendedData/576F.sql
@@ -53,8 +53,8 @@ VALUES (0x7576F06A, 72371, 0x576F021E, 40.7936, -82.3361, 6.44101, 0.007017, 0, 
 /* @teleloc 0x576F021E [40.793598 -82.336098 6.441010] 0.007017 0.000000 0.000000 -0.999975 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7576F06B, 72377, 0x576F010F, 35, -85, -23.945, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Twisted Refuge Booter Gen */
-/* @teleloc 0x576F010F [35.000000 -85.000000 -23.945000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7576F06B, 72377, 0x576F0109, 35, -85, -23.945, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Twisted Refuge Booter Gen */
+/* @teleloc 0x576F0109 [35.000000 -85.000000 -23.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7576F06C, 72388, 0x576F021E, 39.2814, -82.321, 6.44101, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door Reset Stopgap Gen */

--- a/Database/Patches/6 LandBlockExtendedData/7202.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7202.sql
@@ -480,8 +480,8 @@ VALUES (0x772020B0, 10762, 0x720202C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x720202C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x772020B1, 15274, 0x72020134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x72020134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x772020B1, 15274, 0x72020133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x72020133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x772020B1, 0x77202091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/7203.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7203.sql
@@ -480,8 +480,8 @@ VALUES (0x772030B0, 10762, 0x720302C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x720302C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x772030B1, 15274, 0x72030134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x72030134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x772030B1, 15274, 0x72030133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x72030133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x772030B1, 0x77203091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/7302.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7302.sql
@@ -480,8 +480,8 @@ VALUES (0x773020B0, 10762, 0x730202C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x730202C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x773020B1, 15274, 0x73020134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x73020134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x773020B1, 15274, 0x73020133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x73020133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x773020B1, 0x77302091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/7303.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7303.sql
@@ -480,8 +480,8 @@ VALUES (0x773030B0, 10762, 0x730302C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x730302C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x773030B1, 15274, 0x73030134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x73030134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x773030B1, 15274, 0x73030133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x73030133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x773030B1, 0x77303091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/7F03.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7F03.sql
@@ -479,8 +479,8 @@ VALUES (0x77F030AF, 10762, 0x7F0302C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x7F0302C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x77F030B0, 15274, 0x7F030134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x7F030134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x77F030B0, 15274, 0x7F030133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x7F030133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x77F030B0, 0x77F03091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/7F04.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7F04.sql
@@ -479,8 +479,8 @@ VALUES (0x77F040AF, 10762, 0x7F0402C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x7F0402C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x77F040B0, 15274, 0x7F040134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x7F040134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x77F040B0, 15274, 0x7F040133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x7F040133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x77F040B0, 0x77F04091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/8003.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8003.sql
@@ -479,8 +479,8 @@ VALUES (0x780030AF, 10762, 0x800302C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x800302C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x780030B0, 15274, 0x80030134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x80030134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x780030B0, 15274, 0x80030133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x80030133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x780030B0, 0x78003091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/8603.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8603.sql
@@ -479,8 +479,8 @@ VALUES (0x786030A9, 10762, 0x860302C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x860302C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x786030AA, 15274, 0x86030134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x86030134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x786030AA, 15274, 0x86030133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x86030133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x786030AA, 0x7860308B, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/8604.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8604.sql
@@ -479,8 +479,8 @@ VALUES (0x786040A9, 10762, 0x860402C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x860402C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x786040AA, 15274, 0x86040134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x86040134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x786040AA, 15274, 0x86040133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x86040133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x786040AA, 0x7860408B, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/8703.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8703.sql
@@ -479,8 +479,8 @@ VALUES (0x787030A9, 10762, 0x870302C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x870302C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x787030AA, 15274, 0x87030134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x87030134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x787030AA, 15274, 0x87030133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x87030133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x787030AA, 0x7870308B, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/8A04.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8A04.sql
@@ -1,76 +1,76 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x8A04;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04001,   278, 0x8A040110, 24.75, -60, 0, 0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040110 [24.750000 -60.000000 0.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04001,   278, 0x8A040111, 24.75, -60, 0, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040111 [24.750000 -60.000000 0.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04002,   278, 0x8A040110, 15.2237, -60.06, 0, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040110 [15.223700 -60.060001 0.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04002,   278, 0x8A040111, 15.2237, -60.06, 0, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040111 [15.223700 -60.060001 0.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04004,   278, 0x8A040112, 20, -55.25, 0, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040112 [20.000000 -55.250000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04004,   278, 0x8A040113, 20, -55.25, 0, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040113 [20.000000 -55.250000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04006,   278, 0x8A040113, 20, -74.75, 0, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040113 [20.000000 -74.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04006,   278, 0x8A040114, 20, -74.75, 0, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040114 [20.000000 -74.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04007,   278, 0x8A040115, 20, -94.75, 0, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040115 [20.000000 -94.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04007,   278, 0x8A040116, 20, -94.75, 0, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040116 [20.000000 -94.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04009,   278, 0x8A040123, 40, -54.75, 0, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040123 [40.000000 -54.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04009,   278, 0x8A040124, 40, -54.75, 0, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040124 [40.000000 -54.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0400C,   278, 0x8A040178, 70, -115.245, 0, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040178 [70.000000 -115.245003 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A0400C,   278, 0x8A040179, 70, -115.245, 0, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040179 [70.000000 -115.245003 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0400D,   568, 0x8A0401D5, 5.254, -100, 6, 0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0401D5 [5.254000 -100.000000 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0400D,   568, 0x8A040180, 5.254, -100, 6, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040180 [5.254000 -100.000000 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0400E,   278, 0x8A0401DF, 20, -65.25, 6, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0401DF [20.000000 -65.250000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A0400E,   278, 0x8A040187, 20, -65.25, 6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040187 [20.000000 -65.250000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0400F,   278, 0x8A0401E6, 20, -114.75, 6, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0401E6 [20.000000 -114.750000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A0400F,   278, 0x8A04018E, 20, -114.75, 6, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A04018E [20.000000 -114.750000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04010,   278, 0x8A0401F0, 30, -65.25, 6, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0401F0 [30.000000 -65.250000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04010,   278, 0x8A040197, 30, -65.25, 6, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040197 [30.000000 -65.250000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04011,   278, 0x8A0401F7, 30, -114.75, 6, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0401F7 [30.000000 -114.750000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04011,   278, 0x8A04019E, 30, -114.75, 6, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A04019E [30.000000 -114.750000 6.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04012,   278, 0x8A0401FF, 44.75, -80, 6, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0401FF [44.750000 -80.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04012,   278, 0x8A0401A5, 44.75, -80, 6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A0401A5 [44.750000 -80.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04013,   278, 0x8A040203, 44.75, -100, 6, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040203 [44.750000 -100.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04013,   278, 0x8A0401A9, 44.75, -100, 6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A0401A9 [44.750000 -100.000000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A04014,  1296, 0x8A040220, 80, -68, 6, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Door */
 /* @teleloc 0x8A040220 [80.000000 -68.000000 6.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04015,  1387, 0x8A04023D, 106.781, -89.8029, 6.005, -0.54128, 0, 0, -0.840843, False, '2022-08-03 04:23:55'); /* Merchant */
-/* @teleloc 0x8A04023D [106.780998 -89.802902 6.005000] -0.541280 0.000000 0.000000 -0.840843 */
+VALUES (0x78A04015,  1387, 0x8A0401D5, 106.781, -89.8029, 6.005, -0.54128, 0, 0, -0.840843, False, '2023-04-10 10:36:12'); /* Merchant */
+/* @teleloc 0x8A0401D5 [106.780998 -89.802902 6.005000] -0.541280 0.000000 0.000000 -0.840843 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04016,   174, 0x8A040258, 172.606, -112.184, 6, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Well */
-/* @teleloc 0x8A040258 [172.606003 -112.183998 6.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04016,   174, 0x8A0401D6, 172.606, -112.184, 6, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Well */
+/* @teleloc 0x8A0401D6 [172.606003 -112.183998 6.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04017,   794, 0x8A040259, 171.656, -117.047, 9.34375, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Apple Generator */
-/* @teleloc 0x8A040259 [171.656006 -117.046997 9.343750] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04017,   794, 0x8A0401D7, 171.656, -117.047, 9.34375, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Apple Generator */
+/* @teleloc 0x8A0401D7 [171.656006 -117.046997 9.343750] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A04018,  2566, 0x8A04025B, 177.507, -122.888, 6, 0, 0, 0, -1,  True, '2022-08-03 04:23:55'); /* Black Rabbit */
@@ -81,36 +81,36 @@ VALUES (0x78A04019,  2566, 0x8A04025B, 176.195, -123.988, 6, 0.74613, 0, 0, -0.6
 /* @teleloc 0x8A04025B [176.195007 -123.987999 6.000000] 0.746130 0.000000 0.000000 -0.665800 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0401A,  4980, 0x8A04025B, 178.214, -120.7, 6.05, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Refreshing Fountain */
-/* @teleloc 0x8A04025B [178.214005 -120.699997 6.050000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A0401A,  4980, 0x8A0401D9, 178.214, -120.7, 6.05, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Refreshing Fountain */
+/* @teleloc 0x8A0401D9 [178.214005 -120.699997 6.050000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0401B,   152, 0x8A04025C, 190.555, -117.069, 6, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Font */
-/* @teleloc 0x8A04025C [190.554993 -117.069000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0401B,   152, 0x8A0401DA, 190.555, -117.069, 6, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Font */
+/* @teleloc 0x8A0401DA [190.554993 -117.069000 6.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A0401D,   278, 0x8A04027F, 110, -65.151, 12, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Door */
 /* @teleloc 0x8A04027F [110.000000 -65.151001 12.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0401E,  1387, 0x8A040293, 121.095, -82.4068, 12.005, 0.992842, 0, 0, -0.119433, False, '2022-08-03 04:23:55'); /* Merchant */
-/* @teleloc 0x8A040293 [121.095001 -82.406799 12.005000] 0.992842 0.000000 0.000000 -0.119433 */
+VALUES (0x78A0401E,  1387, 0x8A040212, 121.095, -82.4068, 12.005, 0.992842, 0, 0, -0.119433, False, '2023-04-10 10:36:12'); /* Merchant */
+/* @teleloc 0x8A040212 [121.095001 -82.406799 12.005000] 0.992842 0.000000 0.000000 -0.119433 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0401F,   278, 0x8A040295, 124.75, -80, 12, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040295 [124.750000 -80.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0401F,   278, 0x8A040214, 124.75, -80, 12, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040214 [124.750000 -80.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04020,   568, 0x8A040296, 120, -84.75, 12, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040296 [120.000000 -84.750000 12.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04020,   568, 0x8A040215, 120, -84.75, 12, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040215 [120.000000 -84.750000 12.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A04021,   278, 0x8A0402B6, 135.25, -100, 12, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
 /* @teleloc 0x8A0402B6 [135.250000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04023,  7923, 0x8A0402C7, 160, -90, 12, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Linkable Monster Generator ( 3 Min.) */
-/* @teleloc 0x8A0402C7 [160.000000 -90.000000 12.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04023,  7923, 0x8A040243, 160, -90, 12, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x8A040243 [160.000000 -90.000000 12.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x78A04023, 0x78A04018, '2022-08-03 04:23:55') /* Black Rabbit (2566) */
@@ -118,76 +118,76 @@ VALUES (0x78A04023, 0x78A04018, '2022-08-03 04:23:55') /* Black Rabbit (2566) */
      , (0x78A04023, 0x78A04026, '2022-08-03 04:23:55') /* Russet Rat (4132) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04024,   165, 0x8A0402C8, 160, -100, 12.05, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Pool */
-/* @teleloc 0x8A0402C8 [160.000000 -100.000000 12.050000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04024,   165, 0x8A040244, 160, -100, 12.05, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Pool */
+/* @teleloc 0x8A040244 [160.000000 -100.000000 12.050000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04025,  1912, 0x8A0402D0, 168.38, -86.0268, 12, -1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Chest */
-/* @teleloc 0x8A0402D0 [168.380005 -86.026802 12.000000] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04025,  1912, 0x8A04024C, 168.38, -86.0268, 12, -1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Chest */
+/* @teleloc 0x8A04024C [168.380005 -86.026802 12.000000] -1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A04026,  4132, 0x8A0402D0, 173.335, -86.6571, 12.01, -0.273225, 0, 0, -0.96195,  True, '2022-08-03 04:23:55'); /* Russet Rat */
 /* @teleloc 0x8A0402D0 [173.335007 -86.657097 12.010000] -0.273225 0.000000 0.000000 -0.961950 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04027,   278, 0x8A0402D2, 174.755, -90, 12, 0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0402D2 [174.755005 -90.000000 12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04027,   278, 0x8A04024E, 174.755, -90, 12, 0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A04024E [174.755005 -90.000000 12.000000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04028,   153, 0x8A0402D3, 170, -100, 12, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Fountain */
-/* @teleloc 0x8A0402D3 [170.000000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04028,   153, 0x8A04024F, 170, -100, 12, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Fountain */
+/* @teleloc 0x8A04024F [170.000000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04029,   278, 0x8A0402D5, 174.75, -100, 12, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0402D5 [174.750000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04029,   278, 0x8A040251, 174.75, -100, 12, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040251 [174.750000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0402A,   568, 0x8A0402D6, 165.25, -100, 12, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0402D6 [165.250000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0402A,   568, 0x8A040252, 165.25, -100, 12, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040252 [165.250000 -100.000000 12.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0402B,  1296, 0x8A0402FF, 124.75, -70, 18, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A0402FF [124.750000 -70.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0402B,  1296, 0x8A04026E, 124.75, -70, 18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A04026E [124.750000 -70.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0402C,  1296, 0x8A040303, 124.75, -90, 18, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040303 [124.750000 -90.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0402C,  1296, 0x8A040272, 124.75, -90, 18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A040272 [124.750000 -90.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0402D,   568, 0x8A040331, 165.25, -100, 18, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040331 [165.250000 -100.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0402D,   568, 0x8A04029A, 165.25, -100, 18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A04029A [165.250000 -100.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0402E,  1301, 0x8A040332, 165.25, -110, 18, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040332 [165.250000 -110.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A0402E,  1301, 0x8A04029B, 165.25, -110, 18, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A04029B [165.250000 -110.000000 18.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0402F,   278, 0x8A040337, 170, -115.25, 18, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040337 [170.000000 -115.250000 18.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A0402F,   278, 0x8A0402A0, 170, -115.25, 18, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A0402A0 [170.000000 -115.250000 18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04030,   143, 0x8A04033D, 177.167, -124.05, 18.0125, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Chest */
-/* @teleloc 0x8A04033D [177.167007 -124.050003 18.012501] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04030,   143, 0x8A0402A6, 177.167, -124.05, 18.0125, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Chest */
+/* @teleloc 0x8A0402A6 [177.167007 -124.050003 18.012501] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04031,   278, 0x8A04033F, 180, -115.245, 18, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A04033F [180.000000 -115.245003 18.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04031,   278, 0x8A0402A8, 180, -115.245, 18, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A0402A8 [180.000000 -115.245003 18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04032,   143, 0x8A040346, 186.087, -121.753, 18.0125, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Chest */
-/* @teleloc 0x8A040346 [186.087006 -121.752998 18.012501] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78A04032,   143, 0x8A0402AF, 186.087, -121.753, 18.0125, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Chest */
+/* @teleloc 0x8A0402AF [186.087006 -121.752998 18.012501] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04033,   278, 0x8A040348, 190, -115.245, 18, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A040348 [190.000000 -115.245003 18.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A04033,   278, 0x8A0402B1, 190, -115.245, 18, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A0402B1 [190.000000 -115.245003 18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04034,   165, 0x8A04039A, 178.17, -97.9414, 24.05, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Pool */
-/* @teleloc 0x8A04039A [178.169998 -97.941399 24.049999] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04034,   165, 0x8A0402DE, 178.17, -97.9414, 24.05, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Pool */
+/* @teleloc 0x8A0402DE [178.169998 -97.941399 24.049999] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A04035,   278, 0x8A04039C, 180, -104.75, 24, 0, 0, 0, -1, False, '2022-08-03 04:23:55'); /* Door */
-/* @teleloc 0x8A04039C [180.000000 -104.750000 24.000000] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x78A04035,   278, 0x8A0402E0, 180, -104.75, 24, 0, 0, 0, -1, False, '2023-04-10 10:36:12'); /* Door */
+/* @teleloc 0x8A0402E0 [180.000000 -104.750000 24.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A04038, 15759, 0x8A04021D, 130, -73, 12, -0.707107, 0, 0, -0.707107, False, '2022-08-03 04:23:55'); /* Linkable Item Generator */
@@ -211,12 +211,12 @@ VALUES (0x78A0403B, 69988, 0x8A04021D, 125.7, -72, 13, -0.707107, 0, 0, -0.70710
 /* @teleloc 0x8A04021D [125.699997 -72.000000 13.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0403C, 42818, 0x8A0401F0, 100, -25, 12, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Portal to Cragstone */
-/* @teleloc 0x8A0401F0 [100.000000 -25.000000 12.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A0403C, 42818, 0x8A0401ED, 100, -25, 12, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Portal to Cragstone */
+/* @teleloc 0x8A0401ED [100.000000 -25.000000 12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78A0403D, 42846, 0x8A040210, 120, -25, 12, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Portal to Hebian-To */
-/* @teleloc 0x8A040210 [120.000000 -25.000000 12.000000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x78A0403D, 42846, 0x8A04020F, 120, -25, 12, 1, 0, 0, 0, False, '2023-04-10 10:36:12'); /* Portal to Hebian-To */
+/* @teleloc 0x8A04020F [120.000000 -25.000000 12.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78A0403E, 42835, 0x8A040209, 120, -3, 12, 1, 0, 0, 0, False, '2022-08-03 04:23:55'); /* Portal to Sanamar */

--- a/Database/Patches/6 LandBlockExtendedData/8B03.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8B03.sql
@@ -17,8 +17,8 @@ VALUES (0x78B03003, 43202, 0x8B030333, 250, -106.305, -48.063, 1, 0, 0, 0, False
 /* @teleloc 0x8B030333 [250.000000 -106.305000 -48.063000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78B03004, 43202, 0x8B03010D, 166.357, -59.978, -114.063, -0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Surface */
-/* @teleloc 0x8B03010D [166.356995 -59.978001 -114.063004] -0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x78B03004, 43202, 0x8B030100, 166.357, -59.978, -114.063, -0.707107, 0, 0, -0.707107, False, '2023-04-10 10:36:12'); /* Surface */
+/* @teleloc 0x8B030100 [166.356995 -59.978001 -114.063004] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x78B03006, 43219, 0x8B03022D, 60.5365, -0.018513, -71.992, 0.694806, 0, 0, -0.719197,  True, '2022-01-08 18:29:57'); /* Subverted Silver Scope Knight */

--- a/Database/Patches/6 LandBlockExtendedData/8D02.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8D02.sql
@@ -479,8 +479,8 @@ VALUES (0x78D020AF, 10762, 0x8D0202C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x8D0202C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78D020B0, 15274, 0x8D020134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x8D020134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x78D020B0, 15274, 0x8D020133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x8D020133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x78D020B0, 0x78D02091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */

--- a/Database/Patches/6 LandBlockExtendedData/8E02.sql
+++ b/Database/Patches/6 LandBlockExtendedData/8E02.sql
@@ -479,8 +479,8 @@ VALUES (0x78E020AF, 10762, 0x8E0202C3, 119, -141, 0.005, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x8E0202C3 [119.000000 -141.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x78E020B0, 15274, 0x8E020134, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2021-11-01 00:00:00'); /* Linkable Monster Gen (1 min.) */
-/* @teleloc 0x8E020134 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
+VALUES (0x78E020B0, 15274, 0x8E020133, 119.849, -154.436, -5.995, 0.034997, 0, 0, 0.999387, False, '2023-04-10 10:36:12'); /* Linkable Monster Gen (1 min.) */
+/* @teleloc 0x8E020133 [119.848999 -154.436005 -5.995000] 0.034997 0.000000 0.000000 0.999387 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x78E020B0, 0x78E02091, '2021-11-01 00:00:00') /* Young Olthoi (29332) */


### PR DESCRIPTION
Some cellblocks were incorrectly placed, whether by error or the dungeons were shifted/re-indexed at some point. This fixes those errors. 

Note that was done automatically by the server in the WorldOject.AdjustDungeonCells function. This just takes those adjust positions and defines them in the database.

Below is the full listing of GUIDs that were moved for reference. Note that landblock 01e4 (North Glenden Prison) is not included here; this will be submitted separately as the content in the dungeon needs to be updated. By teleporting to the "Test Location", type /loc to confirm the new landblock. _e.g. @teleloc 0x001A0180 190 -100 0.005 will put you at 0x001A017D_ (use _/cloak on_ so you do not get moved when colliding with the object)

**Platinum Legion Keep (001a)**
_Test Location: @teleloc 0x001A0180 190 -100 0.005_
Linkable Monster Generator ( 3 Min.) - 0x7001A000 moved from 0x001A0180 to 0x001A017D
Door - 0x7001A001 moved from 0x001A01E9 to 0x001A01EA
Lever - 0x7001A00A moved from 0x001A0205 to 0x001A0206
Door - 0x7001A002 moved from 0x001A01FA to 0x001A01FB
Lever - 0x7001A00C moved from 0x001A02CE to 0x001A02CF
Door - 0x7001A003 moved from 0x001A02AE to 0x001A02AC
Torch - 0x7001A00B moved from 0x001A029D to 0x001A029E

**Dark Design (002d)**
_Test Location: @teleloc 0x002D0101 80 -230.051 -41.995_
Acid - 0x7002D3EE moved from 0x002D0101 to 0x002D0102

**Collegium Occultus (0044)**
_Test Location: @teleloc 0x00440201 70.113 -149.918 0.308_
Exit - 0x700443EB moved from 0x00440201 to 0x004401FE

**Temple of Stirring Shadows (0045)**
_Test Location: @teleloc 0x0045014A 320 -410 -12_
Acid - 0x70045456 moved from 0x0045014A to 0x00450127
Acid - 0x70045457 moved from 0x00450127 to 0x0045012D
Acid - 0x70045458 moved from 0x0045012D to 0x0045012E
Acid - 0x70045459 moved from 0x0045012E to 0x00450134
Acid - 0x7004545A moved from 0x00450144 to 0x0045013C
Acid - 0x7004545B moved from 0x0045013C to 0x00450144
Acid - 0x7004545C moved from 0x00450152 to 0x0045014A
Acid - 0x7004545D moved from 0x0045015A to 0x00450152
Acid - 0x7004545E moved from 0x0045015B to 0x0045015A
Acid - 0x7004545F moved from 0x00450161 to 0x0045015B
Acid - 0x70045460 moved from 0x0045015A to 0x00450161

**Eastern Temple Catacombs / Western Temple Catacombs (004d)**
_Test Location: @teleloc 0x004D0590 89.7738 -370.225 -12_
Pressure Plate - 0x7004D15F moved from 0x004D0590 to 0x004D04A1
Pressure Plate - 0x7004D162 moved from 0x004D0584 to 0x004D0445
Pressure Plate - 0x7004D165 moved from 0x004D058E to 0x004D0491
Pressure Plate - 0x7004D168 moved from 0x004D059B to 0x004D04D7

**Harbinger's Lair (005d)**
_Test Location: @teleloc 0x005D0101 16.7485 -2.75706 -35.9955_
Linkable Monster Generator - 0x7005D3E8 moved from 0x005D0101 to 0x005D0106

**Tanada House of Pancakes (005f)**
_Test Location: @teleloc 0x005F01C8 11.9422 -84.8439 1.554_
Empty Plate - 0x7005F044 moved from 0x005F01C8 to 0x005F01C4

**Insatiable Vault (0096)**
_Test Location: @teleloc 0x00960309 83.105 -36.2565 -23.995_
Linkable Monster Generator ( 2 Min.) - 0x70096001 moved from 0x00960309 to 0x00960308

**Pyramid (Kazyk Ri) / Pyramid (Minik Ra) / Pyramid (Nivinizk) (00cb)**
_Test Location: @teleloc 0x00CB01CA 180 -310 -30_
Falatacot Patrol Trap - 0x700CB0EC moved from 0x00CB01CA to 0x00CB0186
Falatacot Patrol Trap - 0x700CB0EF moved from 0x00CB01D9 to 0x00CB01D8
Falatacot Patrol Trap - 0x700CB0FD moved from 0x00CB0162 to 0x00CB0163
Falatacot Patrol Trap - 0x700CB128 moved from 0x00CB0245 to 0x00CB0246
Falatacot Patrol Trap - 0x700CB129 moved from 0x00CB023E to 0x00CB023F
Falatacot Patrol Trap - 0x700CB12F moved from 0x00CB036C to 0x00CB0366

**Sclavus Umbral Forge (00e3)**
_Test Location: @teleloc 0x00E3011B 140 -220 -30_
Acid - 0x700E3426 moved from 0x00E3011B to 0x00E30113
Acid - 0x700E3427 moved from 0x00E3011B to 0x00E30107
Acid - 0x700E3428 moved from 0x00E3011B to 0x00E3011A
Acid - 0x700E3429 moved from 0x00E3011B to 0x00E30114
Acid - 0x700E342A moved from 0x00E3011B to 0x00E3010D
Acid - 0x700E342B moved from 0x00E3011B to 0x00E30100
Acid - 0x700E342C moved from 0x00E3011B to 0x00E30106

**Mhoire Armory (Entrance) / Mhoire Armory (Return from Armory?) / Mhoire Armory (Return from Forges?) (00ea)**
_Test Location: @teleloc 0x00EA059C 30 -84.75 -6_
Door - 0x700EA1AF moved from 0x00EA059C to 0x00EA059B
Door - 0x700EA1B1 moved from 0x00EA042D to 0x00EA042F
Door - 0x700EA1BB moved from 0x00EA0481 to 0x00EA0483
Door - 0x700EA1BC moved from 0x00EA053A to 0x00EA053C
Door - 0x700EA1BD moved from 0x00EA053E to 0x00EA0540
Door - 0x700EA1BE moved from 0x00EA0546 to 0x00EA0548
Door - 0x700EA1BF moved from 0x00EA0542 to 0x00EA0544
Door - 0x700EA1C0 moved from 0x00EA0602 to 0x00EA0604
Armory Door - 0x700EA1C1 moved from 0x00EA05FA to 0x00EA05FC
Door - 0x700EA1C2 moved from 0x00EA05FE to 0x00EA0600
Door - 0x700EA1C3 moved from 0x00EA0606 to 0x00EA0608
Armory Door - 0x700EA1C5 moved from 0x00EA0448 to 0x00EA045B
Door - 0x700EA1C6 moved from 0x00EA0438 to 0x00EA043A
Door - 0x700EA1C7 moved from 0x00EA0435 to 0x00EA0437
Door - 0x700EA1C8 moved from 0x00EA051E to 0x00EA0520
Door - 0x700EA1C9 moved from 0x00EA051B to 0x00EA051D
Door - 0x700EA1CA moved from 0x00EA0501 to 0x00EA0503
Door - 0x700EA1CB moved from 0x00EA0504 to 0x00EA0506
Door - 0x700EA1CC moved from 0x00EA05BF to 0x00EA05C1
Door - 0x700EA1CD moved from 0x00EA05C2 to 0x00EA05C4
Door - 0x700EA1CF moved from 0x00EA05E1 to 0x00EA05E3
Door - 0x700EA1DC moved from 0x00EA05B3 to 0x00EA05B5

**Nightmare Gate (00f1)**
_Test Location: @teleloc 0x00F10495 120 -90 -12_
Platform - 0x700F1432 moved from 0x00F10495 to 0x00F10358
Platform - 0x700F1433 moved from 0x00F103EF to 0x00F10345

**Mage Academy (0139)**
_Test Location: @teleloc 0x01390399 36.584 -63.0517 1.266_
Lever - 0x701390DE moved from 0x01390399 to 0x01390398
Linkable Monster Generator ( 5 Min.) - 0x701390DF moved from 0x01390399 to 0x01390398
Linkable Monster Generator ( 5 Min.) - 0x701390E0 moved from 0x01390399 to 0x01390398
Linkable Monster Generator ( 5 Min.) - 0x701390E1 moved from 0x01390399 to 0x01390398
Surface Portal - 0x701390E2 moved from 0x01390399 to 0x01390398
Linkable Monster Generator ( 5 Min.) - 0x701390E3 moved from 0x01390399 to 0x01390398

**Burial Temple (013e)**
_Test Location: @teleloc 0x013E0100 30 -200 -18_
Surface Portal - 0x7013E000 moved from 0x013E0100 to 0x013E0278
Door - 0x7013E001 moved from 0x013E0102 to 0x013E027A
Door - 0x7013E002 moved from 0x013E0106 to 0x013E027E
Lever - 0x7013E009 moved from 0x013E0108 to 0x013E0280
Lever - 0x7013E00E moved from 0x013E0146 to 0x013E02C9
Sarcophagus - 0x7013E006 moved from 0x013E0108 to 0x013E0280
Door - 0x7013E00A moved from 0x013E010A to 0x013E0282
Door - 0x7013E015 moved from 0x013E016A to 0x013E02ED
Button - 0x7013E00F moved from 0x013E0148 to 0x013E02CB
Button - 0x7013E014 moved from 0x013E016A to 0x013E02ED
Door - 0x7013E017 moved from 0x013E0185 to 0x013E0308
Coffin - 0x7013E027 moved from 0x013E0201 to 0x013E0387
Sarcophagus - 0x7013E028 moved from 0x013E0201 to 0x013E0387
Door - 0x7013E02B moved from 0x013E024B to 0x013E03D5
Door - 0x7013E02C moved from 0x013E024E to 0x013E03D8
Door - 0x7013E02E moved from 0x013E0251 to 0x013E03DB
Surface Portal - 0x7013E032 moved from 0x013E028B to 0x013E0415
Sarcophagus - 0x7013E033 moved from 0x013E0108 to 0x013E0280
Lightning Trap - 0x7013E056 moved from 0x013E01FA to 0x013E037D
Pressure Plate - 0x7013E01E moved from 0x013E01F7 to 0x013E037A
Pressure Plate - 0x7013E01F moved from 0x013E01FA to 0x013E037D
Sarcophagus - 0x7013E057 moved from 0x013E01FA to 0x013E037D
Sarcophagus - 0x7013E05B moved from 0x013E0200 to 0x013E0383
Linkable Monster Generator ( 5 Min.) - 0x7013E06A moved from 0x013E0275 to 0x013E03FF
Linkable Monster Generator ( 3 Min.) - 0x7013E06B moved from 0x013E0275 to 0x013E03FF

**Abayar's Laboratory (018e)**
_Test Location: @teleloc 0x018E037A 26.721 -149.887 -5.995_
Linkable Monster Generator ( 2 Min.) - 0x7018E000 moved from 0x018E037A to 0x018E024C

**Greater K'nath Lair / K'nath Lair (0193)**
_Test Location: @teleloc 0x01930119 1.88466 -38.3127 0_
Granite Golem Generator - 0x70193030 moved from 0x01930119 to 0x01930140
Granite Golem Generator - 0x70193043 moved from 0x01930146 to 0x0193016D

**Commander's Quarters / North Glenden Prison (01e4)**
_Test Location: @teleloc 0x01E401A4 37.688 -13.6337 6.005_
Linkable Monster Generator ( 7 Min.) - 0x701E43E8 moved from 0x01E401A4 to 0x01E401FE
Item Scarab Generator - 0x701E43E9 moved from 0x01E40209 to 0x01E40263
Item Alchemical Generator - 0x701E43EA moved from 0x01E4019C to 0x01E401F6
Item Clothing Generator - 0x701E43EB moved from 0x01E4017C to 0x01E401D6
Item Food Generator - 0x701E43EC moved from 0x01E40149 to 0x01E401A3
Item Powder Generator - 0x701E43ED moved from 0x01E40132 to 0x01E4018C
Item Clothing Generator - 0x701E43EE moved from 0x01E40129 to 0x01E40183
Chest - 0x701E43EF moved from 0x01E40126 to 0x01E40180
Chest - 0x701E43F1 moved from 0x01E40132 to 0x01E4018C
Chest - 0x701E43F2 moved from 0x01E40132 to 0x01E4018C
Chest - 0x701E43F3 moved from 0x01E40149 to 0x01E401A3
Chest - 0x701E43F4 moved from 0x01E40158 to 0x01E401B2
Door - 0x701E43F5 moved from 0x01E40175 to 0x01E401CF
Chest - 0x701E43F6 moved from 0x01E4019C to 0x01E401F6
Surface - 0x701E43F7 moved from 0x01E401AC to 0x01E40206
Door - 0x701E43F8 moved from 0x01E401C4 to 0x01E4021E
Chest - 0x701E43F9 moved from 0x01E40209 to 0x01E40263

**Abandoned Tumerok Site (0284)**
_Test Location: @teleloc 0x0284010E 135.003 -120.005 -17.995_
Door - 0x70284003 moved from 0x0284010E to 0x02840116

**Ravenous Vault (039d)**
_Test Location: @teleloc 0x039D02A2 110 -35 47.937_
Linkable Monster Generator ( 5 Min.) - 0x7039D000 moved from 0x039D02A2 to 0x039D029C

**Nuhmudira's Dungeon (536d)**
_Test Location: @teleloc 0x536D01BF 105.25 -100 -6_
Door - 0x7536D00E moved from 0x536D01BF to 0x536D023F
Bookcase - 0x7536D00F moved from 0x536D01C4 to 0x536D0244
Tome - 0x7536D010 moved from 0x536D01C4 to 0x536D0244
Candle - 0x7536D021 moved from 0x536D01B8 to 0x536D0236
Linkable Monster Generator ( 10 Min.) - 0x7536D011 moved from 0x536D01C4 to 0x536D0244
Door - 0x7536D012 moved from 0x536D01CB to 0x536D024B
Door - 0x7536D013 moved from 0x536D01CC to 0x536D024C
Door - 0x7536D014 moved from 0x536D01CD to 0x536D024D
Door - 0x7536D015 moved from 0x536D01DE to 0x536D025E
Door - 0x7536D016 moved from 0x536D01E5 to 0x536D0265
Door - 0x7536D017 moved from 0x536D01EC to 0x536D026C
Door - 0x7536D018 moved from 0x536D01ED to 0x536D026D
Door - 0x7536D019 moved from 0x536D01EE to 0x536D026E
Door - 0x7536D01A moved from 0x536D01F8 to 0x536D0278
Door - 0x7536D01B moved from 0x536D01F9 to 0x536D0279
Door - 0x7536D01C moved from 0x536D01FA to 0x536D027A
Door - 0x7536D01D moved from 0x536D0203 to 0x536D0283
Door - 0x7536D01E moved from 0x536D0207 to 0x536D0287
Nuhmudira's Mansion - 0x7536D01F moved from 0x536D0209 to 0x536D0289
Door - 0x7536D020 moved from 0x536D020B to 0x536D028B

**Twisted Refuge (576f)**
_Test Location: @teleloc 0x576F010F 35 -85 -23.945_
Twisted Refuge Booter Gen - 0x7576F06B moved from 0x576F010F to 0x576F0109

**Tutorial Dungeon (7202)**
_Test Location: @teleloc 0x72020134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x772020B1 moved from 0x72020134 to 0x72020133

**Tutorial Dungeon (7203)**
_Test Location: @teleloc 0x72030134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x772030B1 moved from 0x72030134 to 0x72030133

**Tutorial Dungeon (7302)**
_Test Location: @teleloc 0x73020134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x773020B1 moved from 0x73020134 to 0x73020133

**Tutorial Dungeon (7303)**
_Test Location: @teleloc 0x73030134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x773030B1 moved from 0x73030134 to 0x73030133

**Tutorial Dungeon (7f03)**
_Test Location: @teleloc 0x7F030134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x77F030B0 moved from 0x7F030134 to 0x7F030133

**Tutorial Dungeon (7f04)**
_Test Location: @teleloc 0x7F040134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x77F040B0 moved from 0x7F040134 to 0x7F040133

**Tutorial Dungeon (8003)**
_Test Location: @teleloc 0x80030134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x780030B0 moved from 0x80030134 to 0x80030133

**Tutorial Dungeon (8603)**
_Test Location: @teleloc 0x86030134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x786030AA moved from 0x86030134 to 0x86030133

**Tutorial Dungeon (8604)**
_Test Location: @teleloc 0x86040134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x786040AA moved from 0x86040134 to 0x86040133

**Tutorial Dungeon (8703)**
_Test Location: @teleloc 0x87030134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x787030AA moved from 0x87030134 to 0x87030133

**Nightclub (8a04)**
_Test Location: @teleloc 0x8A040110 24.75 -60 0_
Door - 0x78A04001 moved from 0x8A040110 to 0x8A040111
Door - 0x78A04002 moved from 0x8A040110 to 0x8A040111
Door - 0x78A04004 moved from 0x8A040112 to 0x8A040113
Door - 0x78A04006 moved from 0x8A040113 to 0x8A040114
Door - 0x78A04007 moved from 0x8A040115 to 0x8A040116
Door - 0x78A04009 moved from 0x8A040123 to 0x8A040124
Door - 0x78A0400C moved from 0x8A040178 to 0x8A040179
Door - 0x78A0400D moved from 0x8A0401D5 to 0x8A040180
Door - 0x78A0400E moved from 0x8A0401DF to 0x8A040187
Door - 0x78A0400F moved from 0x8A0401E6 to 0x8A04018E
Door - 0x78A04010 moved from 0x8A0401F0 to 0x8A040197
Door - 0x78A04011 moved from 0x8A0401F7 to 0x8A04019E
Door - 0x78A04012 moved from 0x8A0401FF to 0x8A0401A5
Door - 0x78A04013 moved from 0x8A040203 to 0x8A0401A9
Merchant - 0x78A04015 moved from 0x8A04023D to 0x8A0401D5
Well - 0x78A04016 moved from 0x8A040258 to 0x8A0401D6
Apple Generator - 0x78A04017 moved from 0x8A040259 to 0x8A0401D7
Refreshing Fountain - 0x78A0401A moved from 0x8A04025B to 0x8A0401D9
Font - 0x78A0401B moved from 0x8A04025C to 0x8A0401DA
Merchant - 0x78A0401E moved from 0x8A040293 to 0x8A040212
Door - 0x78A0401F moved from 0x8A040295 to 0x8A040214
Door - 0x78A04020 moved from 0x8A040296 to 0x8A040215
Linkable Monster Generator ( 3 Min.) - 0x78A04023 moved from 0x8A0402C7 to 0x8A040243
Pool - 0x78A04024 moved from 0x8A0402C8 to 0x8A040244
Chest - 0x78A04025 moved from 0x8A0402D0 to 0x8A04024C
Door - 0x78A04027 moved from 0x8A0402D2 to 0x8A04024E
Fountain - 0x78A04028 moved from 0x8A0402D3 to 0x8A04024F
Door - 0x78A04029 moved from 0x8A0402D5 to 0x8A040251
Door - 0x78A0402A moved from 0x8A0402D6 to 0x8A040252
Door - 0x78A0402B moved from 0x8A0402FF to 0x8A04026E
Door - 0x78A0402C moved from 0x8A040303 to 0x8A040272
Door - 0x78A0402D moved from 0x8A040331 to 0x8A04029A
Door - 0x78A0402E moved from 0x8A040332 to 0x8A04029B
Door - 0x78A0402F moved from 0x8A040337 to 0x8A0402A0
Chest - 0x78A04030 moved from 0x8A04033D to 0x8A0402A6
Door - 0x78A04031 moved from 0x8A04033F to 0x8A0402A8
Chest - 0x78A04032 moved from 0x8A040346 to 0x8A0402AF
Door - 0x78A04033 moved from 0x8A040348 to 0x8A0402B1
Pool - 0x78A04034 moved from 0x8A04039A to 0x8A0402DE
Door - 0x78A04035 moved from 0x8A04039C to 0x8A0402E0
Portal to Cragstone - 0x78A0403C moved from 0x8A0401F0 to 0x8A0401ED
Portal to Hebian-To - 0x78A0403D moved from 0x8A040210 to 0x8A04020F

**Apostate Nexus (Scintillating)/Apostate Nexus (Shimmering)/Heart of the Apostate Nexi / Mysterious Portal (8b03)**
_Test Location: @teleloc 0x8B03010D 166.357 -59.978 -114.063_
Surface - 0x78B03004 moved from 0x8B03010D to 0x8B030100

**Tutorial Dungeon (8d02)**
_Test Location: @teleloc 0x8D020134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x78D020B0 moved from 0x8D020134 to 0x8D020133

**Tutorial Dungeon (8e02)**
_Test Location: @teleloc 0x8E020134 119.849 -154.436 -5.995_
Linkable Monster Gen (1 min.) - 0x78E020B0 moved from 0x8E020134 to 0x8E020133
