### PR TITLE
Misc Updates

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Book/Writable/47190 Orders for Zrikux.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Writable/47190 Orders for Zrikux.sql
@@ -31,4 +31,7 @@ VALUES (47190,   1, 0x0200105C) /* Setup */
      , (47190,  22, 0x3400002B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
-VALUES (47190, 0, 1000);
+VALUES (47190, 1, 1000);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (47190, 0, 0xFFFFFFFF, '', 'prewritten', True, '[You cannot translate this text]');

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/52084 Training Dummy.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/52084 Training Dummy.sql
@@ -412,7 +412,7 @@ VALUES (52084,   1,  5000, 0, 0, 5001) /* MaxHealth */
      , (52084,   5,     0, 0, 0, 500) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (52084, 34, 0, 3, 0, 500, 0, 0) /* WarMagic            Specialized */;
+VALUES (52084, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (52084,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/52085 Training Dummy.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/52085 Training Dummy.sql
@@ -411,7 +411,7 @@ VALUES (52085,   1,  5000, 0, 0, 5001) /* MaxHealth */
      , (52085,   5,     0, 0, 0, 500) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (52085, 34, 0, 3, 0, 500, 0, 0) /* WarMagic            Specialized */;
+VALUES (52085, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (52085,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/52086 Training Dummy.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/52086 Training Dummy.sql
@@ -411,7 +411,7 @@ VALUES (52086,   1,  5000, 0, 0, 5001) /* MaxHealth */
      , (52086,   5,     0, 0, 0, 500) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (52086, 34, 0, 3, 0, 500, 0, 0) /* WarMagic            Specialized */;
+VALUES (52086, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (52086,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -430,4 +430,4 @@ VALUES (52086,  5 /* HeartBeat */,      1, NULL, 0x8000003D /* NonCombat */, 0x4
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 3941 /* Heavy Lightning Ring */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 3997 /* Heavy Lightning Ring */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/45705 Formless Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/45705 Formless Shadow.sql
@@ -21,7 +21,7 @@ VALUES (45705,   1, True ) /* Stuck */
      , (45705,   6, True ) /* AiUsesMana */
      , (45705,  11, False) /* IgnoreCollisions */
      , (45705,  12, True ) /* ReportCollisions */
-     , (45705,  13, False) /* Ethereal */
+     , (45705,  13, True ) /* Ethereal */
      , (45705,  14, True ) /* GravityStatus */
      , (45705,  19, True ) /* Attackable */
      , (45705,  29, True ) /* NoCorpse */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/45705 Formless Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/45705 Formless Shadow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 45705;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (45705, 'ace45705-formlessshadow', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (45705, 'ace45705-formlessshadow', 10, '2023-04-23 11:11:42') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45705,   1,         16) /* ItemType - Creature */
@@ -14,7 +14,6 @@ VALUES (45705,   1,         16) /* ItemType - Creature */
      , (45705,  68,          3) /* TargetingTactic - Random, Focused */
      , (45705,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (45705, 133,          4) /* ShowableOnRadar - ShowAlways */
-     , (45705, 140,          1) /* AiOptions - CanOpenDoors */
      , (45705, 146,          0) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -22,18 +21,20 @@ VALUES (45705,   1, True ) /* Stuck */
      , (45705,   6, True ) /* AiUsesMana */
      , (45705,  11, False) /* IgnoreCollisions */
      , (45705,  12, True ) /* ReportCollisions */
-     , (45705,  13, True ) /* Ethereal */
+     , (45705,  13, False) /* Ethereal */
      , (45705,  14, True ) /* GravityStatus */
      , (45705,  19, True ) /* Attackable */
+     , (45705,  29, True ) /* NoCorpse */
      , (45705,  42, True ) /* AllowEdgeSlide */
      , (45705,  50, True ) /* NeverFailCasting */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (45705,   1,       5) /* HeartbeatInterval */
      , (45705,   2,       0) /* HeartbeatTimestamp */
-     , (45705,   3,     2.5) /* HealthRate */
+     , (45705,   3,     -75) /* HealthRate */
      , (45705,   4,     2.5) /* StaminaRate */
      , (45705,   5,       1) /* ManaRate */
+     , (45705,  12,     0.5) /* Shade */
      , (45705,  13,       1) /* ArmorModVsSlash */
      , (45705,  14,       1) /* ArmorModVsPierce */
      , (45705,  15,       1) /* ArmorModVsBludgeon */
@@ -46,8 +47,8 @@ VALUES (45705,   1,       5) /* HeartbeatInterval */
      , (45705,  36,       1) /* ChargeSpeed */
      , (45705,  39,     0.5) /* DefaultScale */
      , (45705,  64,     0.5) /* ResistSlash */
-     , (45705,  65,     0.5) /* ResistPierce */
-     , (45705,  66,     0.5) /* ResistBludgeon */
+     , (45705,  65,     0.3) /* ResistPierce */
+     , (45705,  66,     0.3) /* ResistBludgeon */
      , (45705,  67,    0.65) /* ResistFire */
      , (45705,  68,     0.1) /* ResistCold */
      , (45705,  69,     0.2) /* ResistAcid */
@@ -83,28 +84,35 @@ VALUES (45705,   1, 300, 0, 0) /* Strength */
      , (45705,   6, 330, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (45705,   1,  2900, 0, 0, 1500) /* MaxHealth */
-     , (45705,   3,  2720, 0, 0, 2920) /* MaxStamina */
-     , (45705,   5,  2740, 0, 0, 2870) /* MaxMana */;
+VALUES (45705,   1,  1350, 0, 0, 1500) /* MaxHealth */
+     , (45705,   3,  2620, 0, 0, 2920) /* MaxStamina */
+     , (45705,   5,  2540, 0, 0, 2870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (45705,  6, 0, 3, 0, 320, 0, 0) /* MeleeDefense        Specialized */
      , (45705,  7, 0, 3, 0, 232, 0, 0) /* MissileDefense      Specialized */
-     , (45705, 14, 0, 3, 0, 300, 0, 0) /* ArcaneLore          Specialized */
      , (45705, 15, 0, 3, 0, 190, 0, 0) /* MagicDefense        Specialized */
-     , (45705, 20, 0, 3, 0, 150, 0, 0) /* Deception           Specialized */
+     , (45705, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
      , (45705, 31, 0, 3, 0, 258, 0, 0) /* CreatureEnchantment Specialized */
      , (45705, 33, 0, 3, 0, 258, 0, 0) /* LifeMagic           Specialized */
      , (45705, 34, 0, 3, 0, 258, 0, 0) /* WarMagic            Specialized */
-     , (45705, 45, 0, 3, 0, 355, 0, 0) /* LightWeapons        Specialized */;
+     , (45705, 45, 0, 3, 0, 565, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (45705,  0, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (45705,  1, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (45705,  2, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (45705,  3, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (45705,  4, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (45705,  5, 1024, 60,  0.5,  500,  500,  500,  500,  500,  500,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (45705,  6, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (45705,  7, 1024,  0,    0,  500,  500,  500,  500,  500,  500,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (45705,  8, 1024, 60,  0.5,  500,  500,  500,  500,  500,  500,  500,  500,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (45705,  0, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (45705,  1, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (45705,  2, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (45705,  3, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (45705,  4, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (45705,  5, 1024, 60,  0.5,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (45705,  6, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (45705,  7, 1024,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (45705,  8, 1024, 60,  0.5,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (45705,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 3998 /* Dark Vortex */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/44062 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/44062 Door.sql
@@ -14,7 +14,8 @@ VALUES (44062,   1, True ) /* Stuck */
      , (44062,  34, False) /* DefaultOpen */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (44062,  54,       2) /* UseRadius */;
+VALUES (44062,  11,     300) /* ResetInterval */
+     , (44062,  54,       2) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (44062,   1, 'Door') /* Name */;

--- a/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/51436 Frozen Coconut.sql
+++ b/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/51436 Frozen Coconut.sql
@@ -5,8 +5,9 @@ VALUES (51436, 'ace51436-frozencoconut', 4, '2021-11-01 00:00:00') /* Missile */
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51436,   1,        256) /* ItemType - MissileWeapon */
+     , (51436,   3,         61) /* PaletteTemplate - Maroon */
      , (51436,   5,         20) /* EncumbranceVal */
-     , (51436,   8,        500) /* Mass */
+     , (51436,   8,         20) /* Mass */
      , (51436,   9,    4194304) /* ValidLocations - MissileWeapon */
      , (51436,  11,         30) /* MaxStackSize */
      , (51436,  12,          1) /* StackSize */
@@ -24,7 +25,8 @@ VALUES (51436,   1,        256) /* ItemType - MissileWeapon */
      , (51436,  51,          2) /* CombatUse - Missile */
      , (51436,  93,     132116) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, Inelastic */
      , (51436, 307,         35) /* DamageRating */
-     , (51436, 313,         30) /* CritRating */;
+     , (51436, 313,         30) /* CritRating */
+     , (51436, 353,         10) /* WeaponType - Thrown */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (51436,   1, True ) /* Stuck */
@@ -50,5 +52,6 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (51436,   1, 0x020000ED) /* Setup */
      , (51436,   3, 0x20000095) /* SoundTable */
      , (51436,   6, 0x04000BF8) /* PaletteBase */
+     , (51436,   7, 0x1000041C) /* ClothingBase */
      , (51436,   8, 0x06002913) /* Icon */
      , (51436,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Stackable/Misc/46347 Partially Restored Page.sql
+++ b/Database/Patches/9 WeenieDefaults/Stackable/Misc/46347 Partially Restored Page.sql
@@ -10,6 +10,7 @@ VALUES (46347,   1,        128) /* ItemType - Misc */
      , (46347,  12,          1) /* StackSize */
      , (46347,  13,         25) /* StackUnitEncumbrance */
      , (46347,  15,         20) /* StackUnitValue */
+     , (46347,  16,          1) /* ItemUseable - No */
      , (46347,  19,         20) /* Value */
      , (46347,  33,          1) /* Bonded - Bonded */
      , (46347,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */

--- a/Database/Patches/9 WeenieDefaults/Stackable/Misc/46349 Torn Strip of Parchment.sql
+++ b/Database/Patches/9 WeenieDefaults/Stackable/Misc/46349 Torn Strip of Parchment.sql
@@ -10,6 +10,7 @@ VALUES (46349,   1,        128) /* ItemType - Misc */
      , (46349,  12,          1) /* StackSize */
      , (46349,  13,         25) /* StackUnitEncumbrance */
      , (46349,  15,         20) /* StackUnitValue */
+     , (46349,  16,          1) /* ItemUseable - No */
      , (46349,  19,         20) /* Value */
      , (46349,  33,          1) /* Bonded - Bonded */
      , (46349,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */


### PR DESCRIPTION
Lowers war magic on Training Dummies to give a chance to resist. The one casting Heavy Lightning Ring now casts the alternative, less damaging version of the spell, since damage seemed excessive (could easily 1-hit player). This ring spell's visual effect also does not match its hit box, making it particularly difficult to avoid.

Formless Shadows in Shadow Geraine's Host now die on their own as they should, and cast Dark Vortex on death, like the Aerbax Formless Shadows.

Adds missing palette and clothing base to Frozen Coconut.

Adds ItemUseable - No to two Lost Lore pages. These are either the result or target of a crafting interaction, and should not be useable.

Adds missing "You cannot translate this text" to Orders for Zrukux.