### PR TITLE
updated to match previous dropped wcid

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/45439 Smite.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/45439 Smite.sql
@@ -6,11 +6,12 @@ VALUES (45439, 'ace45439-smite', 6, '2021-11-01 00:00:00') /* MeleeWeapon */;
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45439,   1,          1) /* ItemType - MeleeWeapon */
      , (45439,   5,        750) /* EncumbranceVal */
+     , (45439,   8,         90) /* Mass */
      , (45439,   9,    1048576) /* ValidLocations - MeleeWeapon */
      , (45439,  16,          1) /* ItemUseable - No */
      , (45439,  17,        282) /* RareId */
-     , (45439,  18,          1) /* UiEffects - Magical */
      , (45439,  19,      50000) /* Value */
+     , (45439,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
      , (45439,  44,         72) /* Damage */
      , (45439,  45,          1) /* DamageType - Slash */
      , (45439,  46,          2) /* DefaultCombatStyle - OneHanded */
@@ -39,15 +40,15 @@ VALUES (45439,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (45439,   5,   -0.05) /* ManaRate */
-     , (45439,  21,       1) /* WeaponLength */
+     , (45439,  21,       0) /* WeaponLength */
      , (45439,  22,     0.4) /* DamageVariance */
      , (45439,  26,       0) /* MaximumVelocity */
      , (45439,  29,    1.18) /* WeaponDefense */
-     , (45439,  39,       1) /* DefaultScale */
+     , (45439,  39,     1.1) /* DefaultScale */
      , (45439,  62,    1.18) /* WeaponOffense */
      , (45439,  63,       1) /* DamageMod */
-     , (45439,  77,       1) /* PhysicsScriptIntensity */
-     , (45439, 136,       1) /* CriticalMultiplier */;
+														 
+     , (45439, 136,       3) /* CriticalMultiplier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (45439,   1, 'Smite') /* Name */
@@ -57,9 +58,11 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (45439,   1, 0x0200131A) /* Setup */
      , (45439,   3, 0x20000014) /* SoundTable */
      , (45439,   6, 0x04000BEF) /* PaletteBase */
+     , (45439,   7, 0x10000860) /* ClothingBase */
      , (45439,   8, 0x06005BCD) /* Icon */
      , (45439,  22, 0x3400002B) /* PhysicsEffectTable */
-     , (45439,  30,         88) /* PhysicsScript - Create */
+     , (45439,  36, 0x0E000012) /* MutateFilter */
+     , (45439,  46, 0x38000032) /* TsysMutationFilter */
      , (45439,  52, 0x06005B0C) /* IconUnderlay */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/45464 Guardian of Pwyll.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/45464 Guardian of Pwyll.sql
@@ -6,25 +6,74 @@ VALUES (45464, 'ace45464-guardianofpwyll', 6, '2021-11-01 00:00:00') /* MeleeWea
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (45464,   1,          1) /* ItemType - MeleeWeapon */
      , (45464,   5,        500) /* EncumbranceVal */
+     , (45464,   8,         90) /* Mass */
      , (45464,   9,    1048576) /* ValidLocations - MeleeWeapon */
      , (45464,  16,          1) /* ItemUseable - No */
+     , (45464,  17,        189) /* RareId */
      , (45464,  19,      50000) /* Value */
+     , (45464,  26,          1) /* AccountRequirements - AsheronsCall_Subscription */
+     , (45464,  44,         66) /* Damage */
+     , (45464,  45,          2) /* DamageType - Pierce */
+     , (45464,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (45464,  47,          2) /* AttackType - Thrust */
+     , (45464,  48,         45) /* WeaponSkill - LightWeapons */
+     , (45464,  49,         50) /* WeaponTime */
      , (45464,  51,          1) /* CombatUse - Melee */
      , (45464,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-     , (45464, 151,          2) /* HookType - Wall */;
+     , (45464, 106,        350) /* ItemSpellcraft */
+     , (45464, 107,       2200) /* ItemCurMana */
+     , (45464, 108,       2200) /* ItemMaxMana */
+     , (45464, 109,          0) /* ItemDifficulty */
+     , (45464, 151,          2) /* HookType - Wall */
+     , (45464, 166,          1) /* SlayerCreatureType - Olthoi */
+     , (45464, 179,         16) /* ImbuedEffect - PierceRending */
+     , (45464, 265,         41) /* EquipmentSetId - RareDamageBoost */
+     , (45464, 319,         50) /* ItemMaxLevel */
+     , (45464, 320,          1) /* ItemXpStyle - Fixed */
+     , (45464, 353,          2) /* WeaponType - Sword */;
+
+INSERT INTO `weenie_properties_int64` (`object_Id`, `type`, `value`)
+VALUES (45464,   4,          0) /* ItemTotalXp */
+     , (45464,   5, 2000000000) /* ItemBaseXp */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (45464,  22, True ) /* Inscribable */;
+VALUES (45464,  11, True ) /* IgnoreCollisions */
+     , (45464,  13, True ) /* Ethereal */
+     , (45464,  14, True ) /* GravityStatus */
+     , (45464,  19, True ) /* Attackable */
+     , (45464,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (45464,  39,     1.1) /* DefaultScale */;
+VALUES (45464,   5,  -0.033) /* ManaRate */
+     , (45464,  21,       0) /* WeaponLength */
+     , (45464,  22,   0.205) /* DamageVariance */
+     , (45464,  26,       0) /* MaximumVelocity */
+     , (45464,  29,    1.18) /* WeaponDefense */
+     , (45464,  39,     1.1) /* DefaultScale */
+     , (45464,  62,    1.18) /* WeaponOffense */
+     , (45464,  63,       1) /* DamageMod */
+     , (45464, 138,     1.2) /* SlayerDamageBonus */
+     , (45464, 151,       1) /* IgnoreShield */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (45464,   1, 'Guardian of Pwyll') /* Name */;
+VALUES (45464,   1, 'Guardian of Pwyll') /* Name */
+     , (45464,  16, 'This sword and swords like it were granted to knights and nobles as a reward for exemplary service to the kingdom and the upholding of the Code of High King Pwyll. Given by the High King himself these swords were always presented with great ceremony for all to see. As a symbol, the loyalty and honor of the wielder cannot be questioned. As a sword, a truer blade cannot be found, serving as shield for the innocent and an implement of justice to the guilty.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (45464,   1, 0x02001364) /* Setup */
      , (45464,   3, 0x20000014) /* SoundTable */
+     , (45464,   6, 0x04000BEF) /* PaletteBase */
+     , (45464,   7, 0x10000860) /* ClothingBase */
      , (45464,   8, 0x06005BB7) /* Icon */
      , (45464,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (45464,  36, 0x0E000012) /* MutateFilter */
+     , (45464,  46, 0x38000032) /* TsysMutationFilter */
      , (45464,  52, 0x06005B0C) /* IconUnderlay */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (45464,  4395,      2)  /* Aura of Incantation of Blood Drinker Self */
+     , (45464,  4400,      2)  /* Aura of Incantation of Defender Self */
+     , (45464,  4548,      2)  /* Incantation of Fealty Self */
+     , (45464,  4590,      2)  /* Incantation of Light Weapon Mastery Self */
+     , (45464,  4661,      3)  /* Epic Blood Thirst */
+     , (45464,  4711,      2)  /* Epic Light Weapon Aptitude */;


### PR DESCRIPTION
LootGenerationFactory_rare.cs is currently dropping old pre moa wcid weapons.  This is to fix the weapons, so that when the change is accepted on that ACE file all weapons match what was previously dropped.