### PR TITLE
On Strike Updates

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/5860.sql
+++ b/Database/Patches/6 LandBlockExtendedData/5860.sql
@@ -1,7 +1,7 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x5860;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860000,  7923, 0x58600195, 120.778, -152.623, 0.055, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 3 Min.) */
+VALUES (0x75860000,  7924, 0x58600195, 120.778, -152.623, 0.055, 1, 0, 0, 0, False, '2023-03-23 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x58600195 [120.778000 -152.623001 0.055000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -89,7 +89,7 @@ VALUES (0x75860002, 72981, 0x58600173, 110, -108.482, -0.063, 1, 0, 0, 0, False,
 /* @teleloc 0x58600173 [110.000000 -108.482002 -0.063000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x75860003,  4139, 0x58600194, 119.998, -144.752, 0.055, 0, 0, 0, -1, False, '2023-03-23 00:00:00'); /* Door */
+VALUES (0x75860003, 73162, 0x58600194, 119.998, -144.752, 0.055, 0, 0, 0, -1, False, '2023-03-23 00:00:00');
 /* @teleloc 0x58600194 [119.998001 -144.751999 0.055000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -522,3 +522,59 @@ VALUES (0x7586008D, 72972, 0x5860031D, 166.692, -111.743, 30.0066, 0.707107, 0, 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7586008E, 72972, 0x5860031D, 166.607, -108.225, 30.0066, 0.707107, 0, 0, -0.707107,  True, '2023-03-23 00:00:00'); /* Mosswart Worker */
 /* @teleloc 0x5860031D [166.606995 -108.224998 30.006599] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586008F, 73161, 0x5860011F, 16.2834, -169.421, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:37:47'); /* Fire */
+/* @teleloc 0x5860011F [16.283400 -169.421005 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860090, 73161, 0x5860014D, 60.2159, -150.027, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:38:56'); /* Fire */
+/* @teleloc 0x5860014D [60.215900 -150.026993 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860091, 73161, 0x58600148, 59.3237, -117.278, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:39:22'); /* Fire */
+/* @teleloc 0x58600148 [59.323700 -117.278000 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860092, 73161, 0x58600126, 26.5842, -100.158, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:39:43'); /* Fire */
+/* @teleloc 0x58600126 [26.584200 -100.157997 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860093, 73161, 0x58600114, 20.5372, -79.8273, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:40:04'); /* Fire */
+/* @teleloc 0x58600114 [20.537201 -79.827301 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860095, 73161, 0x586001CB, 186.077, -109.287, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:43:03'); /* Fire */
+/* @teleloc 0x586001CB [186.076996 -109.287003 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860096, 73161, 0x586001EC, 220.411, -79.9973, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:43:31'); /* Fire */
+/* @teleloc 0x586001EC [220.410995 -79.997299 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860097, 73161, 0x586001C9, 193.624, -71.743, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:43:57'); /* Fire */
+/* @teleloc 0x586001C9 [193.623993 -71.742996 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860098, 73161, 0x586001C9, 192.835, -69.9504, 1.875, 1, 0, 0, 0, False, '2023-05-07 14:44:05'); /* Fire */
+/* @teleloc 0x586001C9 [192.835007 -69.950401 1.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x75860099, 73161, 0x586001C9, 194.503, -69.2899, 2.02854, 1, 0, 0, 0, False, '2023-05-07 14:45:01'); /* Fire */
+/* @teleloc 0x586001C9 [194.503006 -69.289902 2.028540] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586009E, 73161, 0x58600208, 229.43, -165.089, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:53:21'); /* Fire */
+/* @teleloc 0x58600208 [229.429993 -165.089005 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7586009F, 73161, 0x586001E9, 210.164, -189.519, 0.875, 1, 0, 0, 0, False, '2023-05-07 14:54:02'); /* Fire */
+/* @teleloc 0x586001E9 [210.164001 -189.518997 0.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x758600A2, 73161, 0x58600144, 46.7355, -189.882, 1.875, 1, 0, 0, 0, False, '2023-05-07 15:02:11'); /* Fire */
+/* @teleloc 0x58600144 [46.735500 -189.882004 1.875000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x758600A3, 73161, 0x58600138, 44.7217, -189.229, 0.875, 1, 0, 0, 0, False, '2023-05-07 15:02:44'); /* Fire */
+/* @teleloc 0x58600138 [44.721699 -189.229004 0.875000] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970 Mosswart Messenger.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970 Mosswart Messenger.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72970;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72970, 'ace72970-mosswartmessenger', 10, '2023-04-09 17:44:47') /* Creature */;
+VALUES (72970, 'ace72970-mosswartmessenger', 10, '2023-05-07 03:49:47') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72970,   1,         16) /* ItemType - Creature */
@@ -11,6 +11,8 @@ VALUES (72970,   1,         16) /* ItemType - Creature */
      , (72970,   7,         -1) /* ContainersCapacity */
      , (72970,  16,         32) /* ItemUseable - Remote */
      , (72970,  25,        175) /* Level */
+     , (72970,  81,          2) /* MaxGeneratedObjects */
+     , (72970,  82,          0) /* InitGeneratedObjects */
      , (72970,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (72970,  95,          8) /* RadarBlipColor - Yellow */
      , (72970, 133,          2) /* ShowableOnRadar - ShowMovement */
@@ -44,6 +46,7 @@ VALUES (72970,   1,       5) /* HeartbeatInterval */
      , (72970,  34,     0.9) /* PowerupTime */
      , (72970,  36,       1) /* ChargeSpeed */
      , (72970,  39,     1.1) /* DefaultScale */
+     , (72970,  43,       2) /* GeneratorRadius */
      , (72970,  54,       3) /* UseRadius */
      , (72970,  64,     0.5) /* ResistSlash */
      , (72970,  65,     0.8) /* ResistPierce */
@@ -104,15 +107,15 @@ VALUES (72970,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72970, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (72970,  0,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (72970,  1,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (72970,  2,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (72970,  3,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (72970,  4,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72970,  5,  4, 60, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (72970,  6,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (72970,  7,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72970,  8,  4, 60, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72970,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72970,  1,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72970,  2,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72970,  3,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72970,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72970,  5,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72970,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72970,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72970,  8,  4, 60, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (72970,  1089,   2.03)  /* Lightning Vulnerability Other VI */
@@ -189,8 +192,9 @@ VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NU
      , (@parent_id,  3,  10 /* Tell */, 1, 1, NULL, 'Unacceptable! The Directors must be notified of this.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,  10 /* Tell */, 1, 1, NULL, 'This place is ours now and he will never see his beloved creatures alive again.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,   8 /* Say */, 1, 20, NULL, 'Kill them slowly, make them suffer!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  6,  15 /* Activate */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  7,  77 /* DeleteSelf */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  6,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  7,  15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  8,  77 /* DeleteSelf */, 1, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72970,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -200,3 +204,7 @@ SET @parent_id = LAST_INSERT_ID();
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'You are not welcome here, you should leave before you get hurt!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (72970, -1, 72972, 30, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mosswart Worker (72972) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (72970, -1, 72972, 30, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mosswart Worker (72972) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72970.es
@@ -19,16 +19,18 @@ HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.095
 HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.1
     - Motion: Twitch1
 
-Use:
-    - TurnToTarget
-    - Tell: You are not welcome here, you should leave before you get hurt!
-
 Give: 47831
     - TurnToTarget
     - Tell: You have news from Colton?
     - Delay: 1, DirectBroadcast: The Mosswart opens the letter and looks inside.
     - Delay: 1, Tell: Unacceptable! The Directors must be notified of this.
     - Delay: 1, Tell: This place is ours now and he will never see his beloved creatures alive again.
-    - Delay: 1, Say: Kill them slowly, make them suffer!, Extent: 20
-    - Delay: 1, Activate
+    - Delay: 1, Extent: 20, Say: Kill them slowly, make them suffer!
+    - Generate
+    - Activate
     - Delay: 1, DeleteSelf
+
+Use:
+    - TurnToTarget
+    - Tell: You are not welcome here, you should leave before you get hurt!
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72972 Mosswart Worker.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72972 Mosswart Worker.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72972;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72972, 'ace72972-mosswartworker', 10, '2023-04-09 17:44:47') /* Creature */;
+VALUES (72972, 'ace72972-mosswartworker', 10, '2023-05-07 03:34:01') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72972,   1,         16) /* ItemType - Creature */
@@ -36,24 +36,24 @@ VALUES (72972,   1,       5) /* HeartbeatInterval */
      , (72972,   4,       5) /* StaminaRate */
      , (72972,   5,       2) /* ManaRate */
      , (72972,  12,       1) /* Shade */
-     , (72972,  13,     1.3) /* ArmorModVsSlash */
-     , (72972,  14,     1.5) /* ArmorModVsPierce */
-     , (72972,  15,     1.4) /* ArmorModVsBludgeon */
-     , (72972,  16,       1) /* ArmorModVsCold */
+     , (72972,  13,    0.63) /* ArmorModVsSlash */
+     , (72972,  14,    0.84) /* ArmorModVsPierce */
+     , (72972,  15,    0.84) /* ArmorModVsBludgeon */
+     , (72972,  16,    0.46) /* ArmorModVsCold */
      , (72972,  17,     0.7) /* ArmorModVsFire */
-     , (72972,  18,     1.3) /* ArmorModVsAcid */
+     , (72972,  18,       1) /* ArmorModVsAcid */
      , (72972,  19,     0.9) /* ArmorModVsElectric */
      , (72972,  31,      18) /* VisualAwarenessRange */
      , (72972,  34,     0.9) /* PowerupTime */
      , (72972,  36,       1) /* ChargeSpeed */
      , (72972,  39,     1.2) /* DefaultScale */
-     , (72972,  64,     0.5) /* ResistSlash */
-     , (72972,  65,     0.8) /* ResistPierce */
-     , (72972,  66,     0.8) /* ResistBludgeon */
-     , (72972,  67,       1) /* ResistFire */
-     , (72972,  68,     0.4) /* ResistCold */
-     , (72972,  69,     0.7) /* ResistAcid */
-     , (72972,  70,     1.1) /* ResistElectric */
+     , (72972,  64,    0.45) /* ResistSlash */
+     , (72972,  65,     0.6) /* ResistPierce */
+     , (72972,  66,     0.6) /* ResistBludgeon */
+     , (72972,  67,     0.8) /* ResistFire */
+     , (72972,  68,    0.38) /* ResistCold */
+     , (72972,  69,     0.8) /* ResistAcid */
+     , (72972,  70,       1) /* ResistElectric */
      , (72972,  71,       1) /* ResistHealthBoost */
      , (72972,  72,       1) /* ResistStaminaDrain */
      , (72972,  73,       1) /* ResistStaminaBoost */
@@ -102,22 +102,22 @@ VALUES (72972,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72972, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (72972,  0,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (72972,  1,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (72972,  2,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (72972,  3,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (72972,  4,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72972,  5,  4, 400, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (72972,  6,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (72972,  7,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72972,  8,  4, 400, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72972,  0,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72972,  1,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72972,  2,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72972,  3,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72972,  4,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72972,  5,  4, 400, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72972,  6,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72972,  7,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72972,  8,  4, 400, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (72972,  2172,   2.03)  /* Astyrrian's Gift */
-     , (72972,  2168,   2.03)  /* Gelidite's Gift */
-     , (72972,  2074,   2.02)  /* Gossamer Flesh */
-     , (72972,  2136,   2.05)  /* Icy Torment */
-     , (72972,  2140,   2.05)  /* Alset's Coil */;
+VALUES (72972,  2128,   2.04)  /* Ilservian's Flame */
+     , (72972,  2745,   2.04)  /* Flame Arc VII */
+     , (72972,  2122,   2.04)  /* Disintegration */
+     , (72972,  2717,   2.05)  /* Acid Arc VII */
+     , (72972,  2053,   2.02)  /* Executor's Blessing */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72972,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -176,4 +176,6 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (72972, 9, 72991,  0, 0, 1, False) /* Create Mosswart Worker (72991) for ContainTreasure */;
+VALUES (72972, 2, 47717,  1, 0, 0.33, False) /* Create Acid Spear (47717) for Wield */
+     , (72972, 2, 47793,  1, 0, 0.33, False) /* Create Frost Spear (47793) for Wield */
+     , (72972, 9, 72991,  0, 0, 1, False) /* Create Mosswart Worker (72991) for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72973 Mosswart Grunt.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72973 Mosswart Grunt.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72973;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72973, 'ace72973-mosswartgrunt', 10, '2023-04-09 17:44:47') /* Creature */;
+VALUES (72973, 'ace72973-mosswartgrunt', 10, '2023-05-07 03:33:05') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72973,   1,         16) /* ItemType - Creature */
@@ -35,24 +35,24 @@ VALUES (72973,   1,       5) /* HeartbeatInterval */
      , (72973,   4,       5) /* StaminaRate */
      , (72973,   5,       2) /* ManaRate */
      , (72973,  12,       0) /* Shade */
-     , (72973,  13,     1.3) /* ArmorModVsSlash */
-     , (72973,  14,     1.5) /* ArmorModVsPierce */
-     , (72973,  15,     1.4) /* ArmorModVsBludgeon */
-     , (72973,  16,       1) /* ArmorModVsCold */
+     , (72973,  13,    0.63) /* ArmorModVsSlash */
+     , (72973,  14,    0.84) /* ArmorModVsPierce */
+     , (72973,  15,    0.84) /* ArmorModVsBludgeon */
+     , (72973,  16,    0.46) /* ArmorModVsCold */
      , (72973,  17,     0.7) /* ArmorModVsFire */
-     , (72973,  18,     1.3) /* ArmorModVsAcid */
+     , (72973,  18,       1) /* ArmorModVsAcid */
      , (72973,  19,     0.9) /* ArmorModVsElectric */
      , (72973,  31,      18) /* VisualAwarenessRange */
      , (72973,  34,     0.9) /* PowerupTime */
      , (72973,  36,       1) /* ChargeSpeed */
      , (72973,  39,     1.2) /* DefaultScale */
-     , (72973,  64,     0.5) /* ResistSlash */
-     , (72973,  65,     0.8) /* ResistPierce */
-     , (72973,  66,     0.8) /* ResistBludgeon */
-     , (72973,  67,       1) /* ResistFire */
-     , (72973,  68,     0.4) /* ResistCold */
-     , (72973,  69,     0.7) /* ResistAcid */
-     , (72973,  70,     1.1) /* ResistElectric */
+     , (72973,  64,    0.45) /* ResistSlash */
+     , (72973,  65,     0.6) /* ResistPierce */
+     , (72973,  66,     0.6) /* ResistBludgeon */
+     , (72973,  67,     0.8) /* ResistFire */
+     , (72973,  68,    0.38) /* ResistCold */
+     , (72973,  69,     0.8) /* ResistAcid */
+     , (72973,  70,       1) /* ResistElectric */
      , (72973,  71,       1) /* ResistHealthBoost */
      , (72973,  72,       1) /* ResistStaminaDrain */
      , (72973,  73,       1) /* ResistStaminaBoost */
@@ -100,15 +100,23 @@ VALUES (72973,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72973, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (72973,  0,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (72973,  1,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (72973,  2,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (72973,  3,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (72973,  4,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72973,  5,  4, 400, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (72973,  6,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (72973,  7,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72973,  8,  4, 400, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72973,  0,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72973,  1,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72973,  2,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72973,  3,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72973,  4,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72973,  5,  4, 400, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72973,  6,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72973,  7,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72973,  8,  4, 400, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (72973,  2168,   2.03)  /* Gelidite's Gift */
+     , (72973,  2170,   2.03)  /* Inferno's Gift */
+     , (72973,  2162,   2.03)  /* Olthoi's Gift */
+     , (72973,  2282,   2.03)  /* Futility */
+     , (72973,  2318,   2.03)  /* Gravity Well */
+     , (72973,  2717,   2.06)  /* Acid Arc VII */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72973,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -167,6 +175,6 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (72973, 2, 47717,  1, 0, 0.5, False) /* Create Acid Spear (47717) for Wield */
-     , (72973, 2, 47793,  1, 0, 0.5, False) /* Create Frost Spear (47793) for Wield */
+VALUES (72973, 2, 47717,  1, 0, 0.33, False) /* Create Acid Spear (47717) for Wield */
+     , (72973, 2, 47793,  1, 0, 0.33, False) /* Create Frost Spear (47793) for Wield */
      , (72973, 9, 72992,  0, 0, 1, False) /* Create Mosswart Grunt (72992) for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72982 Mosswart Tribesman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mosswart/72982 Mosswart Tribesman.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72982;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72982, 'ace72982-mosswarttribesman', 10, '2023-04-09 17:44:47') /* Creature */;
+VALUES (72982, 'ace72982-mosswarttribesman', 10, '2023-05-07 04:09:48') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72982,   1,         16) /* ItemType - Creature */
@@ -16,7 +16,6 @@ VALUES (72982,   1,         16) /* ItemType - Creature */
      , (72982,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
      , (72982,  72,         50) /* FriendType - Idol */
      , (72982,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
-     , (72982, 101,     524288) /* AiAllowedCombatStyle - StubbornMissile */
      , (72982, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (72982, 140,          1) /* AiOptions - CanOpenDoors */
      , (72982, 146,     800000) /* XpOverride */;
@@ -26,8 +25,7 @@ VALUES (72982,   1, True ) /* Stuck */
      , (72982,   6, False) /* AiUsesMana */
      , (72982,  11, False) /* IgnoreCollisions */
      , (72982,  12, True ) /* ReportCollisions */
-     , (72982,  13, False) /* Ethereal */
-     , (72982,  52, True ) /* AiImmobile */;
+     , (72982,  13, False) /* Ethereal */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (72982,   1,       5) /* HeartbeatInterval */
@@ -36,24 +34,24 @@ VALUES (72982,   1,       5) /* HeartbeatInterval */
      , (72982,   4,       5) /* StaminaRate */
      , (72982,   5,       2) /* ManaRate */
      , (72982,  12,       1) /* Shade */
-     , (72982,  13,     1.3) /* ArmorModVsSlash */
-     , (72982,  14,     1.5) /* ArmorModVsPierce */
-     , (72982,  15,     1.4) /* ArmorModVsBludgeon */
-     , (72982,  16,       1) /* ArmorModVsCold */
+     , (72982,  13,    0.63) /* ArmorModVsSlash */
+     , (72982,  14,    0.84) /* ArmorModVsPierce */
+     , (72982,  15,    0.84) /* ArmorModVsBludgeon */
+     , (72982,  16,    0.46) /* ArmorModVsCold */
      , (72982,  17,     0.7) /* ArmorModVsFire */
-     , (72982,  18,     1.3) /* ArmorModVsAcid */
+     , (72982,  18,       1) /* ArmorModVsAcid */
      , (72982,  19,     0.9) /* ArmorModVsElectric */
      , (72982,  31,      24) /* VisualAwarenessRange */
      , (72982,  34,     0.9) /* PowerupTime */
      , (72982,  36,       1) /* ChargeSpeed */
      , (72982,  39,     1.2) /* DefaultScale */
-     , (72982,  64,     0.5) /* ResistSlash */
-     , (72982,  65,     0.8) /* ResistPierce */
-     , (72982,  66,     0.8) /* ResistBludgeon */
-     , (72982,  67,       1) /* ResistFire */
-     , (72982,  68,     0.4) /* ResistCold */
-     , (72982,  69,     0.7) /* ResistAcid */
-     , (72982,  70,     1.1) /* ResistElectric */
+     , (72982,  64,    0.45) /* ResistSlash */
+     , (72982,  65,     0.6) /* ResistPierce */
+     , (72982,  66,     0.6) /* ResistBludgeon */
+     , (72982,  67,     0.8) /* ResistFire */
+     , (72982,  68,    0.38) /* ResistCold */
+     , (72982,  69,     0.8) /* ResistAcid */
+     , (72982,  70,       1) /* ResistElectric */
      , (72982,  71,       1) /* ResistHealthBoost */
      , (72982,  72,       1) /* ResistStaminaDrain */
      , (72982,  73,       1) /* ResistStaminaBoost */
@@ -94,7 +92,7 @@ VALUES (72982,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72982,  7, 0, 3, 0, 460, 0, 0) /* MissileDefense      Specialized */
      , (72982, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
      , (72982, 24, 0, 3, 0,  50, 0, 0) /* Run                 Specialized */
-     , (72982, 33, 0, 3, 0, 290, 0, 0) /* LifeMagic           Specialized */
+     , (72982, 31, 0, 3, 0, 290, 0, 0) /* CreatureEnchantment Specialized */
      , (72982, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
      , (72982, 44, 0, 3, 0, 430, 0, 0) /* HeavyWeapons        Specialized */
      , (72982, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */
@@ -102,15 +100,21 @@ VALUES (72982,  6, 0, 3, 0, 420, 0, 0) /* MeleeDefense        Specialized */
      , (72982, 47, 0, 3, 0, 430, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (72982,  0,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (72982,  1,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (72982,  2,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (72982,  3,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (72982,  4,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (72982,  5,  4, 60, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (72982,  6,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (72982,  7,  4,  0,    0,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (72982,  8,  4, 60, 0.75,  340,  442,  510,  476,  340,  238,  442,  306,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (72982,  0,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (72982,  1,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (72982,  2,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (72982,  3,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (72982,  4,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (72982,  5,  4, 60, 0.75,  400,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (72982,  6,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (72982,  7,  4,  0,    0,  400,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (72982,  8,  4, 60, 0.75,  400,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (72982,  2282,   2.25)  /* Futility */
+     , (72982,  2056,   2.33)  /* Ataxia */
+     , (72982,  2318,    2.5)  /* Gravity Well */
+     , (72982,  2054,      3)  /* Synaptic Misfire */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72982,  5 /* HeartBeat */,  0.045, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -167,6 +171,3 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (72982, 2, 72994,  1, 0, 0, False) /* Create Frost Javelin (72994) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/72983 Scavenging Rat.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/72983 Scavenging Rat.sql
@@ -33,24 +33,24 @@ VALUES (72983,   1,       5) /* HeartbeatInterval */
      , (72983,   4,       5) /* StaminaRate */
      , (72983,   5,       2) /* ManaRate */
      , (72983,  12,     0.5) /* Shade */
-     , (72983,  13,     0.4) /* ArmorModVsSlash */
-     , (72983,  14,     0.4) /* ArmorModVsPierce */
-     , (72983,  15,     0.8) /* ArmorModVsBludgeon */
-     , (72983,  16,    0.12) /* ArmorModVsCold */
-     , (72983,  17,     0.7) /* ArmorModVsFire */
-     , (72983,  18,    0.12) /* ArmorModVsAcid */
+     , (72983,  13,     0.6) /* ArmorModVsSlash */
+     , (72983,  14,     0.6) /* ArmorModVsPierce */
+     , (72983,  15,       1) /* ArmorModVsBludgeon */
+     , (72983,  16,     0.6) /* ArmorModVsCold */
+     , (72983,  17,       1) /* ArmorModVsFire */
+     , (72983,  18,       1) /* ArmorModVsAcid */
      , (72983,  19,     0.8) /* ArmorModVsElectric */
      , (72983,  31,      22) /* VisualAwarenessRange */
      , (72983,  34,       2) /* PowerupTime */
      , (72983,  36,       1) /* ChargeSpeed */
-     , (72983,  39,       2) /* DefaultScale */
-     , (72983,  64,    0.75) /* ResistSlash */
-     , (72983,  65,    0.75) /* ResistPierce */
-     , (72983,  66,       1) /* ResistBludgeon */
-     , (72983,  67,       1) /* ResistFire */
-     , (72983,  68,    0.58) /* ResistCold */
-     , (72983,  69,    0.58) /* ResistAcid */
-     , (72983,  70,       1) /* ResistElectric */
+     , (72983,  39,     1.5) /* DefaultScale */
+     , (72983,  64,    0.65) /* ResistSlash */
+     , (72983,  65,    0.65) /* ResistPierce */
+     , (72983,  66,    0.65) /* ResistBludgeon */
+     , (72983,  67,    0.45) /* ResistFire */
+     , (72983,  68,    0.65) /* ResistCold */
+     , (72983,  69,    0.65) /* ResistAcid */
+     , (72983,  70,    0.75) /* ResistElectric */
      , (72983,  71,       1) /* ResistHealthBoost */
      , (72983,  72,       1) /* ResistStaminaDrain */
      , (72983,  73,       1) /* ResistStaminaBoost */
@@ -73,7 +73,7 @@ VALUES (72983,   1, 0x0200003D) /* Setup */
      , (72983,   8, 0x0600103B) /* Icon */
      , (72983,  19, 0x00000056) /* ActivationAnimation */
      , (72983,  22, 0x34000023) /* PhysicsEffectTable */
-     , (72983,  30,         87) /* PhysicsScript - BreatheLightning */
+     , (72983,  30,         86) /* PhysicsScript - BreatheAcid */
      , (72983,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -91,15 +91,15 @@ VALUES (72983,   1,  1600, 0, 0, 1740) /* MaxHealth */
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (72983,  6, 0, 2, 0, 522, 0, 0) /* MeleeDefense        Trained */
-     , (72983,  7, 0, 2, 0, 149, 0, 0) /* MissileDefense      Trained */
-     , (72983, 15, 0, 2, 0, 170, 0, 0) /* MagicDefense        Trained */
+     , (72983,  7, 0, 2, 0, 550, 0, 0) /* MissileDefense      Trained */
+     , (72983, 15, 0, 2, 0, 380, 0, 0) /* MagicDefense        Trained */
      , (72983, 45, 0, 2, 0, 553, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (72983,  0,  2, 400, 0.75,  430,  172,  172,  344,   52,  301,   52,  344,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */
      , (72983, 16,  4, 400, 0.75,  430,  172,  172,  344,   52,  301,   52,  344,    0, 2, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75) /* Torso */
      , (72983, 17,  4, 400,    0,  430,  172,  172,  344,   52,  301,   52,  344,    0, 3,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25) /* Tail */
-     , (72983, 22, 64, 800,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+     , (72983, 22, 32, 800,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72983,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/72990 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/72990 Door.sql
@@ -29,8 +29,8 @@ VALUES (72990,   1, 'Door') /* Name */
      , (72990,  14, 'This door cannot be activated from here.') /* Use */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (72990,   1, 0x0200024F) /* Setup */
+VALUES (72990,   1, 0x02000281) /* Setup */
      , (72990,   2, 0x09000016) /* MotionTable */
      , (72990,   3, 0x20000022) /* SoundTable */
-     , (72990,   8, 0x06001317) /* Icon */
+     , (72990,   8, 0x06001412) /* Icon */
      , (72990,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/73162 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/73162 Door.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73162;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73162, 'ace73162-doordungeonactivated3min', 19, '2005-02-09 10:00:00') /* Door */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73162,   1,        128) /* ItemType - Misc */
+     , (73162,   8,        500) /* Mass */
+     , (73162,  16,          1) /* ItemUseable - No */
+     , (73162,  19,          0) /* Value */
+     , (73162,  83,          2) /* ActivationResponse - Use */
+     , (73162,  93,         24) /* PhysicsState - ReportCollisions, IgnoreCollisions */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73162,   1, True ) /* Stuck */
+     , (73162,   2, False) /* Open */
+     , (73162,  12, True ) /* ReportCollisions */
+     , (73162,  13, False) /* Ethereal */
+     , (73162,  14, False) /* GravityStatus */
+     , (73162,  33, False) /* ResetMessagePending */
+     , (73162,  34, False) /* DefaultOpen */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73162,  11,     180) /* ResetInterval */
+     , (73162,  54,       2) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73162,   1, 'Door') /* Name */
+     , (73162,  14, 'This door cannot be activated from here.') /* Use */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73162,   1, 0x0200024F) /* Setup */
+     , (73162,   2, 0x09000016) /* MotionTable */
+     , (73162,   3, 0x20000022) /* SoundTable */
+     , (73162,   8, 0x06001317) /* Icon */
+     , (73162,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/HotSpot/Misc/73161 Fire.sql
+++ b/Database/Patches/9 WeenieDefaults/HotSpot/Misc/73161 Fire.sql
@@ -1,0 +1,44 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73161;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73161, 'ace73161-fire', 13, '2005-02-09 10:00:00') /* HotSpot */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73161,   1,        128) /* ItemType - Misc */
+     , (73161,   5,          1) /* EncumbranceVal */
+     , (73161,   8,          1) /* Mass */
+     , (73161,   9,          0) /* ValidLocations - None */
+     , (73161,  16,          1) /* ItemUseable - No */
+     , (73161,  19,          1) /* Value */
+     , (73161,  44,         20) /* Damage */
+     , (73161,  45,         16) /* DamageType - Fire */
+     , (73161,  93,         12) /* PhysicsState - Ethereal, ReportCollisions */
+     , (73161, 119,          0) /* Active */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73161,   1, True ) /* Stuck */
+     , (73161,  11, False) /* IgnoreCollisions */
+     , (73161,  12, True ) /* ReportCollisions */
+     , (73161,  13, True ) /* Ethereal */
+     , (73161,  14, False) /* GravityStatus */
+     , (73161,  18, True ) /* Visibility */
+     , (73161,  24, True ) /* UiHidden */
+     , (73161,  55, True ) /* IsHot */
+     , (73161,  57, False) /* AffectsAis */
+     , (73161,  65, True ) /* IgnoreMagicResist */
+     , (73161,  66, True ) /* IgnoreMagicArmor */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73161,  22,     0.5) /* DamageVariance */
+     , (73161,  39,    1.75) /* DefaultScale */
+     , (73161, 105,       1) /* HotspotCycleTime */
+     , (73161, 106,       0) /* HotspotCycleTimeVariance */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73161,   1, 'Fire') /* Name */
+     , (73161,  17, 'The fire burns you for %i of damage.') /* ActivationTalk */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73161,   1, 0x02000638) /* Setup */
+     , (73161,   3, 0x2000005F) /* SoundTable */
+     , (73161,   8, 0x06001049) /* Icon */;


### PR DESCRIPTION
Revisions to the quest based on Loud Lou retail video:

Rebalanced mobs, and corrected their spell books.
Entrance door now stays open for 3 min.
Respawn set to 5 min (up from 3 min).
Updated emote of Mosswart Messenger to spawn 2 adds. 
Added missing fire hotspots.
Corrected appearance of a door.