### PR TITLE
Climbing the Spire Updates

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/27426 Shadow Nightmare.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/27426 Shadow Nightmare.sql
@@ -20,7 +20,8 @@ VALUES (27426,   1,         16) /* ItemType - Creature */
      , (27426, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (27426, 140,          1) /* AiOptions - CanOpenDoors */
      , (27426, 146,     250000) /* XpOverride */
-     , (27426, 188,          1) /* HeritageGroup - Aluvian */;
+     , (27426, 188,          1) /* HeritageGroup - Aluvian */
+     , (27426, 307,          2) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (27426,   1, True ) /* Stuck */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33163 Captain Faalx.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33163 Captain Faalx.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 33163;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (33163, 'ace33163-captainfaalx', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (33163, 'ace33163-captainfaalx', 10, '2023-05-02 12:18:58') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (33163,   1,         16) /* ItemType - Creature */
@@ -20,7 +20,8 @@ VALUES (33163,   1,         16) /* ItemType - Creature */
      , (33163, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (33163, 140,          1) /* AiOptions - CanOpenDoors */
      , (33163, 146,     500000) /* XpOverride */
-     , (33163, 188,          1) /* HeritageGroup - Aluvian */;
+     , (33163, 188,          1) /* HeritageGroup - Aluvian */
+     , (33163, 307,          7) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (33163,   1, True ) /* Stuck */
@@ -75,22 +76,6 @@ VALUES (33163,   1, 0x02000001) /* Setup */
      , (33163,   6, 0x0400007E) /* PaletteBase */
      , (33163,   8, 0x06001BBE) /* Icon */
      , (33163,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33163,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33163,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -102,8 +87,8 @@ VALUES (33163,   1, 180, 0, 0) /* Strength */
      , (33163,   6, 130, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (33163,   1, 19860, 0, 0, 20000) /* MaxHealth */
-     , (33163,   3, 20100, 0, 0, 20200) /* MaxStamina */
+VALUES (33163,   1, 19900, 0, 0, 20000) /* MaxHealth */
+     , (33163,   3, 20000, 0, 0, 20200) /* MaxStamina */
      , (33163,   5, 20000, 0, 0, 20130) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
@@ -117,15 +102,15 @@ VALUES (33163,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
      , (33163, 46, 0, 3, 0, 387, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33163,  0,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33163,  1,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33163,  2,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33163,  3,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33163,  4,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33163,  5,  4, 60, 0.75,  190,  190,  152,  162,  114,  175,  131,  190,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33163,  6,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33163,  7,  4,  0,    0,  190,  190,  152,  162,  114,  175,  131,  190,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33163,  8,  4, 60, 0.75,  190,  190,  152,  162,  114,  175,  131,  190,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33163,  0,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33163,  1,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33163,  2,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33163,  3,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33163,  4,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33163,  5,  4, 60, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33163,  6,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33163,  7,  4,  0,    0,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33163,  8,  4, 60, 0.75,  190,   95,   95,   95,   95,   95,   95,   95,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (33163,   234,   2.02)  /* Vulnerability Other VI */
@@ -172,7 +157,13 @@ VALUES (33163, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33163, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33163, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33163, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33163, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33163, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33163, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33163, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33163, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33163, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33163, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33163, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33163, -1, 33185, 1, 1, 1, 1, 4, -1, 0, 0, 0x006F010D, 0, 0, 78.1649, 1, 0, 0, 0) /* Generate Spire's Head (33185) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33165 Shadow Cyst.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33165 Shadow Cyst.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 33165;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (33165, 'ace33165-shadowcyst', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (33165, 'ace33165-shadowcyst', 10, '2023-05-02 04:30:16') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (33165,   1,         16) /* ItemType - Creature */
@@ -36,26 +36,24 @@ VALUES (33165,   1,       5) /* HeartbeatInterval */
      , (33165,   4,     2.5) /* StaminaRate */
      , (33165,   5,       1) /* ManaRate */
      , (33165,  12,     0.5) /* Shade */
-     , (33165,  13,    0.92) /* ArmorModVsSlash */
-     , (33165,  14,    0.65) /* ArmorModVsPierce */
-     , (33165,  15,    0.58) /* ArmorModVsBludgeon */
-     , (33165,  16,    0.58) /* ArmorModVsCold */
-     , (33165,  17,    0.94) /* ArmorModVsFire */
-     , (33165,  18,    0.65) /* ArmorModVsAcid */
-     , (33165,  19,    0.48) /* ArmorModVsElectric */
-     , (33165,  31,      18) /* VisualAwarenessRange */
-     , (33165,  34,     1.1) /* PowerupTime */
+     , (33165,  13,       1) /* ArmorModVsSlash */
+     , (33165,  14,    0.76) /* ArmorModVsPierce */
+     , (33165,  15,    0.84) /* ArmorModVsBludgeon */
+     , (33165,  16,    0.57) /* ArmorModVsCold */
+     , (33165,  17,       1) /* ArmorModVsFire */
+     , (33165,  18,    0.62) /* ArmorModVsAcid */
+     , (33165,  19,    0.76) /* ArmorModVsElectric */
+     , (33165,  31,      25) /* VisualAwarenessRange */
+     , (33165,  34,     1.2) /* PowerupTime */
      , (33165,  36,       1) /* ChargeSpeed */
-     , (33165,  39,     1.1) /* DefaultScale */
-     , (33165,  41,       0) /* RegenerationInterval */
-     , (33165,  43,       3) /* GeneratorRadius */
-     , (33165,  64,    0.88) /* ResistSlash */
+     , (33165,  39,       1) /* DefaultScale */
+     , (33165,  64,       1) /* ResistSlash */
      , (33165,  65,     0.5) /* ResistPierce */
-     , (33165,  66,    0.65) /* ResistBludgeon */
-     , (33165,  67,    0.89) /* ResistFire */
+     , (33165,  66,    0.67) /* ResistBludgeon */
+     , (33165,  67,       1) /* ResistFire */
      , (33165,  68,     0.1) /* ResistCold */
      , (33165,  69,     0.2) /* ResistAcid */
-     , (33165,  70,     0.2) /* ResistElectric */
+     , (33165,  70,     0.5) /* ResistElectric */
      , (33165,  71,       1) /* ResistHealthBoost */
      , (33165,  72,       1) /* ResistStaminaDrain */
      , (33165,  73,       1) /* ResistStaminaBoost */
@@ -96,52 +94,65 @@ VALUES (33165,   1, 60000, 0, 0, 60140) /* MaxHealth */
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (33165,  6, 0, 3, 0, 350, 0, 0) /* MeleeDefense        Specialized */
-     , (33165,  7, 0, 3, 0, 345, 0, 0) /* MissileDefense      Specialized */
-     , (33165, 14, 0, 3, 0, 320, 0, 0) /* ArcaneLore          Specialized */
+     , (33165,  7, 0, 3, 0, 445, 0, 0) /* MissileDefense      Specialized */
      , (33165, 15, 0, 3, 0, 250, 0, 0) /* MagicDefense        Specialized */
-     , (33165, 20, 0, 3, 0, 150, 0, 0) /* Deception           Specialized */
+     , (33165, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
      , (33165, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
      , (33165, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
      , (33165, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (33165, 44, 0, 3, 0, 355, 0, 0) /* HeavyWeapons        Specialized */
      , (33165, 45, 0, 3, 0, 355, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33165,  0,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33165,  1,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33165,  2,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33165,  3,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33165,  4,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33165,  5,  4, 105,  0.5,  500,  460,  325,  290,  290,  470,  325,  240,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33165,  6,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33165,  7,  4,  0,    0,  500,  460,  325,  290,  290,  470,  325,  240,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33165,  8,  4, 105,  0.5,  500,  460,  325,  290,  290,  470,  325,  240,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33165,  0,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33165,  1,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33165,  2,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33165,  3,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33165,  4,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33165,  5,  4, 105,  0.5,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33165,  6,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33165,  7,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33165,  8,  4, 105,  0.5,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33165,  2053,  2.005)  /* Executor's Blessing */
-     , (33165,  2073,   2.02)  /* Adja's Intervention */
-     , (33165,  2128,   2.02)  /* Ilservian's Flame */
-     , (33165,  2132,   2.02)  /* The Spike */
-     , (33165,  2136,   2.02)  /* Icy Torment */
-     , (33165,  2140,   2.02)  /* Alset's Coil */
-     , (33165,  2146,   2.02)  /* Evisceration */
-     , (33165,  2164,   2.02)  /* Swordsman's Gift */
-     , (33165,  2168,   2.02)  /* Gelidite's Gift */
-     , (33165,  2172,   2.02)  /* Astyrrian's Gift */
-     , (33165,  2174,   2.02)  /* Archer's Gift */
-     , (33165,  2328,   2.02)  /* Vitality Siphon */
-     , (33165,  2329,   2.02)  /* Essence Void */
-     , (33165,  2330,   2.02)  /* Vigor Siphon */
-     , (33165,  3210,   2.01)  /* Agitate */
-     , (33165,  3211,   2.01)  /* Annoyance */
-     , (33165,  3212,   2.01)  /* Guilt Trip */
-     , (33165,  3213,   2.01)  /* Heart Ache */
-     , (33165,  3214,   2.01)  /* Sorrow */
-     , (33165,  3215,   2.01)  /* Underfoot */
-     , (33165,  3915,   2.03)  /* Black Madness */;
+VALUES (33165,  2136,  2.036)  /* Icy Torment */
+     , (33165,  2140,  2.036)  /* Alset's Coil */
+     , (33165,  2128,  2.036)  /* Ilservian's Flame */
+     , (33165,  2132,  2.036)  /* The Spike */
+     , (33165,  2146,  2.036)  /* Evisceration */
+     , (33165,  2138,  2.005)  /* Blizzard */
+     , (33165,  2142,  2.005)  /* Tempest */
+     , (33165,  2130,  2.005)  /* Infernae */
+     , (33165,  2134,  2.005)  /* Fusillade */
+     , (33165,  2125,  2.005)  /* Flensing Wings */
+     , (33165,  2318,   2.01)  /* Gravity Well */
+     , (33165,  2228,   2.01)  /* Broadside of a Barn */
+     , (33165,  2282,   2.01)  /* Futility */
+     , (33165,  2328,  2.009)  /* Vitality Siphon */
+     , (33165,  2330,  2.009)  /* Vigor Siphon */
+     , (33165,  2329,  2.009)  /* Essence Void */
+     , (33165,  2157,  2.009)  /* Fiery Blessing */
+     , (33165,  3914,  2.009)  /* Dark Vortex */
+     , (33165,  3915,  2.009)  /* Black Madness */
+     , (33165,  2062,  2.009)  /* Anemia */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (33165, 15 /* WoundedTaunt */,      1, NULL, NULL, NULL, NULL, NULL, 0.15, 0.26);
+VALUES (33165, 15 /* WoundedTaunt */,      1, NULL, NULL, NULL, NULL, NULL, 0.74, 0.76);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (33165, 15 /* WoundedTaunt */,      1, NULL, NULL, NULL, NULL, NULL, 0.49, 0.51);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (33165, 15 /* WoundedTaunt */,      1, NULL, NULL, NULL, NULL, NULL, 0.24, 0.26);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -161,5 +172,15 @@ VALUES (33165, 9, 33169,  0, 0, 0, False) /* Create Boney Lump of Flesh (33169) 
      , (33165, 9, 33169,  0, 0, 0, False) /* Create Boney Lump of Flesh (33169) for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (33165, -1, 25663, 1, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Void Knight (25663) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (33165, -1, 31280, 1, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Twisted Shadow (31280) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (33165, -1, 25663, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Void Knight (25663) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 31280, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Twisted Shadow (31280) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 31280, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Twisted Shadow (31280) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 25665, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Wretched (25665) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 27426, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Shadow Nightmare (27426) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 33166, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Isin Dule's Lieutenant (33166) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 33167, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Umbral Soldier (33167) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 25665, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Wretched (25665) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 27426, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Shadow Nightmare (27426) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 73156, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Isin Dule's Captain (73156) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 25663, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Void Knight (25663) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33165, -1, 25665, 1800, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Wretched (25665) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33165.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33165.es
@@ -1,0 +1,9 @@
+WoundedTaunt: MinHealth: 0.74, MaxHealth: 0.76
+    - Generate
+
+WoundedTaunt: MinHealth: 0.49, MaxHealth: 0.51
+    - Generate
+
+WoundedTaunt: MinHealth: 0.24, MaxHealth: 0.26
+    - Generate
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33166 Isin Dule's Lieutenant.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33166 Isin Dule's Lieutenant.sql
@@ -1,0 +1,152 @@
+DELETE FROM `weenie` WHERE `class_Id` = 33166;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (33166, 'ace33166-isinduleslieutenant', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (33166,   1,         16) /* ItemType - Creature */
+     , (33166,   2,         22) /* CreatureType - Shadow */
+     , (33166,   3,         93) /* PaletteTemplate - DyeSpringBlack */
+     , (33166,   6,         -1) /* ItemsCapacity */
+     , (33166,   7,         -1) /* ContainersCapacity */
+     , (33166,  16,          1) /* ItemUseable - No */
+     , (33166,  25,        160) /* Level */
+     , (33166,  40,          2) /* CombatMode - Melee */
+     , (33166,  68,          3) /* TargetingTactic - Random, Focused */
+     , (33166,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (33166, 113,          1) /* Gender - Male */
+     , (33166, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (33166, 140,          1) /* AiOptions - CanOpenDoors */
+     , (33166, 146,     470000) /* XpOverride */
+     , (33166, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (33166,   1, True ) /* Stuck */
+     , (33166,   6, False) /* AiUsesMana */
+     , (33166,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (33166,   1,       5) /* HeartbeatInterval */
+     , (33166,   2,       0) /* HeartbeatTimestamp */
+     , (33166,   3,    0.69) /* HealthRate */
+     , (33166,   4,     2.5) /* StaminaRate */
+     , (33166,   5,       1) /* ManaRate */
+     , (33166,  12,     0.5) /* Shade */
+     , (33166,  13,       1) /* ArmorModVsSlash */
+     , (33166,  14,     0.8) /* ArmorModVsPierce */
+     , (33166,  15,    0.85) /* ArmorModVsBludgeon */
+     , (33166,  16,     0.6) /* ArmorModVsCold */
+     , (33166,  17,     1.1) /* ArmorModVsFire */
+     , (33166,  18,    0.69) /* ArmorModVsAcid */
+     , (33166,  19,       1) /* ArmorModVsElectric */
+     , (33166,  31,      28) /* VisualAwarenessRange */
+     , (33166,  34,     1.1) /* PowerupTime */
+     , (33166,  36,       1) /* ChargeSpeed */
+     , (33166,  39,     1.2) /* DefaultScale */
+     , (33166,  64,     0.8) /* ResistSlash */
+     , (33166,  65,     0.5) /* ResistPierce */
+     , (33166,  66,    0.69) /* ResistBludgeon */
+     , (33166,  67,    0.82) /* ResistFire */
+     , (33166,  68,     0.1) /* ResistCold */
+     , (33166,  69,     0.2) /* ResistAcid */
+     , (33166,  70,     0.2) /* ResistElectric */
+     , (33166,  71,       1) /* ResistHealthBoost */
+     , (33166,  72,       1) /* ResistStaminaDrain */
+     , (33166,  73,       1) /* ResistStaminaBoost */
+     , (33166,  74,       1) /* ResistManaDrain */
+     , (33166,  75,       1) /* ResistManaBoost */
+     , (33166,  80,     1.5) /* AiUseMagicDelay */
+     , (33166, 104,      10) /* ObviousRadarRange */
+     , (33166, 122,       3) /* AiAcquireHealth */
+     , (33166, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (33166,   1, 'Isin Dule''s Lieutenant') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (33166,   1, 0x02000001) /* Setup */
+     , (33166,   2, 0x09000001) /* MotionTable */
+     , (33166,   3, 0x20000001) /* SoundTable */
+     , (33166,   4, 0x30000028) /* CombatTable */
+     , (33166,   6, 0x0400007E) /* PaletteBase */
+     , (33166,   8, 0x06001BBE) /* Icon */
+     , (33166,  22, 0x34000063) /* PhysicsEffectTable */
+     , (33166,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (33166,   1, 180, 0, 0) /* Strength */
+     , (33166,   2, 200, 0, 0) /* Endurance */
+     , (33166,   3, 240, 0, 0) /* Quickness */
+     , (33166,   4, 220, 0, 0) /* Coordination */
+     , (33166,   5, 200, 0, 0) /* Focus */
+     , (33166,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (33166,   1,  2650, 0, 0, 2750) /* MaxHealth */
+     , (33166,   3,  2720, 0, 0, 2920) /* MaxStamina */
+     , (33166,   5,  2740, 0, 0, 2870) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33166,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
+     , (33166,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Specialized */
+     , (33166, 15, 0, 3, 0, 323, 0, 0) /* MagicDefense        Specialized */
+     , (33166, 31, 0, 3, 0, 317, 0, 0) /* CreatureEnchantment Specialized */
+     , (33166, 33, 0, 3, 0, 317, 0, 0) /* LifeMagic           Specialized */
+     , (33166, 34, 0, 3, 0, 317, 0, 0) /* WarMagic            Specialized */
+     , (33166, 45, 0, 3, 0, 407, 0, 0) /* LightWeapons        Specialized */
+     , (33166, 46, 0, 3, 0, 387, 0, 0) /* FinesseWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (33166,  0,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33166,  1,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33166,  2,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33166,  3,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33166,  4,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33166,  5,  4, 60, 0.75,  190,  190,  152,  162,  114,  209,  131,  190,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33166,  6,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33166,  7,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33166,  8,  4, 60, 0.75,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (33166,   234,   2.02)  /* Vulnerability Other VI */
+     , (33166,   267,   2.02)  /* Defenselessness Other VI */
+     , (33166,   285,   2.02)  /* Magic Yield Other VI */
+     , (33166,   628,   2.01)  /* Life Magic Ineptitude Other VI */
+     , (33166,  1065,   2.02)  /* Cold Vulnerability Other VI */
+     , (33166,  1089,   2.02)  /* Lightning Vulnerability Other VI */
+     , (33166,  1132,   2.02)  /* Blade Vulnerability Other VI */
+     , (33166,  1156,   2.02)  /* Piercing Vulnerability Other VI */
+     , (33166,  1784,   2.04)  /* Horizon's Blades */
+     , (33166,  1785,   2.04)  /* Cassius' Ring of Fire */
+     , (33166,  1786,   2.04)  /* Nuhmudira's Spines */
+     , (33166,  1787,   2.04)  /* Halo of Frost */
+     , (33166,  1788,   2.04)  /* Eye of the Storm */
+     , (33166,  2053,   2.01)  /* Executor's Blessing */
+     , (33166,  2056,   2.02)  /* Ataxia */
+     , (33166,  2084,   2.01)  /* Belly of Lead */
+     , (33166,  2125,   2.04)  /* Flensing Wings */
+     , (33166,  2130,   2.04)  /* Infernae */
+     , (33166,  2134,   2.04)  /* Fusillade */
+     , (33166,  2138,   2.04)  /* Blizzard */
+     , (33166,  2142,   2.04)  /* Tempest */
+     , (33166,  2328,   2.01)  /* Vitality Siphon */
+     , (33166,  2329,   2.01)  /* Essence Void */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (33166, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) for Wield */
+     , (33166, 2, 21152,  1, 93, 0, False) /* Create Covenant Breastplate (21152) for Wield */
+     , (33166, 2, 21157,  1, 93, 0, False) /* Create Covenant Pauldrons (21157) for Wield */
+     , (33166, 2, 21151,  1, 93, 0, False) /* Create Covenant Bracers (21151) for Wield */
+     , (33166, 2, 21153,  1, 93, 0, False) /* Create Covenant Gauntlets (21153) for Wield */
+     , (33166, 2, 21154,  1, 93, 0, False) /* Create Covenant Girth (21154) for Wield */
+     , (33166, 2, 21155,  1, 93, 0, False) /* Create Covenant Greaves (21155) for Wield */
+     , (33166, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
+     , (33166, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
+     , (33166, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
+     , (33166, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33166, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33166, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33166, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33166, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33166, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33166, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33167 Umbral Soldier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33167 Umbral Soldier.sql
@@ -71,22 +71,6 @@ VALUES (33167,   1, 0x02000001) /* Setup */
      , (33167,   6, 0x0400007E) /* PaletteBase */
      , (33167,   8, 0x06001BBE) /* Icon */
      , (33167,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33167,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33167,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -159,4 +143,10 @@ VALUES (33167, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33167, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33167, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33167, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33167, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33167, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33167, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33167, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33167, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33167, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33167, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33167, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33168 Panumbral Soldier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33168 Panumbral Soldier.sql
@@ -77,22 +77,6 @@ VALUES (33168,   1, 0x02000001) /* Setup */
      , (33168,   6, 0x0400007E) /* PaletteBase */
      , (33168,   8, 0x06001BBE) /* Icon */
      , (33168,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33168,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33168,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -169,4 +153,10 @@ VALUES (33168, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33168, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33168, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33168, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33168, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33168, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33168, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33168, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33168, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33168, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33168, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33168, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33170 Lieutenant Beraxis.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33170 Lieutenant Beraxis.sql
@@ -71,22 +71,6 @@ VALUES (33170,   1, 0x02000001) /* Setup */
      , (33170,   6, 0x0400007E) /* PaletteBase */
      , (33170,   8, 0x06001BBE) /* Icon */
      , (33170,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33170,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33170,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -148,14 +132,6 @@ VALUES (33170,   234,   2.02)  /* Vulnerability Other VI */
      , (33170,  2328,   2.01)  /* Vitality Siphon */
      , (33170,  2329,   2.01)  /* Essence Void */;
 
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (33170,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  88 /* LocalSignal */, 0, 1, NULL, 'LtDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33170, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) for Wield */
      , (33170, 2, 21152,  1, 93, 0, False) /* Create Covenant Breastplate (21152) for Wield */
@@ -167,4 +143,10 @@ VALUES (33170, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33170, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33170, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33170, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33170, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33170, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33170, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33170, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33170, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33170, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33170, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33170, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33171 Lieutenant Shenza.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33171 Lieutenant Shenza.sql
@@ -71,22 +71,6 @@ VALUES (33171,   1, 0x02000001) /* Setup */
      , (33171,   6, 0x0400007E) /* PaletteBase */
      , (33171,   8, 0x06001BBE) /* Icon */
      , (33171,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33171,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33171,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -148,14 +132,6 @@ VALUES (33171,   234,   2.02)  /* Vulnerability Other VI */
      , (33171,  2328,   2.01)  /* Vitality Siphon */
      , (33171,  2329,   2.01)  /* Essence Void */;
 
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (33171,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  88 /* LocalSignal */, 0, 1, NULL, 'LtDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33171, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) for Wield */
      , (33171, 2, 21152,  1, 93, 0, False) /* Create Covenant Breastplate (21152) for Wield */
@@ -167,4 +143,10 @@ VALUES (33171, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33171, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33171, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33171, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33171, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33171, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33171, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33171, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33171, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33171, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33171, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33171, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33172 Lieutenant Yezusthule.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33172 Lieutenant Yezusthule.sql
@@ -71,22 +71,6 @@ VALUES (33172,   1, 0x02000001) /* Setup */
      , (33172,   6, 0x0400007E) /* PaletteBase */
      , (33172,   8, 0x06001BBE) /* Icon */
      , (33172,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33172,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33172,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -148,14 +132,6 @@ VALUES (33172,   234,   2.02)  /* Vulnerability Other VI */
      , (33172,  2328,   2.01)  /* Vitality Siphon */
      , (33172,  2329,   2.01)  /* Essence Void */;
 
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (33172,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  88 /* LocalSignal */, 0, 1, NULL, 'LtDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33172, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) for Wield */
      , (33172, 2, 21152,  1, 93, 0, False) /* Create Covenant Breastplate (21152) for Wield */
@@ -167,4 +143,10 @@ VALUES (33172, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33172, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33172, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33172, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33172, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33172, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33172, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33172, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33172, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33172, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33172, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33172, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33174 Panumbral Soldier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33174 Panumbral Soldier.sql
@@ -13,7 +13,7 @@ VALUES (33174,   1,         16) /* ItemType - Creature */
      , (33174,  25,        160) /* Level */
      , (33174,  40,          2) /* CombatMode - Melee */
      , (33174,  68,          3) /* TargetingTactic - Random, Focused */
-     , (33174,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (33174,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (33174, 113,          1) /* Gender - Male */
      , (33174, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (33174, 140,          1) /* AiOptions - CanOpenDoors */
@@ -71,22 +71,6 @@ VALUES (33174,   1, 0x02000001) /* Setup */
      , (33174,   6, 0x0400007E) /* PaletteBase */
      , (33174,   8, 0x06001BBE) /* Icon */
      , (33174,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33174,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33174,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -159,4 +143,10 @@ VALUES (33174, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33174, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33174, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33174, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33174, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33174, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33174, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33174, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33174, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33174, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33174, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33174, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33175 Umbral Soldier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33175 Umbral Soldier.sql
@@ -13,7 +13,7 @@ VALUES (33175,   1,         16) /* ItemType - Creature */
      , (33175,  25,        160) /* Level */
      , (33175,  40,          2) /* CombatMode - Melee */
      , (33175,  68,          3) /* TargetingTactic - Random, Focused */
-     , (33175,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (33175,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (33175, 113,          1) /* Gender - Male */
      , (33175, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (33175, 140,          1) /* AiOptions - CanOpenDoors */
@@ -71,22 +71,6 @@ VALUES (33175,   1, 0x02000001) /* Setup */
      , (33175,   6, 0x0400007E) /* PaletteBase */
      , (33175,   8, 0x06001BBE) /* Icon */
      , (33175,  22, 0x34000063) /* PhysicsEffectTable */
-     , (33175,  32,       5920) /* WieldedTreasureType - 
-                                   |  10.00% chance of Shadow Blade (33080)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33081)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33082)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  10.00% chance of Shadow Blade (33083)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105)
-                                   |  60.00% chance of Shadow Blade (33084)
-                                   |         with
-                                   |            100.00% chance of Shield of Isin Dule (33105) */
      , (33175,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -159,4 +143,10 @@ VALUES (33175, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) fo
      , (33175, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
      , (33175, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33175, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
-     , (33175, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */;
+     , (33175, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (33175, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (33175, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (33175, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (33175, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (33175, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (33175, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/73156 Isin Dule's Captain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/73156 Isin Dule's Captain.sql
@@ -1,0 +1,153 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73156;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73156, 'ace73156-isindulescaptain', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73156,   1,         16) /* ItemType - Creature */
+     , (73156,   2,         22) /* CreatureType - Shadow */
+     , (73156,   3,         93) /* PaletteTemplate - DyeSpringBlack */
+     , (73156,   6,         -1) /* ItemsCapacity */
+     , (73156,   7,         -1) /* ContainersCapacity */
+     , (73156,  16,          1) /* ItemUseable - No */
+     , (73156,  25,        160) /* Level */
+     , (73156,  40,          2) /* CombatMode - Melee */
+     , (73156,  68,          3) /* TargetingTactic - Random, Focused */
+     , (73156,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73156, 113,          1) /* Gender - Male */
+     , (73156, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73156, 140,          1) /* AiOptions - CanOpenDoors */
+     , (73156, 146,     470000) /* XpOverride */
+     , (73156, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73156,   1, True ) /* Stuck */
+     , (73156,   6, False) /* AiUsesMana */
+     , (73156,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73156,   1,       5) /* HeartbeatInterval */
+     , (73156,   2,       0) /* HeartbeatTimestamp */
+     , (73156,   3,    0.69) /* HealthRate */
+     , (73156,   4,     2.5) /* StaminaRate */
+     , (73156,   5,       1) /* ManaRate */
+     , (73156,  12,     0.5) /* Shade */
+     , (73156,  13,       1) /* ArmorModVsSlash */
+     , (73156,  14,     0.8) /* ArmorModVsPierce */
+     , (73156,  15,    0.85) /* ArmorModVsBludgeon */
+     , (73156,  16,     0.6) /* ArmorModVsCold */
+     , (73156,  17,     1.1) /* ArmorModVsFire */
+     , (73156,  18,    0.69) /* ArmorModVsAcid */
+     , (73156,  19,       1) /* ArmorModVsElectric */
+     , (73156,  31,      28) /* VisualAwarenessRange */
+     , (73156,  34,     1.1) /* PowerupTime */
+     , (73156,  36,       1) /* ChargeSpeed */
+     , (73156,  39,     1.2) /* DefaultScale */
+     , (73156,  64,     0.8) /* ResistSlash */
+     , (73156,  65,     0.5) /* ResistPierce */
+     , (73156,  66,    0.69) /* ResistBludgeon */
+     , (73156,  67,    0.82) /* ResistFire */
+     , (73156,  68,     0.1) /* ResistCold */
+     , (73156,  69,     0.2) /* ResistAcid */
+     , (73156,  70,     0.2) /* ResistElectric */
+     , (73156,  71,       1) /* ResistHealthBoost */
+     , (73156,  72,       1) /* ResistStaminaDrain */
+     , (73156,  73,       1) /* ResistStaminaBoost */
+     , (73156,  74,       1) /* ResistManaDrain */
+     , (73156,  75,       1) /* ResistManaBoost */
+     , (73156,  76,     0.5) /* Translucency */
+     , (73156,  80,     1.5) /* AiUseMagicDelay */
+     , (73156, 104,      10) /* ObviousRadarRange */
+     , (73156, 122,       3) /* AiAcquireHealth */
+     , (73156, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73156,   1, 'Isin Dule''s Captain') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73156,   1, 0x02000001) /* Setup */
+     , (73156,   2, 0x09000001) /* MotionTable */
+     , (73156,   3, 0x20000001) /* SoundTable */
+     , (73156,   4, 0x30000028) /* CombatTable */
+     , (73156,   6, 0x0400007E) /* PaletteBase */
+     , (73156,   8, 0x06001BBE) /* Icon */
+     , (73156,  22, 0x34000063) /* PhysicsEffectTable */
+     , (73156,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73156,   1, 180, 0, 0) /* Strength */
+     , (73156,   2, 200, 0, 0) /* Endurance */
+     , (73156,   3, 240, 0, 0) /* Quickness */
+     , (73156,   4, 220, 0, 0) /* Coordination */
+     , (73156,   5, 200, 0, 0) /* Focus */
+     , (73156,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73156,   1,  2650, 0, 0, 2750) /* MaxHealth */
+     , (73156,   3,  2720, 0, 0, 2920) /* MaxStamina */
+     , (73156,   5,  2740, 0, 0, 2870) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73156,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
+     , (73156,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Specialized */
+     , (73156, 15, 0, 3, 0, 323, 0, 0) /* MagicDefense        Specialized */
+     , (73156, 31, 0, 3, 0, 317, 0, 0) /* CreatureEnchantment Specialized */
+     , (73156, 33, 0, 3, 0, 317, 0, 0) /* LifeMagic           Specialized */
+     , (73156, 34, 0, 3, 0, 317, 0, 0) /* WarMagic            Specialized */
+     , (73156, 45, 0, 3, 0, 407, 0, 0) /* LightWeapons        Specialized */
+     , (73156, 46, 0, 3, 0, 387, 0, 0) /* FinesseWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73156,  0,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73156,  1,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73156,  2,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73156,  3,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73156,  4,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73156,  5,  4, 60, 0.75,  190,  190,  152,  162,  114,  209,  131,  190,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73156,  6,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73156,  7,  4,  0,    0,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73156,  8,  4, 60, 0.75,  190,  190,  152,  162,  114,  209,  131,  190,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73156,   234,   2.02)  /* Vulnerability Other VI */
+     , (73156,   267,   2.02)  /* Defenselessness Other VI */
+     , (73156,   285,   2.02)  /* Magic Yield Other VI */
+     , (73156,   628,   2.01)  /* Life Magic Ineptitude Other VI */
+     , (73156,  1065,   2.02)  /* Cold Vulnerability Other VI */
+     , (73156,  1089,   2.02)  /* Lightning Vulnerability Other VI */
+     , (73156,  1132,   2.02)  /* Blade Vulnerability Other VI */
+     , (73156,  1156,   2.02)  /* Piercing Vulnerability Other VI */
+     , (73156,  1784,   2.04)  /* Horizon's Blades */
+     , (73156,  1785,   2.04)  /* Cassius' Ring of Fire */
+     , (73156,  1786,   2.04)  /* Nuhmudira's Spines */
+     , (73156,  1787,   2.04)  /* Halo of Frost */
+     , (73156,  1788,   2.04)  /* Eye of the Storm */
+     , (73156,  2053,   2.01)  /* Executor's Blessing */
+     , (73156,  2056,   2.02)  /* Ataxia */
+     , (73156,  2084,   2.01)  /* Belly of Lead */
+     , (73156,  2125,   2.04)  /* Flensing Wings */
+     , (73156,  2130,   2.04)  /* Infernae */
+     , (73156,  2134,   2.04)  /* Fusillade */
+     , (73156,  2138,   2.04)  /* Blizzard */
+     , (73156,  2142,   2.04)  /* Tempest */
+     , (73156,  2328,   2.01)  /* Vitality Siphon */
+     , (73156,  2329,   2.01)  /* Essence Void */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (73156, 2, 21159,  1, 93, 0, False) /* Create Covenant Tassets (21159) for Wield */
+     , (73156, 2, 21152,  1, 93, 0, False) /* Create Covenant Breastplate (21152) for Wield */
+     , (73156, 2, 21157,  1, 93, 0, False) /* Create Covenant Pauldrons (21157) for Wield */
+     , (73156, 2, 21151,  1, 93, 0, False) /* Create Covenant Bracers (21151) for Wield */
+     , (73156, 2, 21153,  1, 93, 0, False) /* Create Covenant Gauntlets (21153) for Wield */
+     , (73156, 2, 21154,  1, 93, 0, False) /* Create Covenant Girth (21154) for Wield */
+     , (73156, 2, 21155,  1, 93, 0, False) /* Create Covenant Greaves (21155) for Wield */
+     , (73156, 2, 21150,  1, 93, 0, False) /* Create Covenant Sollerets (21150) for Wield */
+     , (73156, 2, 87038,  1, 93, 0, False) /* Create Helm of Isin Dule (87038) for Wield */
+     , (73156, 2,  2597,  1, 92, 0, False) /* Create Flared Pants (2597) for Wield */
+     , (73156, 2,  2588,  1, 14, 0, False) /* Create Flared Shirt (2588) for Wield */
+     , (73156, 2, 33105,  1, 0, 0, False) /* Create Shield of Isin Dule (33105) for Wield */
+     , (73156, 10, 33080,  1, 0, 0.2, False) /* Create Shadow Blade (33080) for WieldTreasure */
+     , (73156, 10, 33081,  1, 0, 0.2, False) /* Create Shadow Blade (33081) for WieldTreasure */
+     , (73156, 10, 33082,  1, 0, 0.2, False) /* Create Shadow Blade (33082) for WieldTreasure */
+     , (73156, 10, 33083,  1, 0, 0.2, False) /* Create Shadow Blade (33083) for WieldTreasure */
+     , (73156, 10, 33084,  1, 0, 0.2, False) /* Create Shadow Blade (33084) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87017 Isin Dule Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87017 Isin Dule Generator.sql
@@ -27,7 +27,7 @@ VALUES (87017,   1, 0x0200026B) /* Setup */
      , (87017,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87017, -1, 87071, 1600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Spawn 1 Generator (87071) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87017, -1, 87072, 1600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Spawn 2 Generator (87072) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87017, -1, 87073, 1600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Spawn 3 Generator (87073) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87017, -1, 87070, 1600, 1, 1, 1, 4, -1, 0, 0, 0x0B0C0027, 106.419, 153.249, 109.888, -0.997383, 0, 0, -0.072292) /* Generate Portal Controller (87070) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+VALUES (87017, -1, 87071, 1200, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Spawn 1 Generator (87071) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87017, -1, 87072, 1200, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Spawn 2 Generator (87072) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87017, -1, 87073, 1200, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1) /* Generate Spawn 3 Generator (87073) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87017, -1, 87070, 1200, 1, 1, 1, 4, -1, 0, 0, 0x0B0C0027, 106.419, 153.249, 109.888, -0.997383, 0, 0, -0.072292) /* Generate Portal Controller (87070) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;


### PR DESCRIPTION
Revisions to the Shield of Isin Dule quest based on pcap and ImmortalBob retail video:

Corrects Shadow Cyst spell book based on what it casts in the video. The spells are just level 7 versions of the same spells the low level Shadow Cyst (from world db) casts, with a few replacements.

Adds missing mobs the Shadow Cyst can generate. In the pcap, there is Isin Dule's Lieutenant, and in a retail screenshot, there is Isin Dule's Captain.  Neither appear in the video. This could be because dealing enough damage can skip over the health ranges to generate them (if this was based on wounded taunt).

Adjusts Shadow Cyst resistances (using those for the world Shadow Cyst, with higher armor level). ImmortalBob deals very high damage (over 6k on criticals) prior to the Shadow Cyst casting fire protection on itself (reducing damage to over 2k on criticals).

Corrected scale on Shadow Cyst to match the pcap (should be a scale of 1).

The wielded treasure profile (5920) used for some of the soldier type shadows appears to be broken, causing them to spawn unarmed. I used the create list to accomplish the same thing (1 of 5 possible swords) and shield equipped.

Reduced wave generator delay to 1200 (was 1600 previously), to speed up respawn of the shadows needed to enter the spire. It is about 20 min between when ImmortalBob kills the first wave to when he exits back out at the top of the spire. The shadows below can be seen to have already respawned by then.