### PR TITLE
Rescue Mouf Updates

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/584D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/584D.sql
@@ -83,7 +83,7 @@ VALUES (0x7584D0E5, 48742, 0x584D012B, 166.517, -46.9643, -24, 1, 0, 0, 0, False
 /* @teleloc 0x584D012B [166.516998 -46.964298 -24.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D0E6,  1154, 0x584D0370, 160, -90, 6.00442, 0.696707, 0, 0, 0.717356, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x7584D0E6,  4219, 0x584D0370, 160, -90, 6.00442, 0.696707, 0, 0, 0.717356, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 7 Min.) */
 /* @teleloc 0x584D0370 [160.000000 -90.000000 6.004420] 0.696707 0.000000 0.000000 0.717356 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -97,11 +97,9 @@ VALUES (0x7584D0E6, 0x7584D0E7, '2021-11-01 00:00:00') /* Uber Penguin (28661) *
      , (0x7584D0E6, 0x7584D0EE, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D0EF, '2021-11-01 00:00:00') /* Uber Penguin (28661) */
      , (0x7584D0E6, 0x7584D0F0, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D0F1, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D0F2, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D0F3, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D0F4, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D0F8, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D0FA, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D0FB, '2021-11-01 00:00:00') /* Wall of Ice (46303) */
      , (0x7584D0E6, 0x7584D0FC, '2021-11-01 00:00:00') /* Uber Penguin (28661) */
@@ -130,13 +128,9 @@ VALUES (0x7584D0E6, 0x7584D0E7, '2021-11-01 00:00:00') /* Uber Penguin (28661) *
      , (0x7584D0E6, 0x7584D116, '2021-11-01 00:00:00') /* Frigid Ice Golem (46305) */
      , (0x7584D0E6, 0x7584D117, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D118, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D11A, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D11E, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D11F, '2021-11-01 00:00:00') /* Wall of Ice (46303) */
-     , (0x7584D0E6, 0x7584D120, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
-     , (0x7584D0E6, 0x7584D121, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D123, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
-     , (0x7584D0E6, 0x7584D124, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D125, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D126, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D127, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
@@ -165,25 +159,62 @@ VALUES (0x7584D0E6, 0x7584D0E7, '2021-11-01 00:00:00') /* Uber Penguin (28661) *
      , (0x7584D0E6, 0x7584D13F, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D140, '2021-11-01 00:00:00') /* Frigid Ice Golem (46305) */
      , (0x7584D0E6, 0x7584D141, '2021-11-01 00:00:00') /* Frigid Ice Golem (46305) */
-     , (0x7584D0E6, 0x7584D142, '2021-11-01 00:00:00') /* Uber Penguin (28661) */
-     , (0x7584D0E6, 0x7584D143, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D147, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D149, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D14B, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D14C, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D14D, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D14E, '2021-11-01 00:00:00') /* Frigid Mist Golem (46306) */
      , (0x7584D0E6, 0x7584D14F, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D150, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
-     , (0x7584D0E6, 0x7584D151, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D152, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
-     , (0x7584D0E6, 0x7584D153, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D154, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D158, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
-     , (0x7584D0E6, 0x7584D159, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
      , (0x7584D0E6, 0x7584D15A, '2021-11-01 00:00:00') /* Baby Penguin (46143) */
      , (0x7584D0E6, 0x7584D15B, '2021-11-01 00:00:00') /* Uber Penguin (28659) */
-     , (0x7584D0E6, 0x7584D15C, '2021-11-01 00:00:00') /* Pillar of Frost (46300) */;
+     , (0x7584D0E6, 0x7584D15C, '2021-11-01 00:00:00') /* Pillar of Frost (46300) */
+     , (0x7584D0E6, 0x7584D162, '2023-04-29 13:03:49') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D163, '2023-04-29 13:05:02') /* Wall of Ice (46303) */
+     , (0x7584D0E6, 0x7584D164, '2023-04-29 13:13:09') /* Hoarfrost (42338) */
+     , (0x7584D0E6, 0x7584D165, '2023-04-29 13:38:18') /* Frigid Ice Golem (46305) */
+     , (0x7584D0E6, 0x7584D166, '2023-04-29 13:39:22') /* Frigid Ice Golem (46305) */
+     , (0x7584D0E6, 0x7584D167, '2023-04-29 13:40:29') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D168, '2023-04-29 13:40:51') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D169, '2023-04-29 13:41:51') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D16A, '2023-04-29 13:42:42') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D16B, '2023-04-29 13:45:41') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D16C, '2023-04-29 13:46:17') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D16E, '2023-04-29 13:58:01') /* Hoarfrost (42338) */
+     , (0x7584D0E6, 0x7584D16F, '2023-04-29 14:00:03') /* Frigid Ice Golem (46305) */
+     , (0x7584D0E6, 0x7584D170, '2023-04-29 14:03:30') /* Algid Warrior (73154) */
+     , (0x7584D0E6, 0x7584D172, '2023-04-29 14:50:55') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D173, '2023-04-29 14:51:07') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D176, '2023-04-29 15:02:02') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D177, '2023-04-29 15:02:26') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D178, '2023-04-29 15:02:39') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D17A, '2023-04-29 16:24:53') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D17B, '2023-04-29 16:25:26') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D17D, '2023-04-29 16:32:40') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D17F, '2023-04-29 16:34:30') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D180, '2023-04-29 16:35:47') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D181, '2023-04-29 16:37:14') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D182, '2023-04-29 16:58:20') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D183, '2023-04-29 17:01:07') /* Uber Penguin (28659) */
+     , (0x7584D0E6, 0x7584D184, '2023-04-29 17:06:48') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D185, '2023-04-29 17:13:07') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D188, '2023-04-30 08:45:25') /* Wall of Ice (46303) */
+     , (0x7584D0E6, 0x7584D189, '2023-04-30 08:46:42') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D18A, '2023-04-30 08:46:53') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D18B, '2023-04-30 08:47:10') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D18C, '2023-04-30 08:48:00') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D18E, '2023-04-30 08:56:03') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D18F, '2023-04-30 08:57:43') /* Uber Penguin (28659) */
+     , (0x7584D0E6, 0x7584D190, '2023-04-30 08:58:11') /* Uber Penguin (28659) */
+     , (0x7584D0E6, 0x7584D191, '2023-04-30 08:58:21') /* Uber Penguin (28659) */
+     , (0x7584D0E6, 0x7584D194, '2023-04-30 09:00:26') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D195, '2023-04-30 09:00:37') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D196, '2023-04-30 09:01:00') /* Baby Penguin (46143) */
+     , (0x7584D0E6, 0x7584D197, '2023-04-30 09:03:19') /* Frigid Mist Golem (46306) */
+     , (0x7584D0E6, 0x7584D198, '2023-04-30 09:10:27') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D199, '2023-04-30 09:10:36') /* Uber Penguin (28661) */
+     , (0x7584D0E6, 0x7584D19A, '2023-04-30 09:11:36') /* Frigid Ice Golem (46305) */
+     , (0x7584D0E6, 0x7584D19B, '2023-04-30 09:11:48') /* Frigid Ice Golem (46305) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D0E7, 28661, 0x584D0370, 160, -90, 6.00442, 0.696707, 0, 0, 0.717356,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
@@ -226,10 +257,6 @@ VALUES (0x7584D0F0, 46143, 0x584D033D, 120, -60, 6.00161, 0.930508, 0, 0, 0.3662
 /* @teleloc 0x584D033D [120.000000 -60.000000 6.001610] 0.930508 0.000000 0.000000 0.366272 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D0F1, 46143, 0x584D033C, 119.515, -45.6554, 6.00161, 0.659983, 0, 0, -0.75128,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D033C [119.514999 -45.655399 6.001610] 0.659983 0.000000 0.000000 -0.751280 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D0F2, 46143, 0x584D0352, 140, -60, 6.00161, -0.999862, 0, 0, 0.016592,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
 /* @teleloc 0x584D0352 [140.000000 -60.000000 6.001610] -0.999862 0.000000 0.000000 0.016592 */
 
@@ -240,10 +267,6 @@ VALUES (0x7584D0F3, 46306, 0x584D0351, 140, -48.5, 6.01, 1, 0, 0, 0,  True, '202
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D0F4, 46143, 0x584D036D, 160, -60, 6.00161, 0.988771, 0, 0, 0.149438,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
 /* @teleloc 0x584D036D [160.000000 -60.000000 6.001610] 0.988771 0.000000 0.000000 0.149438 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D0F8, 46143, 0x584D036B, 157.167, -44.9625, 6.00161, 0.335134, 0, 0, -0.942171,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D036B [157.167007 -44.962502 6.001610] 0.335134 0.000000 0.000000 -0.942171 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D0FA, 46143, 0x584D0350, 140, -40, 6.00161, 0.995004, 0, 0, 0.099833,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
@@ -358,10 +381,6 @@ VALUES (0x7584D118, 46143, 0x584D022A, 142.426, -60.8971, -5.99839, 0.014642, 0,
 /* @teleloc 0x584D022A [142.425995 -60.897099 -5.998390] 0.014642 0.000000 0.000000 -0.999893 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D11A, 46143, 0x584D022C, 135.292, -79.8032, -5.99839, -0.700421, 0, 0, -0.71373,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D022C [135.292007 -79.803200 -5.998390] -0.700421 0.000000 0.000000 -0.713730 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D11E, 46306, 0x584D0230, 145.573, -73.2671, -5.99, -0.009311, 0, 0, 0.999957,  True, '2021-11-01 00:00:00'); /* Frigid Mist Golem */
 /* @teleloc 0x584D0230 [145.572998 -73.267097 -5.990000] -0.009311 0.000000 0.000000 0.999957 */
 
@@ -370,20 +389,8 @@ VALUES (0x7584D11F, 46303, 0x584D0232, 150.001, -85.2332, -6.08175, 0.006073, 0,
 /* @teleloc 0x584D0232 [150.001007 -85.233200 -6.081750] 0.006073 0.000000 0.000000 0.999982 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D120, 28659, 0x584D0241, 164.454, -69.1554, -5.99518, 0.696409, 0, 0, -0.717645,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D0241 [164.453995 -69.155403 -5.995180] 0.696409 0.000000 0.000000 -0.717645 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D121, 28659, 0x584D0289, 186.585, -73.6561, -5.99518, -0.664851, 0, 0, -0.746976,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D0289 [186.585007 -73.656097 -5.995180] -0.664851 0.000000 0.000000 -0.746976 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D123, 46306, 0x584D0285, 190, -59, -5.99, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Frigid Mist Golem */
 /* @teleloc 0x584D0285 [190.000000 -59.000000 -5.990000] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D124, 46143, 0x584D026A, 176.029, -64.1594, -5.99839, 0.801664, 0, 0, -0.597774,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D026A [176.029007 -64.159401 -5.998390] 0.801664 0.000000 0.000000 -0.597774 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D125, 28659, 0x584D0291, 200, -50, -5.99518, -0.583327, 0, 0, -0.812237,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
@@ -502,26 +509,6 @@ VALUES (0x7584D141, 46305, 0x584D0385, 175.431, -77.6489, 6.011, 0.714108, 0, 0,
 /* @teleloc 0x584D0385 [175.431000 -77.648903 6.011000] 0.714108 0.000000 0.000000 -0.700036 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D142, 28661, 0x584D0376, 165.542, -55.0514, 6.00442, 0.492119, 0, 0, -0.870528,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D0376 [165.542007 -55.051399 6.004420] 0.492119 0.000000 0.000000 -0.870528 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D143, 46143, 0x584D0365, 145.621, -60.1867, 6.00161, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D0365 [145.621002 -60.186699 6.001610] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D147, 46143, 0x584D036C, 157.788, -49.5979, 6.00161, -0.99518, 0, 0, -0.098063,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D036C [157.787994 -49.597900 6.001610] -0.995180 0.000000 0.000000 -0.098063 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D149, 46143, 0x584D0350, 139.433, -37.2009, 6.00161, 0.995004, 0, 0, 0.099833,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D0350 [139.432999 -37.200901 6.001610] 0.995004 0.000000 0.000000 0.099833 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D14B, 28659, 0x584D0234, 164.217, -29.5534, -5.99518, -0.712205, 0, 0, -0.701971,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D0234 [164.216995 -29.553400 -5.995180] -0.712205 0.000000 0.000000 -0.701971 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D14C, 46306, 0x584D027A, 189.792, -29.789, -5.99, 0.379232, 0, 0, -0.925302,  True, '2021-11-01 00:00:00'); /* Frigid Mist Golem */
 /* @teleloc 0x584D027A [189.792007 -29.789000 -5.990000] 0.379232 0.000000 0.000000 -0.925302 */
 
@@ -542,28 +529,12 @@ VALUES (0x7584D150, 28659, 0x584D0263, 179.292, -40.9178, -5.99518, 0.915692, 0,
 /* @teleloc 0x584D0263 [179.292007 -40.917801 -5.995180] 0.915692 0.000000 0.000000 -0.401881 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D151, 28659, 0x584D0295, 197.885, -57.6019, -5.99518, 0.992216, 0, 0, -0.12453,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D0295 [197.884995 -57.601898 -5.995180] 0.992216 0.000000 0.000000 -0.124530 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D152, 28659, 0x584D0299, 200, -70, -5.99518, -0.844372, 0, 0, -0.535758,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
 /* @teleloc 0x584D0299 [200.000000 -70.000000 -5.995180] -0.844372 0.000000 0.000000 -0.535758 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D153, 46143, 0x584D0285, 185.798, -64.2223, -5.99839, 0.947221, 0, 0, 0.320582,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
-/* @teleloc 0x584D0285 [185.798004 -64.222298 -5.998390] 0.947221 0.000000 0.000000 0.320582 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D154, 28659, 0x584D026A, 181.029, -62.1587, -5.99518, 0.947167, 0, 0, 0.320741,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D026A [181.029007 -62.158699 -5.995180] 0.947167 0.000000 0.000000 0.320741 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D158, 46143, 0x584D022C, 142.798, -78.9811, -5.99839, 0.850999, 0, 0, -0.525167,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
 /* @teleloc 0x584D022C [142.798004 -78.981102 -5.998390] 0.850999 0.000000 0.000000 -0.525167 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7584D159, 28659, 0x584D021A, 125.89, -69.9556, -5.99518, 0.673805, 0, 0, -0.738909,  True, '2021-11-01 00:00:00'); /* Uber Penguin */
-/* @teleloc 0x584D021A [125.889999 -69.955597 -5.995180] 0.673805 0.000000 0.000000 -0.738909 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D15A, 46143, 0x584D0230, 149.417, -70.0122, -5.99839, -0.699736, 0, 0, -0.714401,  True, '2021-11-01 00:00:00'); /* Baby Penguin */
@@ -587,3 +558,211 @@ VALUES (0x7584D15D, 0x7584D15E, '2021-11-01 00:00:00') /* Mouf (45853) */;
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7584D15E, 45853, 0x584D012C, 168.015, -60.8938, -23.9985, -0.897783, 0, 0, -0.440438,  True, '2021-11-01 00:00:00'); /* Mouf */
 /* @teleloc 0x584D012C [168.014999 -60.893799 -23.998501] -0.897783 0.000000 0.000000 -0.440438 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D162, 46306, 0x584D0393, 194.583, -145.633, 6.011, 0.707107, 0, 0, 0.707107,  True, '2023-04-29 13:03:49'); /* Frigid Mist Golem */
+/* @teleloc 0x584D0393 [194.582993 -145.632996 6.011000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D163, 46303, 0x584D03A2, 205.25, -150, 6, -0.707107, 0, 0, 0.707107,  True, '2023-04-29 13:05:02'); /* Wall of Ice */
+/* @teleloc 0x584D03A2 [205.250000 -150.000000 6.000000] -0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D164, 42338, 0x584D02BA, 229.936, -139.884, -5.992, 0, 0, 0, -1,  True, '2023-04-29 13:13:09'); /* Hoarfrost */
+/* @teleloc 0x584D02BA [229.936005 -139.884003 -5.992000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D165, 46305, 0x584D02A9, 205.194, -140.022, -5.989, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 13:38:18'); /* Frigid Ice Golem */
+/* @teleloc 0x584D02A9 [205.194000 -140.022003 -5.989000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D166, 46305, 0x584D02A5, 205.296, -129.919, -5.989, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 13:39:22'); /* Frigid Ice Golem */
+/* @teleloc 0x584D02A5 [205.296005 -129.919006 -5.989000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D167, 28661, 0x584D0290, 188.94, -139.94, -5.99558, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 13:40:29'); /* Uber Penguin */
+/* @teleloc 0x584D0290 [188.940002 -139.940002 -5.995580] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D168, 28661, 0x584D028F, 188.358, -130.416, -5.99558, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 13:40:51'); /* Uber Penguin */
+/* @teleloc 0x584D028F [188.358002 -130.416000 -5.995580] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D169, 28661, 0x584D02AB, 219.97, -100.002, -5.99558, 0, 0, 0, -1,  True, '2023-04-29 13:41:51'); /* Uber Penguin */
+/* @teleloc 0x584D02AB [219.970001 -100.001999 -5.995580] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D16A, 46306, 0x584D02B7, 229.943, -108.049, -5.989, 0.707107, 0, 0, 0.707107,  True, '2023-04-29 13:42:42'); /* Frigid Mist Golem */
+/* @teleloc 0x584D02B7 [229.942993 -108.049004 -5.989000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D16B, 28661, 0x584D02C1, 248.875, -128.788, -5.99558, 0.382684, 0, 0, -0.92388,  True, '2023-04-29 13:45:41'); /* Uber Penguin */
+/* @teleloc 0x584D02C1 [248.875000 -128.787994 -5.995580] 0.382684 0.000000 0.000000 -0.923880 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D16C, 28661, 0x584D02B9, 234.475, -130.031, -5.99558, 0.707107, 0, 0, 0.707107,  True, '2023-04-29 13:46:17'); /* Uber Penguin */
+/* @teleloc 0x584D02B9 [234.475006 -130.031006 -5.995580] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D16D, 73153, 0x584D02CC, 270.003, -126.822, -6, 1, 0, 0, 0, False, '2023-04-29 13:55:49'); /* Penguin's Friend */
+/* @teleloc 0x584D02CC [270.002991 -126.821999 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D16E, 42338, 0x584D02C6, 264.375, -105.969, -5.992, 0, 0, 0, -1,  True, '2023-04-29 13:58:01'); /* Hoarfrost */
+/* @teleloc 0x584D02C6 [264.375000 -105.969002 -5.992000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D16F, 46305, 0x584D02C9, 274.629, -105.797, -5.989, 0, 0, 0, -1,  True, '2023-04-29 14:00:03'); /* Frigid Ice Golem */
+/* @teleloc 0x584D02C9 [274.628998 -105.796997 -5.989000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D170, 73154, 0x584D02C8, 269.925, -98.6376, -5.99675, 0, 0, 0, -1,  True, '2023-04-29 14:03:30'); /* Algid Warrior */
+/* @teleloc 0x584D02C8 [269.924988 -98.637604 -5.996750] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D171, 73155, 0x584D02C8, 269.999, -96.4576, -6, 1, 0, 0, 0, False, '2023-04-29 14:39:25'); /* Chorizite Chest */
+/* @teleloc 0x584D02C8 [269.998993 -96.457603 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D172, 28661, 0x584D02C5, 259.983, -100.062, -5.99558, 0, 0, 0, -1,  True, '2023-04-29 14:50:55'); /* Uber Penguin */
+/* @teleloc 0x584D02C5 [259.983002 -100.061996 -5.995580] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D173, 28661, 0x584D02CD, 279.997, -99.9471, -5.99558, 0, 0, 0, -1,  True, '2023-04-29 14:51:07'); /* Uber Penguin */
+/* @teleloc 0x584D02CD [279.997009 -99.947098 -5.995580] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D176, 46143, 0x584D038A, 184.389, -149.836, 6.00161, 0.707107, 0, 0, 0.707107,  True, '2023-04-29 15:02:02'); /* Baby Penguin */
+/* @teleloc 0x584D038A [184.389008 -149.835999 6.001610] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D177, 46143, 0x584D0393, 188.218, -152.605, 6.00161, 0.382684, 0, 0, 0.92388,  True, '2023-04-29 15:02:26'); /* Baby Penguin */
+/* @teleloc 0x584D0393 [188.218002 -152.604996 6.001610] 0.382684 0.000000 0.000000 0.923880 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D178, 46143, 0x584D0393, 188.064, -146.012, 6.00161, -0.701967, 0, 0, 0.71221,  True, '2023-04-29 15:02:39'); /* Baby Penguin */
+/* @teleloc 0x584D0393 [188.063995 -146.011993 6.001610] -0.701967 0.000000 0.000000 0.712210 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D17A, 46143, 0x584D0364, 152.129, -48.2475, 6.00161, 0.753667, 0, 0, -0.657257,  True, '2023-04-29 16:24:53'); /* Baby Penguin */
+/* @teleloc 0x584D0364 [152.128998 -48.247501 6.001610] 0.753667 0.000000 0.000000 -0.657257 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D17B, 46143, 0x584D0347, 128.882, -46.3242, 6.00161, 0.918164, 0, 0, 0.396202,  True, '2023-04-29 16:25:26'); /* Baby Penguin */
+/* @teleloc 0x584D0347 [128.882004 -46.324200 6.001610] 0.918164 0.000000 0.000000 0.396202 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D17D, 46306, 0x584D01D0, 99.8989, -9.87575, -5.989, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 16:32:40'); /* Frigid Mist Golem */
+/* @teleloc 0x584D01D0 [99.898903 -9.875750 -5.989000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D17F, 46306, 0x584D0258, 179.273, -9.81963, -5.989, 0.707107, 0, 0, 0.707107,  True, '2023-04-29 16:34:30'); /* Frigid Mist Golem */
+/* @teleloc 0x584D0258 [179.272995 -9.819630 -5.989000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D180, 28661, 0x584D0243, 169.921, -19.9975, -5.99558, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 16:35:47'); /* Uber Penguin */
+/* @teleloc 0x584D0243 [169.921005 -19.997499 -5.995580] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D181, 28661, 0x584D0246, 169.876, -30.0212, -5.99558, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 16:37:14'); /* Uber Penguin */
+/* @teleloc 0x584D0246 [169.876007 -30.021200 -5.995580] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D182, 46143, 0x584D026A, 180.001, -60.1003, -5.99839, 0, 0, 0, -1,  True, '2023-04-29 16:58:20'); /* Baby Penguin */
+/* @teleloc 0x584D026A [180.001007 -60.100300 -5.998390] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D183, 28659, 0x584D0254, 170.023, -69.9742, -5.99518, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 17:01:07'); /* Uber Penguin */
+/* @teleloc 0x584D0254 [170.022995 -69.974197 -5.995180] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D184, 46306, 0x584D0385, 180.335, -79.9906, 6.011, 0.707107, 0, 0, 0.707107,  True, '2023-04-29 17:06:48'); /* Frigid Mist Golem */
+/* @teleloc 0x584D0385 [180.335007 -79.990601 6.011000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D185, 46143, 0x584D022B, 139.237, -69.7489, -5.99839, 0.707107, 0, 0, -0.707107,  True, '2023-04-29 17:13:07'); /* Baby Penguin */
+/* @teleloc 0x584D022B [139.237000 -69.748901 -5.998390] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D186, 73153, 0x584D014B, 149.951, -109.979, -21, 1, 0, 0, 0, False, '2023-04-29 17:15:09'); /* Penguin's Friend */
+/* @teleloc 0x584D014B [149.951004 -109.978996 -21.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D187, 73153, 0x584D0119, 133.007, -80.0002, -24, 1, 0, 0, 0, False, '2023-04-29 17:18:50'); /* Penguin's Friend */
+/* @teleloc 0x584D0119 [133.007004 -80.000198 -24.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D188, 46303, 0x584D030D, 74.8008, -149.995, 6, 0.707107, 0, 0, -0.707107,  True, '2023-04-30 08:45:25'); /* Wall of Ice */
+/* @teleloc 0x584D030D [74.800797 -149.994995 6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D189, 46143, 0x584D0322, 92.3045, -147.865, 6.00161, 0.92388, 0, 0, -0.382684,  True, '2023-04-30 08:46:42'); /* Baby Penguin */
+/* @teleloc 0x584D0322 [92.304497 -147.865005 6.001610] 0.923880 0.000000 0.000000 -0.382684 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D18A, 46143, 0x584D0322, 92.9394, -154.619, 6.00161, 0.382684, 0, 0, 0.92388,  True, '2023-04-30 08:46:53'); /* Baby Penguin */
+/* @teleloc 0x584D0322 [92.939400 -154.619003 6.001610] 0.382684 0.000000 0.000000 0.923880 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D18B, 46143, 0x584D0322, 88.6096, -151.339, 6.00161, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 08:47:10'); /* Baby Penguin */
+/* @teleloc 0x584D0322 [88.609596 -151.339005 6.001610] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D18C, 46306, 0x584D0323, 85.518, -157.242, 6.011, 0.707107, 0, 0, -0.707107,  True, '2023-04-30 08:48:00'); /* Frigid Mist Golem */
+/* @teleloc 0x584D0323 [85.517998 -157.242004 6.011000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D18E, 46306, 0x584D017B, 30.0004, -120.167, -5.989, 1, 0, 0, 0,  True, '2023-04-30 08:56:03'); /* Frigid Mist Golem */
+/* @teleloc 0x584D017B [30.000401 -120.167000 -5.989000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D18F, 28659, 0x584D0198, 59.9238, -99.9892, -5.99518, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 08:57:43'); /* Uber Penguin */
+/* @teleloc 0x584D0198 [59.923801 -99.989197 -5.995180] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D190, 28659, 0x584D01FC, 110.103, -129.941, -5.99518, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 08:58:11'); /* Uber Penguin */
+/* @teleloc 0x584D01FC [110.102997 -129.940994 -5.995180] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D191, 28659, 0x584D01FA, 109.934, -109.955, -5.99518, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 08:58:21'); /* Uber Penguin */
+/* @teleloc 0x584D01FA [109.933998 -109.955002 -5.995180] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D194, 46143, 0x584D01DF, 103.412, -113.451, -5.99839, 1, 0, 0, 0,  True, '2023-04-30 09:00:26'); /* Baby Penguin */
+/* @teleloc 0x584D01DF [103.412003 -113.450996 -5.998390] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D195, 46143, 0x584D01E1, 103.371, -126.421, -5.99839, 0, 0, 0, -1,  True, '2023-04-30 09:00:37'); /* Baby Penguin */
+/* @teleloc 0x584D01E1 [103.371002 -126.420998 -5.998390] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D196, 46143, 0x584D01E0, 98.0254, -120.179, -5.99839, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 09:01:00'); /* Baby Penguin */
+/* @teleloc 0x584D01E0 [98.025398 -120.179001 -5.998390] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D197, 46306, 0x584D01B9, 79.9355, -109.868, -5.989, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 09:03:19'); /* Frigid Mist Golem */
+/* @teleloc 0x584D01B9 [79.935501 -109.867996 -5.989000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D198, 28661, 0x584D018D, 53.1984, -121.299, -5.99558, 0, 0, 0, -1,  True, '2023-04-30 09:10:27'); /* Uber Penguin */
+/* @teleloc 0x584D018D [53.198399 -121.299004 -5.995580] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D199, 28661, 0x584D019D, 60.9627, -130.787, -5.99558, 0.707107, 0, 0, 0.707107,  True, '2023-04-30 09:10:36'); /* Uber Penguin */
+/* @teleloc 0x584D019D [60.962700 -130.787003 -5.995580] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D19A, 46305, 0x584D0160, -0.043952, -118.817, -5.989, 0.707107, 0, 0, -0.707107,  True, '2023-04-30 09:11:36'); /* Frigid Ice Golem */
+/* @teleloc 0x584D0160 [-0.043952 -118.817001 -5.989000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D19B, 46305, 0x584D0161, 7.61509, -101.361, -5.989, 0.707107, 0, 0, -0.707107,  True, '2023-04-30 09:11:48'); /* Frigid Ice Golem */
+/* @teleloc 0x584D0161 [7.615090 -101.361000 -5.989000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D19C, 73153, 0x584D0228, 143.165, -0.043909, -6, 1, 0, 0, 0, False, '2023-04-30 14:25:01'); /* Penguin's Friend */
+/* @teleloc 0x584D0228 [143.164993 -0.043909 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7584D19D, 73153, 0x584D0228, 136.665, 0.07162, -6, 1, 0, 0, 0, False, '2023-04-30 14:25:11'); /* Penguin's Friend */
+/* @teleloc 0x584D0228 [136.664993 0.071620 -6.000000] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/8 QuestDefDB/chestchorizite73155.sql
+++ b/Database/Patches/8 QuestDefDB/chestchorizite73155.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'chestchorizite73155';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('chestchorizite73155', 72000, -1, 'quest timer', '2020-01-24 19:57:17');

--- a/Database/Patches/9 WeenieDefaults/Chest/Container/73155 Chorizite Chest.sql
+++ b/Database/Patches/9 WeenieDefaults/Chest/Container/73155 Chorizite Chest.sql
@@ -1,0 +1,55 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73155;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73155, 'ace73155-chorizitechest', 20, '2021-11-01 00:00:00') /* Chest */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73155,   1,        512) /* ItemType - Container */
+     , (73155,   5,      10415) /* EncumbranceVal */
+     , (73155,   6,        120) /* ItemsCapacity */
+     , (73155,   7,         10) /* ContainersCapacity */
+     , (73155,   8,       3000) /* Mass */
+     , (73155,  16,         48) /* ItemUseable - ViewedRemote */
+     , (73155,  19,       2500) /* Value */
+     , (73155,  36,       9999) /* ResistMagic */
+     , (73155,  38,        600) /* ResistLockpick */
+     , (73155,  81,         10) /* MaxGeneratedObjects */
+     , (73155,  82,          5) /* InitGeneratedObjects */
+     , (73155,  83,          2) /* ActivationResponse - Use */
+     , (73155,  93,       1048) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity */
+     , (73155,  96,      55000) /* EncumbranceCapacity */
+     , (73155, 100,          1) /* GeneratorType - Relative */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73155,   1, True ) /* Stuck */
+     , (73155,   2, False) /* Open */
+     , (73155,   3, True ) /* Locked */
+     , (73155,  12, True ) /* ReportCollisions */
+     , (73155,  13, False) /* Ethereal */
+     , (73155,  33, False) /* ResetMessagePending */
+     , (73155,  34, False) /* DefaultOpen */
+     , (73155,  35, True ) /* DefaultLocked */
+     , (73155,  86, True ) /* ChestRegenOnClose */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73155,  11,     180) /* ResetInterval */
+     , (73155,  39,     1.1) /* DefaultScale */
+     , (73155,  43,       1) /* GeneratorRadius */
+     , (73155,  54,       1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73155,   1, 'Chorizite Chest') /* Name */
+     , (73155,  14, 'Use this item to open it and see its contents.') /* Use */
+     , (73155,  33, 'chestchorizite73155') /* Quest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73155,   1, 0x0200007C) /* Setup */
+     , (73155,   2, 0x09000004) /* MotionTable */
+     , (73155,   3, 0x20000021) /* SoundTable */
+     , (73155,   6, 0x0400102D) /* PaletteBase */
+     , (73155,   7, 0x10000358) /* ClothingBase */
+     , (73155,   8, 0x060023E5) /* Icon */
+     , (73155,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73155, -1, 2001, 0, 1, 1, 2, 72, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate RANDOMLY GENERATED TREASURE from Loot Tier 8 from Death Treasure Table id: 2001 (x1 up to max of 1) - Regenerate upon PickUp - Location to (re)Generate: ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/42338 Hoarfrost.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/42338 Hoarfrost.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 42338;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (42338, 'ace42338-hoarfrost', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (42338, 'ace42338-hoarfrost', 10, '2023-04-29 01:15:47') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (42338,   1,         16) /* ItemType - Creature */
@@ -14,7 +14,8 @@ VALUES (42338,   1,         16) /* ItemType - Creature */
      , (42338,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
      , (42338, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (42338, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (42338, 146,      30000) /* XpOverride */;
+     , (42338, 146,     800000) /* XpOverride */
+     , (42338, 307,          2) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (42338,   1, True ) /* Stuck */
@@ -33,19 +34,19 @@ VALUES (42338,   1,       5) /* HeartbeatInterval */
      , (42338,   3,     0.9) /* HealthRate */
      , (42338,   4,     0.5) /* StaminaRate */
      , (42338,   5,       2) /* ManaRate */
-     , (42338,  13,    0.85) /* ArmorModVsSlash */
-     , (42338,  14,    0.85) /* ArmorModVsPierce */
-     , (42338,  15,    0.85) /* ArmorModVsBludgeon */
+     , (42338,  13,    0.95) /* ArmorModVsSlash */
+     , (42338,  14,    0.95) /* ArmorModVsPierce */
+     , (42338,  15,    0.95) /* ArmorModVsBludgeon */
      , (42338,  16,       1) /* ArmorModVsCold */
-     , (42338,  17,     0.8) /* ArmorModVsFire */
-     , (42338,  18,   0.085) /* ArmorModVsAcid */
-     , (42338,  19,    0.85) /* ArmorModVsElectric */
+     , (42338,  17,    0.85) /* ArmorModVsFire */
+     , (42338,  18,       1) /* ArmorModVsAcid */
+     , (42338,  19,       1) /* ArmorModVsElectric */
      , (42338,  31,      20) /* VisualAwarenessRange */
      , (42338,  39,     1.6) /* DefaultScale */
      , (42338,  64,    0.45) /* ResistSlash */
      , (42338,  65,    0.45) /* ResistPierce */
      , (42338,  66,    0.45) /* ResistBludgeon */
-     , (42338,  67,    0.65) /* ResistFire */
+     , (42338,  67,    0.55) /* ResistFire */
      , (42338,  68,       0) /* ResistCold */
      , (42338,  69,     0.3) /* ResistAcid */
      , (42338,  70,     0.3) /* ResistElectric */
@@ -71,50 +72,48 @@ VALUES (42338,   1, 0x02000BEF) /* Setup */
      , (42338,  22, 0x34000075) /* PhysicsEffectTable */
      , (42338,  35,         20) /* DeathTreasureType - Loot Tier: 6 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (42338,  0,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (42338,  1,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (42338,  2,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (42338,  3,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (42338,  4,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (42338,  5,  8, 100, 0.75,  400,   60,   60,   60,   60,   60,   60,   60,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (42338,  6,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (42338,  7,  8,  0,    0,  400,   60,   60,   60,   60,   60,   60,   60,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (42338,  8,  8, 100, 0.75,  400,   60,   60,   60,   60,   60,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (42338,   1, 250, 0, 0) /* Strength */
-     , (42338,   2, 250, 0, 0) /* Endurance */
-     , (42338,   3, 250, 0, 0) /* Quickness */
-     , (42338,   4, 250, 0, 0) /* Coordination */
-     , (42338,   5, 350, 0, 0) /* Focus */
-     , (42338,   6, 350, 0, 0) /* Self */;
+VALUES (42338,   1, 190, 0, 0) /* Strength */
+     , (42338,   2, 200, 0, 0) /* Endurance */
+     , (42338,   3, 200, 0, 0) /* Quickness */
+     , (42338,   4, 200, 0, 0) /* Coordination */
+     , (42338,   5, 200, 0, 0) /* Focus */
+     , (42338,   6, 240, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (42338,   1,  1500, 0, 0, 1625) /* MaxHealth */
-     , (42338,   3,  5000, 0, 0, 5250) /* MaxStamina */
-     , (42338,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (42338,   1,  1600, 0, 0, 1700) /* MaxHealth */
+     , (42338,   3,  1800, 0, 0, 2000) /* MaxStamina */
+     , (42338,   5,  1000, 0, 0, 1240) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (42338,  6, 0, 3, 0, 138, 0, 0) /* MeleeDefense        Specialized */
-     , (42338,  7, 0, 3, 0, 266, 0, 0) /* MissileDefense      Specialized */
-     , (42338, 14, 0, 2, 0, 130, 0, 0) /* ArcaneLore          Trained */
-     , (42338, 15, 0, 3, 0, 152, 0, 0) /* MagicDefense        Specialized */
-     , (42338, 20, 0, 2, 0, 150, 0, 0) /* Deception           Trained */
-     , (42338, 24, 0, 2, 0, 100, 0, 0) /* Run                 Trained */
-     , (42338, 31, 0, 3, 0,  70, 0, 0) /* CreatureEnchantment Specialized */
-     , (42338, 33, 0, 3, 0,  70, 0, 0) /* LifeMagic           Specialized */
-     , (42338, 34, 0, 3, 0,  70, 0, 0) /* WarMagic            Specialized */
-     , (42338, 45, 0, 3, 0, 140, 0, 0) /* LightWeapons        Specialized */
-     , (42338, 47, 0, 3, 0,  80, 0, 0) /* MissileWeapons      Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (42338,  0,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (42338,  1,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (42338,  2,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (42338,  3,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (42338,  4,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (42338,  5,  8, 20, 0.75,  120,  102,  102,  102,  120,   96,   10,  102,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (42338,  6,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (42338,  7,  8,  0,    0,  120,  102,  102,  102,  120,   96,   10,  102,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (42338,  8,  8, 30, 0.75,  120,  102,  102,  102,  120,   96,   10,  102,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (42338,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
+     , (42338,  7, 0, 3, 0, 350, 0, 0) /* MissileDefense      Specialized */
+     , (42338, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (42338, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (42338, 31, 0, 3, 0, 220, 0, 0) /* CreatureEnchantment Specialized */
+     , (42338, 33, 0, 3, 0, 220, 0, 0) /* LifeMagic           Specialized */
+     , (42338, 34, 0, 3, 0, 200, 0, 0) /* WarMagic            Specialized */
+     , (42338, 45, 0, 3, 0, 440, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (42338,  2136,  2.004)  /* Icy Torment */
-     , (42338,  2731,  2.017)  /* Frost Arc VII */
-     , (42338,  1843,  2.008)  /* Foon-Ki's Glacial Floe */
-     , (42338,  2168,  2.017)  /* Gelidite's Gift */
-     , (42338,  2074,  2.017)  /* Gossamer Flesh */;
+VALUES (42338,  2136,  2.004) /* Icy Torment */
+     , (42338,  2731,  2.017) /* Frost Arc VII */
+     , (42338,  1843,  2.008) /* Foon-Ki's Glacial Floe */
+     , (42338,  2168,  2.017) /* Gelidite's Gift */
+     , (42338,  2074,  2.017) /* Gossamer Flesh */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (42338, 9,  6876,  0, 0, 0.02, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */
      , (42338, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/73154 Algid Warrior.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/73154 Algid Warrior.sql
@@ -1,0 +1,111 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73154;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73154, 'ace73154-algidwarrior', 10, '2023-04-30 09:19:16') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73154,   1,         16) /* ItemType - Creature */
+     , (73154,   2,         62) /* CreatureType - Elemental */
+     , (73154,   3,          2) /* PaletteTemplate - Blue */
+     , (73154,   6,         -1) /* ItemsCapacity */
+     , (73154,   7,         -1) /* ContainersCapacity */
+     , (73154,  16,         32) /* ItemUseable - Remote */
+     , (73154,  25,        165) /* Level */
+     , (73154,  27,          0) /* ArmorType - None */
+     , (73154,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (73154,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (73154, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (73154, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73154, 140,          1) /* AiOptions - CanOpenDoors */
+     , (73154, 146,    4000000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73154,   1, True ) /* Stuck */
+     , (73154, 120, True ) /* TreasureCorpse */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73154,   1,       5) /* HeartbeatInterval */
+     , (73154,   2,       0) /* HeartbeatTimestamp */
+     , (73154,   3,     0.9) /* HealthRate */
+     , (73154,   4,     0.5) /* StaminaRate */
+     , (73154,   5,       2) /* ManaRate */
+     , (73154,  13,    0.85) /* ArmorModVsSlash */
+     , (73154,  14,       1) /* ArmorModVsPierce */
+     , (73154,  15,       1) /* ArmorModVsBludgeon */
+     , (73154,  16,       1) /* ArmorModVsCold */
+     , (73154,  17,    0.85) /* ArmorModVsFire */
+     , (73154,  18,       1) /* ArmorModVsAcid */
+     , (73154,  19,       1) /* ArmorModVsElectric */
+     , (73154,  31,      20) /* VisualAwarenessRange */
+     , (73154,  39,     1.3) /* DefaultScale */
+     , (73154,  64,    0.55) /* ResistSlash */
+     , (73154,  65,    0.45) /* ResistPierce */
+     , (73154,  66,    0.45) /* ResistBludgeon */
+     , (73154,  67,    0.65) /* ResistFire */
+     , (73154,  68,       0) /* ResistCold */
+     , (73154,  69,     0.3) /* ResistAcid */
+     , (73154,  70,     0.3) /* ResistElectric */
+     , (73154,  71,       1) /* ResistHealthBoost */
+     , (73154,  72,    0.25) /* ResistStaminaDrain */
+     , (73154,  73,       1) /* ResistStaminaBoost */
+     , (73154,  74,       1) /* ResistManaDrain */
+     , (73154,  75,       1) /* ResistManaBoost */
+     , (73154,  80,       3) /* AiUseMagicDelay */
+     , (73154, 104,      10) /* ObviousRadarRange */
+     , (73154, 122,       2) /* AiAcquireHealth */
+     , (73154, 125,    0.25) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73154,   1, 'Algid Warrior') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73154,   1, 0x02001482) /* Setup */
+     , (73154,   2, 0x09000001) /* MotionTable */
+     , (73154,   3, 0x2000005A) /* SoundTable */
+     , (73154,   4, 0x30000000) /* CombatTable */
+     , (73154,   6, 0x04001DEA) /* PaletteBase */
+     , (73154,   7, 0x10000634) /* ClothingBase */
+     , (73154,   8, 0x06002402) /* Icon */
+     , (73154,  22, 0x34000075) /* PhysicsEffectTable */
+     , (73154,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73154,   1, 450, 0, 0) /* Strength */
+     , (73154,   2, 460, 0, 0) /* Endurance */
+     , (73154,   3, 450, 0, 0) /* Quickness */
+     , (73154,   4, 450, 0, 0) /* Coordination */
+     , (73154,   5, 350, 0, 0) /* Focus */
+     , (73154,   6, 350, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73154,   1, 19500, 0, 0, 19730) /* MaxHealth */
+     , (73154,   3, 18000, 0, 0, 18460) /* MaxStamina */
+     , (73154,   5,  9750, 0, 0, 10100) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73154,  6, 0, 3, 0, 395, 0, 0) /* MeleeDefense        Specialized */
+     , (73154,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
+     , (73154, 15, 0, 3, 0, 305, 0, 0) /* MagicDefense        Specialized */
+     , (73154, 31, 0, 3, 0, 240, 0, 0) /* CreatureEnchantment Specialized */
+     , (73154, 33, 0, 3, 0, 240, 0, 0) /* LifeMagic           Specialized */
+     , (73154, 34, 0, 3, 0, 240, 0, 0) /* WarMagic            Specialized */
+     , (73154, 45, 0, 3, 0, 410, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73154,  0,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73154,  1,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73154,  2,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73154,  3,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73154,  4,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73154,  5,  8, 300, 0.75,  350,  100,  100,  100,  100,  100,  100,  100,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73154,  6,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73154,  7,  8,  0,    0,  350,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73154,  8,  8, 300, 0.75,  350,  100,  100,  100,  100,  100,  100,  100,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73154,  4425,   2.06)  /* Incantation of Frost Arc */
+     , (73154,  1093,   2.02)  /* Fire Protection Self V */
+     , (73154,  1787,   2.04)  /* Halo of Frost */
+     , (73154,  4312,   2.05)  /* Incantation of Imperil Other */
+     , (73154,  4447,   2.07)  /* Incantation of Frost Bolt */
+     , (73154,  4479,   2.05)  /* Incantation of Cold Vulnerability Other */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Penguin/46143 Baby Penguin.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Penguin/46143 Baby Penguin.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46143;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46143, 'ace46143-babypenguin', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (46143, 'ace46143-babypenguin', 10, '2023-04-29 12:58:01') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46143,   1,         16) /* ItemType - Creature */
@@ -97,15 +97,47 @@ VALUES (46143,  6, 0, 3, 0,  35, 0, 0) /* MeleeDefense        Specialized */
      , (46143, 45, 0, 3, 0,  40, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (46143,  0,  2,  5,  0.6,  100,  130,  100,  110,   98,   80,  100,   98,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (46143,  1,  4, 100,  0.3,  100,  130,  100,  110,   98,   80,  100,   98,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (46143,  2,  4, 100,  0.4,  100,  130,  100,  110,   98,   80,  100,   98,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (46143,  3,  4, 100,  0.3,  100,  130,  100,  110,   98,   80,  100,   98,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (46143,  4,  4, 100,  0.4,  100,  130,  100,  110,   98,   80,  100,   98,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (46143,  5,  4,  5,  0.4,  100,  130,  100,  110,   98,   80,  100,   98,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (46143,  6,  4, 100,  0.3,  100,  130,  100,  110,   98,   80,  100,   98,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (46143,  7,  4, 100,  0.4,  100,  130,  100,  110,   98,   80,  100,   98,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (46143,  8,  4,  5,  0.4,  100,  130,  100,  110,   98,   80,  100,   98,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (46143,  0,  2,  5,  0.6,  100,   50,   50,   50,   50,   50,   50,   50,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (46143,  1,  4, 100,  0.3,  100,   50,   50,   50,   50,   50,   50,   50,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (46143,  2,  4, 100,  0.4,  100,   50,   50,   50,   50,   50,   50,   50,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (46143,  3,  4, 100,  0.3,  100,   50,   50,   50,   50,   50,   50,   50,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (46143,  4,  4, 100,  0.4,  100,   50,   50,   50,   50,   50,   50,   50,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (46143,  5,  4,  5,  0.4,  100,   50,   50,   50,   50,   50,   50,   50,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (46143,  6,  4, 100,  0.3,  100,   50,   50,   50,   50,   50,   50,   50,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (46143,  7,  4, 100,  0.4,  100,   50,   50,   50,   50,   50,   50,   50,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (46143,  8,  4,  5,  0.4,  100,   50,   50,   50,   50,   50,   50,   50,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46143,  5 /* HeartBeat */,  0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46143,  5 /* HeartBeat */,  0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46143,  5 /* HeartBeat */,  0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46143,  5 /* HeartBeat */,  0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (46143, 18 /* Scream */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Penguin/46143.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Penguin/46143.es
@@ -1,0 +1,16 @@
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.172
+    - Move: 0x00000000 [6 6 0] 1 0 0 0
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.272
+    - Move: 0x00000000 [0 12 0] 1 0 0 0
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.372
+    - Move: 0x00000000 [-6 6 0] 1 0 0 0
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.472
+    - Move: 0x00000000 [0 0 0] 1 0 0 0
+
+Scream:
+    - DirectBroadcast: The baby penguin shrieks when it sees you, alerting a nearby adult.
+    - Generate
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Penguin/46299 Tiny.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Penguin/46299 Tiny.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46299;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46299, 'ace46299-tiny', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (46299, 'ace46299-tiny', 10, '2023-04-30 02:45:29') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46299,   1,         16) /* ItemType - Creature */
@@ -16,7 +16,7 @@ VALUES (46299,   1,         16) /* ItemType - Creature */
      , (46299,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (46299, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (46299, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (46299, 146,    1400000) /* XpOverride */;
+     , (46299, 146,    4000000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (46299,   1, True ) /* Stuck */;
@@ -85,7 +85,7 @@ VALUES (46299,   1, 37650, 0, 0, 38000) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (46299,  6, 0, 3, 0, 135, 0, 0) /* MeleeDefense        Specialized */
      , (46299,  7, 0, 3, 0, 300, 0, 0) /* MissileDefense      Specialized */
-     , (46299, 15, 0, 3, 0, 100, 0, 0) /* MagicDefense        Specialized */
+     , (46299, 15, 0, 3, 0, 200, 0, 0) /* MagicDefense        Specialized */
      , (46299, 22, 0, 2, 0,   2, 0, 0) /* Jump                Trained */
      , (46299, 24, 0, 2, 0,   2, 0, 0) /* Run                 Trained */
      , (46299, 31, 0, 3, 0,  40, 0, 0) /* CreatureEnchantment Specialized */
@@ -94,30 +94,32 @@ VALUES (46299,  6, 0, 3, 0, 135, 0, 0) /* MeleeDefense        Specialized */
      , (46299, 45, 0, 3, 0,  85, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (46299,  0,  2, 175,  0.6,  600,  780,  600,  660,  480,  480,  600,  480,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (46299,  1,  4, 175,  0.3,  600,  780,  600,  660,  480,  480,  600,  480,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (46299,  2,  4, 175,  0.4,  600,  780,  600,  660,  480,  480,  600,  480,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (46299,  3,  4, 175,  0.3,  600,  780,  600,  660,  480,  480,  600,  480,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (46299,  4,  4, 175,  0.4,  600,  780,  600,  660,  480,  480,  600,  480,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (46299,  5,  4, 190,  0.4,  600,  780,  600,  660,  480,  480,  600,  480,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (46299,  6,  4, 175,  0.3,  600,  780,  600,  660,  480,  480,  600,  480,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (46299,  7,  4, 175,  0.4,  600,  780,  600,  660,  480,  480,  600,  480,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (46299,  8,  4, 180,  0.4,  600,  780,  600,  660,  480,  480,  600,  480,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */
-     , (46299, 22, 32, 175,  0.3,  600,  780,  600,  660,  480,  480,  600,  480,    0, 0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Breath */;
+VALUES (46299,  0,  2, 175,  0.6,  600,  300,  300,  300,  300,  300,  300,  300,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (46299,  1,  4, 175,  0.3,  600,  300,  300,  300,  300,  300,  300,  300,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (46299,  2,  4, 175,  0.4,  600,  300,  300,  300,  300,  300,  300,  300,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (46299,  3,  4, 175,  0.3,  600,  300,  300,  300,  300,  300,  300,  300,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (46299,  4,  4, 175,  0.4,  600,  300,  300,  300,  300,  300,  300,  300,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (46299,  5,  4, 190,  0.4,  600,  300,  300,  300,  300,  300,  300,  300,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (46299,  6,  4, 175,  0.3,  600,  300,  300,  300,  300,  300,  300,  300,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (46299,  7,  4, 175,  0.4,  600,  300,  300,  300,  300,  300,  300,  300,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (46299,  8,  4, 180,  0.4,  600,  300,  300,  300,  300,  300,  300,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */
+     , (46299, 22, 32, 175,  0.3,  600,  300,  300,  300,  300,  300,  300,  300,    0, 0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (46299,   628,   2.03)  /* Life Magic Ineptitude Other VI */
-     , (46299,   652,   2.02)  /* War Magic Ineptitude Other VI */
-     , (46299,  1053,  2.005)  /* Bludgeoning Vulnerability Other VI */
-     , (46299,  1065,  2.005)  /* Cold Vulnerability Other VI */
-     , (46299,  1089,  2.005)  /* Lightning Vulnerability Other VI */
-     , (46299,  1611,   2.02)  /* Lure Blade VI */
-     , (46299,  2135,   2.05)  /* Winter's Embrace */
-     , (46299,  2136,   2.05)  /* Icy Torment */
-     , (46299,  2139,   2.05)  /* Luminous Wrath */
-     , (46299,  2141,   2.05)  /* Lhen's Flare */
-     , (46299,  2731,   2.04)  /* Frost Arc VII */
-     , (46299,  2738,   2.04)  /* Lightning Arc VII */;
+VALUES (46299,  4312,   2.02)  /* Incantation of Imperil Other */
+     , (46299,  4477,   2.02)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (46299,  4479,   2.02)  /* Incantation of Cold Vulnerability Other */
+     , (46299,  4483,   2.02)  /* Incantation of Lightning Vulnerability Other */
+     , (46299,  4448,   2.02)  /* Incantation of Frost Streak */
+     , (46299,  4447,   2.03)  /* Incantation of Frost Bolt */
+     , (46299,  4450,   2.02)  /* Incantation of Lightning Blast */
+     , (46299,  4452,   2.02)  /* Incantation of Lightning Streak */
+     , (46299,  4425,   2.04)  /* Incantation of Frost Arc */
+     , (46299,  4426,   2.04)  /* Incantation of Lightning Arc */
+     , (46299,  4633,   2.03)  /* Incantation of Vulnerability Other */
+     , (46299,  4579,   2.03)  /* Incantation of Life Magic Ineptitude Other */
+     , (46299,  4635,   2.03)  /* Incantation of War Magic Ineptitude Other */
+     , (46299,  4451,   2.04)  /* Incantation of Lightning Bolt */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (46299,  5 /* HeartBeat */,  0.085, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Penguin/46307 Penguin Guard.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Penguin/46307 Penguin Guard.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46307;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46307, 'ace46307-penguinguard', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (46307, 'ace46307-penguinguard', 10, '2023-04-30 02:54:24') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46307,   1,         16) /* ItemType - Creature */
@@ -56,5 +56,5 @@ VALUES (46307,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 1.5, 1, 0x100000A1 /* ExitPortal */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 6, 1, NULL, 'The Penguin Guard sees the severed head of Tiny in your hand. His eyes widen with fear and he quickly flees through portalspace!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  77 /* DeleteSelf */, 2, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Penguin/46307.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Penguin/46307.es
@@ -1,0 +1,3 @@
+Generation:
+    - Delay: 6, LocalBroadcast: The Penguin Guard sees the severed head of Tiny in your hand. His eyes widen with fear and he quickly flees through portalspace!
+    - Delay: 2, DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Snowman/46278 Cowardly Snowman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Snowman/46278 Cowardly Snowman.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46278;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46278, 'ace46278-cowardlysnowman', 10, '2022-08-22 03:09:27') /* Creature */;
+VALUES (46278, 'ace46278-cowardlysnowman', 10, '2023-04-30 03:27:45') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46278,   1,         16) /* ItemType - Creature */
@@ -10,12 +10,10 @@ VALUES (46278,   1,         16) /* ItemType - Creature */
      , (46278,   7,         -1) /* ContainersCapacity */
      , (46278,  16,          1) /* ItemUseable - No */
      , (46278,  25,        105) /* Level */
-     , (46278,  40,          2) /* CombatMode - Melee */
      , (46278,  68,          9) /* TargetingTactic - Random, TopDamager */
      , (46278,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
-     , (46278, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (46278, 101,     524288) /* AiAllowedCombatStyle - StubbornMissile */
      , (46278, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (46278, 140,          1) /* AiOptions - CanOpenDoors */
      , (46278, 146,       2000) /* XpOverride */
      , (46278, 307,          5) /* DamageRating */;
 
@@ -26,7 +24,8 @@ VALUES (46278,   1, True ) /* Stuck */
      , (46278,  12, True ) /* ReportCollisions */
      , (46278,  13, False) /* Ethereal */
      , (46278,  14, True ) /* GravityStatus */
-     , (46278,  19, True ) /* Attackable */;
+     , (46278,  19, True ) /* Attackable */
+     , (46278,  52, True ) /* AiImmobile */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (46278,   1,       5) /* HeartbeatInterval */
@@ -41,7 +40,7 @@ VALUES (46278,   1,       5) /* HeartbeatInterval */
      , (46278,  17,     0.3) /* ArmorModVsFire */
      , (46278,  18,    0.68) /* ArmorModVsAcid */
      , (46278,  19,    0.68) /* ArmorModVsElectric */
-     , (46278,  31,      10) /* VisualAwarenessRange */
+     , (46278,  31,      25) /* VisualAwarenessRange */
      , (46278,  34,       1) /* PowerupTime */
      , (46278,  36,     1.3) /* ChargeSpeed */
      , (46278,  39,     0.9) /* DefaultScale */
@@ -90,23 +89,21 @@ VALUES (46278,   1,   280, 0, 0, 460) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (46278,  6, 0, 3, 0,  70, 0, 0) /* MeleeDefense        Specialized */
      , (46278,  7, 0, 3, 0, 103, 0, 0) /* MissileDefense      Specialized */
-     , (46278, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
      , (46278, 15, 0, 3, 0,  58, 0, 0) /* MagicDefense        Specialized */
      , (46278, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
-     , (46278, 24, 0, 3, 0,  80, 0, 0) /* Run                 Specialized */
      , (46278, 45, 0, 3, 0, 110, 0, 0) /* LightWeapons        Specialized */
-     , (46278, 47, 0, 3, 0,  70, 0, 0) /* MissileWeapons      Specialized */;
+     , (46278, 47, 0, 3, 0, 140, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (46278,  0,  4,  0,    0,   90,   61,   38,   61,    9,   27,   61,   61,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (46278,  1,  4,  0,    0,  100,   68,   42,   68,   10,   30,   68,   68,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (46278,  2,  4,  0,    0,  110,   75,   46,   75,   11,   33,   75,   75,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (46278,  3,  4,  0,    0,  100,   68,   42,   68,   10,   30,   68,   68,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (46278,  4,  4,  0,    0,  100,   68,   42,   68,   10,   30,   68,   68,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (46278,  5,  4, 10, 0.75,  100,   68,   42,   68,   10,   30,   68,   68,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (46278,  6,  4,  0,    0,  100,   68,   42,   68,   10,   30,   68,   68,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (46278,  7,  4,  0,    0,  100,   68,   42,   68,   10,   30,   68,   68,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (46278,  8,  4, 10, 0.75,  100,   68,   42,   68,   10,   30,   68,   68,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (46278,  0,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (46278,  1,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (46278,  2,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (46278,  3,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (46278,  4,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (46278,  5,  4, 10, 0.75,  150,   75,   75,   75,   75,   75,   75,   75,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (46278,  6,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (46278,  7,  4,  0,    0,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (46278,  8,  4, 10, 0.75,  150,   75,   75,   75,   75,   75,   75,   75,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (46278,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -139,6 +136,14 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46278, 18 /* Scream */,   0.25, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Aim for the face!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (46278, 2, 46282,  1, 0, 0, False) /* Create Iceball (46282) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Snowman/46278.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Snowman/46278.es
@@ -1,0 +1,14 @@
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.025
+    - Motion: Twitch2
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.03
+    - Motion: Twitch1
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.025
+    - Motion: Twitch2
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.03
+    - Motion: Twitch1
+
+Scream: Probability: 0.25
+    - Say: Aim for the face!

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46303 Wall of Ice.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46303 Wall of Ice.sql
@@ -43,7 +43,6 @@ VALUES (46303,   1,       5) /* HeartbeatInterval */
      , (46303,  19,    0.89) /* ArmorModVsElectric */
      , (46303,  31,      10) /* VisualAwarenessRange */
      , (46303,  34,     3.3) /* PowerupTime */
-     , (46303,  39,     1.1) /* DefaultScale */
      , (46303,  64,     0.5) /* ResistSlash */
      , (46303,  65,     0.5) /* ResistPierce */
      , (46303,  66,    0.75) /* ResistBludgeon */
@@ -56,7 +55,6 @@ VALUES (46303,   1,       5) /* HeartbeatInterval */
      , (46303,  73,       1) /* ResistStaminaBoost */
      , (46303,  74,       1) /* ResistManaDrain */
      , (46303,  75,       1) /* ResistManaBoost */
-     , (46303,  76,     0.3) /* Translucency */
      , (46303,  80,       3) /* AiUseMagicDelay */
      , (46303, 104,      10) /* ObviousRadarRange */
      , (46303, 122,       2) /* AiAcquireHealth */

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46320 Security Station.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46320 Security Station.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46320;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46320, 'ace46320-securitystation', 10, '2021-11-17 16:56:08') /* Creature */;
+VALUES (46320, 'ace46320-securitystation', 10, '2023-04-29 06:12:28') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46320,   1,         16) /* ItemType - Creature */
@@ -38,15 +38,14 @@ VALUES (46320,   1, 0x02001B80) /* Setup */
      , (46320,  22, 0x34000089) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (46320,  6 /* Give */,      1, 46288 /* Tiny's Head */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (46320, 6 /* Give */, 1, 46288 /* Tiny's Head */, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You hold the head of Tiny up to the Security Station window. Seeing a face he recognizes, the guard opens the door.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  18 /* DirectBroadcast */, 1, 1, NULL, 'The Penguin Guard sees the severed head of Tiny in your hand. His eyes widen with fear and he quickly flees through portalspace!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 18 /* DirectBroadcast */, 0, 1, NULL, 'You hold the head of Tiny up to the Security Station window. Seeing a face he recognizes, the guard opens the door.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 2, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (46320, -1, 46307, 300, 1, 1, 1, 4, -1, 0, 0, 0x584D011B, 140, -60, -23.9952, -0.707107, 0, 0, -0.707107) /* Generate Penguin Guard (46307) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46320.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46320.es
@@ -1,0 +1,4 @@
+Give: Tiny's Head (46288)
+    - DirectBroadcast: You hold the head of Tiny up to the Security Station window. Seeing a face he recognizes, the guard opens the door.
+    - Activate
+    - Generate

--- a/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/46282 Iceball.sql
+++ b/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/46282 Iceball.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46282;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46282, 'ace46282-iceball', 4, '2019-02-10 00:00:00') /* Missile */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46282,   1,        256) /* ItemType - MissileWeapon */
+     , (46282,   3,          2) /* PaletteTemplate - Blue */
+     , (46282,   5,         50) /* EncumbranceVal */
+     , (46282,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (46282,  11,       5000) /* MaxStackSize */
+     , (46282,  12,          1) /* StackSize */
+     , (46282,  13,         50) /* StackUnitEncumbrance */
+     , (46282,  15,        100) /* StackUnitValue */
+     , (46282,  16,          1) /* ItemUseable - No */
+     , (46282,  19,        100) /* Value */
+     , (46282,  36,       9999) /* ResistMagic */
+     , (46282,  44,        150) /* Damage */
+     , (46282,  45,          8) /* DamageType - Cold */
+     , (46282,  46,        128) /* DefaultCombatStyle - ThrownWeapon */
+     , (46282,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (46282,  49,         20) /* WeaponTime */
+     , (46282,  51,          2) /* CombatUse - Missile */
+     , (46282,  93,     132116) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, Inelastic */
+     , (46282, 150,        103) /* HookPlacement - Hook */
+     , (46282, 151,          2) /* HookType - Wall */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46282,  17, True ) /* Inelastic */
+     , (46282,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46282,  21,     1.5) /* WeaponLength */
+     , (46282,  22,    0.25) /* DamageVariance */
+     , (46282,  26,      15) /* MaximumVelocity */
+     , (46282,  27,       1) /* RotationSpeed */
+     , (46282,  29,     0.8) /* WeaponDefense */
+     , (46282,  39,     0.6) /* DefaultScale */
+     , (46282,  78,       1) /* Friction */
+     , (46282,  79,       0) /* Elasticity */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46282,   1, 'Iceball') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46282,   1, 0x020006FF) /* Setup */
+     , (46282,   3, 0x20000014) /* SoundTable */
+     , (46282,   6, 0x04000BF8) /* PaletteBase */
+     , (46282,   7, 0x10000181) /* ClothingBase */
+     , (46282,   8, 0x06002FC1) /* Icon */
+     , (46282,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/PressurePlate/Misc/73153 Penguin's Friend.sql
+++ b/Database/Patches/9 WeenieDefaults/PressurePlate/Misc/73153 Penguin's Friend.sql
@@ -1,0 +1,47 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73153;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73153, 'ace73153-trappenguinfriend', 24, '2005-02-09 10:00:00') /* PressurePlate */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73153,   1,        128) /* ItemType - Misc */
+     , (73153,   5,        500) /* EncumbranceVal */
+     , (73153,   8,        250) /* Mass */
+     , (73153,   9,          0) /* ValidLocations - None */
+     , (73153,  16,          1) /* ItemUseable - No */
+     , (73153,  19,       1000) /* Value */
+     , (73153,  83,       2048) /* ActivationResponse - Emote */
+     , (73153,  93,       1036) /* PhysicsState - Ethereal, ReportCollisions, Gravity */
+     , (73153, 106,        400) /* ItemSpellcraft */
+     , (73153, 119,          1) /* Active */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73153,   1, True ) /* Stuck */
+     , (73153,  11, False) /* IgnoreCollisions */
+     , (73153,  12, True ) /* ReportCollisions */
+     , (73153,  13, True ) /* Ethereal */
+     , (73153,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73153,  11,       2) /* ResetInterval */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73153,   1, 'Penguin''s Friend') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73153,   1, 0x02000450) /* Setup */
+     , (73153,   2, 0x09000021) /* MotionTable */
+     , (73153,   8, 0x060012D2) /* Icon */
+     , (73153,  23,        149) /* UseSound - TriggerActivated */;
+
+INSERT INTO `weenie_properties_i_i_d` (`object_Id`, `type`, `value`)
+VALUES (73153,  16, 0x00000000) /* ActivationTarget */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73153,  8 /* Activation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'A powerful wave of magic washes over you removing enchantments and making your form vulnerable to the cold.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4479 /* Incantation of Cold Vulnerability Other */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Revisions based on Loud Lou and Berek retail videos:

Populates a previously empty section of the dungeon with Algid Warrior guarding a Chorizite Chest (seen on Lou video). Also cleans up positions of some other spawns.

Adds roaming emote to Baby Penguins.

Corrects Wall of Ice scale and transparency (it should have none) based on pcap and video.

Cowardly Snowmen are now armed with their pcapped iceballs, and set to persistent missile, as seen in the Lou video. Also added flavor text emote.

Corrected Tiny's spellbook (he casts level 8s) as seen on the Berek video.

Added Penguin's Friend floor traps (seen in both videos), which cast level 8 cold vul.

Revised the guard station penguin scene to match timing from the video (meaning, players can now see the guard penguin before he disappears).

Set respawn to a 7 min generator as seen on the Lou video (previously was left at default of 13 min).