### PR TITLE
Rynthid Testing Fix Broken Reset

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/587A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/587A.sql
@@ -13,7 +13,7 @@ VALUES (0x7587A078, 52096, 0x587A01FD, 510, -114.75, 0, 1, 0, 0, 0, False, '2023
 /* @teleloc 0x587A01FD [510.000000 -114.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7587A079,  4219, 0x587A01A3, 443.803, -65.686, 0.0085, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+VALUES (0x7587A079,  7924, 0x587A01A3, 443.803, -65.686, 0.0085, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x587A01A3 [443.803009 -65.685997 0.008500] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -62,10 +62,14 @@ VALUES (0x7587A079, 0x7587A07A, '2023-03-23 00:00:00') /* Fiesty Mite (46705) */
      , (0x7587A079, 0x7587A0A7, '2023-03-23 00:00:00') /* Training Dummy (52085) */
      , (0x7587A079, 0x7587A0A8, '2023-03-23 00:00:00') /* Training Dummy (52086) */
      , (0x7587A079, 0x7587A0A9, '2023-03-23 00:00:00') /* Training Dummy (52085) */
-     , (0x7587A079, 0x7587A0DF, '2023-03-23 00:00:00') /* Gurog Bruiser (88145) */
-     , (0x7587A079, 0x7587A0E0, '2023-03-23 00:00:00') /* Gurog Bruiser (88145) */
      , (0x7587A079, 0x7587A0E1, '2023-03-23 00:00:00') /* Gurog Bruiser (88145) */
-     , (0x7587A079, 0x7587A0E2, '2023-03-23 00:00:00') /* Gurog Bruiser (88145) */;
+     , (0x7587A079, 0x7587A0E2, '2023-03-23 00:00:00') /* Gurog Bruiser (88145) */
+     , (0x7587A079, 0x7587A0EF, '2023-04-15 14:15:43') /* Gurog Bruiser (88145) */
+     , (0x7587A079, 0x7587A0F0, '2023-04-15 14:15:49') /* Gurog Bruiser (88145) */
+     , (0x7587A079, 0x7587A0F3, '2023-04-15 14:18:21') /* Gurog Bruiser (88145) */
+     , (0x7587A079, 0x7587A0F4, '2023-04-15 14:19:30') /* Gurog Bruiser (88145) */
+     , (0x7587A079, 0x7587A0F5, '2023-04-15 14:23:27') /* Gurog Bruiser (88145) */
+     , (0x7587A079, 0x7587A0F6, '2023-04-15 14:24:25') /* Gurog Bruiser (88145) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7587A07A, 46705, 0x587A01A3, 443.803, -65.686, 0.0085, 0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Fiesty Mite */
@@ -252,8 +256,8 @@ VALUES (0x7587A0AA,  1542, 0x587A0177, 328.7, -180, -0.063, 0.707107, 0, 0, -0.7
 /* @teleloc 0x587A0177 [328.700012 -180.000000 -0.063000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7587A0B0, 88100, 0x587A026B, 655.248, -90, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x587A026B [655.247986 -90.000000 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x7587A0B0, 88100, 0x587A026B, 655.248, -90, 0.055, 0.707107, 0, 0, 0.707107, False, '2023-03-23 00:00:00'); /* Door */
+/* @teleloc 0x587A026B [655.247986 -90.000000 0.055000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7587A0B1, 88100, 0x587A0260, 644.75, -50, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Door */
@@ -264,8 +268,8 @@ VALUES (0x7587A0B2, 88100, 0x587A014A, 209.998, -44.7519, 0.055, 1, 0, 0, 0, Fal
 /* @teleloc 0x587A014A [209.998001 -44.751900 0.055000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7587A0B3, 88100, 0x587A0270, 680, -64.75, 0.055, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Door */
-/* @teleloc 0x587A0270 [680.000000 -64.750000 0.055000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7587A0B3, 88100, 0x587A0270, 680, -64.75, 0.055, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Door */
+/* @teleloc 0x587A0270 [680.000000 -64.750000 0.055000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7587A0B4, 88100, 0x587A0150, 209.998, -94.75, 0.055, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Door */
@@ -416,14 +420,6 @@ VALUES (0x7587A0DD, 88112, 0x587A0179, 330.266, -310.003, 0.055, 0.707107, 0, 0,
 /* @teleloc 0x587A0179 [330.265991 -310.002991 0.055000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7587A0DF, 88145, 0x587A0166, 276.838, -209.705, 0.0065, 0.664115, 0, 0, 0.74763,  True, '2023-03-23 00:00:00'); /* Gurog Bruiser */
-/* @teleloc 0x587A0166 [276.838013 -209.705002 0.006500] 0.664115 0.000000 0.000000 0.747630 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7587A0E0, 88145, 0x587A016D, 309.685, -254.745, 0.0065, 0.992645, 0, 0, -0.121065,  True, '2023-03-23 00:00:00'); /* Gurog Bruiser */
-/* @teleloc 0x587A016D [309.684998 -254.744995 0.006500] 0.992645 0.000000 0.000000 -0.121065 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7587A0E1, 88145, 0x587A0129, 129.831, -230.123, 0.0065, -0.633624, 0, 0, -0.773641,  True, '2023-03-23 00:00:00'); /* Gurog Bruiser */
 /* @teleloc 0x587A0129 [129.830994 -230.123001 0.006500] -0.633624 0.000000 0.000000 -0.773641 */
 
@@ -464,8 +460,8 @@ VALUES (0x7587A0EB, 88155, 0x587A0271, 679.893, -68.8304, 0.055, 0.031352, 0, 0,
 /* @teleloc 0x587A0271 [679.893005 -68.830399 0.055000] 0.031352 0.000000 0.000000 -0.999508 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7587A0EC, 88155, 0x587A0262, 648.608, -50.3146, 0.055, -0.707107, 0, 0, 0.707107, False, '2023-03-23 00:00:00'); /* Drudge Test Master Generator */
-/* @teleloc 0x587A0262 [648.607971 -50.314602 0.055000] -0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x7587A0EC, 88155, 0x587A0262, 649.608, -50.3146, 0.055, 0.707107, 0, 0, -0.707107, False, '2023-03-23 00:00:00'); /* Drudge Test Master Generator */
+/* @teleloc 0x587A0262 [649.607971 -50.314602 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7587A0ED, 88111, 0x587A0252, 629.795, -19.9711, 0.055, 0, 0, 0, 1, False, '2023-03-23 00:00:00'); /* Rynthid Test 2 Portal Generator */
@@ -474,3 +470,27 @@ VALUES (0x7587A0ED, 88111, 0x587A0252, 629.795, -19.9711, 0.055, 0, 0, 0, 1, Fal
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7587A0EE, 88126, 0x587A0168, 297.058, -209.615, 0.055, 0.729576, 0, 0, 0.6839, False, '2023-03-23 00:00:00'); /* Gurog Test Blue Portal Energy Generator */
 /* @teleloc 0x587A0168 [297.058014 -209.615005 0.055000] 0.729576 0.000000 0.000000 0.683900 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7587A0EF, 88145, 0x587A015D, 267.498, -228.929, 0.0065, 0, 0, 0, -1,  True, '2023-04-15 14:15:43'); /* Gurog Bruiser */
+/* @teleloc 0x587A015D [267.497986 -228.929001 0.006500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7587A0F0, 88145, 0x587A015D, 272.63, -229.133, 0.0065, 0, 0, 0, -1,  True, '2023-04-15 14:15:49'); /* Gurog Bruiser */
+/* @teleloc 0x587A015D [272.630005 -229.132996 0.006500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7587A0F3, 88145, 0x587A0169, 310.487, -208.296, 0.0065, 0.707107, 0, 0, 0.707107,  True, '2023-04-15 14:18:21'); /* Gurog Bruiser */
+/* @teleloc 0x587A0169 [310.487000 -208.296005 0.006500] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7587A0F4, 88145, 0x587A016B, 310.44, -226.464, 0.0065, 1, 0, 0, 0,  True, '2023-04-15 14:19:30'); /* Gurog Bruiser */
+/* @teleloc 0x587A016B [310.440002 -226.464005 0.006500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7587A0F5, 88145, 0x587A0172, 312.614, -299.885, 0.0065, 1, 0, 0, 0,  True, '2023-04-15 14:23:27'); /* Gurog Bruiser */
+/* @teleloc 0x587A0172 [312.614014 -299.885010 0.006500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7587A0F6, 88145, 0x587A0172, 307.408, -300.037, 0.0065, 1, 0, 0, 0,  True, '2023-04-15 14:24:25'); /* Gurog Bruiser */
+/* @teleloc 0x587A0172 [307.407990 -300.036987 0.006500] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/88154 Drudge Wilter.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/88154 Drudge Wilter.sql
@@ -25,6 +25,7 @@ VALUES (88154,   1, True ) /* Stuck */
      , (88154,  11, False) /* IgnoreCollisions */
      , (88154,  12, True ) /* ReportCollisions */
      , (88154,  13, False) /* Ethereal */
+     , (88154,  29, True ) /* NoCorpse */
      , (88154, 103, True ) /* NonProjectileMagicImmune */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
@@ -44,7 +45,7 @@ VALUES (88154,   1,       5) /* HeartbeatInterval */
      , (88154,  31,      18) /* VisualAwarenessRange */
      , (88154,  34,       1) /* PowerupTime */
      , (88154,  36,       1) /* ChargeSpeed */
-     , (88154,  39,     1.3) /* DefaultScale */
+     , (88154,  39,     1.5) /* DefaultScale */
      , (88154,  64,    0.75) /* ResistSlash */
      , (88154,  65,    0.75) /* ResistPierce */
      , (88154,  66,    0.75) /* ResistBludgeon */
@@ -71,8 +72,7 @@ VALUES (88154,   1, 0x020007DD) /* Setup */
      , (88154,   6, 0x04000F6C) /* PaletteBase */
      , (88154,   7, 0x10000486) /* ClothingBase */
      , (88154,   8, 0x06001035) /* Icon */
-     , (88154,  22, 0x3400001A) /* PhysicsEffectTable */
-     , (88154,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+     , (88154,  22, 0x3400001A) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (88154,   1, 330, 0, 0) /* Strength */

--- a/Database/Patches/9 WeenieDefaults/Creature/Gurog/88145 Gurog Bruiser.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Gurog/88145 Gurog Bruiser.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 88145;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (88145, 'ace88145-gurogbruiser', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (88145, 'ace88145-gurogbruiser', 10, '2023-04-15 02:39:48') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (88145,   1,         16) /* ItemType - Creature */
@@ -23,6 +23,7 @@ VALUES (88145,   1, True ) /* Stuck */
      , (88145,  11, False) /* IgnoreCollisions */
      , (88145,  12, True ) /* ReportCollisions */
      , (88145,  13, False) /* Ethereal */
+     , (88145,  29, True ) /* NoCorpse */
      , (88145,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
@@ -64,13 +65,23 @@ INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (88145,   1, 'Gurog Bruiser') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (88145,   1, 0x02001A2C) /* Setup */
+VALUES (88145,   1, 0x02001A2B) /* Setup */
      , (88145,   2, 0x090001A8) /* MotionTable */
      , (88145,   3, 0x200000D5) /* SoundTable */
      , (88145,   4, 0x30000000) /* CombatTable */
      , (88145,   8, 0x06002B2E) /* Icon */
-     , (88145,  22, 0x340000CD) /* PhysicsEffectTable */
-     , (88145,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+     , (88145,  22, 0x340000CD) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (88145,  0,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (88145,  1,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (88145,  2,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (88145,  3,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (88145,  4,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (88145,  5,  4,200,  0.5,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (88145,  6,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (88145,  7,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (88145,  8,  4,200,  0.5,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (88145,   1, 550, 0, 0) /* Strength */
@@ -81,7 +92,7 @@ VALUES (88145,   1, 550, 0, 0) /* Strength */
      , (88145,   6, 410, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (88145,   1,  1655, 0, 0, 1900) /* MaxHealth */
+VALUES (88145,   1,  4755, 0, 0, 5000) /* MaxHealth */
      , (88145,   3,  3500, 0, 0, 3990) /* MaxStamina */
      , (88145,   5,  1000, 0, 0, 1410) /* MaxMana */;
 
@@ -96,21 +107,3 @@ VALUES (88145,  6, 0, 3, 0, 470, 0, 0) /* MeleeDefense        Specialized */
      , (88145, 45, 0, 3, 0, 420, 0, 0) /* LightWeapons        Specialized */
      , (88145, 46, 0, 3, 0, 420, 0, 0) /* FinesseWeapons      Specialized */;
 
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (88145,  0,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (88145,  1,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (88145,  2,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (88145,  3,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (88145,  4,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (88145,  5,  4, 200,  0.5,  500,  500,  275,  500,  500,  275,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (88145,  6,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (88145,  7,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (88145,  8,  4, 200,  0.5,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (88145,  4312,   2.02)  /* Incantation of Imperil Other */
-     , (88145,  4446,   2.02)  /* Incantation of Frost Blast */
-     , (88145,  4447,   2.25)  /* Incantation of Frost Bolt */;
-
-INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (88145, 2, 43397,  0, 0, 1, False) /* Create Frost Greataxe (43397) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/88109 Rynthid Assessment Door Controller.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/88109 Rynthid Assessment Door Controller.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 88109;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (88109, 'ace88109-rynthidassessmentdoorcontroller', 10, '2022-06-21 15:22:25') /* Creature */;
+VALUES (88109, 'ace88109-rynthidassessmentdoorcontroller', 10, '2023-04-15 12:30:16') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (88109,   1,         16) /* ItemType - Creature */
@@ -110,4 +110,5 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  88 /* LocalSignal */, 0, 1, NULL, 'OpenDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  88 /* LocalSignal */, 180, 1, NULL, 'CloseDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  1,  88 /* LocalSignal */, 180, 1, NULL, 'CloseDoor', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/88109.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/88109.es
@@ -1,3 +1,4 @@
 Generation:
     - LocalSignal: OpenDoor
     - Delay: 180, LocalSignal: CloseDoor
+    - DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88106 Moars Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88106 Moars Test Master Generator.sql
@@ -25,7 +25,7 @@ VALUES (88106,   1, 0x0200026B) /* Setup */
      , (88106,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88106, -1, 88107, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Moars Raging Generator (88107) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88106, -1, 88108, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Moars Enraged Generator (88108) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88106, -1, 88107, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Moars Raging Generator (88107) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88106, -1, 88109, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+VALUES (88106, -1, 88107, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Moars Raging Generator (88107) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88106, -1, 88108, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Moars Enraged Generator (88108) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88106, -1, 88107, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Moars Raging Generator (88107) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88106, -1, 88109, 120, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88123 Wasp Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88123 Wasp Test Master Generator.sql
@@ -25,5 +25,5 @@ VALUES (88123,   1, 0x0200026B) /* Setup */
      , (88123,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88123, -1, 88124, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Swamp Phyntos Wasp Generator (88124) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88123, -1, 88109, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (88123, -1, 88124, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Swamp Phyntos Wasp Generator (88124) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88123, -1, 88109, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88140 Margul Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88140 Margul Test Master Generator.sql
@@ -25,7 +25,7 @@ VALUES (88140,   1, 0x0200026B) /* Setup */
      , (88140,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88140, -1, 88137, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Margul Roamer (88137) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88140, -1, 88138, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Fierce Margul Roamer (88138) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88140, -1, 88139, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Vicious Margul Roamer (88139) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88140, -1, 88109, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+VALUES (88140, -1, 88137, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Margul Roamer (88137) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88140, -1, 88138, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Fierce Margul Roamer (88138) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88140, -1, 88139, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Vicious Margul Roamer (88139) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88140, -1, 88109, 120, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88150 Grievver Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88150 Grievver Test Master Generator.sql
@@ -25,5 +25,5 @@ VALUES (88150,   1, 0x0200026B) /* Setup */
      , (88150,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88150, -1, 88151, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Grievver Violator Generator (88151) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88150, -1, 88109, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+VALUES (88150, -1, 88151, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Grievver Violator Generator (88151) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88150, -1, 88109, 120, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88155 Drudge Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88155 Drudge Test Master Generator.sql
@@ -25,5 +25,5 @@ VALUES (88155,   1, 0x0200026B) /* Setup */
      , (88155,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88155, -1, 88156, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Drudge Wilter Generator (88156) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
-     , (88155, -1, 88109, 600, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+VALUES (88155, -1, 88156, 300, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Drudge Wilter Generator (88156) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (88155, -1, 88109, 120, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 0.707107, 0, 0, 0.707107) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88162 Remoran Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88162 Remoran Test Master Generator.sql
@@ -25,7 +25,7 @@ VALUES (88162,   1, 0x0200026B) /* Setup */
      , (88162,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88162, -1, 88159, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Remoran Sapper (88159) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88162, -1, 88160, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Fierce Remoran Sapper (88160) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88162, -1, 88161, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Vicious Remoran Sapper (88161) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88162, -1, 88109, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (88162, -1, 88159, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Remoran Sapper (88159) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88162, -1, 88160, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Fierce Remoran Sapper (88160) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88162, -1, 88161, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Vicious Remoran Sapper (88161) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88162, -1, 88109, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/88168 Mukkir Test Master Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/88168 Mukkir Test Master Generator.sql
@@ -25,7 +25,7 @@ VALUES (88168,   1, 0x0200026B) /* Setup */
      , (88168,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (88168, -1, 88165, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Mukkir (88165) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88168, -1, 88166, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Fierce Mukkir (88166) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88168, -1, 88167, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Vicious Mukkir (88167) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (88168, -1, 88109, 600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (88168, -1, 88165, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Mukkir (88165) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88168, -1, 88166, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Fierce Mukkir (88166) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88168, -1, 88167, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Vicious Mukkir (88167) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (88168, -1, 88109, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Rynthid Assessment Door Controller (88109) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;


### PR DESCRIPTION
Currently, the door tests in this quest only reset when the landblock resets, meaning players are stuck waiting for a respawn that will never come. This corrects this issue by having the door controller stopgap delete itself after it closes its door, allowing the generator it is on to start its cycle from the beginning.

Drudge Wilter scale is adjusted to match retail video.

Gurog Bruiser stats and art are adjusted to match retail video. These Gurog do not appear to ever cast and only melee with their fists. They do not wield an axe. Also, their HP was lower than it should be based on how much damage it takes to kill them on the video.

More Gurog Bruisers added to locations that were missing them. 

No corpse is set on both of these mobs, and loot profile removed, as seen on the video.

A Drudge Test Gen's position is adjusted, because it could spawn Drudges behind the door, making them unreachable to mages. 