### PR TITLE
Dark Isle Updates

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40147 Black Coral Golem Viceroy.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40147 Black Coral Golem Viceroy.sql
@@ -93,15 +93,13 @@ VALUES (40147,   1,  2900, 0, 0, 3250) /* MaxHealth */
      , (40147,   5,  4500, 0, 0, 4980) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40147,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (40147,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (40147, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (40147, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (40147, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (40147, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40147, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
-     , (40147, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
-     , (40147, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
+VALUES (40147,  6, 0, 2, 0, 391, 0, 0) /* MeleeDefense        Trained */
+     , (40147,  7, 0, 2, 0, 240, 0, 0) /* MissileDefense      Trained */
+     , (40147, 15, 0, 2, 0, 220, 0, 0) /* MagicDefense        Trained */
+     , (40147, 31, 0, 2, 0, 125, 0, 0) /* CreatureEnchantment Trained */
+     , (40147, 33, 0, 2, 0, 125, 0, 0) /* LifeMagic           Trained */
+     , (40147, 34, 0, 2, 0, 125, 0, 0) /* WarMagic            Trained */
+     , (40147, 45, 0, 2, 0, 400, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40147,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -109,24 +107,24 @@ VALUES (40147,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,
      , (40147,  2,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
      , (40147,  3,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
      , (40147,  4,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40147,  5, 12, 250, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40147,  5,  4, 250, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
      , (40147,  6,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (40147,  7,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40147,  8, 20, 250, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (40147,  8,  4, 250, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40147,  2074,   2.15)  /* Gossamer Flesh */
-     , (40147,  2136,   2.18)  /* Icy Torment */
-     , (40147,  2138,   2.15)  /* Blizzard */
-     , (40147,  1839,   2.15)  /* Blistering Creeper */
-     , (40147,  1843,   2.15)  /* Foon-Ki's Glacial Floe */
-     , (40147,  2137,   2.03)  /* Sudden Frost */
-     , (40147,  2135,   2.15)  /* Winter's Embrace */
-     , (40147,  2123,   2.02)  /* Celdiseth's Searing */
-     , (40147,  2122,   2.15)  /* Disintegration */
-     , (40147,  2120,   2.02)  /* Dissolving Vortex */
-     , (40147,  2168,   2.15)  /* Gelidite's Gift */
-     , (40147,   526,   2.02)  /* Acid Vulnerability Other VI */;
+VALUES (40147,  2074,   2.03) /* Gossamer Flesh */
+     , (40147,  2136,   2.03) /* Icy Torment */
+     , (40147,  2138,   2.03) /* Blizzard */
+     , (40147,  1839,   2.03) /* Blistering Creeper */
+     , (40147,  1843,   2.03) /* Foon-Ki's Glacial Floe */
+     , (40147,  2137,   2.04) /* Sudden Frost */
+     , (40147,  2135,   2.04) /* Winter's Embrace */
+     , (40147,  2123,   2.04) /* Celdiseth's Searing */
+     , (40147,  2122,   2.04) /* Disintegration */
+     , (40147,  2120,   2.04) /* Dissolving Vortex */
+     , (40147,  2168,   2.04) /* Gelidite's Gift */
+     , (40147,   526,   2.04) /* Acid Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (40147,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -153,4 +151,4 @@ VALUES (40147, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44
      , (40147, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (40147, -1, 40289, 4, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Black Coral Golem (40289) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (40147, -1, 40147, 4, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Black Coral Golem (40147) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40149 Black Coral Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40149 Black Coral Golem.sql
@@ -91,41 +91,30 @@ VALUES (40149,   1,  1350, 0, 0, 1500) /* MaxHealth */
      , (40149,   3,  1200, 0, 0, 1500) /* MaxStamina */
      , (40149,   5,  1000, 0, 0, 1190) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40149,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (40149,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (40149, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (40149, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (40149, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (40149, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40149, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
-     , (40149, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
-     , (40149, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40149,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (40149,  1,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
      , (40149,  2,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
      , (40149,  3,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
      , (40149,  4,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40149,  5, 12, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40149,  5,  4, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
      , (40149,  6,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (40149,  7,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40149,  8, 20, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (40149,  8,  4, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40149,  2074,   2.15)  /* Gossamer Flesh */
-     , (40149,  2136,   2.18)  /* Icy Torment */
-     , (40149,  2138,   2.15)  /* Blizzard */
-     , (40149,  1839,   2.15)  /* Blistering Creeper */
-     , (40149,  1843,   2.15)  /* Foon-Ki's Glacial Floe */
-     , (40149,  2137,   2.03)  /* Sudden Frost */
-     , (40149,  2135,   2.15)  /* Winter's Embrace */
-     , (40149,  2123,   2.02)  /* Celdiseth's Searing */
-     , (40149,  2122,   2.15)  /* Disintegration */
-     , (40149,  2120,   2.02)  /* Dissolving Vortex */
-     , (40149,  2168,   2.15)  /* Gelidite's Gift */
-     , (40149,   526,   2.02)  /* Acid Vulnerability Other VI */;
+VALUES (40149,  2074,   2.03) /* Gossamer Flesh */
+     , (40149,  2136,   2.03) /* Icy Torment */
+     , (40149,  2138,   2.03) /* Blizzard */
+     , (40149,  1839,   2.03) /* Blistering Creeper */
+     , (40149,  1843,   2.03) /* Foon-Ki's Glacial Floe */
+     , (40149,  2137,   2.04) /* Sudden Frost */
+     , (40149,  2135,   2.04) /* Winter's Embrace */
+     , (40149,  2123,   2.04) /* Celdiseth's Searing */
+     , (40149,  2122,   2.04) /* Disintegration */
+     , (40149,  2120,   2.04) /* Dissolving Vortex */
+     , (40149,  2168,   2.04) /* Gelidite's Gift */
+     , (40149,   526,   2.04) /* Acid Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (40149,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -162,3 +151,12 @@ VALUES (40149, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (40149, -1, 40147, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Black Coral Golem Viceroy (40147) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40149,  34, 0, 2, 0, 230, 0, 0) /* WarMagic */
+     , (40149,  33, 0, 2, 0, 230, 0, 0) /* LifeMagic */
+     , (40149,  31, 0, 2, 0, 230, 0, 0) /* CreatureEnchantment */
+     , (40149,  45, 0, 2, 0, 530, 0, 0) /* LightWeapons */
+     , (40149,   6, 0, 2, 0, 529, 0, 0) /* MeleeDefense */
+     , (40149,   7, 0, 2, 0, 368, 0, 0) /* MissileDefense */
+     , (40149,  15, 0, 2, 0, 296, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40153 Blighted Coral Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40153 Blighted Coral Golem.sql
@@ -88,27 +88,16 @@ VALUES (40153,   1,  1600, 0, 0, 1755) /* MaxHealth */
      , (40153,   3,  1300, 0, 0, 1610) /* MaxStamina */
      , (40153,   5,  1100, 0, 0, 1300) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40153,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (40153,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (40153, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (40153, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (40153, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (40153, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40153, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
-     , (40153, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
-     , (40153, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40153,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (40153,  1,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
      , (40153,  2,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
      , (40153,  3,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
      , (40153,  4,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40153,  5, 12, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40153,  5,  4, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
      , (40153,  6,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (40153,  7,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40153,  8, 20, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (40153,  8,  4, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (40153,  2074,   2.15)  /* Gossamer Flesh */
@@ -148,3 +137,12 @@ VALUES (40153, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (40153, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (40153, 9, 42348,  0, 0, 0.05, False) /* Create Black Coral Heart (42348) for ContainTreasure */
      , (40153, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40153,  34, 0, 2, 0, 255, 0, 0) /* WarMagic */
+     , (40153,  33, 0, 2, 0, 255, 0, 0) /* LifeMagic */
+     , (40153,  31, 0, 2, 0, 255, 0, 0) /* CreatureEnchantment */
+     , (40153,  45, 0, 2, 0, 540, 0, 0) /* LightWeapons */
+     , (40153,   6, 0, 2, 0, 556, 0, 0) /* MeleeDefense */
+     , (40153,   7, 0, 2, 0, 400, 0, 0) /* MissileDefense */
+     , (40153,  15, 0, 2, 0, 300, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40153 Blighted Coral Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40153 Blighted Coral Golem.sql
@@ -100,18 +100,18 @@ VALUES (40153,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,
      , (40153,  8,  4, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40153,  2074,   2.15)  /* Gossamer Flesh */
-     , (40153,  2136,   2.18)  /* Icy Torment */
-     , (40153,  2138,   2.15)  /* Blizzard */
-     , (40153,  1839,   2.15)  /* Blistering Creeper */
-     , (40153,  1843,   2.15)  /* Foon-Ki's Glacial Floe */
-     , (40153,  2137,   2.03)  /* Sudden Frost */
-     , (40153,  2135,   2.15)  /* Winter's Embrace */
-     , (40153,  2123,   2.02)  /* Celdiseth's Searing */
-     , (40153,  2122,   2.15)  /* Disintegration */
-     , (40153,  2120,   2.02)  /* Dissolving Vortex */
-     , (40153,  2168,   2.15)  /* Gelidite's Gift */
-     , (40153,   526,   2.02)  /* Acid Vulnerability Other VI */;
+VALUES (40153,  2074,   2.03) /* Gossamer Flesh */
+     , (40153,  2136,   2.03) /* Icy Torment */
+     , (40153,  2138,   2.03) /* Blizzard */
+     , (40153,  1839,   2.03) /* Blistering Creeper */
+     , (40153,  1843,   2.03) /* Foon-Ki's Glacial Floe */
+     , (40153,  2137,   2.04) /* Sudden Frost */
+     , (40153,  2135,   2.04) /* Winter's Embrace */
+     , (40153,  2123,   2.04) /* Celdiseth's Searing */
+     , (40153,  2122,   2.04) /* Disintegration */
+     , (40153,  2120,   2.04) /* Dissolving Vortex */
+     , (40153,  2168,   2.04) /* Gelidite's Gift */
+     , (40153,   526,   2.04) /* Acid Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (40153,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40289 Black Coral Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40289 Black Coral Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 40289;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (40289, 'ace40289-blackcoralgolem', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (40289, 'ace40289-blackcoralgolem', 10, '2023-05-15 07:45:37') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (40289,   1,         16) /* ItemType - Creature */
@@ -75,6 +75,17 @@ VALUES (40289,   1, 0x020007CA) /* Setup */
      , (40289,  22, 0x3400005B) /* PhysicsEffectTable */
      , (40289,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40289,  0,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40289,  1,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40289,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40289,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40289,  4,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40289,  5,  4,120, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40289,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40289,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40289,  8,  4,150, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (40289,   1, 290, 0, 0) /* Strength */
      , (40289,   2, 300, 0, 0) /* Endurance */
@@ -88,58 +99,36 @@ VALUES (40289,   1,  1350, 0, 0, 1500) /* MaxHealth */
      , (40289,   3,  1200, 0, 0, 1500) /* MaxStamina */
      , (40289,   5,  1011, 0, 0, 1190) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40289,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (40289,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (40289, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (40289, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (40289, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (40289, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40289, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
-     , (40289, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
-     , (40289, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40289,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40289,  1,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40289,  2,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40289,  3,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40289,  4,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40289,  5, 12, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40289,  6,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40289,  7,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40289,  8, 20, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40289,  2074,   2.15)  /* Gossamer Flesh */
-     , (40289,  2136,   2.18)  /* Icy Torment */
-     , (40289,  2138,   2.15)  /* Blizzard */
-     , (40289,  1839,   2.15)  /* Blistering Creeper */
-     , (40289,  1843,   2.15)  /* Foon-Ki's Glacial Floe */
-     , (40289,  2137,   2.03)  /* Sudden Frost */
-     , (40289,  2135,   2.15)  /* Winter's Embrace */
-     , (40289,  2123,   2.02)  /* Celdiseth's Searing */
-     , (40289,  2122,   2.15)  /* Disintegration */
-     , (40289,  2120,   2.02)  /* Dissolving Vortex */
-     , (40289,  2168,   2.15)  /* Gelidite's Gift */
-     , (40289,   526,   2.02)  /* Acid Vulnerability Other VI */;
+VALUES (40289,  2074,   2.03) /* Gossamer Flesh */
+     , (40289,  2136,   2.03) /* Icy Torment */
+     , (40289,  2138,   2.03) /* Blizzard */
+     , (40289,  1839,   2.03) /* Blistering Creeper */
+     , (40289,  1843,   2.03) /* Foon-Ki's Glacial Floe */
+     , (40289,  2137,   2.04) /* Sudden Frost */
+     , (40289,  2135,   2.04) /* Winter's Embrace */
+     , (40289,  2123,   2.04) /* Celdiseth's Searing */
+     , (40289,  2122,   2.04) /* Disintegration */
+     , (40289,  2120,   2.04) /* Dissolving Vortex */
+     , (40289,  2168,   2.04) /* Gelidite's Gift */
+     , (40289,   526,   2.04) /* Acid Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (40289,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (40289, 5 /* HeartBeat */, 0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (40289,  5 /* HeartBeat */,      1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (40289, 5 /* HeartBeat */, 1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x41000014 /* Sleeping */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 1, 5 /* Motion */, 0, 1, 0x41000014 /* Sleeping */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (40289, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
@@ -148,3 +137,12 @@ VALUES (40289, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (40289, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (40289, 9, 42348,  0, 0, 0.05, False) /* Create Black Coral Heart (42348) for ContainTreasure */
      , (40289, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40289,  34, 0, 2, 0, 230, 0, 0) /* WarMagic */
+     , (40289,  33, 0, 2, 0, 230, 0, 0) /* LifeMagic */
+     , (40289,  31, 0, 2, 0, 230, 0, 0) /* CreatureEnchantment */
+     , (40289,  45, 0, 2, 0, 530, 0, 0) /* LightWeapons */
+     , (40289,   6, 0, 2, 0, 529, 0, 0) /* MeleeDefense */
+     , (40289,   7, 0, 2, 0, 368, 0, 0) /* MissileDefense */
+     , (40289,  15, 0, 2, 0, 296, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40290 Blighted Coral Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40290 Blighted Coral Golem.sql
@@ -103,18 +103,18 @@ VALUES (40290,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,
      , (40290,  8,  4, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40290,  2074,   2.15)  /* Gossamer Flesh */
-     , (40290,  2136,   2.18)  /* Icy Torment */
-     , (40290,  2138,   2.15)  /* Blizzard */
-     , (40290,  1839,   2.15)  /* Blistering Creeper */
-     , (40290,  1843,   2.15)  /* Foon-Ki's Glacial Floe */
-     , (40290,  2137,   2.03)  /* Sudden Frost */
-     , (40290,  2135,   2.15)  /* Winter's Embrace */
-     , (40290,  2123,   2.02)  /* Celdiseth's Searing */
-     , (40290,  2122,   2.15)  /* Disintegration */
-     , (40290,  2120,   2.02)  /* Dissolving Vortex */
-     , (40290,  2168,   2.15)  /* Gelidite's Gift */
-     , (40290,   526,   2.02)  /* Acid Vulnerability Other VI */;
+VALUES (40290,  2074,   2.03) /* Gossamer Flesh */
+     , (40290,  2136,   2.03) /* Icy Torment */
+     , (40290,  2138,   2.03) /* Blizzard */
+     , (40290,  1839,   2.03) /* Blistering Creeper */
+     , (40290,  1843,   2.03) /* Foon-Ki's Glacial Floe */
+     , (40290,  2137,   2.04) /* Sudden Frost */
+     , (40290,  2135,   2.04) /* Winter's Embrace */
+     , (40290,  2123,   2.04) /* Celdiseth's Searing */
+     , (40290,  2122,   2.04) /* Disintegration */
+     , (40290,  2120,   2.04) /* Dissolving Vortex */
+     , (40290,  2168,   2.04) /* Gelidite's Gift */
+     , (40290,   526,   2.04) /* Acid Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (40290,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40290 Blighted Coral Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40290 Blighted Coral Golem.sql
@@ -91,27 +91,16 @@ VALUES (40290,   1,  1600, 0, 0, 1755) /* MaxHealth */
      , (40290,   3,  1300, 0, 0, 1610) /* MaxStamina */
      , (40290,   5,  1100, 0, 0, 1300) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40290,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (40290,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (40290, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (40290, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (40290, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (40290, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40290, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
-     , (40290, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
-     , (40290, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40290,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (40290,  1,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
      , (40290,  2,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
      , (40290,  3,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
      , (40290,  4,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40290,  5, 12, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40290,  5,  4, 120, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
      , (40290,  6,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (40290,  7,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40290,  8, 20, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (40290,  8,  4, 150, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (40290,  2074,   2.15)  /* Gossamer Flesh */
@@ -162,3 +151,12 @@ VALUES (40290, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (40290, -1, 70081, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Blighted Coral Golem Viceroy (70081) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40290,  34, 0, 2, 0, 255, 0, 0) /* WarMagic */
+     , (40290,  33, 0, 2, 0, 255, 0, 0) /* LifeMagic */
+     , (40290,  31, 0, 2, 0, 255, 0, 0) /* CreatureEnchantment */
+     , (40290,  45, 0, 2, 0, 540, 0, 0) /* LightWeapons */
+     , (40290,   6, 0, 2, 0, 556, 0, 0) /* MeleeDefense */
+     , (40290,   7, 0, 2, 0, 400, 0, 0) /* MissileDefense */
+     , (40290,  15, 0, 2, 0, 300, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/70081 Blighted Coral Golem Viceroy.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/70081 Blighted Coral Golem Viceroy.sql
@@ -92,27 +92,16 @@ VALUES (70081,   1,  2900, 0, 0, 3350) /* MaxHealth */
      , (70081,   3,  4300, 0, 0, 5000) /* MaxStamina */
      , (70081,   5,  4500, 0, 0, 4980) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (70081,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (70081,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (70081, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (70081, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
-     , (70081, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (70081, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (70081, 33, 0, 3, 0, 450, 0, 0) /* LifeMagic           Specialized */
-     , (70081, 34, 0, 3, 0, 450, 0, 0) /* WarMagic            Specialized */
-     , (70081, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (70081,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (70081,  1,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
      , (70081,  2,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
      , (70081,  3,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
      , (70081,  4,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (70081,  5, 12, 350, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (70081,  5,  4, 350, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
      , (70081,  6,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
      , (70081,  7,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (70081,  8, 20, 350, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+     , (70081,  8,  4, 350, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (70081,  2074,   2.15)  /* Gossamer Flesh */
@@ -154,3 +143,12 @@ VALUES (70081, 9, 44470,  1, 0, 0, False) /* Create Corrupted Essence (44470) fo
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (70081, -1, 40153, 4, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Blighted Coral Golem (40153) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (70081,  34, 0, 2, 0, 140, 0, 0) /* WarMagic */
+     , (70081,  33, 0, 2, 0, 140, 0, 0) /* LifeMagic */
+     , (70081,  31, 0, 2, 0, 140, 0, 0) /* CreatureEnchantment */
+     , (70081,  45, 0, 2, 0, 400, 0, 0) /* LightWeapons */
+     , (70081,   6, 0, 2, 0, 373, 0, 0) /* MeleeDefense */
+     , (70081,   7, 0, 2, 0, 500, 0, 0) /* MissileDefense */
+     , (70081,  15, 0, 2, 0, 280, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/70081 Blighted Coral Golem Viceroy.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/70081 Blighted Coral Golem Viceroy.sql
@@ -104,18 +104,18 @@ VALUES (70081,  0,  4,  0,    0,  350,  277,  315,  350,  294,  294,  294,  294,
      , (70081,  8,  4, 350, 0.75,  350,  277,  315,  350,  294,  294,  294,  294,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (70081,  2074,   2.15)  /* Gossamer Flesh */
-     , (70081,  2136,   2.18)  /* Icy Torment */
-     , (70081,  2138,   2.15)  /* Blizzard */
-     , (70081,  1839,   2.15)  /* Blistering Creeper */
-     , (70081,  1843,   2.15)  /* Foon-Ki's Glacial Floe */
-     , (70081,  2137,   2.03)  /* Sudden Frost */
-     , (70081,  2135,   2.15)  /* Winter's Embrace */
-     , (70081,  2123,   2.02)  /* Celdiseth's Searing */
-     , (70081,  2122,   2.15)  /* Disintegration */
-     , (70081,  2120,   2.02)  /* Dissolving Vortex */
-     , (70081,  2168,   2.15)  /* Gelidite's Gift */
-     , (70081,   526,   2.02)  /* Acid Vulnerability Other VI */;
+VALUES (70081,  2074,   2.03) /* Gossamer Flesh */
+     , (70081,  2136,   2.03) /* Icy Torment */
+     , (70081,  2138,   2.03) /* Blizzard */
+     , (70081,  1839,   2.03) /* Blistering Creeper */
+     , (70081,  1843,   2.03) /* Foon-Ki's Glacial Floe */
+     , (70081,  2137,   2.04) /* Sudden Frost */
+     , (70081,  2135,   2.04) /* Winter's Embrace */
+     , (70081,  2123,   2.04) /* Celdiseth's Searing */
+     , (70081,  2122,   2.04) /* Disintegration */
+     , (70081,  2120,   2.04) /* Dissolving Vortex */
+     , (70081,  2168,   2.04) /* Gelidite's Gift */
+     , (70081,   526,   2.04) /* Acid Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (70081,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33623 Biaka Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33623 Biaka Mukkir.sql
@@ -88,14 +88,14 @@ VALUES (33623,   1, 12000, 0, 0, 12205) /* MaxHealth */
      , (33623,   5,   220, 0, 0, 505) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33623,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (33623,  7, 0, 3, 0, 200, 0, 0) /* MissileDefense      Specialized */
-     , (33623, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
-     , (33623, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
-     , (33623, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (33623, 33, 0, 3, 0, 310, 0, 0) /* LifeMagic           Specialized */
-     , (33623, 34, 0, 3, 0, 310, 0, 0) /* WarMagic            Specialized */
-     , (33623, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33623,  6, 0, 2, 0, 180, 0, 0) /* MeleeDefense        Trained */
+     , (33623,  7, 0, 2, 0, 200, 0, 0) /* MissileDefense      Trained */
+     , (33623, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
+     , (33623, 31, 0, 2, 0, 217, 0, 0) /* CreatureEnchantment Trained */
+     , (33623, 32, 0, 2, 0,  55, 0, 0) /* ItemEnchantment     Trained */
+     , (33623, 33, 0, 2, 0, 217, 0, 0) /* LifeMagic           Trained */
+     , (33623, 34, 0, 2, 0, 217, 0, 0) /* WarMagic            Trained */
+     , (33623, 45, 0, 2, 0, 388, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33623,  0,  4,  5,    0,  350,  245,  280,  210,  350,  350,  385,  350,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33626 Hellion Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33626 Hellion Mukkir.sql
@@ -40,6 +40,7 @@ VALUES (33626,   1,       5) /* HeartbeatInterval */
      , (33626,  31,      17) /* VisualAwarenessRange */
      , (33626,  34,     0.5) /* PowerupTime */
      , (33626,  36,       1) /* ChargeSpeed */
+     , (33626,  41,      60) /* RegenerationInterval */
      , (33626,  43,       4) /* GeneratorRadius */
      , (33626,  64,    0.75) /* ResistSlash */
      , (33626,  65,     0.9) /* ResistPierce */
@@ -87,14 +88,14 @@ VALUES (33626,   1,  9001, 0, 0, 9203) /* MaxHealth */
      , (33626,   5,   220, 0, 0, 500) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33626,  6, 0, 3, 0, 160, 0, 0) /* MeleeDefense        Specialized */
-     , (33626,  7, 0, 3, 0, 200, 0, 0) /* MissileDefense      Specialized */
-     , (33626, 15, 0, 3, 0, 370, 0, 0) /* MagicDefense        Specialized */
-     , (33626, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
-     , (33626, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (33626, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (33626, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (33626, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33626,  6, 0, 2, 0, 378, 0, 0) /* MeleeDefense        Trained */
+     , (33626,  7, 0, 2, 0, 463, 0, 0) /* MissileDefense      Trained */
+     , (33626, 15, 0, 2, 0, 370, 0, 0) /* MagicDefense        Trained */
+     , (33626, 31, 0, 2, 0, 140, 0, 0) /* CreatureEnchantment Trained */
+     , (33626, 32, 0, 2, 0, 140, 0, 0) /* ItemEnchantment     Trained */
+     , (33626, 33, 0, 2, 0, 193, 0, 0) /* LifeMagic           Trained */
+     , (33626, 34, 0, 2, 0, 193, 0, 0) /* WarMagic            Trained */
+     , (33626, 45, 0, 2, 0, 385, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33626,  0,  4,  5,    0,  350,  245,  280,  210,  350,  350,  385,  350,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33732 Degenerate Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33732 Degenerate Mukkir.sql
@@ -55,8 +55,7 @@ VALUES (33732,   1,       5) /* HeartbeatInterval */
      , (33732,  77,       1) /* PhysicsScriptIntensity */
      , (33732, 104,      10) /* ObviousRadarRange */
      , (33732, 117,     0.6) /* FocusedProbability */
-     , (33732, 125,       1) /* ResistHealthDrain */
-     , (33732, 166,       1) /* ResistNether */;
+     , (33732, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33732,   1, 'Degenerate Mukkir') /* Name */;
@@ -85,16 +84,6 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (33732,   1,   416, 0, 0, 618) /* MaxHealth */
      , (33732,   3,   500, 0, 0, 905) /* MaxStamina */
      , (33732,   5,   220, 0, 0, 500) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33732,  6, 0, 3, 0, 160, 0, 0) /* MeleeDefense        Specialized */
-     , (33732,  7, 0, 3, 0, 200, 0, 0) /* MissileDefense      Specialized */
-     , (33732, 15, 0, 3, 0, 370, 0, 0) /* MagicDefense        Specialized */
-     , (33732, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
-     , (33732, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (33732, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (33732, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (33732, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33732,  0,  4,  5,    0,  350,  245,  280,  210,  350,  350,  385,  350,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
@@ -184,3 +173,13 @@ VALUES (33732, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33732, -1, 33626, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Hellion Mukkir (33626) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33732,  34, 0, 2, 0, 193, 0, 0) /* WarMagic */
+     , (33732,  33, 0, 2, 0, 193, 0, 0) /* LifeMagic */
+     , (33732,  31, 0, 2, 0, 140, 0, 0) /* CreatureEnchantment */
+     , (33732,  32, 0, 2, 0, 0, 0, 0) /* ItemEnchantment */
+     , (33732,  45, 0, 2, 0, 385, 0, 0) /* LightWeapons */
+     , (33732,   6, 0, 2, 0, 325, 0, 0) /* MeleeDefense */
+     , (33732,   7, 0, 2, 0, 404, 0, 0) /* MissileDefense */
+     , (33732,  15, 0, 2, 0, 300, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33733 Depraved Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33733 Depraved Mukkir.sql
@@ -55,8 +55,7 @@ VALUES (33733,   1,       5) /* HeartbeatInterval */
      , (33733,  77,       1) /* PhysicsScriptIntensity */
      , (33733, 104,      10) /* ObviousRadarRange */
      , (33733, 117,     0.6) /* FocusedProbability */
-     , (33733, 125,       1) /* ResistHealthDrain */
-     , (33733, 166,       1) /* ResistNether */;
+     , (33733, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33733,   1, 'Depraved Mukkir') /* Name */;
@@ -85,16 +84,6 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (33733,   1,   415, 0, 0, 620) /* MaxHealth */
      , (33733,   3,   500, 0, 0, 910) /* MaxStamina */
      , (33733,   5,   220, 0, 0, 505) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33733,  6, 0, 3, 0, 185, 0, 0) /* MeleeDefense        Specialized */
-     , (33733,  7, 0, 3, 0, 210, 0, 0) /* MissileDefense      Specialized */
-     , (33733, 15, 0, 3, 0, 370, 0, 0) /* MagicDefense        Specialized */
-     , (33733, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
-     , (33733, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (33733, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (33733, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (33733, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33733,  0,  4,  5,    0,  350,  245,  280,  210,  350,  350,  385,  350,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
@@ -184,3 +173,13 @@ VALUES (33733, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33733, -1, 33623, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Biaka Mukkir (33623) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33733,  34, 0, 2, 0, 197, 0, 0) /* WarMagic */
+     , (33733,  33, 0, 2, 0, 197, 0, 0) /* LifeMagic */
+     , (33733,  31, 0, 2, 0, 197, 0, 0) /* CreatureEnchantment */
+     , (33733,  32, 0, 2, 0, -142, 0, 0) /* ItemEnchantment */
+     , (33733,  45, 0, 2, 0, 388, 0, 0) /* LightWeapons */
+     , (33733,   6, 0, 2, 0, 185, 0, 0) /* MeleeDefense */
+     , (33733,   7, 0, 2, 0, 526, 0, 0) /* MissileDefense */
+     , (33733,  15, 0, 2, 0, 319, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33733 Depraved Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/33733 Depraved Mukkir.sql
@@ -178,7 +178,7 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (33733,  34, 0, 2, 0, 197, 0, 0) /* WarMagic */
      , (33733,  33, 0, 2, 0, 197, 0, 0) /* LifeMagic */
      , (33733,  31, 0, 2, 0, 197, 0, 0) /* CreatureEnchantment */
-     , (33733,  32, 0, 2, 0, -142, 0, 0) /* ItemEnchantment */
+     , (33733,  32, 0, 2, 0, 142, 0, 0) /* ItemEnchantment */
      , (33733,  45, 0, 2, 0, 388, 0, 0) /* LightWeapons */
      , (33733,   6, 0, 2, 0, 185, 0, 0) /* MeleeDefense */
      , (33733,   7, 0, 2, 0, 526, 0, 0) /* MissileDefense */

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/40281 Degenerate Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/40281 Degenerate Mukkir.sql
@@ -52,8 +52,7 @@ VALUES (40281,   1,       5) /* HeartbeatInterval */
      , (40281,  77,       1) /* PhysicsScriptIntensity */
      , (40281, 104,      10) /* ObviousRadarRange */
      , (40281, 117,     0.6) /* FocusedProbability */
-     , (40281, 125,       1) /* ResistHealthDrain */
-     , (40281, 166,       1) /* ResistNether */;
+     , (40281, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40281,   1, 'Degenerate Mukkir') /* Name */;
@@ -82,16 +81,6 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (40281,   1,   416, 0, 0, 618) /* MaxHealth */
      , (40281,   3,   500, 0, 0, 905) /* MaxStamina */
      , (40281,   5,   220, 0, 0, 500) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40281,  6, 0, 3, 0, 160, 0, 0) /* MeleeDefense        Specialized */
-     , (40281,  7, 0, 3, 0, 200, 0, 0) /* MissileDefense      Specialized */
-     , (40281, 15, 0, 3, 0, 370, 0, 0) /* MagicDefense        Specialized */
-     , (40281, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
-     , (40281, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40281, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (40281, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (40281, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40281,  0,  4,  5,    0,  350,  245,  280,  210,  350,  350,  385,  350,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
@@ -170,3 +159,13 @@ VALUES (40281, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (40281, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (40281, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
      , (40281, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40281,  34, 0, 2, 0, 193, 0, 0) /* WarMagic */
+     , (40281,  33, 0, 2, 0, 193, 0, 0) /* LifeMagic */
+     , (40281,  31, 0, 2, 0, 140, 0, 0) /* CreatureEnchantment */
+     , (40281,  32, 0, 2, 0, 0, 0, 0) /* ItemEnchantment */
+     , (40281,  45, 0, 2, 0, 385, 0, 0) /* LightWeapons */
+     , (40281,   6, 0, 2, 0, 325, 0, 0) /* MeleeDefense */
+     , (40281,   7, 0, 2, 0, 404, 0, 0) /* MissileDefense */
+     , (40281,  15, 0, 2, 0, 300, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/40282 Depraved Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/40282 Depraved Mukkir.sql
@@ -52,8 +52,7 @@ VALUES (40282,   1,       5) /* HeartbeatInterval */
      , (40282,  77,       1) /* PhysicsScriptIntensity */
      , (40282, 104,      10) /* ObviousRadarRange */
      , (40282, 117,     0.6) /* FocusedProbability */
-     , (40282, 125,       1) /* ResistHealthDrain */
-     , (40282, 166,       1) /* ResistNether */;
+     , (40282, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40282,   1, 'Depraved Mukkir') /* Name */;
@@ -82,16 +81,6 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (40282,   1,   415, 0, 0, 620) /* MaxHealth */
      , (40282,   3,   500, 0, 0, 910) /* MaxStamina */
      , (40282,   5,   220, 0, 0, 505) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40282,  6, 0, 3, 0, 185, 0, 0) /* MeleeDefense        Specialized */
-     , (40282,  7, 0, 3, 0, 210, 0, 0) /* MissileDefense      Specialized */
-     , (40282, 15, 0, 3, 0, 370, 0, 0) /* MagicDefense        Specialized */
-     , (40282, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
-     , (40282, 31, 0, 3, 0, 140, 0, 0) /* CreatureEnchantment Specialized */
-     , (40282, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (40282, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (40282, 45, 0, 3, 0, 267, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40282,  0,  4,  5,    0,  350,  245,  280,  210,  350,  350,  385,  350,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
@@ -178,3 +167,13 @@ VALUES (40282, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (40282, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (40282, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
      , (40282, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40282,  34, 0, 2, 0, 197, 0, 0) /* WarMagic */
+     , (40282,  33, 0, 2, 0, 197, 0, 0) /* LifeMagic */
+     , (40282,  31, 0, 2, 0, 197, 0, 0) /* CreatureEnchantment */
+     , (40282,  32, 0, 2, 0, -142, 0, 0) /* ItemEnchantment */
+     , (40282,  45, 0, 2, 0, 388, 0, 0) /* LightWeapons */
+     , (40282,   6, 0, 2, 0, 185, 0, 0) /* MeleeDefense */
+     , (40282,   7, 0, 2, 0, 526, 0, 0) /* MissileDefense */
+     , (40282,  15, 0, 2, 0, 319, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Mukkir/40282 Depraved Mukkir.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Mukkir/40282 Depraved Mukkir.sql
@@ -172,7 +172,7 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (40282,  34, 0, 2, 0, 197, 0, 0) /* WarMagic */
      , (40282,  33, 0, 2, 0, 197, 0, 0) /* LifeMagic */
      , (40282,  31, 0, 2, 0, 197, 0, 0) /* CreatureEnchantment */
-     , (40282,  32, 0, 2, 0, -142, 0, 0) /* ItemEnchantment */
+     , (40282,  32, 0, 2, 0, 142, 0, 0) /* ItemEnchantment */
      , (40282,  45, 0, 2, 0, 388, 0, 0) /* LightWeapons */
      , (40282,   6, 0, 2, 0, 185, 0, 0) /* MeleeDefense */
      , (40282,   7, 0, 2, 0, 526, 0, 0) /* MissileDefense */

--- a/Database/Patches/9 WeenieDefaults/Creature/Niffis/33636 Glissnal Sleech.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Niffis/33636 Glissnal Sleech.sql
@@ -95,23 +95,19 @@ VALUES (33636,   1,  9000, 0, 0, 9180) /* MaxHealth */
      , (33636,   5,  1000, 0, 0, 1480) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33636,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (33636,  7, 0, 3, 0, 300, 0, 0) /* MissileDefense      Specialized */
-     , (33636, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33636, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (33636, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33636, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (33636, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (33636, 33, 0, 3, 0, 350, 0, 0) /* LifeMagic           Specialized */
-     , (33636, 34, 0, 3, 0, 320, 0, 0) /* WarMagic            Specialized */
-     , (33636, 45, 0, 3, 0, 210, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33636,  6, 0, 2, 0, 458, 0, 0) /* MeleeDefense        Trained */
+     , (33636,  7, 0, 2, 0, 554, 0, 0) /* MissileDefense      Trained */
+     , (33636, 15, 0, 2, 0, 247, 0, 0) /* MagicDefense        Trained */
+     , (33636, 33, 0, 2, 0, 155, 0, 0) /* LifeMagic           Trained */
+     , (33636, 34, 0, 2, 0, 155, 0, 0) /* WarMagic            Trained */
+     , (33636, 45, 0, 2, 0, 435, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33636,  0,  4, 220, 0.75,  650,  650,  358,  293,  618,  553,  618,  553,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */
-     , (33636, 16,  4,  0,    0,  650,  650,  358,  293,  618,  553,  618,  553,    0, 2,  0.5, 0.48,  0.1,  0.5,  0.6,  0.1,  0.5, 0.48,  0.1,  0.5,  0.6, 0.22) /* Torso */
-     , (33636, 21,  4,  0,    0,  650,  650,  358,  293,  618,  553,  618,  553,    0, 2,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0, 0.28) /* Wings */
-     , (33636, 24,  4,  0,    0,  650,  650,  358,  293,  618,  553,  618,  553,    0, 2, 0.06, 0.22,  0.3,  0.1,  0.2,  0.3, 0.06, 0.22,  0.3,  0.1,  0.2, 0.22) /* UpperTentacle */
-     , (33636, 25,  4, 220,  0.5,  650,  650,  358,  293,  618,  553,  618,  553,    0, 3,    0,    0,  0.3,    0,  0.1,  0.3,    0,    0,  0.3,    0,  0.1, 0.28) /* LowerTentacle */;
+VALUES (33636,  0,  4, 150, 0.75,  600,  650,  358,  293,  618,  553,  618,  553,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */
+     , (33636, 16,  4, 150,    0,  600,  650,  358,  293,  618,  553,  618,  553,    0, 2,  0.5, 0.48,  0.1,  0.5,  0.6,  0.1,  0.5, 0.48,  0.1,  0.5,  0.6, 0.22) /* Torso */
+     , (33636, 21,  4, 150,    0,  600,  650,  358,  293,  618,  553,  618,  553,    0, 2,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0, 0.28) /* Wings */
+     , (33636, 24,  4, 150,    0,  600,  650,  358,  293,  618,  553,  618,  553,    0, 2, 0.06, 0.22,  0.3,  0.1,  0.2,  0.3, 0.06, 0.22,  0.3,  0.1,  0.2, 0.22) /* UpperTentacle */
+     , (33636, 25,  4, 150,  0.5,  600,  650,  358,  293,  618,  553,  618,  553,    0, 3,    0,    0,  0.3,    0,  0.1,  0.3,    0,    0,  0.3,    0,  0.1, 0.28) /* LowerTentacle */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (33636,  2074,   2.15)  /* Gossamer Flesh */

--- a/Database/Patches/9 WeenieDefaults/Creature/Niffis/33738 Listris Sleech.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Niffis/33738 Listris Sleech.sql
@@ -94,16 +94,13 @@ VALUES (33738,   1,   435, 0, 0, 620) /* MaxHealth */
      , (33738,   5,  1000, 0, 0, 1490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33738,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (33738,  7, 0, 3, 0, 290, 0, 0) /* MissileDefense      Specialized */
-     , (33738, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33738, 15, 0, 3, 0, 275, 0, 0) /* MagicDefense        Specialized */
-     , (33738, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33738, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (33738, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (33738, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (33738, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (33738, 45, 0, 3, 0, 210, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33738,  6, 0, 2, 0, 483, 0, 0) /* MeleeDefense        Trained */
+     , (33738,  7, 0, 2, 0, 514, 0, 0) /* MissileDefense      Trained */
+     , (33738, 15, 0, 2, 0, 247, 0, 0) /* MagicDefense        Trained */
+     , (33738, 31, 0, 2, 0, 157, 0, 0) /* CreatureEnchantment Trained */
+     , (33738, 33, 0, 2, 0, 157, 0, 0) /* LifeMagic           Trained */
+     , (33738, 34, 0, 2, 0, 157, 0, 0) /* WarMagic            Trained */
+     , (33738, 45, 0, 2, 0, 435, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33738,  0,  4, 200, 0.75,  650,  650,  618,  618,  650,  650,  650,  650,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Niffis/33739 Parfal Sleech.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Niffis/33739 Parfal Sleech.sql
@@ -19,7 +19,6 @@ VALUES (33739,   1,         16) /* ItemType - Creature */
      , (33739,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (33739, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (33739, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (33739, 140,          1) /* AiOptions - CanOpenDoors */
      , (33739, 146,     290000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -94,23 +93,19 @@ VALUES (33739,   1,   435, 0, 0, 615) /* MaxHealth */
      , (33739,   5,  1000, 0, 0, 1480) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33739,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (33739,  7, 0, 3, 0, 290, 0, 0) /* MissileDefense      Specialized */
-     , (33739, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33739, 15, 0, 3, 0, 275, 0, 0) /* MagicDefense        Specialized */
-     , (33739, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33739, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (33739, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (33739, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (33739, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (33739, 45, 0, 3, 0, 210, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33739,  6, 0, 2, 0, 458, 0, 0) /* MeleeDefense        Trained */
+     , (33739,  7, 0, 2, 0, 554, 0, 0) /* MissileDefense      Trained */
+     , (33739, 15, 0, 2, 0, 247, 0, 0) /* MagicDefense        Trained */
+     , (33739, 33, 0, 2, 0, 155, 0, 0) /* LifeMagic           Trained */
+     , (33739, 34, 0, 2, 0, 155, 0, 0) /* WarMagic            Trained */
+     , (33739, 45, 0, 2, 0, 435, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33739,  0,  4, 200, 0.75,  650,  650,  618,  618,  650,  650,  650,  650,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */
-     , (33739, 16,  4,  0,    0,  650,  650,  618,  618,  650,  650,  650,  650,    0, 2,  0.5, 0.48,  0.1,  0.5,  0.6,  0.1,  0.5, 0.48,  0.1,  0.5,  0.6, 0.22) /* Torso */
-     , (33739, 21,  4,  0,    0,  650,  650,  618,  618,  650,  650,  650,  650,    0, 2,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0, 0.28) /* Wings */
-     , (33739, 24,  4,  0,    0,  650,  650,  618,  618,  650,  650,  650,  650,    0, 2, 0.06, 0.22,  0.3,  0.1,  0.2,  0.3, 0.06, 0.22,  0.3,  0.1,  0.2, 0.22) /* UpperTentacle */
-     , (33739, 25,  4, 200,  0.5,  650,  650,  618,  618,  650,  650,  650,  650,    0, 3,    0,    0,  0.3,    0,  0.1,  0.3,    0,    0,  0.3,    0,  0.1, 0.28) /* LowerTentacle */;
+VALUES (33739,  0,  4, 100, 0.75,  600,  650,  618,  618,  650,  650,  650,  650,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */
+     , (33739, 16,  4, 100,    0,  600,  650,  618,  618,  650,  650,  650,  650,    0, 2,  0.5, 0.48,  0.1,  0.5,  0.6,  0.1,  0.5, 0.48,  0.1,  0.5,  0.6, 0.22) /* Torso */
+     , (33739, 21,  4, 100,    0,  600,  650,  618,  618,  650,  650,  650,  650,    0, 2,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0, 0.28) /* Wings */
+     , (33739, 24,  4, 100,    0,  600,  650,  618,  618,  650,  650,  650,  650,    0, 2, 0.06, 0.22,  0.3,  0.1,  0.2,  0.3, 0.06, 0.22,  0.3,  0.1,  0.2, 0.22) /* UpperTentacle */
+     , (33739, 25,  4, 100,  0.5,  600,  650,  618,  618,  650,  650,  650,  650,    0, 3,    0,    0,  0.3,    0,  0.1,  0.3,    0,    0,  0.3,    0,  0.1, 0.28) /* LowerTentacle */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (33739,  2074,   2.15)  /* Gossamer Flesh */

--- a/Database/Patches/9 WeenieDefaults/Creature/Niffis/40285 Listris Sleech.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Niffis/40285 Listris Sleech.sql
@@ -91,16 +91,13 @@ VALUES (40285,   1,   435, 0, 0, 620) /* MaxHealth */
      , (40285,   5,  1000, 0, 0, 1490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40285,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (40285,  7, 0, 3, 0, 290, 0, 0) /* MissileDefense      Specialized */
-     , (40285, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (40285, 15, 0, 3, 0, 275, 0, 0) /* MagicDefense        Specialized */
-     , (40285, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (40285, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (40285, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (40285, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (40285, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (40285, 45, 0, 3, 0, 210, 0, 0) /* LightWeapons        Specialized */;
+VALUES (40285,  6, 0, 2, 0, 483, 0, 0) /* MeleeDefense        Trained */
+     , (40285,  7, 0, 2, 0, 514, 0, 0) /* MissileDefense      Trained */
+     , (40285, 15, 0, 2, 0, 247, 0, 0) /* MagicDefense        Trained */
+     , (40285, 31, 0, 2, 0, 157, 0, 0) /* CreatureEnchantment Trained */
+     , (40285, 33, 0, 2, 0, 157, 0, 0) /* LifeMagic           Trained */
+     , (40285, 34, 0, 2, 0, 157, 0, 0) /* WarMagic            Trained */
+     , (40285, 45, 0, 2, 0, 435, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40285,  0,  4, 200, 0.75,  650,  650,  618,  618,  650,  650,  650,  650,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Niffis/40286 Parfal Sleech.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Niffis/40286 Parfal Sleech.sql
@@ -17,7 +17,6 @@ VALUES (40286,   1,         16) /* ItemType - Creature */
      , (40286,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (40286, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (40286, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (40286, 140,          1) /* AiOptions - CanOpenDoors */
      , (40286, 146,     290000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -91,23 +90,19 @@ VALUES (40286,   1,   435, 0, 0, 615) /* MaxHealth */
      , (40286,   5,  1000, 0, 0, 1480) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40286,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
-     , (40286,  7, 0, 3, 0, 290, 0, 0) /* MissileDefense      Specialized */
-     , (40286, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (40286, 15, 0, 3, 0, 275, 0, 0) /* MagicDefense        Specialized */
-     , (40286, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (40286, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (40286, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (40286, 33, 0, 3, 0, 300, 0, 0) /* LifeMagic           Specialized */
-     , (40286, 34, 0, 3, 0, 300, 0, 0) /* WarMagic            Specialized */
-     , (40286, 45, 0, 3, 0, 210, 0, 0) /* LightWeapons        Specialized */;
+VALUES (40286,  6, 0, 2, 0, 458, 0, 0) /* MeleeDefense        Trained */
+     , (40286,  7, 0, 2, 0, 554, 0, 0) /* MissileDefense      Trained */
+     , (40286, 15, 0, 2, 0, 247, 0, 0) /* MagicDefense        Trained */
+     , (40286, 33, 0, 2, 0, 155, 0, 0) /* LifeMagic           Trained */
+     , (40286, 34, 0, 2, 0, 155, 0, 0) /* WarMagic            Trained */
+     , (40286, 45, 0, 2, 0, 435, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40286,  0,  4, 200, 0.75,  650,  650,  618,  618,  650,  650,  650,  650,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */
-     , (40286, 16,  4,  0,    0,  650,  650,  618,  618,  650,  650,  650,  650,    0, 2,  0.5, 0.48,  0.1,  0.5,  0.6,  0.1,  0.5, 0.48,  0.1,  0.5,  0.6, 0.22) /* Torso */
-     , (40286, 21,  4,  0,    0,  650,  650,  618,  618,  650,  650,  650,  650,    0, 2,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0, 0.28) /* Wings */
-     , (40286, 24,  4,  0,    0,  650,  650,  618,  618,  650,  650,  650,  650,    0, 2, 0.06, 0.22,  0.3,  0.1,  0.2,  0.3, 0.06, 0.22,  0.3,  0.1,  0.2, 0.22) /* UpperTentacle */
-     , (40286, 25,  4, 200,  0.5,  650,  650,  618,  618,  650,  650,  650,  650,    0, 3,    0,    0,  0.3,    0,  0.1,  0.3,    0,    0,  0.3,    0,  0.1, 0.28) /* LowerTentacle */;
+VALUES (40286,  0,  4, 100, 0.75,  600,  650,  618,  618,  650,  650,  650,  650,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */
+     , (40286, 16,  4, 100,    0,  600,  650,  618,  618,  650,  650,  650,  650,    0, 2,  0.5, 0.48,  0.1,  0.5,  0.6,  0.1,  0.5, 0.48,  0.1,  0.5,  0.6, 0.22) /* Torso */
+     , (40286, 21,  4, 100,    0,  600,  650,  618,  618,  650,  650,  650,  650,    0, 2,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0, 0.28) /* Wings */
+     , (40286, 24,  4, 100,    0,  600,  650,  618,  618,  650,  650,  650,  650,    0, 2, 0.06, 0.22,  0.3,  0.1,  0.2,  0.3, 0.06, 0.22,  0.3,  0.1,  0.2, 0.22) /* UpperTentacle */
+     , (40286, 25,  4, 100,  0.5,  600,  650,  618,  618,  650,  650,  650,  650,    0, 3,    0,    0,  0.3,    0,  0.1,  0.3,    0,    0,  0.3,    0,  0.1, 0.28) /* LowerTentacle */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (40286,  2074,   2.15)  /* Gossamer Flesh */

--- a/Database/Patches/9 WeenieDefaults/Creature/Niffis/70331 Ehlyis Sleech.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Niffis/70331 Ehlyis Sleech.sql
@@ -94,16 +94,13 @@ VALUES (70331,   1, 12000, 0, 0, 12185) /* MaxHealth */
      , (70331,   5,  1000, 0, 0, 1490) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (70331,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (70331,  7, 0, 3, 0, 300, 0, 0) /* MissileDefense      Specialized */
-     , (70331, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (70331, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
-     , (70331, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (70331, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (70331, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (70331, 33, 0, 3, 0, 350, 0, 0) /* LifeMagic           Specialized */
-     , (70331, 34, 0, 3, 0, 320, 0, 0) /* WarMagic            Specialized */
-     , (70331, 45, 0, 3, 0, 210, 0, 0) /* LightWeapons        Specialized */;
+VALUES (70331,  6, 0, 2, 0, 483, 0, 0) /* MeleeDefense        Trained */
+     , (70331,  7, 0, 2, 0, 514, 0, 0) /* MissileDefense      Trained */
+     , (70331, 15, 0, 2, 0, 247, 0, 0) /* MagicDefense        Trained */
+     , (70331, 31, 0, 2, 0, 157, 0, 0) /* CreatureEnchantment Trained */
+     , (70331, 33, 0, 2, 0, 157, 0, 0) /* LifeMagic           Trained */
+     , (70331, 34, 0, 2, 0, 157, 0, 0) /* WarMagic            Trained */
+     , (70331, 45, 0, 2, 0, 435, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (70331,  0,  4, 220, 0.75,  650,  650,  358,  293,  618,  553,  618,  553,    0, 1, 0.44,  0.3,    0,  0.4,  0.1,    0, 0.44,  0.3,    0,  0.4,  0.1,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Remoran/33629 Fouled Remoran.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Remoran/33629 Fouled Remoran.sql
@@ -94,18 +94,6 @@ VALUES (33629,   1,  9000, 0, 0, 9160) /* MaxHealth */
      , (33629,   3,  3000, 0, 0, 3320) /* MaxStamina */
      , (33629,   5,  3000, 0, 0, 3340) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33629,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (33629,  7, 0, 3, 0, 230, 0, 0) /* MissileDefense      Specialized */
-     , (33629, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33629, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (33629, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33629, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (33629, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (33629, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
-     , (33629, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (33629, 45, 0, 3, 0, 228, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33629,  0,  2, 130,  0.5,  425,  404,  234,  191,  404,  319,  404,  361,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
      , (33629,  5,  4, 130,  0.4,  425,  404,  234,  191,  404,  319,  404,  361,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Hand */
@@ -134,3 +122,12 @@ VALUES (33629, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33629, -1, 40283, 3600, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Remoran Corsair (40283) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33629,  34, 0, 2, 0, 228, 0, 0) /* WarMagic */
+     , (33629,  33, 0, 2, 0, 228, 0, 0) /* LifeMagic */
+     , (33629,  31, 0, 2, 0, 228, 0, 0) /* CreatureEnchantment */
+     , (33629,  45, 0, 2, 0, 421, 0, 0) /* LightWeapons */
+     , (33629,   6, 0, 2, 0, 380, 0, 0) /* MeleeDefense */
+     , (33629,   7, 0, 2, 0, 272, 0, 0) /* MissileDefense */
+     , (33629,  15, 0, 2, 0, 311, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Remoran/33736 Remoran Corsair.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Remoran/33736 Remoran Corsair.sql
@@ -62,8 +62,7 @@ VALUES (33736,   1,       5) /* HeartbeatInterval */
      , (33736,  75,       1) /* ResistManaBoost */
      , (33736,  80,       2) /* AiUseMagicDelay */
      , (33736, 104,      10) /* ObviousRadarRange */
-     , (33736, 125,       1) /* ResistHealthDrain */
-     , (33736, 166,     0.3) /* ResistNether */;
+     , (33736, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33736,   1, 'Remoran Corsair') /* Name */
@@ -92,18 +91,6 @@ INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`
 VALUES (33736,   1,   450, 0, 0, 610) /* MaxHealth */
      , (33736,   3,   300, 0, 0, 620) /* MaxStamina */
      , (33736,   5,   300, 0, 0, 640) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33736,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (33736,  7, 0, 3, 0, 230, 0, 0) /* MissileDefense      Specialized */
-     , (33736, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33736, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (33736, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33736, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (33736, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (33736, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
-     , (33736, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (33736, 45, 0, 3, 0, 228, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33736,  0,  2, 130,  0.5,  625,  594,  469,  406,  594,  469,  594,  531,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
@@ -140,3 +127,12 @@ VALUES (33736, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33736, -1, 33629, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Fouled Remoran (33629) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33736,  34, 0, 2, 0, 228, 0, 0) /* WarMagic */
+     , (33736,  33, 0, 2, 0, 228, 0, 0) /* LifeMagic */
+     , (33736,  31, 0, 2, 0, 228, 0, 0) /* CreatureEnchantment */
+     , (33736,  45, 0, 2, 0, 421, 0, 0) /* LightWeapons */
+     , (33736,   6, 0, 2, 0, 327, 0, 0) /* MeleeDefense */
+     , (33736,   7, 0, 2, 0, 230, 0, 0) /* MissileDefense */
+     , (33736,  15, 0, 2, 0, 291, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Remoran/33737 Horrid Remoran.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Remoran/33737 Horrid Remoran.sql
@@ -62,8 +62,7 @@ VALUES (33737,   1,       5) /* HeartbeatInterval */
      , (33737,  75,       1) /* ResistManaBoost */
      , (33737,  80,       2) /* AiUseMagicDelay */
      , (33737, 104,      10) /* ObviousRadarRange */
-     , (33737, 125,       1) /* ResistHealthDrain */
-     , (33737, 166,     0.3) /* ResistNether */;
+     , (33737, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33737,   1, 'Horrid Remoran') /* Name */
@@ -94,24 +93,21 @@ VALUES (33737,   1,   450, 0, 0, 615) /* MaxHealth */
      , (33737,   5,   300, 0, 0, 650) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33737,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (33737,  7, 0, 3, 0, 230, 0, 0) /* MissileDefense      Specialized */
-     , (33737, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33737, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (33737, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33737, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (33737, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (33737, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
-     , (33737, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (33737, 45, 0, 3, 0, 228, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33737,  6, 0, 2, 0, 397, 0, 0) /* MeleeDefense        Trained */
+     , (33737,  7, 0, 2, 0, 528, 0, 0) /* MissileDefense      Trained */
+     , (33737, 15, 0, 2, 0, 309, 0, 0) /* MagicDefense        Trained */
+     , (33737, 31, 0, 2, 0, 229, 0, 0) /* CreatureEnchantment Trained */
+     , (33737, 33, 0, 2, 0, 229, 0, 0) /* LifeMagic           Trained */
+     , (33737, 34, 0, 2, 0, 229, 0, 0) /* WarMagic            Trained */
+     , (33737, 45, 0, 2, 0, 422, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33737,  0,  2, 130,  0.5,  625,  594,  469,  406,  594,  469,  594,  531,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (33737,  5,  4, 130,  0.4,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Hand */
-     , (33737, 16,  1,  0,    0,  625,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Torso */
-     , (33737, 17,  1, 130, 0.75,  625,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
-     , (33737, 19,  4,  0,    0,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Leg */
-     , (33737, 21,  4,  0,    0,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
+VALUES (33737,  0,  2, 130,  0.5,  400,  594,  469,  406,  594,  469,  594,  531,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (33737,  5,  4, 130,  0.4,  400,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Hand */
+     , (33737, 16,  1,  0,    0,  400,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Torso */
+     , (33737, 17,  1, 130, 0.75,  400,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
+     , (33737, 19,  4,  0,    0,  400,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Leg */
+     , (33737, 21,  4,  0,    0,  400,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (33737,  2174,   2.15)  /* Archer's Gift */

--- a/Database/Patches/9 WeenieDefaults/Creature/Remoran/40283 Remoran Corsair.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Remoran/40283 Remoran Corsair.sql
@@ -59,8 +59,7 @@ VALUES (40283,   1,       5) /* HeartbeatInterval */
      , (40283,  75,       1) /* ResistManaBoost */
      , (40283,  80,       2) /* AiUseMagicDelay */
      , (40283, 104,      10) /* ObviousRadarRange */
-     , (40283, 125,       1) /* ResistHealthDrain */
-     , (40283, 166,     0.3) /* ResistNether */;
+     , (40283, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40283,   1, 'Remoran Corsair') /* Name */
@@ -90,18 +89,6 @@ VALUES (40283,   1,   450, 0, 0, 610) /* MaxHealth */
      , (40283,   3,   300, 0, 0, 620) /* MaxStamina */
      , (40283,   5,   300, 0, 0, 640) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40283,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (40283,  7, 0, 3, 0, 230, 0, 0) /* MissileDefense      Specialized */
-     , (40283, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (40283, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (40283, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (40283, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (40283, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (40283, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
-     , (40283, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (40283, 45, 0, 3, 0, 228, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40283,  0,  2, 130,  0.5,  625,  594,  469,  406,  594,  469,  594,  531,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
      , (40283,  5,  4, 130,  0.4,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Hand */
@@ -126,3 +113,12 @@ VALUES (40283, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (40283, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (40283, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
      , (40283, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40283,  34, 0, 2, 0, 228, 0, 0) /* WarMagic */
+     , (40283,  33, 0, 2, 0, 228, 0, 0) /* LifeMagic */
+     , (40283,  31, 0, 2, 0, 228, 0, 0) /* CreatureEnchantment */
+     , (40283,  45, 0, 2, 0, 421, 0, 0) /* LightWeapons */
+     , (40283,   6, 0, 2, 0, 327, 0, 0) /* MeleeDefense */
+     , (40283,   7, 0, 2, 0, 230, 0, 0) /* MissileDefense */
+     , (40283,  15, 0, 2, 0, 291, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Remoran/40284 Horrid Remoran.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Remoran/40284 Horrid Remoran.sql
@@ -59,8 +59,7 @@ VALUES (40284,   1,       5) /* HeartbeatInterval */
      , (40284,  75,       1) /* ResistManaBoost */
      , (40284,  80,       2) /* AiUseMagicDelay */
      , (40284, 104,      10) /* ObviousRadarRange */
-     , (40284, 125,       1) /* ResistHealthDrain */
-     , (40284, 166,     0.3) /* ResistNether */;
+     , (40284, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40284,   1, 'Horrid Remoran') /* Name */
@@ -91,24 +90,21 @@ VALUES (40284,   1,   450, 0, 0, 615) /* MaxHealth */
      , (40284,   5,   300, 0, 0, 650) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40284,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (40284,  7, 0, 3, 0, 230, 0, 0) /* MissileDefense      Specialized */
-     , (40284, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (40284, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (40284, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (40284, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (40284, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (40284, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
-     , (40284, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (40284, 45, 0, 3, 0, 228, 0, 0) /* LightWeapons        Specialized */;
+VALUES (40284,  6, 0, 2, 0, 397, 0, 0) /* MeleeDefense        Trained */
+     , (40284,  7, 0, 2, 0, 528, 0, 0) /* MissileDefense      Trained */
+     , (40284, 15, 0, 2, 0, 309, 0, 0) /* MagicDefense        Trained */
+     , (40284, 31, 0, 2, 0, 229, 0, 0) /* CreatureEnchantment Trained */
+     , (40284, 33, 0, 2, 0, 229, 0, 0) /* LifeMagic           Trained */
+     , (40284, 34, 0, 2, 0, 229, 0, 0) /* WarMagic            Trained */
+     , (40284, 45, 0, 2, 0, 422, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40284,  0,  2, 130,  0.5,  625,  594,  469,  406,  594,  469,  594,  531,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (40284,  5,  4, 130,  0.4,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Hand */
-     , (40284, 16,  1,  0,    0,  625,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Torso */
-     , (40284, 17,  1, 130, 0.75,  625,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
-     , (40284, 19,  4,  0,    0,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Leg */
-     , (40284, 21,  4,  0,    0,  625,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
+VALUES (40284,  0,  2, 130,  0.5,  400,  594,  469,  406,  594,  469,  594,  531,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (40284,  5,  4, 130,  0.4,  400,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* Hand */
+     , (40284, 16,  1,  0,    0,  400,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Torso */
+     , (40284, 17,  1, 130, 0.75,  400,  594,  469,  406,  594,  469,  594,  531,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tail */
+     , (40284, 19,  4,  0,    0,  400,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Leg */
+     , (40284, 21,  4,  0,    0,  400,  594,  469,  406,  594,  469,  594,  531,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Wings */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (40284,  2174,   2.15)  /* Archer's Gift */

--- a/Database/Patches/9 WeenieDefaults/Creature/Remoran/70082 Dark Remoran.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Remoran/70082 Dark Remoran.sql
@@ -95,16 +95,13 @@ VALUES (70082,   1,  9000, 0, 0, 9160) /* MaxHealth */
      , (70082,   5,  3000, 0, 0, 3340) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (70082,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
-     , (70082,  7, 0, 3, 0, 230, 0, 0) /* MissileDefense      Specialized */
-     , (70082, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (70082, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (70082, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (70082, 31, 0, 3, 0, 175, 0, 0) /* CreatureEnchantment Specialized */
-     , (70082, 32, 0, 3, 0, 175, 0, 0) /* ItemEnchantment     Specialized */
-     , (70082, 33, 0, 3, 0, 175, 0, 0) /* LifeMagic           Specialized */
-     , (70082, 34, 0, 3, 0, 175, 0, 0) /* WarMagic            Specialized */
-     , (70082, 45, 0, 3, 0, 228, 0, 0) /* LightWeapons        Specialized */;
+VALUES (70082,  6, 0, 2, 0, 403, 0, 0) /* MeleeDefense        Trained */
+     , (70082,  7, 0, 2, 0, 532, 0, 0) /* MissileDefense      Trained */
+     , (70082, 15, 0, 2, 0, 311, 0, 0) /* MagicDefense        Trained */
+     , (70082, 31, 0, 2, 0, 234, 0, 0) /* CreatureEnchantment Trained */
+     , (70082, 33, 0, 2, 0, 234, 0, 0) /* LifeMagic           Trained */
+     , (70082, 34, 0, 2, 0, 234, 0, 0) /* WarMagic            Trained */
+     , (70082, 45, 0, 2, 0, 428, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (70082,  0,  2, 130,  0.5,  425,  404,  234,  191,  404,  319,  404,  361,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33631 Degenerate Shadow Commander.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33631 Degenerate Shadow Commander.sql
@@ -16,7 +16,7 @@ VALUES (33631,   1,         16) /* ItemType - Creature */
      , (33631,  68,          3) /* TargetingTactic - Random, Focused */
      , (33631,  81,          2) /* MaxGeneratedObjects */
      , (33631,  82,          2) /* InitGeneratedObjects */
-     , (33631,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (33631,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (33631, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (33631, 103,          3) /* GeneratorDestructionType - Kill */
      , (33631, 113,          2) /* Gender - Female */
@@ -32,8 +32,7 @@ VALUES (33631,   1, True ) /* Stuck */
      , (33631,  12, True ) /* ReportCollisions */
      , (33631,  13, False) /* Ethereal */
      , (33631,  14, True ) /* GravityStatus */
-     , (33631,  19, True ) /* Attackable */
-     , (33631,  42, True ) /* AllowEdgeSlide */;
+     , (33631,  19, True ) /* Attackable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (33631,   1,       5) /* HeartbeatInterval */
@@ -53,7 +52,7 @@ VALUES (33631,   1,       5) /* HeartbeatInterval */
      , (33631,  34,     1.2) /* PowerupTime */
      , (33631,  36,       1) /* ChargeSpeed */
      , (33631,  39,     1.2) /* DefaultScale */
-     , (33631,  41,       0) /* RegenerationInterval */
+     , (33631,  41,      60) /* RegenerationInterval */
      , (33631,  43,       4) /* GeneratorRadius */
      , (33631,  64,     0.7) /* ResistSlash */
      , (33631,  65,     0.5) /* ResistPierce */
@@ -101,46 +100,39 @@ VALUES (33631,   1,  9000, 0, 0, 9200) /* MaxHealth */
      , (33631,   5,   280, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33631,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33631,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33631, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33631, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33631, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33631, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33631, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33631, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33631, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33631, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33631, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33631,  6, 0, 2, 0, 501, 0, 0) /* MeleeDefense        Trained */
+     , (33631,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (33631, 15, 0, 2, 0, 262, 0, 0) /* MagicDefense        Trained */
+     , (33631, 31, 0, 2, 0, 108, 0, 0) /* CreatureEnchantment Trained */
+     , (33631, 33, 0, 2, 0, 108, 0, 0) /* LifeMagic           Trained */
+     , (33631, 34, 0, 2, 0, 108, 0, 0) /* WarMagic            Trained */
+     , (33631, 45, 0, 2, 0, 468, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33631,  0,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33631,  1,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33631,  2,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33631,  3,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33631,  4,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33631,  5,  4, 50, 0.75,  500,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33631,  6,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33631,  7,  4,  0,    0,  500,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33631,  8,  4, 60, 0.75,   60,   36,   48,   51,   54,   30,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33631,  0,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33631,  1,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33631,  2,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33631,  3,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33631,  4,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33631,  5,  4, 50, 0.75,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33631,  6,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33631,  7,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33631,  8,  4, 60, 0.75,  400,   36,   48,   51,   54,   30,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33631,  2140,  2.036)  /* Alset's Coil */
-     , (33631,  2136,  2.036)  /* Icy Torment */
-     , (33631,  4452,  2.009)  /* Incantation of Lightning Streak */
-     , (33631,  2141,  2.036)  /* Lhen's Flare */
-     , (33631,  2133,  2.036)  /* Outlander's Insolence */
-     , (33631,  2137,  2.005)  /* Sudden Frost */
-     , (33631,  2132,  2.005)  /* The Spike */
-     , (33631,  2174,  2.005)  /* Archer's Gift */
-     , (33631,  2172,  2.005)  /* Astyrrian's Gift */
-     , (33631,  2168,   2.01)  /* Gelidite's Gift */
-     , (33631,  2074,   2.01)  /* Gossamer Flesh */
-     , (33631,  2318,   2.01)  /* Gravity Well */
-     , (33631,  1161,  2.009)  /* Heal Self VI */
-     , (33631,  2282,   2.02)  /* Futility */
+VALUES (33631,  2074,   2.02)  /* Gossamer Flesh */
+     , (33631,  2132,   2.02)  /* The Spike */
+     , (33631,  2133,   2.02)  /* Outlander's Insolence */
+     , (33631,  2136,   2.02)  /* Icy Torment */
+     , (33631,  2137,   2.02)  /* Sudden Frost */
+     , (33631,  2140,   2.02)  /* Alset's Coil */
+     , (33631,  2141,   2.02)  /* Lhen's Flare */
      , (33631,  2164,   2.02)  /* Swordsman's Gift */
-     , (33631,  1265,  2.009)  /* Drain Mana Other VI */;
+     , (33631,  2168,   2.02)  /* Gelidite's Gift */
+     , (33631,  2172,   2.02)  /* Astyrrian's Gift */
+     , (33631,  2174,   2.03)  /* Archer's Gift */
+     , (33631,  2282,   2.03)  /* Futility */
+     , (33631,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33631, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
@@ -150,5 +142,5 @@ VALUES (33631, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (33631, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44469) for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (33631, -1, 40291, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40291) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (33631, -1, 40293, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40293) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (33631, -1, 40291, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40291) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33631, -1, 40293, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40293) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33632 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33632 Degenerate Shadow.sql
@@ -93,45 +93,39 @@ VALUES (33632,   1,   605, 0, 0, 805) /* MaxHealth */
      , (33632,   5,   300, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33632,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (33632,  7, 0, 3, 0, 220, 0, 0) /* MissileDefense      Specialized */
-     , (33632, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33632, 15, 0, 3, 0, 257, 0, 0) /* MagicDefense        Specialized */
-     , (33632, 31, 0, 3, 0, 375, 0, 0) /* CreatureEnchantment Specialized */
-     , (33632, 33, 0, 3, 0, 375, 0, 0) /* LifeMagic           Specialized */
-     , (33632, 34, 0, 3, 0, 375, 0, 0) /* WarMagic            Specialized */
-     , (33632, 44, 0, 3, 0, 300, 0, 0) /* HeavyWeapons        Specialized */
-     , (33632, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33632, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33632, 47, 0, 3, 0, 250, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33632,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (33632,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (33632, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (33632, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (33632, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (33632, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (33632, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33632,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33632,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33632,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33632,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33632,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33632,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33632,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33632,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33632,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33632,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33632,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33632,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33632,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33632,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33632,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33632,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33632,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33632,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33632,    74,  2.036)  /* Frost Bolt VI */
-     , (33632,    80,  2.036)  /* Lightning Bolt VI */
-     , (33632,    91,  2.036)  /* Force Bolt VI */
-     , (33632,    97,  2.036)  /* Whirling Blade VI */
-     , (33632,   138,  2.005)  /* Frost Volley VI */
-     , (33632,   142,  2.005)  /* Lightning Volley VI */
-     , (33632,   146,  2.005)  /* Flame Volley VI */
-     , (33632,   154,  2.005)  /* Blade Volley VI */
-     , (33632,   234,   2.01)  /* Vulnerability Other VI */
-     , (33632,   267,   2.01)  /* Defenselessness Other VI */
-     , (33632,   285,   2.01)  /* Magic Yield Other VI */
-     , (33632,  1161,  2.009)  /* Heal Self VI */
-     , (33632,  1242,  2.009)  /* Drain Health Other VI */
-     , (33632,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (33632,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (33632,  2074,   2.02)  /* Gossamer Flesh */
+     , (33632,  2132,   2.02)  /* The Spike */
+     , (33632,  2133,   2.02)  /* Outlander's Insolence */
+     , (33632,  2136,   2.02)  /* Icy Torment */
+     , (33632,  2137,   2.02)  /* Sudden Frost */
+     , (33632,  2140,   2.02)  /* Alset's Coil */
+     , (33632,  2141,   2.02)  /* Lhen's Flare */
+     , (33632,  2164,   2.02)  /* Swordsman's Gift */
+     , (33632,  2168,   2.02)  /* Gelidite's Gift */
+     , (33632,  2172,   2.02)  /* Astyrrian's Gift */
+     , (33632,  2174,   2.03)  /* Archer's Gift */
+     , (33632,  2282,   2.03)  /* Futility */
+     , (33632,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33632, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33633 Depraved Shadow Commander.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33633 Depraved Shadow Commander.sql
@@ -16,7 +16,7 @@ VALUES (33633,   1,         16) /* ItemType - Creature */
      , (33633,  68,          3) /* TargetingTactic - Random, Focused */
      , (33633,  81,          2) /* MaxGeneratedObjects */
      , (33633,  82,          2) /* InitGeneratedObjects */
-     , (33633,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (33633,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (33633, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (33633, 103,          3) /* GeneratorDestructionType - Kill */
      , (33633, 113,          1) /* Gender - Male */
@@ -31,8 +31,7 @@ VALUES (33633,   1, True ) /* Stuck */
      , (33633,  12, True ) /* ReportCollisions */
      , (33633,  13, False) /* Ethereal */
      , (33633,  14, True ) /* GravityStatus */
-     , (33633,  19, True ) /* Attackable */
-     , (33633,  42, True ) /* AllowEdgeSlide */;
+     , (33633,  19, True ) /* Attackable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (33633,   1,       5) /* HeartbeatInterval */
@@ -100,46 +99,39 @@ VALUES (33633,   1, 12000, 0, 0, 12205) /* MaxHealth */
      , (33633,   5,  1000, 0, 0, 1140) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33633,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33633,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33633, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33633, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33633, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33633, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33633, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33633, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33633, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33633, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33633, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33633,  6, 0, 2, 0, 512, 0, 0) /* MeleeDefense        Trained */
+     , (33633,  7, 0, 2, 0, 600, 0, 0) /* MissileDefense      Trained */
+     , (33633, 15, 0, 2, 0, 264, 0, 0) /* MagicDefense        Trained */
+     , (33633, 31, 0, 2, 0, 105, 0, 0) /* CreatureEnchantment Trained */
+     , (33633, 33, 0, 2, 0, 105, 0, 0) /* LifeMagic           Trained */
+     , (33633, 34, 0, 2, 0, 105, 0, 0) /* WarMagic            Trained */
+     , (33633, 45, 0, 2, 0, 463, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33633,  0,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33633,  1,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33633,  2,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33633,  3,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33633,  4,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33633,  1,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33633,  2,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33633,  3,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33633,  4,  4,  0,    0,  510,  500,  400,  425,  550,  300,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
      , (33633,  5,  4, 50, 0.75,  500,  500,  400,  425,  550,  300,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33633,  6,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33633,  7,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33633,  6,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33633,  7,  4,  0,    0,  510,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (33633,  8,  4, 60, 0.75,  500,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33633,  1161,  2.009)  /* Heal Self VI */
-     , (33633,  1265,  2.009)  /* Drain Mana Other VI */
-     , (33633,  2074,   2.01)  /* Gossamer Flesh */
-     , (33633,  2132,  2.005)  /* The Spike */
-     , (33633,  2133,  2.036)  /* Outlander's Insolence */
-     , (33633,  2136,  2.036)  /* Icy Torment */
-     , (33633,  2137,  2.005)  /* Sudden Frost */
-     , (33633,  2140,  2.036)  /* Alset's Coil */
-     , (33633,  2141,  2.036)  /* Lhen's Flare */
+VALUES (33633,  2074,   2.02)  /* Gossamer Flesh */
+     , (33633,  2132,   2.02)  /* The Spike */
+     , (33633,  2133,   2.02)  /* Outlander's Insolence */
+     , (33633,  2136,   2.02)  /* Icy Torment */
+     , (33633,  2137,   2.02)  /* Sudden Frost */
+     , (33633,  2140,   2.02)  /* Alset's Coil */
+     , (33633,  2141,   2.02)  /* Lhen's Flare */
      , (33633,  2164,   2.02)  /* Swordsman's Gift */
-     , (33633,  2168,   2.01)  /* Gelidite's Gift */
-     , (33633,  2172,  2.005)  /* Astyrrian's Gift */
-     , (33633,  2174,  2.005)  /* Archer's Gift */
-     , (33633,  2282,   2.02)  /* Futility */
-     , (33633,  2318,   2.01)  /* Gravity Well */
-     , (33633,  4452,  2.009)  /* Incantation of Lightning Streak */;
+     , (33633,  2168,   2.02)  /* Gelidite's Gift */
+     , (33633,  2172,   2.02)  /* Astyrrian's Gift */
+     , (33633,  2174,   2.03)  /* Archer's Gift */
+     , (33633,  2282,   2.03)  /* Futility */
+     , (33633,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33633, 9, 44470,  1, 0, 0, False) /* Create Corrupted Essence (44470) for ContainTreasure */
@@ -148,4 +140,5 @@ VALUES (33633, 9, 44470,  1, 0, 0, False) /* Create Corrupted Essence (44470) fo
      , (33633, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (33633, -1, 40295, 3600, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Depraved Shadow (40295) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (33633, -1, 40294, 120, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate  (40294) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33633, -1, 40296, 120, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate  (40296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33634 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33634 Depraved Shadow.sql
@@ -95,45 +95,39 @@ VALUES (33634,   1,   795, 0, 0, 1000) /* MaxHealth */
      , (33634,   5,   300, 0, 0, 870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33634,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33634,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33634, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33634, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33634, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33634, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33634, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33634, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33634, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33634, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33634, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33634,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (33634,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (33634, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (33634, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (33634, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (33634, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (33634, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33634,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33634,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33634,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33634,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33634,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33634,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33634,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33634,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33634,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33634,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33634,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33634,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33634,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33634,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33634,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33634,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33634,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33634,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33634,    74,  2.036)  /* Frost Bolt VI */
-     , (33634,    80,  2.036)  /* Lightning Bolt VI */
-     , (33634,    91,  2.036)  /* Force Bolt VI */
-     , (33634,    97,  2.036)  /* Whirling Blade VI */
-     , (33634,   138,  2.005)  /* Frost Volley VI */
-     , (33634,   142,  2.005)  /* Lightning Volley VI */
-     , (33634,   146,  2.005)  /* Flame Volley VI */
-     , (33634,   154,  2.005)  /* Blade Volley VI */
-     , (33634,   234,   2.01)  /* Vulnerability Other VI */
-     , (33634,   267,   2.01)  /* Defenselessness Other VI */
-     , (33634,   285,   2.01)  /* Magic Yield Other VI */
-     , (33634,  1161,  2.009)  /* Heal Self VI */
-     , (33634,  1242,  2.009)  /* Drain Health Other VI */
-     , (33634,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (33634,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (33634,  2074,   2.02) /* Gossamer Flesh */
+     , (33634,  2132,   2.02) /* The Spike */
+     , (33634,  2133,   2.02) /* Outlander's Insolence */
+     , (33634,  2136,   2.02) /* Icy Torment */
+     , (33634,  2137,   2.02) /* Sudden Frost */
+     , (33634,  2140,   2.02) /* Alset's Coil */
+     , (33634,  2141,   2.02) /* Lhen's Flare */
+     , (33634,  2164,   2.02) /* Swordsman's Gift */
+     , (33634,  2168,   2.02) /* Gelidite's Gift */
+     , (33634,  2172,   2.02) /* Astyrrian's Gift */
+     , (33634,  2174,   2.03) /* Archer's Gift */
+     , (33634,  2282,   2.03) /* Futility */
+     , (33634,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33634, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33702 Degenerate Shadow Commander.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33702 Degenerate Shadow Commander.sql
@@ -1,0 +1,164 @@
+DELETE FROM `weenie` WHERE `class_Id` = 33702;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (33702, 'ace33702-degenerateshadowcommander', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (33702,   1,         16) /* ItemType - Creature */
+     , (33702,   2,         22) /* CreatureType - Shadow */
+     , (33702,   3,         39) /* PaletteTemplate - Black */
+     , (33702,   6,         -1) /* ItemsCapacity */
+     , (33702,   7,         -1) /* ContainersCapacity */
+     , (33702,   8,         90) /* Mass */
+     , (33702,  16,          1) /* ItemUseable - No */
+     , (33702,  25,        185) /* Level */
+     , (33702,  27,          0) /* ArmorType - None */
+     , (33702,  68,          3) /* TargetingTactic - Random, Focused */
+     , (33702,  81,          2) /* MaxGeneratedObjects */
+     , (33702,  82,          2) /* InitGeneratedObjects */
+     , (33702,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (33702, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (33702, 103,          3) /* GeneratorDestructionType - Kill */
+     , (33702, 113,          2) /* Gender - Female */
+     , (33702, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (33702, 140,          1) /* AiOptions - CanOpenDoors */
+     , (33702, 146,     345000) /* XpOverride */
+     , (33702, 188,          1) /* HeritageGroup - Aluvian */
+     , (33702, 307,          5) /* DamageRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (33702,   1, True ) /* Stuck */
+     , (33702,   6, True ) /* AiUsesMana */
+     , (33702,  11, False) /* IgnoreCollisions */
+     , (33702,  12, True ) /* ReportCollisions */
+     , (33702,  13, False) /* Ethereal */
+     , (33702,  14, True ) /* GravityStatus */
+     , (33702,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (33702,   1,       5) /* HeartbeatInterval */
+     , (33702,   2,       0) /* HeartbeatTimestamp */
+     , (33702,   3,     0.7) /* HealthRate */
+     , (33702,   4,     2.5) /* StaminaRate */
+     , (33702,   5,       1) /* ManaRate */
+     , (33702,  12,     0.5) /* Shade */
+     , (33702,  13,     0.6) /* ArmorModVsSlash */
+     , (33702,  14,     0.8) /* ArmorModVsPierce */
+     , (33702,  15,    0.85) /* ArmorModVsBludgeon */
+     , (33702,  16,     0.9) /* ArmorModVsCold */
+     , (33702,  17,     0.5) /* ArmorModVsFire */
+     , (33702,  18,     0.7) /* ArmorModVsAcid */
+     , (33702,  19,    0.75) /* ArmorModVsElectric */
+     , (33702,  31,      20) /* VisualAwarenessRange */
+     , (33702,  34,     1.2) /* PowerupTime */
+     , (33702,  36,       1) /* ChargeSpeed */
+     , (33702,  39,     1.2) /* DefaultScale */
+     , (33702,  41,      60) /* RegenerationInterval */
+     , (33702,  43,       4) /* GeneratorRadius */
+     , (33702,  64,     0.7) /* ResistSlash */
+     , (33702,  65,     0.5) /* ResistPierce */
+     , (33702,  66,     0.7) /* ResistBludgeon */
+     , (33702,  67,     0.8) /* ResistFire */
+     , (33702,  68,     0.1) /* ResistCold */
+     , (33702,  69,     0.2) /* ResistAcid */
+     , (33702,  70,     0.5) /* ResistElectric */
+     , (33702,  71,       1) /* ResistHealthBoost */
+     , (33702,  72,       1) /* ResistStaminaDrain */
+     , (33702,  73,       1) /* ResistStaminaBoost */
+     , (33702,  74,       1) /* ResistManaDrain */
+     , (33702,  75,       1) /* ResistManaBoost */
+     , (33702,  76,     0.5) /* Translucency */
+     , (33702,  80,       3) /* AiUseMagicDelay */
+     , (33702, 104,      10) /* ObviousRadarRange */
+     , (33702, 122,       2) /* AiAcquireHealth */
+     , (33702, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (33702,   1, 'Degenerate Shadow Commander') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (33702,   1, 0x0200004E) /* Setup */
+     , (33702,   2, 0x09000001) /* MotionTable */
+     , (33702,   3, 0x20000002) /* SoundTable */
+     , (33702,   4, 0x30000000) /* CombatTable */
+     , (33702,   8, 0x06001BBE) /* Icon */
+     , (33702,   9, 0x05001057) /* EyesTexture */
+     , (33702,  10, 0x0500108C) /* NoseTexture */
+     , (33702,  11, 0x050010A6) /* MouthTexture */
+     , (33702,  15, 0x04002011) /* HairPalette */
+     , (33702,  16, 0x040002BF) /* EyesPalette */
+     , (33702,  17, 0x040002BA) /* SkinPalette */
+     , (33702,  22, 0x34000063) /* PhysicsEffectTable */
+     , (33702,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (33702,   1, 300, 0, 0) /* Strength */
+     , (33702,   2, 400, 0, 0) /* Endurance */
+     , (33702,   3, 300, 0, 0) /* Quickness */
+     , (33702,   4, 300, 0, 0) /* Coordination */
+     , (33702,   5, 540, 0, 0) /* Focus */
+     , (33702,   6, 560, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (33702,   1,  9000, 0, 0, 9200) /* MaxHealth */
+     , (33702,   3,   300, 0, 0, 700) /* MaxStamina */
+     , (33702,   5,   280, 0, 0, 860) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33702,  6, 0, 2, 0, 501, 0, 0) /* MeleeDefense        Trained */
+     , (33702,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (33702, 15, 0, 2, 0, 262, 0, 0) /* MagicDefense        Trained */
+     , (33702, 31, 0, 2, 0, 108, 0, 0) /* CreatureEnchantment Trained */
+     , (33702, 33, 0, 2, 0, 108, 0, 0) /* LifeMagic           Trained */
+     , (33702, 34, 0, 2, 0, 108, 0, 0) /* WarMagic            Trained */
+     , (33702, 45, 0, 2, 0, 468, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (33702,  0,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33702,  1,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33702,  2,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33702,  3,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33702,  4,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33702,  5,  4, 50, 0.75,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33702,  6,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33702,  7,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33702,  8,  4, 60, 0.75,  400,   36,   48,   51,   54,   30,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (33702,  2074,   2.02)  /* Gossamer Flesh */
+     , (33702,  2132,   2.02)  /* The Spike */
+     , (33702,  2133,   2.02)  /* Outlander's Insolence */
+     , (33702,  2136,   2.02)  /* Icy Torment */
+     , (33702,  2137,   2.02)  /* Sudden Frost */
+     , (33702,  2140,   2.02)  /* Alset's Coil */
+     , (33702,  2141,   2.02)  /* Lhen's Flare */
+     , (33702,  2164,   2.02)  /* Swordsman's Gift */
+     , (33702,  2168,   2.02)  /* Gelidite's Gift */
+     , (33702,  2172,   2.02)  /* Astyrrian's Gift */
+     , (33702,  2174,   2.03)  /* Archer's Gift */
+     , (33702,  2282,   2.03)  /* Futility */
+     , (33702,  2318,   2.03)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (33702, 2, 32637,  1, 0, 0, False) /* Create Shield of Elysa's Royal Guard (32637) for Wield */
+     , (33702, 2, 32852,  1, 0, 0, False) /* Create Blade of the Realm (32852) for Wield */
+     , (33702, 2,  2587,  0, 14, 0, False) /* Create Shirt (2587) for Wield */
+     , (33702, 2,  2601,  0, 14, 0, False) /* Create Loose Pants (2601) for Wield */
+     , (33702, 2, 21150,  0, 21, 0, False) /* Create Covenant Sollerets (21150) for Wield */
+     , (33702, 2, 21151,  0, 21, 0, False) /* Create Covenant Bracers (21151) for Wield */
+     , (33702, 2, 21152,  0, 21, 0, False) /* Create Covenant Breastplate (21152) for Wield */
+     , (33702, 2, 21153,  0, 21, 0, False) /* Create Covenant Gauntlets (21153) for Wield */
+     , (33702, 2, 21154,  0, 21, 0, False) /* Create Covenant Girth (21154) for Wield */
+     , (33702, 2, 21155,  0, 21, 0, False) /* Create Covenant Greaves (21155) for Wield */
+     , (33702, 2, 34027,  0, 21, 0, False) /* Create Shadow Mask (34027) for Wield */
+     , (33702, 2, 21157,  0, 21, 0, False) /* Create Covenant Pauldrons (21157) for Wield */
+     , (33702, 2, 21159,  0, 21, 0, False) /* Create Covenant Tassets (21159) for Wield */
+     , (33702, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+     , (33702, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33702, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
+     , (33702, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33702, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44469) for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (33702, -1, 40292, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40292) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33702, -1, 40293, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40293) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33703 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33703 Degenerate Shadow.sql
@@ -18,7 +18,8 @@ VALUES (33703,   1,         16) /* ItemType - Creature */
      , (33703, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (33703, 140,          1) /* AiOptions - CanOpenDoors */
      , (33703, 146,     200000) /* XpOverride */
-     , (33703, 188,          1) /* HeritageGroup - Aluvian */;
+     , (33703, 188,          1) /* HeritageGroup - Aluvian */
+     , (33703, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (33703,   1, True ) /* Stuck */
@@ -91,45 +92,39 @@ VALUES (33703,   1,   605, 0, 0, 805) /* MaxHealth */
      , (33703,   5,   300, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33703,  6, 0, 3, 0, 300, 0, 0) /* MeleeDefense        Specialized */
-     , (33703,  7, 0, 3, 0, 220, 0, 0) /* MissileDefense      Specialized */
-     , (33703, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33703, 15, 0, 3, 0, 257, 0, 0) /* MagicDefense        Specialized */
-     , (33703, 31, 0, 3, 0, 375, 0, 0) /* CreatureEnchantment Specialized */
-     , (33703, 33, 0, 3, 0, 375, 0, 0) /* LifeMagic           Specialized */
-     , (33703, 34, 0, 3, 0, 375, 0, 0) /* WarMagic            Specialized */
-     , (33703, 44, 0, 3, 0, 300, 0, 0) /* HeavyWeapons        Specialized */
-     , (33703, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33703, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33703, 47, 0, 3, 0, 250, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33703,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (33703,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (33703, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (33703, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (33703, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (33703, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (33703, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33703,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33703,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33703,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33703,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33703,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33703,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33703,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33703,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33703,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33703,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33703,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33703,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33703,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33703,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33703,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33703,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33703,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33703,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33703,    74,  2.036)  /* Frost Bolt VI */
-     , (33703,    80,  2.036)  /* Lightning Bolt VI */
-     , (33703,    91,  2.036)  /* Force Bolt VI */
-     , (33703,    97,  2.036)  /* Whirling Blade VI */
-     , (33703,   138,  2.005)  /* Frost Volley VI */
-     , (33703,   142,  2.005)  /* Lightning Volley VI */
-     , (33703,   146,  2.005)  /* Flame Volley VI */
-     , (33703,   154,  2.005)  /* Blade Volley VI */
-     , (33703,   234,   2.01)  /* Vulnerability Other VI */
-     , (33703,   267,   2.01)  /* Defenselessness Other VI */
-     , (33703,   285,   2.01)  /* Magic Yield Other VI */
-     , (33703,  1161,  2.009)  /* Heal Self VI */
-     , (33703,  1242,  2.009)  /* Drain Health Other VI */
-     , (33703,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (33703,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (33703,  2074,   2.02)  /* Gossamer Flesh */
+     , (33703,  2132,   2.02)  /* The Spike */
+     , (33703,  2133,   2.02)  /* Outlander's Insolence */
+     , (33703,  2136,   2.02)  /* Icy Torment */
+     , (33703,  2137,   2.02)  /* Sudden Frost */
+     , (33703,  2140,   2.02)  /* Alset's Coil */
+     , (33703,  2141,   2.02)  /* Lhen's Flare */
+     , (33703,  2164,   2.02)  /* Swordsman's Gift */
+     , (33703,  2168,   2.02)  /* Gelidite's Gift */
+     , (33703,  2172,   2.02)  /* Astyrrian's Gift */
+     , (33703,  2174,   2.03)  /* Archer's Gift */
+     , (33703,  2282,   2.03)  /* Futility */
+     , (33703,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33703, 2, 32852,  1, 0, 0, False) /* Create Blade of the Realm (32852) for Wield */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33704 Degenerate Shadow Commander.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33704 Degenerate Shadow Commander.sql
@@ -1,0 +1,145 @@
+DELETE FROM `weenie` WHERE `class_Id` = 33704;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (33704, 'ace33704-degenerateshadowcommander', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (33704,   1,         16) /* ItemType - Creature */
+     , (33704,   2,         22) /* CreatureType - Shadow */
+     , (33704,   3,          2) /* PaletteTemplate - Blue */
+     , (33704,   6,         -1) /* ItemsCapacity */
+     , (33704,   7,         -1) /* ContainersCapacity */
+     , (33704,   8,         90) /* Mass */
+     , (33704,  16,          1) /* ItemUseable - No */
+     , (33704,  25,        185) /* Level */
+     , (33704,  27,          0) /* ArmorType - None */
+     , (33704,  68,          3) /* TargetingTactic - Random, Focused */
+     , (33704,  81,          2) /* MaxGeneratedObjects */
+     , (33704,  82,          2) /* InitGeneratedObjects */
+     , (33704,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (33704, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (33704, 103,          3) /* GeneratorDestructionType - Kill */
+     , (33704, 113,          2) /* Gender - Female */
+     , (33704, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (33704, 140,          1) /* AiOptions - CanOpenDoors */
+     , (33704, 146,     345000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (33704,   1, True ) /* Stuck */
+     , (33704,   6, True ) /* AiUsesMana */
+     , (33704,  11, False) /* IgnoreCollisions */
+     , (33704,  12, True ) /* ReportCollisions */
+     , (33704,  13, False) /* Ethereal */
+     , (33704,  14, True ) /* GravityStatus */
+     , (33704,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (33704,   1,       5) /* HeartbeatInterval */
+     , (33704,   2,       0) /* HeartbeatTimestamp */
+     , (33704,   3,     0.7) /* HealthRate */
+     , (33704,   4,     2.5) /* StaminaRate */
+     , (33704,   5,       1) /* ManaRate */
+     , (33704,  12,     0.5) /* Shade */
+     , (33704,  13,     0.6) /* ArmorModVsSlash */
+     , (33704,  14,     0.8) /* ArmorModVsPierce */
+     , (33704,  15,    0.85) /* ArmorModVsBludgeon */
+     , (33704,  16,     0.9) /* ArmorModVsCold */
+     , (33704,  17,     0.5) /* ArmorModVsFire */
+     , (33704,  18,     0.7) /* ArmorModVsAcid */
+     , (33704,  19,    0.75) /* ArmorModVsElectric */
+     , (33704,  31,      20) /* VisualAwarenessRange */
+     , (33704,  34,     1.2) /* PowerupTime */
+     , (33704,  36,       1) /* ChargeSpeed */
+     , (33704,  39,     1.2) /* DefaultScale */
+     , (33704,  41,      60) /* RegenerationInterval */
+     , (33704,  43,       4) /* GeneratorRadius */
+     , (33704,  64,     0.7) /* ResistSlash */
+     , (33704,  65,     0.5) /* ResistPierce */
+     , (33704,  66,     0.7) /* ResistBludgeon */
+     , (33704,  67,     0.8) /* ResistFire */
+     , (33704,  68,     0.1) /* ResistCold */
+     , (33704,  69,     0.2) /* ResistAcid */
+     , (33704,  70,     0.5) /* ResistElectric */
+     , (33704,  71,       1) /* ResistHealthBoost */
+     , (33704,  72,       1) /* ResistStaminaDrain */
+     , (33704,  73,       1) /* ResistStaminaBoost */
+     , (33704,  74,       1) /* ResistManaDrain */
+     , (33704,  75,       1) /* ResistManaBoost */
+     , (33704,  76,     0.5) /* Translucency */
+     , (33704,  80,       3) /* AiUseMagicDelay */
+     , (33704, 104,      10) /* ObviousRadarRange */
+     , (33704, 122,       2) /* AiAcquireHealth */
+     , (33704, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (33704,   1, 'Degenerate Shadow Commander') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (33704,   1, 0x02001526) /* Setup */
+     , (33704,   2, 0x09000186) /* MotionTable */
+     , (33704,   3, 0x200000BE) /* SoundTable */
+     , (33704,   4, 0x30000000) /* CombatTable */
+     , (33704,   6, 0x040019CC) /* PaletteBase */
+     , (33704,   7, 0x100005AB) /* ClothingBase */
+     , (33704,   8, 0x06001BBE) /* Icon */
+     , (33704,  22, 0x34000063) /* PhysicsEffectTable */
+     , (33704,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (33704,   1, 300, 0, 0) /* Strength */
+     , (33704,   2, 400, 0, 0) /* Endurance */
+     , (33704,   3, 300, 0, 0) /* Quickness */
+     , (33704,   4, 300, 0, 0) /* Coordination */
+     , (33704,   5, 540, 0, 0) /* Focus */
+     , (33704,   6, 560, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (33704,   1,  9000, 0, 0, 9200) /* MaxHealth */
+     , (33704,   3,   300, 0, 0, 700) /* MaxStamina */
+     , (33704,   5,   280, 0, 0, 860) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33704,  6, 0, 2, 0, 501, 0, 0) /* MeleeDefense        Trained */
+     , (33704,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (33704, 15, 0, 2, 0, 262, 0, 0) /* MagicDefense        Trained */
+     , (33704, 31, 0, 2, 0, 108, 0, 0) /* CreatureEnchantment Trained */
+     , (33704, 33, 0, 2, 0, 108, 0, 0) /* LifeMagic           Trained */
+     , (33704, 34, 0, 2, 0, 108, 0, 0) /* WarMagic            Trained */
+     , (33704, 45, 0, 2, 0, 468, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (33704,  0,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33704,  1,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33704,  2,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33704,  3,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33704,  4,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33704,  5,  4, 60, 0.75,  400,  300,  400,  425,  450,  250,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33704,  6,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33704,  7,  4,  0,    0,  400,  300,  400,  425,  450,  250,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33704,  8,  4, 80, 0.75,  400,   36,   48,   51,   54,   30,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (33704,  2074,   2.02)  /* Gossamer Flesh */
+     , (33704,  2132,   2.02)  /* The Spike */
+     , (33704,  2133,   2.02)  /* Outlander's Insolence */
+     , (33704,  2136,   2.02)  /* Icy Torment */
+     , (33704,  2137,   2.02)  /* Sudden Frost */
+     , (33704,  2140,   2.02)  /* Alset's Coil */
+     , (33704,  2141,   2.02)  /* Lhen's Flare */
+     , (33704,  2164,   2.02)  /* Swordsman's Gift */
+     , (33704,  2168,   2.02)  /* Gelidite's Gift */
+     , (33704,  2172,   2.02)  /* Astyrrian's Gift */
+     , (33704,  2174,   2.03)  /* Archer's Gift */
+     , (33704,  2282,   2.03)  /* Futility */
+     , (33704,  2318,   2.03)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (33704, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+     , (33704, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33704, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
+     , (33704, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33704, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44469) for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (33704, -1, 40291, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40291) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33704, -1, 40292, 120, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow (40292) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33707 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33707 Depraved Shadow.sql
@@ -19,7 +19,8 @@ VALUES (33707,   1,         16) /* ItemType - Creature */
      , (33707, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (33707, 140,          1) /* AiOptions - CanOpenDoors */
      , (33707, 146,     200000) /* XpOverride */
-     , (33707, 188,          1) /* HeritageGroup - Aluvian */;
+     , (33707, 188,          1) /* HeritageGroup - Aluvian */
+     , (33707, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (33707,   1, True ) /* Stuck */
@@ -61,7 +62,6 @@ VALUES (33707,   1,       5) /* HeartbeatInterval */
      , (33707,  73,       1) /* ResistStaminaBoost */
      , (33707,  74,       1) /* ResistManaDrain */
      , (33707,  75,       1) /* ResistManaBoost */
-     , (33707,  76,     0.5) /* Translucency */
      , (33707,  80,       3) /* AiUseMagicDelay */
      , (33707, 104,      10) /* ObviousRadarRange */
      , (33707, 122,       2) /* AiAcquireHealth */
@@ -93,45 +93,39 @@ VALUES (33707,   1,   795, 0, 0, 1000) /* MaxHealth */
      , (33707,   5,   300, 0, 0, 870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33707,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33707,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33707, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33707, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33707, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33707, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33707, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33707, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33707, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33707, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33707, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33707,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (33707,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (33707, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (33707, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (33707, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (33707, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (33707, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33707,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33707,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33707,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33707,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33707,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33707,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33707,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33707,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33707,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33707,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33707,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33707,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33707,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33707,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33707,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33707,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33707,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33707,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33707,    74,  2.036)  /* Frost Bolt VI */
-     , (33707,    80,  2.036)  /* Lightning Bolt VI */
-     , (33707,    91,  2.036)  /* Force Bolt VI */
-     , (33707,    97,  2.036)  /* Whirling Blade VI */
-     , (33707,   138,  2.005)  /* Frost Volley VI */
-     , (33707,   142,  2.005)  /* Lightning Volley VI */
-     , (33707,   146,  2.005)  /* Flame Volley VI */
-     , (33707,   154,  2.005)  /* Blade Volley VI */
-     , (33707,   234,   2.01)  /* Vulnerability Other VI */
-     , (33707,   267,   2.01)  /* Defenselessness Other VI */
-     , (33707,   285,   2.01)  /* Magic Yield Other VI */
-     , (33707,  1161,  2.009)  /* Heal Self VI */
-     , (33707,  1242,  2.009)  /* Drain Health Other VI */
-     , (33707,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (33707,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (33707,  2074,   2.02) /* Gossamer Flesh */
+     , (33707,  2132,   2.02) /* The Spike */
+     , (33707,  2133,   2.02) /* Outlander's Insolence */
+     , (33707,  2136,   2.02) /* Icy Torment */
+     , (33707,  2137,   2.02) /* Sudden Frost */
+     , (33707,  2140,   2.02) /* Alset's Coil */
+     , (33707,  2141,   2.02) /* Lhen's Flare */
+     , (33707,  2164,   2.02) /* Swordsman's Gift */
+     , (33707,  2168,   2.02) /* Gelidite's Gift */
+     , (33707,  2172,   2.02) /* Astyrrian's Gift */
+     , (33707,  2174,   2.03) /* Archer's Gift */
+     , (33707,  2282,   2.03) /* Futility */
+     , (33707,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33707, 2, 32852,  1, 0, 0, False) /* Create Blade of the Realm (32852) for Wield */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33708 Depraved Shadow Commander.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33708 Depraved Shadow Commander.sql
@@ -1,0 +1,143 @@
+DELETE FROM `weenie` WHERE `class_Id` = 33708;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (33708, 'ace33708-depravedshadowcommander', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (33708,   1,         16) /* ItemType - Creature */
+     , (33708,   2,         22) /* CreatureType - Shadow */
+     , (33708,   3,          2) /* PaletteTemplate - Blue */
+     , (33708,   6,         -1) /* ItemsCapacity */
+     , (33708,   7,         -1) /* ContainersCapacity */
+     , (33708,   8,         90) /* Mass */
+     , (33708,  16,          1) /* ItemUseable - No */
+     , (33708,  25,        200) /* Level */
+     , (33708,  27,          0) /* ArmorType - None */
+     , (33708,  68,          3) /* TargetingTactic - Random, Focused */
+     , (33708,  81,          2) /* MaxGeneratedObjects */
+     , (33708,  82,          2) /* InitGeneratedObjects */
+     , (33708,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (33708, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (33708, 103,          3) /* GeneratorDestructionType - Kill */
+     , (33708, 113,          1) /* Gender - Male */
+     , (33708, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (33708, 140,          1) /* AiOptions - CanOpenDoors */
+     , (33708, 146,     320000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (33708,   1, True ) /* Stuck */
+     , (33708,   6, True ) /* AiUsesMana */
+     , (33708,  11, False) /* IgnoreCollisions */
+     , (33708,  12, True ) /* ReportCollisions */
+     , (33708,  13, False) /* Ethereal */
+     , (33708,  14, True ) /* GravityStatus */
+     , (33708,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (33708,   1,       5) /* HeartbeatInterval */
+     , (33708,   2,       0) /* HeartbeatTimestamp */
+     , (33708,   3,     0.7) /* HealthRate */
+     , (33708,   4,     2.5) /* StaminaRate */
+     , (33708,   5,       1) /* ManaRate */
+     , (33708,  12,       0) /* Shade */
+     , (33708,  13,       1) /* ArmorModVsSlash */
+     , (33708,  14,     0.8) /* ArmorModVsPierce */
+     , (33708,  15,    0.85) /* ArmorModVsBludgeon */
+     , (33708,  16,     1.1) /* ArmorModVsCold */
+     , (33708,  17,     0.6) /* ArmorModVsFire */
+     , (33708,  18,     0.7) /* ArmorModVsAcid */
+     , (33708,  19,    0.75) /* ArmorModVsElectric */
+     , (33708,  31,      20) /* VisualAwarenessRange */
+     , (33708,  34,     1.2) /* PowerupTime */
+     , (33708,  36,       1) /* ChargeSpeed */
+     , (33708,  39,     1.3) /* DefaultScale */
+     , (33708,  41,      60) /* RegenerationInterval */
+     , (33708,  43,       4) /* GeneratorRadius */
+     , (33708,  64,       1) /* ResistSlash */
+     , (33708,  65,     0.5) /* ResistPierce */
+     , (33708,  66,     0.7) /* ResistBludgeon */
+     , (33708,  67,       1) /* ResistFire */
+     , (33708,  68,     0.1) /* ResistCold */
+     , (33708,  69,     0.2) /* ResistAcid */
+     , (33708,  70,     0.5) /* ResistElectric */
+     , (33708,  71,       1) /* ResistHealthBoost */
+     , (33708,  72,       1) /* ResistStaminaDrain */
+     , (33708,  73,       1) /* ResistStaminaBoost */
+     , (33708,  74,       1) /* ResistManaDrain */
+     , (33708,  75,       1) /* ResistManaBoost */
+     , (33708,  76,     0.5) /* Translucency */
+     , (33708,  80,       3) /* AiUseMagicDelay */
+     , (33708, 104,      10) /* ObviousRadarRange */
+     , (33708, 122,       2) /* AiAcquireHealth */
+     , (33708, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (33708,   1, 'Depraved Shadow Commander') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (33708,   1, 0x02001526) /* Setup */
+     , (33708,   2, 0x09000186) /* MotionTable */
+     , (33708,   3, 0x200000BE) /* SoundTable */
+     , (33708,   4, 0x30000000) /* CombatTable */
+     , (33708,   6, 0x040019CC) /* PaletteBase */
+     , (33708,   7, 0x100005AB) /* ClothingBase */
+     , (33708,   8, 0x06001BBE) /* Icon */
+     , (33708,  22, 0x34000063) /* PhysicsEffectTable */
+     , (33708,  35,       1011) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (33708,   1, 310, 0, 0) /* Strength */
+     , (33708,   2, 420, 0, 0) /* Endurance */
+     , (33708,   3, 310, 0, 0) /* Quickness */
+     , (33708,   4, 310, 0, 0) /* Coordination */
+     , (33708,   5, 550, 0, 0) /* Focus */
+     , (33708,   6, 570, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (33708,   1, 12000, 0, 0, 12205) /* MaxHealth */
+     , (33708,   3,  1000, 0, 0, 1210) /* MaxStamina */
+     , (33708,   5,  1000, 0, 0, 1140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33708,  6, 0, 2, 0, 512, 0, 0) /* MeleeDefense        Trained */
+     , (33708,  7, 0, 2, 0, 600, 0, 0) /* MissileDefense      Trained */
+     , (33708, 15, 0, 2, 0, 264, 0, 0) /* MagicDefense        Trained */
+     , (33708, 31, 0, 2, 0, 105, 0, 0) /* CreatureEnchantment Trained */
+     , (33708, 33, 0, 2, 0, 105, 0, 0) /* LifeMagic           Trained */
+     , (33708, 34, 0, 2, 0, 105, 0, 0) /* WarMagic            Trained */
+     , (33708, 45, 0, 2, 0, 463, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (33708,  0,  4,  0,    0,  500,  500,  400,  425,  550,  300,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33708,  1,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33708,  2,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33708,  3,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33708,  4,  4,  0,    0,  510,  500,  400,  425,  550,  300,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33708,  5,  4, 50, 0.75,  500,  500,  400,  425,  550,  300,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33708,  6,  4,  0,    0,  520,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33708,  7,  4,  0,    0,  510,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33708,  8,  4, 60, 0.75,  500,  500,  400,  425,  550,  300,  350,  375,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (33708,  2074,   2.02) /* Gossamer Flesh */
+     , (33708,  2132,   2.02) /* The Spike */
+     , (33708,  2133,   2.02) /* Outlander's Insolence */
+     , (33708,  2136,   2.02) /* Icy Torment */
+     , (33708,  2137,   2.02) /* Sudden Frost */
+     , (33708,  2140,   2.02) /* Alset's Coil */
+     , (33708,  2141,   2.02) /* Lhen's Flare */
+     , (33708,  2164,   2.02) /* Swordsman's Gift */
+     , (33708,  2168,   2.02) /* Gelidite's Gift */
+     , (33708,  2172,   2.02) /* Astyrrian's Gift */
+     , (33708,  2174,   2.03) /* Archer's Gift */
+     , (33708,  2282,   2.03) /* Futility */
+     , (33708,  2318,   2.03) /* Gravity Well */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (33708, 9, 44470,  1, 0, 0, False) /* Create Corrupted Essence (44470) for ContainTreasure */
+     , (33708, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33708, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
+     , (33708, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (33708, -1, 40295, 3600, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Depraved Shadow (40295) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33709 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33709 Depraved Shadow.sql
@@ -94,45 +94,39 @@ VALUES (33709,   1,   795, 0, 0, 1000) /* MaxHealth */
      , (33709,   5,   300, 0, 0, 870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33709,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33709,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33709, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33709, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33709, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33709, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33709, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33709, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33709, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33709, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33709, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33709,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (33709,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (33709, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (33709, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (33709, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (33709, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (33709, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33709,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33709,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33709,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33709,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33709,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33709,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33709,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33709,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33709,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33709,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33709,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33709,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33709,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33709,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33709,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33709,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33709,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33709,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33709,    74,  2.036)  /* Frost Bolt VI */
-     , (33709,    80,  2.036)  /* Lightning Bolt VI */
-     , (33709,    91,  2.036)  /* Force Bolt VI */
-     , (33709,    97,  2.036)  /* Whirling Blade VI */
-     , (33709,   138,  2.005)  /* Frost Volley VI */
-     , (33709,   142,  2.005)  /* Lightning Volley VI */
-     , (33709,   146,  2.005)  /* Flame Volley VI */
-     , (33709,   154,  2.005)  /* Blade Volley VI */
-     , (33709,   234,   2.01)  /* Vulnerability Other VI */
-     , (33709,   267,   2.01)  /* Defenselessness Other VI */
-     , (33709,   285,   2.01)  /* Magic Yield Other VI */
-     , (33709,  1161,  2.009)  /* Heal Self VI */
-     , (33709,  1242,  2.009)  /* Drain Health Other VI */
-     , (33709,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (33709,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (33709,  2074,   2.02) /* Gossamer Flesh */
+     , (33709,  2132,   2.02) /* The Spike */
+     , (33709,  2133,   2.02) /* Outlander's Insolence */
+     , (33709,  2136,   2.02) /* Icy Torment */
+     , (33709,  2137,   2.02) /* Sudden Frost */
+     , (33709,  2140,   2.02) /* Alset's Coil */
+     , (33709,  2141,   2.02) /* Lhen's Flare */
+     , (33709,  2164,   2.02) /* Swordsman's Gift */
+     , (33709,  2168,   2.02) /* Gelidite's Gift */
+     , (33709,  2172,   2.02) /* Astyrrian's Gift */
+     , (33709,  2174,   2.03) /* Archer's Gift */
+     , (33709,  2282,   2.03) /* Futility */
+     , (33709,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33709, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33730 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33730 Degenerate Shadow.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 33730;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (33730, 'ace33730-degenerateshadow', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (33730, 'ace33730-degenerateshadow', 10, '2023-05-18 05:30:27') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (33730,   1,         16) /* ItemType - Creature */
@@ -68,8 +68,7 @@ VALUES (33730,   1,       5) /* HeartbeatInterval */
      , (33730,  80,       3) /* AiUseMagicDelay */
      , (33730, 104,      10) /* ObviousRadarRange */
      , (33730, 122,       2) /* AiAcquireHealth */
-     , (33730, 125,       1) /* ResistHealthDrain */
-     , (33730, 166,     0.6) /* ResistNether */;
+     , (33730, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33730,   1, 'Degenerate Shadow') /* Name */;
@@ -85,6 +84,17 @@ VALUES (33730,   1, 0x0200071B) /* Setup */
      , (33730,  22, 0x34000063) /* PhysicsEffectTable */
      , (33730,  35,       1011) /* DeathTreasureType - Loot Tier: 7 */;
 
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (33730,  0,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33730,  1,  4,  0,    0,  310,  155,  155,  155,  155,  155,  155,  155,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33730,  2,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33730,  3,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33730,  4,  4,  0,    0,  320,  160,  160,  160,  160,  160,  160,  160,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33730,  5,  4, 50, 0.75,  350,  175,  175,  175,  175,  175,  175,  175,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33730,  6,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33730,  7,  4,  0,    0,  350,  175,  175,  175,  175,  175,  175,  175,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33730,  8,  4, 60, 0.75,  420,  210,  210,  210,  210,  210,  210,  210,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (33730,   1, 190, 0, 0) /* Strength */
      , (33730,   2, 210, 0, 0) /* Endurance */
@@ -94,59 +104,41 @@ VALUES (33730,   1, 190, 0, 0) /* Strength */
      , (33730,   6, 140, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (33730,   1,   700, 0, 0, 805) /* MaxHealth */
+VALUES (33730,   1,   700, 0, 0,  805) /* MaxHealth */
      , (33730,   3,  1000, 0, 0, 1210) /* MaxStamina */
      , (33730,   5,  1000, 0, 0, 1140) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33730,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33730,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33730, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33730, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33730, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33730, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33730, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33730, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33730, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33730, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33730, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
-
-INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33730,  0,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33730,  1,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33730,  2,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33730,  3,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33730,  4,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33730,  5,  4, 50, 0.75,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33730,  6,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33730,  7,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33730,  8,  4, 60, 0.75,   60,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33730,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (33730,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (33730, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (33730, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (33730, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (33730, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (33730, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33730,  1161,  2.009)  /* Heal Self VI */
-     , (33730,  1265,  2.009)  /* Drain Mana Other VI */
-     , (33730,  2074,   2.01)  /* Gossamer Flesh */
-     , (33730,  2132,  2.005)  /* The Spike */
-     , (33730,  2133,  2.036)  /* Outlander's Insolence */
-     , (33730,  2136,  2.036)  /* Icy Torment */
-     , (33730,  2137,  2.005)  /* Sudden Frost */
-     , (33730,  2140,  2.036)  /* Alset's Coil */
-     , (33730,  2141,  2.036)  /* Lhen's Flare */
-     , (33730,  2164,   2.02)  /* Swordsman's Gift */
-     , (33730,  2168,   2.01)  /* Gelidite's Gift */
-     , (33730,  2172,  2.005)  /* Astyrrian's Gift */
-     , (33730,  2174,  2.005)  /* Archer's Gift */
-     , (33730,  2282,   2.02)  /* Futility */
-     , (33730,  2318,   2.01)  /* Gravity Well */
-     , (33730,  4452,  2.009)  /* Incantation of Lightning Streak */;
+VALUES (33730,  2074,   2.02) /* Gossamer Flesh */
+     , (33730,  2132,   2.02) /* The Spike */
+     , (33730,  2133,   2.02) /* Outlander's Insolence */
+     , (33730,  2136,   2.02) /* Icy Torment */
+     , (33730,  2137,   2.02) /* Sudden Frost */
+     , (33730,  2140,   2.02) /* Alset's Coil */
+     , (33730,  2141,   2.02) /* Lhen's Flare */
+     , (33730,  2164,   2.02) /* Swordsman's Gift */
+     , (33730,  2168,   2.02) /* Gelidite's Gift */
+     , (33730,  2172,   2.02) /* Astyrrian's Gift */
+     , (33730,  2174,   2.03) /* Archer's Gift */
+     , (33730,  2282,   2.03) /* Futility */
+     , (33730,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (33730,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (33730, 3 /* Death */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (33730, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
@@ -155,4 +147,6 @@ VALUES (33730, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (33730, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (33730, -1, 33631, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow Commander (33631) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (33730, 0.33, 33631, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow Commander (33631) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33730, 0.66, 33702, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow Commander (33702) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33730, 1, 33704, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Degenerate Shadow Commander (33704) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33731 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33731 Depraved Shadow.sql
@@ -67,8 +67,7 @@ VALUES (33731,   1,       5) /* HeartbeatInterval */
      , (33731,  80,       3) /* AiUseMagicDelay */
      , (33731, 104,      10) /* ObviousRadarRange */
      , (33731, 122,       2) /* AiAcquireHealth */
-     , (33731, 125,       1) /* ResistHealthDrain */
-     , (33731, 166,     0.6) /* ResistNether */;
+     , (33731, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33731,   1, 'Depraved Shadow') /* Name */;
@@ -98,46 +97,39 @@ VALUES (33731,   1,   885, 0, 0, 1000) /* MaxHealth */
      , (33731,   5,  1000, 0, 0, 1160) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33731,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (33731,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (33731, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (33731, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (33731, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (33731, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (33731, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (33731, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (33731, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (33731, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (33731, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (33731,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (33731,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (33731, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (33731, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (33731, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (33731, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (33731, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33731,  0,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33731,  1,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33731,  2,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33731,  3,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33731,  4,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33731,  5,  4, 50, 0.75,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33731,  6,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33731,  7,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33731,  8,  4, 60, 0.75,   60,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (33731,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33731,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33731,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33731,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33731,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33731,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33731,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33731,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33731,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33731,  1161,  2.009)  /* Heal Self VI */
-     , (33731,  1265,  2.009)  /* Drain Mana Other VI */
-     , (33731,  2074,   2.01)  /* Gossamer Flesh */
-     , (33731,  2132,  2.005)  /* The Spike */
-     , (33731,  2133,  2.036)  /* Outlander's Insolence */
-     , (33731,  2136,  2.036)  /* Icy Torment */
-     , (33731,  2137,  2.005)  /* Sudden Frost */
-     , (33731,  2140,  2.036)  /* Alset's Coil */
-     , (33731,  2141,  2.036)  /* Lhen's Flare */
-     , (33731,  2164,   2.02)  /* Swordsman's Gift */
-     , (33731,  2168,   2.01)  /* Gelidite's Gift */
-     , (33731,  2172,  2.005)  /* Astyrrian's Gift */
-     , (33731,  2174,  2.005)  /* Archer's Gift */
-     , (33731,  2282,   2.02)  /* Futility */
-     , (33731,  2318,   2.01)  /* Gravity Well */
-     , (33731,  4452,  2.009)  /* Incantation of Lightning Streak */;
+VALUES (33731,  2074,   2.02) /* Gossamer Flesh */
+     , (33731,  2132,   2.02) /* The Spike */
+     , (33731,  2133,   2.02) /* Outlander's Insolence */
+     , (33731,  2136,   2.02) /* Icy Torment */
+     , (33731,  2137,   2.02) /* Sudden Frost */
+     , (33731,  2140,   2.02) /* Alset's Coil */
+     , (33731,  2141,   2.02) /* Lhen's Flare */
+     , (33731,  2164,   2.02) /* Swordsman's Gift */
+     , (33731,  2168,   2.02) /* Gelidite's Gift */
+     , (33731,  2172,   2.02) /* Astyrrian's Gift */
+     , (33731,  2174,   2.03) /* Archer's Gift */
+     , (33731,  2282,   2.03) /* Futility */
+     , (33731,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33731,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -154,4 +146,5 @@ VALUES (33731, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key 
      , (33731, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (33731, -1, 33633, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Depraved Shadow Commander (33633) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (33731, 0.5, 33633, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Depraved Shadow Commander (33633) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (33731, 1, 33708, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Depraved Shadow Commander (33708) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/35154 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/35154 Degenerate Shadow.sql
@@ -20,7 +20,8 @@ VALUES (35154,   1,         16) /* ItemType - Creature */
      , (35154, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (35154, 140,          1) /* AiOptions - CanOpenDoors */
      , (35154, 146,     125000) /* XpOverride */
-     , (35154, 188,          1) /* HeritageGroup - Aluvian */;
+     , (35154, 188,          1) /* HeritageGroup - Aluvian */
+     , (35154, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (35154,   1, True ) /* Stuck */
@@ -94,45 +95,39 @@ VALUES (35154,   1,   300, 0, 0, 500) /* MaxHealth */
      , (35154,   5,   300, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35154,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (35154,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (35154, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (35154, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (35154, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (35154, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (35154, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (35154, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (35154, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (35154, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (35154, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (35154,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (35154,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (35154, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (35154, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (35154, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (35154, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (35154, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35154,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (35154,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (35154,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (35154,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (35154,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (35154,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (35154,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (35154,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (35154,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (35154,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (35154,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (35154,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (35154,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (35154,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (35154,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (35154,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (35154,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (35154,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35154,    74,  2.036)  /* Frost Bolt VI */
-     , (35154,    80,  2.036)  /* Lightning Bolt VI */
-     , (35154,    91,  2.036)  /* Force Bolt VI */
-     , (35154,    97,  2.036)  /* Whirling Blade VI */
-     , (35154,   138,  2.005)  /* Frost Volley VI */
-     , (35154,   142,  2.005)  /* Lightning Volley VI */
-     , (35154,   146,  2.005)  /* Flame Volley VI */
-     , (35154,   154,  2.005)  /* Blade Volley VI */
-     , (35154,   234,   2.01)  /* Vulnerability Other VI */
-     , (35154,   267,   2.01)  /* Defenselessness Other VI */
-     , (35154,   285,   2.01)  /* Magic Yield Other VI */
-     , (35154,  1161,  2.009)  /* Heal Self VI */
-     , (35154,  1242,  2.009)  /* Drain Health Other VI */
-     , (35154,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (35154,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (35154,  2074,   2.02)  /* Gossamer Flesh */
+     , (35154,  2132,   2.02)  /* The Spike */
+     , (35154,  2133,   2.02)  /* Outlander's Insolence */
+     , (35154,  2136,   2.02)  /* Icy Torment */
+     , (35154,  2137,   2.02)  /* Sudden Frost */
+     , (35154,  2140,   2.02)  /* Alset's Coil */
+     , (35154,  2141,   2.02)  /* Lhen's Flare */
+     , (35154,  2164,   2.02)  /* Swordsman's Gift */
+     , (35154,  2168,   2.02)  /* Gelidite's Gift */
+     , (35154,  2172,   2.02)  /* Astyrrian's Gift */
+     , (35154,  2174,   2.03)  /* Archer's Gift */
+     , (35154,  2282,   2.03)  /* Futility */
+     , (35154,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35154,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/35155 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/35155 Degenerate Shadow.sql
@@ -95,45 +95,39 @@ VALUES (35155,   1,   300, 0, 0, 500) /* MaxHealth */
      , (35155,   5,   300, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35155,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (35155,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (35155, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (35155, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (35155, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (35155, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (35155, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (35155, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (35155, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (35155, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (35155, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (35155,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (35155,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (35155, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (35155, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (35155, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (35155, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (35155, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35155,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (35155,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (35155,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (35155,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (35155,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (35155,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (35155,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (35155,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (35155,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (35155,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (35155,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (35155,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (35155,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (35155,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (35155,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (35155,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (35155,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (35155,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35155,    74,  2.036)  /* Frost Bolt VI */
-     , (35155,    80,  2.036)  /* Lightning Bolt VI */
-     , (35155,    91,  2.036)  /* Force Bolt VI */
-     , (35155,    97,  2.036)  /* Whirling Blade VI */
-     , (35155,   138,  2.005)  /* Frost Volley VI */
-     , (35155,   142,  2.005)  /* Lightning Volley VI */
-     , (35155,   146,  2.005)  /* Flame Volley VI */
-     , (35155,   154,  2.005)  /* Blade Volley VI */
-     , (35155,   234,   2.01)  /* Vulnerability Other VI */
-     , (35155,   267,   2.01)  /* Defenselessness Other VI */
-     , (35155,   285,   2.01)  /* Magic Yield Other VI */
-     , (35155,  1161,  2.009)  /* Heal Self VI */
-     , (35155,  1242,  2.009)  /* Drain Health Other VI */
-     , (35155,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (35155,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (35155,  2074,   2.02)  /* Gossamer Flesh */
+     , (35155,  2132,   2.02)  /* The Spike */
+     , (35155,  2133,   2.02)  /* Outlander's Insolence */
+     , (35155,  2136,   2.02)  /* Icy Torment */
+     , (35155,  2137,   2.02)  /* Sudden Frost */
+     , (35155,  2140,   2.02)  /* Alset's Coil */
+     , (35155,  2141,   2.02)  /* Lhen's Flare */
+     , (35155,  2164,   2.02)  /* Swordsman's Gift */
+     , (35155,  2168,   2.02)  /* Gelidite's Gift */
+     , (35155,  2172,   2.02)  /* Astyrrian's Gift */
+     , (35155,  2174,   2.03)  /* Archer's Gift */
+     , (35155,  2282,   2.03)  /* Futility */
+     , (35155,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35155,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/35156 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/35156 Degenerate Shadow.sql
@@ -94,45 +94,39 @@ VALUES (35156,   1,   300, 0, 0, 500) /* MaxHealth */
      , (35156,   5,   300, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35156,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (35156,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (35156, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (35156, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (35156, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (35156, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (35156, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (35156, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (35156, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (35156, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (35156, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (35156,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (35156,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (35156, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (35156, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (35156, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (35156, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (35156, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35156,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (35156,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (35156,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (35156,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (35156,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (35156,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (35156,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (35156,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (35156,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (35156,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (35156,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (35156,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (35156,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (35156,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (35156,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (35156,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (35156,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (35156,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35156,    74,  2.036)  /* Frost Bolt VI */
-     , (35156,    80,  2.036)  /* Lightning Bolt VI */
-     , (35156,    91,  2.036)  /* Force Bolt VI */
-     , (35156,    97,  2.036)  /* Whirling Blade VI */
-     , (35156,   138,  2.005)  /* Frost Volley VI */
-     , (35156,   142,  2.005)  /* Lightning Volley VI */
-     , (35156,   146,  2.005)  /* Flame Volley VI */
-     , (35156,   154,  2.005)  /* Blade Volley VI */
-     , (35156,   234,   2.01)  /* Vulnerability Other VI */
-     , (35156,   267,   2.01)  /* Defenselessness Other VI */
-     , (35156,   285,   2.01)  /* Magic Yield Other VI */
-     , (35156,  1161,  2.009)  /* Heal Self VI */
-     , (35156,  1242,  2.009)  /* Drain Health Other VI */
-     , (35156,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (35156,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (35156,  2074,   2.02)  /* Gossamer Flesh */
+     , (35156,  2132,   2.02)  /* The Spike */
+     , (35156,  2133,   2.02)  /* Outlander's Insolence */
+     , (35156,  2136,   2.02)  /* Icy Torment */
+     , (35156,  2137,   2.02)  /* Sudden Frost */
+     , (35156,  2140,   2.02)  /* Alset's Coil */
+     , (35156,  2141,   2.02)  /* Lhen's Flare */
+     , (35156,  2164,   2.02)  /* Swordsman's Gift */
+     , (35156,  2168,   2.02)  /* Gelidite's Gift */
+     , (35156,  2172,   2.02)  /* Astyrrian's Gift */
+     , (35156,  2174,   2.03)  /* Archer's Gift */
+     , (35156,  2282,   2.03)  /* Futility */
+     , (35156,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35156,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/35157 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/35157 Depraved Shadow.sql
@@ -94,45 +94,39 @@ VALUES (35157,   1,   400, 0, 0, 605) /* MaxHealth */
      , (35157,   5,   300, 0, 0, 870) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35157,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (35157,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (35157, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (35157, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (35157, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (35157, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (35157, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (35157, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (35157, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (35157, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (35157, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (35157,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (35157,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (35157, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (35157, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (35157, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (35157, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (35157, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35157,  0,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (35157,  1,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (35157,  2,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (35157,  3,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (35157,  4,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (35157,  5,  4, 50, 0.75,  500,  500,  400,  425,  300,  550,  350,  375,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (35157,  6,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (35157,  7,  4,  0,    0,  500,  500,  400,  425,  300,  550,  350,  375,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (35157,  8,  4, 60, 0.75,   60,   60,   48,   51,   36,   66,   42,   45,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (35157,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (35157,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (35157,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (35157,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (35157,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (35157,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (35157,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (35157,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (35157,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35157,    74,  2.036)  /* Frost Bolt VI */
-     , (35157,    80,  2.036)  /* Lightning Bolt VI */
-     , (35157,    91,  2.036)  /* Force Bolt VI */
-     , (35157,    97,  2.036)  /* Whirling Blade VI */
-     , (35157,   138,  2.005)  /* Frost Volley VI */
-     , (35157,   142,  2.005)  /* Lightning Volley VI */
-     , (35157,   146,  2.005)  /* Flame Volley VI */
-     , (35157,   154,  2.005)  /* Blade Volley VI */
-     , (35157,   234,   2.01)  /* Vulnerability Other VI */
-     , (35157,   267,   2.01)  /* Defenselessness Other VI */
-     , (35157,   285,   2.01)  /* Magic Yield Other VI */
-     , (35157,  1161,  2.009)  /* Heal Self VI */
-     , (35157,  1242,  2.009)  /* Drain Health Other VI */
-     , (35157,  1254,  2.009)  /* Drain Stamina Other VI */
-     , (35157,  1265,  2.009)  /* Drain Mana Other VI */;
+VALUES (35157,  2074,   2.02) /* Gossamer Flesh */
+     , (35157,  2132,   2.02) /* The Spike */
+     , (35157,  2133,   2.02) /* Outlander's Insolence */
+     , (35157,  2136,   2.02) /* Icy Torment */
+     , (35157,  2137,   2.02) /* Sudden Frost */
+     , (35157,  2140,   2.02) /* Alset's Coil */
+     , (35157,  2141,   2.02) /* Lhen's Flare */
+     , (35157,  2164,   2.02) /* Swordsman's Gift */
+     , (35157,  2168,   2.02) /* Gelidite's Gift */
+     , (35157,  2172,   2.02) /* Astyrrian's Gift */
+     , (35157,  2174,   2.03) /* Archer's Gift */
+     , (35157,  2282,   2.03) /* Futility */
+     , (35157,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35157,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/40291 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/40291 Degenerate Shadow.sql
@@ -20,7 +20,8 @@ VALUES (40291,   1,         16) /* ItemType - Creature */
      , (40291, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (40291, 140,          1) /* AiOptions - CanOpenDoors */
      , (40291, 146,     200000) /* XpOverride */
-     , (40291, 188,          1) /* HeritageGroup - Aluvian */;
+     , (40291, 188,          1) /* HeritageGroup - Aluvian */
+     , (40291, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (40291,   1, True ) /* Stuck */
@@ -62,6 +63,7 @@ VALUES (40291,   1,       5) /* HeartbeatInterval */
      , (40291,  73,       1) /* ResistStaminaBoost */
      , (40291,  74,       1) /* ResistManaDrain */
      , (40291,  75,       1) /* ResistManaBoost */
+     , (40291,  76,     0.5) /* Translucency */
      , (40291,  80,       3) /* AiUseMagicDelay */
      , (40291, 104,      10) /* ObviousRadarRange */
      , (40291, 122,       2) /* AiAcquireHealth */
@@ -96,45 +98,39 @@ VALUES (40291,   1,   605, 0, 0, 805) /* MaxHealth */
      , (40291,   5,   280, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40291,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (40291,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (40291, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (40291, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (40291, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (40291, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (40291, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (40291, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (40291, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (40291, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (40291, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (40291,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (40291,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (40291, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (40291, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (40291, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (40291, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (40291, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40291,  0,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40291,  1,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40291,  2,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40291,  3,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40291,  4,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40291,  5,  4, 50, 0.75,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40291,  6,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40291,  7,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40291,  8,  4, 60, 0.75,   60,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40291,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40291,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40291,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40291,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40291,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40291,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40291,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40291,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40291,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40291,  2140,  2.036)  /* Alset's Coil */
-     , (40291,  2136,  2.036)  /* Icy Torment */
-     , (40291,  2141,  2.036)  /* Lhen's Flare */
-     , (40291,  2133,  2.036)  /* Outlander's Insolence */
-     , (40291,  2137,  2.005)  /* Sudden Frost */
-     , (40291,  2132,  2.005)  /* The Spike */
-     , (40291,  2174,  2.005)  /* Archer's Gift */
-     , (40291,  2172,  2.005)  /* Astyrrian's Gift */
-     , (40291,  2168,   2.01)  /* Gelidite's Gift */
-     , (40291,  2074,   2.01)  /* Gossamer Flesh */
-     , (40291,  2318,   2.01)  /* Gravity Well */
-     , (40291,  4452,  2.009)  /* Incantation of Lightning Streak */
-     , (40291,  2282,   2.02)  /* Futility */
+VALUES (40291,  2074,   2.02)  /* Gossamer Flesh */
+     , (40291,  2132,   2.02)  /* The Spike */
+     , (40291,  2133,   2.02)  /* Outlander's Insolence */
+     , (40291,  2136,   2.02)  /* Icy Torment */
+     , (40291,  2137,   2.02)  /* Sudden Frost */
+     , (40291,  2140,   2.02)  /* Alset's Coil */
+     , (40291,  2141,   2.02)  /* Lhen's Flare */
      , (40291,  2164,   2.02)  /* Swordsman's Gift */
-     , (40291,  1265,  2.009)  /* Drain Mana Other VI */;
+     , (40291,  2168,   2.02)  /* Gelidite's Gift */
+     , (40291,  2172,   2.02)  /* Astyrrian's Gift */
+     , (40291,  2174,   2.03)  /* Archer's Gift */
+     , (40291,  2282,   2.03)  /* Futility */
+     , (40291,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (40291, 2, 32852,  1, 0, 0, False) /* Create Blade of the Realm (32852) for Wield */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/40292 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/40292 Degenerate Shadow.sql
@@ -65,8 +65,7 @@ VALUES (40292,   1,       5) /* HeartbeatInterval */
      , (40292,  80,       3) /* AiUseMagicDelay */
      , (40292, 104,      10) /* ObviousRadarRange */
      , (40292, 122,       2) /* AiAcquireHealth */
-     , (40292, 125,       1) /* ResistHealthDrain */
-     , (40292, 166,     0.6) /* ResistNether */;
+     , (40292, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40292,   1, 'Degenerate Shadow') /* Name */;
@@ -96,46 +95,39 @@ VALUES (40292,   1,   700, 0, 0, 805) /* MaxHealth */
      , (40292,   5,  1000, 0, 0, 1140) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40292,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (40292,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (40292, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (40292, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (40292, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (40292, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (40292, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (40292, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (40292, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (40292, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (40292, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (40292,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (40292,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (40292, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (40292, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (40292, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (40292, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (40292, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40292,  0,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40292,  1,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40292,  2,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40292,  3,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40292,  4,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40292,  5,  4, 50, 0.75,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40292,  6,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40292,  7,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40292,  8,  4, 60, 0.75,   60,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40292,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40292,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40292,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40292,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40292,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40292,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40292,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40292,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40292,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40292,  1161,  2.009)  /* Heal Self VI */
-     , (40292,  1265,  2.009)  /* Drain Mana Other VI */
-     , (40292,  2074,   2.01)  /* Gossamer Flesh */
-     , (40292,  2132,  2.005)  /* The Spike */
-     , (40292,  2133,  2.036)  /* Outlander's Insolence */
-     , (40292,  2136,  2.036)  /* Icy Torment */
-     , (40292,  2137,  2.005)  /* Sudden Frost */
-     , (40292,  2140,  2.036)  /* Alset's Coil */
-     , (40292,  2141,  2.036)  /* Lhen's Flare */
-     , (40292,  2164,   2.02)  /* Swordsman's Gift */
-     , (40292,  2168,   2.01)  /* Gelidite's Gift */
-     , (40292,  2172,  2.005)  /* Astyrrian's Gift */
-     , (40292,  2174,  2.005)  /* Archer's Gift */
-     , (40292,  2282,   2.02)  /* Futility */
-     , (40292,  2318,   2.01)  /* Gravity Well */
-     , (40292,  4452,  2.009)  /* Incantation of Lightning Streak */;
+VALUES (40292,  2074,   2.02) /* Gossamer Flesh */
+     , (40292,  2132,   2.02) /* The Spike */
+     , (40292,  2133,   2.02) /* Outlander's Insolence */
+     , (40292,  2136,   2.02) /* Icy Torment */
+     , (40292,  2137,   2.02) /* Sudden Frost */
+     , (40292,  2140,   2.02) /* Alset's Coil */
+     , (40292,  2141,   2.02) /* Lhen's Flare */
+     , (40292,  2164,   2.02) /* Swordsman's Gift */
+     , (40292,  2168,   2.02) /* Gelidite's Gift */
+     , (40292,  2172,   2.02) /* Astyrrian's Gift */
+     , (40292,  2174,   2.03) /* Archer's Gift */
+     , (40292,  2282,   2.03) /* Futility */
+     , (40292,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (40292, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/40293 Degenerate Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/40293 Degenerate Shadow.sql
@@ -96,46 +96,39 @@ VALUES (40293,   1,   800, 0, 0, 1000) /* MaxHealth */
      , (40293,   5,   280, 0, 0, 860) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40293,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (40293,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (40293, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (40293, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (40293, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (40293, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (40293, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (40293, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (40293, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (40293, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (40293, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (40293,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (40293,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (40293, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (40293, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (40293, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (40293, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (40293, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40293,  0,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40293,  1,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40293,  2,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40293,  3,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40293,  4,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40293,  5,  4, 120, 0.75,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40293,  6,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40293,  7,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40293,  8,  4, 140, 0.75,   60,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40293,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40293,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40293,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40293,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40293,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40293,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40293,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40293,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40293,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40293,  2140,  2.036)  /* Alset's Coil */
-     , (40293,  2136,  2.036)  /* Icy Torment */
-     , (40293,  4452,  2.009)  /* Incantation of Lightning Streak */
-     , (40293,  2141,  2.036)  /* Lhen's Flare */
-     , (40293,  2133,  2.036)  /* Outlander's Insolence */
-     , (40293,  2137,  2.005)  /* Sudden Frost */
-     , (40293,  2132,  2.005)  /* The Spike */
-     , (40293,  2174,  2.005)  /* Archer's Gift */
-     , (40293,  2172,  2.005)  /* Astyrrian's Gift */
-     , (40293,  2168,   2.01)  /* Gelidite's Gift */
-     , (40293,  2074,   2.01)  /* Gossamer Flesh */
-     , (40293,  2318,   2.01)  /* Gravity Well */
-     , (40293,  1161,  2.009)  /* Heal Self VI */
-     , (40293,  2282,   2.02)  /* Futility */
+VALUES (40293,  2074,   2.02)  /* Gossamer Flesh */
+     , (40293,  2132,   2.02)  /* The Spike */
+     , (40293,  2133,   2.02)  /* Outlander's Insolence */
+     , (40293,  2136,   2.02)  /* Icy Torment */
+     , (40293,  2137,   2.02)  /* Sudden Frost */
+     , (40293,  2140,   2.02)  /* Alset's Coil */
+     , (40293,  2141,   2.02)  /* Lhen's Flare */
      , (40293,  2164,   2.02)  /* Swordsman's Gift */
-     , (40293,  1265,  2.009)  /* Drain Mana Other VI */;
+     , (40293,  2168,   2.02)  /* Gelidite's Gift */
+     , (40293,  2172,   2.02)  /* Astyrrian's Gift */
+     , (40293,  2174,   2.03)  /* Archer's Gift */
+     , (40293,  2282,   2.03)  /* Futility */
+     , (40293,  2318,   2.03)  /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (40293, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/40294 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/40294 Depraved Shadow.sql
@@ -1,0 +1,151 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40294;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40294, 'ace40294-depravedshadow', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40294,   1,         16) /* ItemType - Creature */
+     , (40294,   2,         22) /* CreatureType - Shadow */
+     , (40294,   3,         39) /* PaletteTemplate - Black */
+     , (40294,   6,         -1) /* ItemsCapacity */
+     , (40294,   7,         -1) /* ContainersCapacity */
+     , (40294,   8,         90) /* Mass */
+     , (40294,  16,          1) /* ItemUseable - No */
+     , (40294,  25,        185) /* Level */
+     , (40294,  27,          0) /* ArmorType - None */
+     , (40294,  68,          3) /* TargetingTactic - Random, Focused */
+     , (40294,  81,          2) /* MaxGeneratedObjects */
+     , (40294,  82,          2) /* InitGeneratedObjects */
+     , (40294,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (40294, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (40294, 103,          3) /* GeneratorDestructionType - Kill */
+     , (40294, 113,          2) /* Gender - Female */
+     , (40294, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (40294, 140,          1) /* AiOptions - CanOpenDoors */
+     , (40294, 146,     200000) /* XpOverride */
+     , (40294, 188,          1) /* HeritageGroup - Aluvian */
+     , (40294, 307,          5) /* DamageRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40294,   1, True ) /* Stuck */
+     , (40294,   6, True ) /* AiUsesMana */
+     , (40294,  11, False) /* IgnoreCollisions */
+     , (40294,  12, True ) /* ReportCollisions */
+     , (40294,  13, False) /* Ethereal */
+     , (40294,  14, True ) /* GravityStatus */
+     , (40294,  19, True ) /* Attackable */
+     , (40294,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40294,   1,       5) /* HeartbeatInterval */
+     , (40294,   2,       0) /* HeartbeatTimestamp */
+     , (40294,   3,     0.7) /* HealthRate */
+     , (40294,   4,     2.5) /* StaminaRate */
+     , (40294,   5,       1) /* ManaRate */
+     , (40294,  12,       0) /* Shade */
+     , (40294,  13,     0.9) /* ArmorModVsSlash */
+     , (40294,  14,       1) /* ArmorModVsPierce */
+     , (40294,  15,       1) /* ArmorModVsBludgeon */
+     , (40294,  16,     1.1) /* ArmorModVsCold */
+     , (40294,  17,     0.9) /* ArmorModVsFire */
+     , (40294,  18,       1) /* ArmorModVsAcid */
+     , (40294,  19,       1) /* ArmorModVsElectric */
+     , (40294,  31,      20) /* VisualAwarenessRange */
+     , (40294,  34,     1.2) /* PowerupTime */
+     , (40294,  36,       1) /* ChargeSpeed */
+     , (40294,  39,     1.1) /* DefaultScale */
+     , (40294,  64,     0.7) /* ResistSlash */
+     , (40294,  65,     0.5) /* ResistPierce */
+     , (40294,  66,     0.7) /* ResistBludgeon */
+     , (40294,  67,     0.8) /* ResistFire */
+     , (40294,  68,     0.1) /* ResistCold */
+     , (40294,  69,     0.2) /* ResistAcid */
+     , (40294,  70,     0.5) /* ResistElectric */
+     , (40294,  71,       1) /* ResistHealthBoost */
+     , (40294,  72,       1) /* ResistStaminaDrain */
+     , (40294,  73,       1) /* ResistStaminaBoost */
+     , (40294,  74,       1) /* ResistManaDrain */
+     , (40294,  75,       1) /* ResistManaBoost */
+     , (40294,  80,       3) /* AiUseMagicDelay */
+     , (40294, 104,      10) /* ObviousRadarRange */
+     , (40294, 122,       2) /* AiAcquireHealth */
+     , (40294, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40294,   1, 'Depraved Shadow') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40294,   1, 0x0200004E) /* Setup */
+     , (40294,   2, 0x09000001) /* MotionTable */
+     , (40294,   3, 0x20000002) /* SoundTable */
+     , (40294,   4, 0x30000000) /* CombatTable */
+     , (40294,   6, 0x0400007E) /* PaletteBase */
+     , (40294,   8, 0x06001BBE) /* Icon */
+     , (40294,  22, 0x34000063) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40294,   1, 210, 0, 0) /* Strength */
+     , (40294,   2, 230, 0, 0) /* Endurance */
+     , (40294,   3, 280, 0, 0) /* Quickness */
+     , (40294,   4, 260, 0, 0) /* Coordination */
+     , (40294,   5, 240, 0, 0) /* Focus */
+     , (40294,   6, 160, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40294,   1,   885, 0, 0, 1000) /* MaxHealth */
+     , (40294,   3,  1000, 0, 0, 1230) /* MaxStamina */
+     , (40294,   5,  1000, 0, 0, 1160) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40294,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (40294,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (40294, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (40294, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (40294, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (40294, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (40294, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40294,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40294,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40294,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40294,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40294,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40294,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40294,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40294,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40294,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40294,  2074,   2.02) /* Gossamer Flesh */
+     , (40294,  2132,   2.02) /* The Spike */
+     , (40294,  2133,   2.02) /* Outlander's Insolence */
+     , (40294,  2136,   2.02) /* Icy Torment */
+     , (40294,  2137,   2.02) /* Sudden Frost */
+     , (40294,  2140,   2.02) /* Alset's Coil */
+     , (40294,  2141,   2.02) /* Lhen's Flare */
+     , (40294,  2164,   2.02) /* Swordsman's Gift */
+     , (40294,  2168,   2.02) /* Gelidite's Gift */
+     , (40294,  2172,   2.02) /* Astyrrian's Gift */
+     , (40294,  2174,   2.03) /* Archer's Gift */
+     , (40294,  2282,   2.03) /* Futility */
+     , (40294,  2318,   2.03) /* Gravity Well */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (40294, 2, 32852,  1, 0, 0, False) /* Create Blade of the Realm (32852) for Wield */
+     , (40294, 2, 32698,  1, 0, 0, False) /* Create Shield of Strathelar (32698) for Wield */
+     , (40294, 2,  2587,  0, 14, 0, False) /* Create Shirt (2587) for Wield */
+     , (40294, 2,  2601,  0, 14, 0, False) /* Create Loose Pants (2601) for Wield */
+     , (40294, 2, 21150,  0, 21, 0, False) /* Create Covenant Sollerets (21150) for Wield */
+     , (40294, 2, 21151,  0, 21, 0, False) /* Create Covenant Bracers (21151) for Wield */
+     , (40294, 2, 21152,  0, 21, 0, False) /* Create Covenant Breastplate (21152) for Wield */
+     , (40294, 2, 21153,  0, 21, 0, False) /* Create Covenant Gauntlets (21153) for Wield */
+     , (40294, 2, 21154,  0, 21, 0, False) /* Create Covenant Girth (21154) for Wield */
+     , (40294, 2, 21155,  0, 21, 0, False) /* Create Covenant Greaves (21155) for Wield */
+     , (40294, 2, 34027,  0, 21, 0, False) /* Create Shadow Mask (34027) for Wield */
+     , (40294, 2, 21157,  0, 21, 0, False) /* Create Covenant Pauldrons (21157) for Wield */
+     , (40294, 2, 21159,  0, 21, 0, False) /* Create Covenant Tassets (21159) for Wield */
+     , (40294, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+     , (40294, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (40294, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
+     , (40294, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/40295 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/40295 Depraved Shadow.sql
@@ -65,8 +65,7 @@ VALUES (40295,   1,       5) /* HeartbeatInterval */
      , (40295,  80,       3) /* AiUseMagicDelay */
      , (40295, 104,      10) /* ObviousRadarRange */
      , (40295, 122,       2) /* AiAcquireHealth */
-     , (40295, 125,       1) /* ResistHealthDrain */
-     , (40295, 166,     0.6) /* ResistNether */;
+     , (40295, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40295,   1, 'Depraved Shadow') /* Name */;
@@ -96,46 +95,39 @@ VALUES (40295,   1,   885, 0, 0, 1000) /* MaxHealth */
      , (40295,   5,  1000, 0, 0, 1160) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40295,  6, 0, 3, 0, 310, 0, 0) /* MeleeDefense        Specialized */
-     , (40295,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (40295, 14, 0, 3, 0, 200, 0, 0) /* ArcaneLore          Specialized */
-     , (40295, 15, 0, 3, 0, 243, 0, 0) /* MagicDefense        Specialized */
-     , (40295, 31, 0, 3, 0, 225, 0, 0) /* CreatureEnchantment Specialized */
-     , (40295, 33, 0, 3, 0, 225, 0, 0) /* LifeMagic           Specialized */
-     , (40295, 34, 0, 3, 0, 225, 0, 0) /* WarMagic            Specialized */
-     , (40295, 44, 0, 3, 0, 308, 0, 0) /* HeavyWeapons        Specialized */
-     , (40295, 45, 0, 3, 0, 308, 0, 0) /* LightWeapons        Specialized */
-     , (40295, 46, 0, 3, 0, 293, 0, 0) /* FinesseWeapons      Specialized */
-     , (40295, 47, 0, 3, 0, 220, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (40295,  6, 0, 2, 0, 539, 0, 0) /* MeleeDefense        Trained */
+     , (40295,  7, 0, 2, 0, 610, 0, 0) /* MissileDefense      Trained */
+     , (40295, 15, 0, 2, 0, 367, 0, 0) /* MagicDefense        Trained */
+     , (40295, 31, 0, 2, 0, 285, 0, 0) /* CreatureEnchantment Trained */
+     , (40295, 33, 0, 2, 0, 285, 0, 0) /* LifeMagic           Trained */
+     , (40295, 34, 0, 2, 0, 285, 0, 0) /* WarMagic            Trained */
+     , (40295, 45, 0, 2, 0, 513, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40295,  0,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40295,  1,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40295,  2,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40295,  3,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40295,  4,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40295,  5,  4, 50, 0.75,  500,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40295,  6,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40295,  7,  4,  0,    0,  500,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40295,  8,  4, 60, 0.75,   60,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40295,  0,  4,  0,    0,  400,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40295,  1,  4,  0,    0,  330,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40295,  2,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40295,  3,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40295,  4,  4,  0,    0,  340,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40295,  5,  4, 50, 0.75,  370,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40295,  6,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40295,  7,  4,  0,    0,  370,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40295,  8,  4, 60, 0.75,  440,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40295,  1161,  2.009)  /* Heal Self VI */
-     , (40295,  1265,  2.009)  /* Drain Mana Other VI */
-     , (40295,  2074,   2.01)  /* Gossamer Flesh */
-     , (40295,  2132,  2.005)  /* The Spike */
-     , (40295,  2133,  2.036)  /* Outlander's Insolence */
-     , (40295,  2136,  2.036)  /* Icy Torment */
-     , (40295,  2137,  2.005)  /* Sudden Frost */
-     , (40295,  2140,  2.036)  /* Alset's Coil */
-     , (40295,  2141,  2.036)  /* Lhen's Flare */
-     , (40295,  2164,   2.02)  /* Swordsman's Gift */
-     , (40295,  2168,   2.01)  /* Gelidite's Gift */
-     , (40295,  2172,  2.005)  /* Astyrrian's Gift */
-     , (40295,  2174,  2.005)  /* Archer's Gift */
-     , (40295,  2282,   2.02)  /* Futility */
-     , (40295,  2318,   2.01)  /* Gravity Well */
-     , (40295,  4452,  2.009)  /* Incantation of Lightning Streak */;
+VALUES (40295,  2074,   2.02) /* Gossamer Flesh */
+     , (40295,  2132,   2.02) /* The Spike */
+     , (40295,  2133,   2.02) /* Outlander's Insolence */
+     , (40295,  2136,   2.02) /* Icy Torment */
+     , (40295,  2137,   2.02) /* Sudden Frost */
+     , (40295,  2140,   2.02) /* Alset's Coil */
+     , (40295,  2141,   2.02) /* Lhen's Flare */
+     , (40295,  2164,   2.02) /* Swordsman's Gift */
+     , (40295,  2168,   2.02) /* Gelidite's Gift */
+     , (40295,  2172,   2.02) /* Astyrrian's Gift */
+     , (40295,  2174,   2.03) /* Archer's Gift */
+     , (40295,  2282,   2.03) /* Futility */
+     , (40295,  2318,   2.03) /* Gravity Well */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (40295, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/40296 Depraved Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/40296 Depraved Shadow.sql
@@ -1,0 +1,137 @@
+DELETE FROM `weenie` WHERE `class_Id` = 40296;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (40296, 'ace40296-depravedshadow', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (40296,   1,         16) /* ItemType - Creature */
+     , (40296,   2,         22) /* CreatureType - Shadow */
+     , (40296,   3,          2) /* PaletteTemplate - Blue */
+     , (40296,   6,         -1) /* ItemsCapacity */
+     , (40296,   7,         -1) /* ContainersCapacity */
+     , (40296,   8,         90) /* Mass */
+     , (40296,  16,          1) /* ItemUseable - No */
+     , (40296,  25,        185) /* Level */
+     , (40296,  27,          0) /* ArmorType - None */
+     , (40296,  68,          3) /* TargetingTactic - Random, Focused */
+     , (40296,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (40296, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (40296, 113,          1) /* Gender - Male */
+     , (40296, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (40296, 140,          1) /* AiOptions - CanOpenDoors */
+     , (40296, 146,     200000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (40296,   1, True ) /* Stuck */
+     , (40296,   6, True ) /* AiUsesMana */
+     , (40296,  11, False) /* IgnoreCollisions */
+     , (40296,  12, True ) /* ReportCollisions */
+     , (40296,  13, False) /* Ethereal */
+     , (40296,  14, True ) /* GravityStatus */
+     , (40296,  19, True ) /* Attackable */
+     , (40296,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (40296,   1,       5) /* HeartbeatInterval */
+     , (40296,   2,       0) /* HeartbeatTimestamp */
+     , (40296,   3,     0.7) /* HealthRate */
+     , (40296,   4,     2.5) /* StaminaRate */
+     , (40296,   5,       1) /* ManaRate */
+     , (40296,  12,     0.5) /* Shade */
+     , (40296,  13,     0.9) /* ArmorModVsSlash */
+     , (40296,  14,       1) /* ArmorModVsPierce */
+     , (40296,  15,       1) /* ArmorModVsBludgeon */
+     , (40296,  16,     1.1) /* ArmorModVsCold */
+     , (40296,  17,     0.9) /* ArmorModVsFire */
+     , (40296,  18,       1) /* ArmorModVsAcid */
+     , (40296,  19,       1) /* ArmorModVsElectric */
+     , (40296,  31,      20) /* VisualAwarenessRange */
+     , (40296,  34,     1.2) /* PowerupTime */
+     , (40296,  36,       1) /* ChargeSpeed */
+     , (40296,  39,     1.1) /* DefaultScale */
+     , (40296,  64,     0.8) /* ResistSlash */
+     , (40296,  65,     0.5) /* ResistPierce */
+     , (40296,  66,     0.7) /* ResistBludgeon */
+     , (40296,  67,     0.8) /* ResistFire */
+     , (40296,  68,     0.1) /* ResistCold */
+     , (40296,  69,     0.2) /* ResistAcid */
+     , (40296,  70,     0.5) /* ResistElectric */
+     , (40296,  71,       1) /* ResistHealthBoost */
+     , (40296,  72,       1) /* ResistStaminaDrain */
+     , (40296,  73,       1) /* ResistStaminaBoost */
+     , (40296,  74,       1) /* ResistManaDrain */
+     , (40296,  75,       1) /* ResistManaBoost */
+     , (40296,  76,     0.5) /* Translucency */
+     , (40296,  80,       3) /* AiUseMagicDelay */
+     , (40296, 104,      10) /* ObviousRadarRange */
+     , (40296, 122,       2) /* AiAcquireHealth */
+     , (40296, 125,       1) /* ResistHealthDrain */
+     , (40296, 166,     0.6) /* ResistNether */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (40296,   1, 'Depraved Shadow') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (40296,   1, 0x02001526) /* Setup */
+     , (40296,   2, 0x09000186) /* MotionTable */
+     , (40296,   3, 0x200000BE) /* SoundTable */
+     , (40296,   4, 0x30000000) /* CombatTable */
+     , (40296,   6, 0x040019CC) /* PaletteBase */
+     , (40296,   7, 0x100005AB) /* ClothingBase */
+     , (40296,   8, 0x06001BBE) /* Icon */
+     , (40296,  22, 0x34000063) /* PhysicsEffectTable */
+     , (40296,  35,       1011) /* DeathTreasureType - Loot Tier: 7 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (40296,   1, 300, 0, 0) /* Strength */
+     , (40296,   2, 400, 0, 0) /* Endurance */
+     , (40296,   3, 300, 0, 0) /* Quickness */
+     , (40296,   4, 300, 0, 0) /* Coordination */
+     , (40296,   5, 540, 0, 0) /* Focus */
+     , (40296,   6, 560, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (40296,   1,   800, 0, 0, 1000) /* MaxHealth */
+     , (40296,   3,   300, 0, 0, 700) /* MaxStamina */
+     , (40296,   5,   280, 0, 0, 860) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40296,  6, 0, 2, 0, 534, 0, 0) /* MeleeDefense        Trained */
+     , (40296,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (40296, 15, 0, 2, 0, 319, 0, 0) /* MagicDefense        Trained */
+     , (40296, 31, 0, 2, 0, 283, 0, 0) /* CreatureEnchantment Trained */
+     , (40296, 33, 0, 2, 0, 283, 0, 0) /* LifeMagic           Trained */
+     , (40296, 34, 0, 2, 0, 283, 0, 0) /* WarMagic            Trained */
+     , (40296, 45, 0, 2, 0, 517, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (40296,  0,  4,  0,    0,  380,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40296,  1,  4,  0,    0,  310,  450,  500,  500,  550,  450,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40296,  2,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40296,  3,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40296,  4,  4,  0,    0,  320,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40296,  5,  4, 50, 0.75,  350,  450,  500,  500,  550,  450,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40296,  6,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40296,  7,  4,  0,    0,  350,  450,  500,  500,  550,  450,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40296,  8,  4, 60, 0.75,  420,   54,   60,   60,   66,   54,   60,   60,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (40296,  2074,   2.02)  /* Gossamer Flesh */
+     , (40296,  2132,   2.02)  /* The Spike */
+     , (40296,  2133,   2.02)  /* Outlander's Insolence */
+     , (40296,  2136,   2.02)  /* Icy Torment */
+     , (40296,  2137,   2.02)  /* Sudden Frost */
+     , (40296,  2140,   2.02)  /* Alset's Coil */
+     , (40296,  2141,   2.02)  /* Lhen's Flare */
+     , (40296,  2164,   2.02)  /* Swordsman's Gift */
+     , (40296,  2168,   2.02)  /* Gelidite's Gift */
+     , (40296,  2172,   2.02)  /* Astyrrian's Gift */
+     , (40296,  2174,   2.03)  /* Archer's Gift */
+     , (40296,  2282,   2.03)  /* Futility */
+     , (40296,  2318,   2.03)  /* Gravity Well */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (40296, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+     , (40296, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (40296, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
+     , (40296, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/33639 Shambling Ruschk Chieftain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/33639 Shambling Ruschk Chieftain.sql
@@ -39,7 +39,7 @@ VALUES (33639,   1,       5) /* HeartbeatInterval */
      , (33639,  12,       0) /* Shade */
      , (33639,  13,     0.9) /* ArmorModVsSlash */
      , (33639,  14,     0.6) /* ArmorModVsPierce */
-     , (33639,  15,     1.1) /* ArmorModVsBludgeon */
+     , (33639,  15,       1) /* ArmorModVsBludgeon */
      , (33639,  16,     0.8) /* ArmorModVsCold */
      , (33639,  17,     0.6) /* ArmorModVsFire */
      , (33639,  18,       1) /* ArmorModVsAcid */
@@ -50,13 +50,13 @@ VALUES (33639,   1,       5) /* HeartbeatInterval */
      , (33639,  39,     1.3) /* DefaultScale */
      , (33639,  41,      60) /* RegenerationInterval */
      , (33639,  43,       4) /* GeneratorRadius */
-     , (33639,  64,     0.7) /* ResistSlash */
-     , (33639,  65,       8) /* ResistPierce */
-     , (33639,  66,     0.5) /* ResistBludgeon */
-     , (33639,  67,     0.9) /* ResistFire */
-     , (33639,  68,     0.5) /* ResistCold */
-     , (33639,  69,     0.4) /* ResistAcid */
-     , (33639,  70,     0.4) /* ResistElectric */
+     , (33639,  64,     0.2) /* ResistSlash */
+     , (33639,  65,     0.4) /* ResistPierce */
+     , (33639,  66,     0.2) /* ResistBludgeon */
+     , (33639,  67,     0.4) /* ResistFire */
+     , (33639,  68,     0.2) /* ResistCold */
+     , (33639,  69,     0.2) /* ResistAcid */
+     , (33639,  70,     0.2) /* ResistElectric */
      , (33639,  71,       1) /* ResistHealthBoost */
      , (33639,  72,     0.5) /* ResistStaminaDrain */
      , (33639,  73,       1) /* ResistStaminaBoost */
@@ -91,16 +91,13 @@ VALUES (33639,   1,  9000, 0, 0, 9195) /* MaxHealth */
      , (33639,   5,   390, 0, 0, 410) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33639,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (33639,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (33639, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33639, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
-     , (33639, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33639, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (33639, 32, 0, 3, 0, 275, 0, 0) /* ItemEnchantment     Specialized */
-     , (33639, 33, 0, 3, 0, 325, 0, 0) /* LifeMagic           Specialized */
-     , (33639, 34, 0, 3, 0, 330, 0, 0) /* WarMagic            Specialized */
-     , (33639, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
+VALUES (33639,  6, 0, 2, 0, 411, 0, 0) /* MeleeDefense        Trained */
+     , (33639,  7, 0, 2, 0, 472, 0, 0) /* MissileDefense      Trained */
+     , (33639, 15, 0, 2, 0, 349, 0, 0) /* MagicDefense        Trained */
+     , (33639, 44, 0, 2, 0, 440, 0, 0) /* HeavyWeapons        Trained */
+     , (33639, 45, 0, 2, 0, 440, 0, 0) /* LightWeapons        Trained */
+     , (33639, 46, 0, 2, 0, 476, 0, 0) /* FinesseWeapons      Trained */
+     , (33639, 47, 0, 2, 0, 121, 0, 0) /* MissileWeapons      Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33639,  0,  4,  0,    0,  300,  270,  180,  330,  240,  180,  300,  240,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -113,22 +110,17 @@ VALUES (33639,  0,  4,  0,    0,  300,  270,  180,  330,  240,  180,  300,  240,
      , (33639,  7,  4,  0,    0,  300,  270,  180,  330,  240,  180,  300,  240,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (33639,  8,  4, 50,  0.4,  300,  270,  180,  330,  240,  180,  300,  240,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33639,  2074,   2.02)  /* Gossamer Flesh */
-     , (33639,  2136,   2.02)  /* Icy Torment */
-     , (33639,  2168,   2.02)  /* Gelidite's Gift */;
-
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (33639, 2, 48633,  1, 0, 0, False) /* Create Glacial Blade (48633) for Wield */
-     , (33639, 2, 48630,  1, 0, 0, False) /* Create Frozen Dagger (48630) for Wield */
-     , (33639, 2, 48631,  1, 0, 0, False) /* Create Ice Shard (48631) for Wield */
-     , (33639, 2, 48632,  1, 0, 0, False) /* Create Tursh's Spear (48632) for Wield */
-     , (33639, 2, 48629,  1, 0, 0, False) /* Create Icy Club (48629) for Wield */
-     , (33639, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44469) for ContainTreasure */
+VALUES (33639, 9, 44469,  1, 0, 0, False) /* Create Lesser Corrupted Essence (44469) for ContainTreasure */
      , (33639, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (33639, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (33639, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (33639, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (33639, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33639, 10, 48633,  1, 0, 0.2, False) /* Create Glacial Blade (48633) for WieldTreasure */
+     , (33639, 10, 48630,  1, 0, 0.2, False) /* Create Frozen Dagger (48630) for WieldTreasure */
+     , (33639, 10, 48631,  1, 0, 0.2, False) /* Create Ice Shard (48631) for WieldTreasure */
+     , (33639, 10, 48632,  1, 0, 0.2, False) /* Create Frigid Splinter (48632) for WieldTreasure */
+     , (33639, 10, 48629,  1, 0, 0.2, False) /* Create Icy Club (48629) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33639, -1, 40287, 3600, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Shambling Undead Ruschk (40287) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/33641 Sodden Ruschk Chieftain.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/33641 Sodden Ruschk Chieftain.sql
@@ -89,45 +89,37 @@ VALUES (33641,   1, 12000, 0, 0, 12200) /* MaxHealth */
      , (33641,   3,  3000, 0, 0, 3400) /* MaxStamina */
      , (33641,   5,   400, 0, 0, 420) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33641,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
-     , (33641,  7, 0, 3, 0, 400, 0, 0) /* MissileDefense      Specialized */
-     , (33641, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33641, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
-     , (33641, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33641, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (33641, 32, 0, 3, 0, 275, 0, 0) /* ItemEnchantment     Specialized */
-     , (33641, 33, 0, 3, 0, 325, 0, 0) /* LifeMagic           Specialized */
-     , (33641, 34, 0, 3, 0, 330, 0, 0) /* WarMagic            Specialized */
-     , (33641, 45, 0, 3, 0, 400, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33641,  0,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33641,  1,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33641,  2,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33641,  3,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33641,  4,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33641,  5,  4, 60,  0.5,  300,  270,  210,  330,  240,  180,  300,  240,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33641,  6,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33641,  7,  4,  0,    0,  300,  270,  210,  330,  240,  180,  300,  240,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33641,  8,  4, 50,  0.4,  300,  270,  210,  330,  240,  180,  300,  240,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33641,  2074,   2.02)  /* Gossamer Flesh */
-     , (33641,  2136,   2.02)  /* Icy Torment */
-     , (33641,  2168,   2.02)  /* Gelidite's Gift */;
+VALUES (33641,  0,  4,  0,    0,  350,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33641,  1,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33641,  2,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33641,  3,  4,  0,    0,  300,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33641,  4,  4,  0,    0,  300,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33641,  5,  4, 60,  0.5,  350,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33641,  6,  4,  0,    0,  350,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33641,  7,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33641,  8,  4, 50,  0.4,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (33641, 2, 48585,  1, 0, 0, False) /* Create Frozen Dagger (48585) for Wield */
-     , (33641, 2, 48588,  1, 0, 0, False) /* Create Glacial Blade (48588) for Wield */
-     , (33641, 2, 48584,  1, 0, 0, False) /* Create Icy Club (48584) for Wield */
-     , (33641, 2, 48587,  1, 0, 0, False) /* Create Frigid Splinter (48587) for Wield */
-     , (33641, 2, 48586,  1, 0, 0, False) /* Create Ice Shard (48586) for Wield */
-     , (33641, 9, 44470,  1, 0, 0, False) /* Create Corrupted Essence (44470) for ContainTreasure */
+VALUES (33641, 9, 44470,  1, 0, 0, False) /* Create Corrupted Essence (44470) for ContainTreasure */
      , (33641, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (33641, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (33641, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (33641, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (33641, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33641, 10, 48585,  1, 0, 0.2, False) /* Create Frozen Dagger (48585) for WieldTreasure */
+     , (33641, 10, 48588,  1, 0, 0.2, False) /* Create Glacial Blade (48588) for WieldTreasure */
+     , (33641, 10, 48584,  1, 0, 0.2, False) /* Create Icy Club (48584) for WieldTreasure */
+     , (33641, 10, 48587,  1, 0, 0.2, False) /* Create Frigid Splinter (48587) for WieldTreasure */
+     , (33641, 10, 48586,  1, 0, 0.2, False) /* Create Ice Shard (48586) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33641, -1, 33642, 3600, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Sodden Undead Ruschk (33642) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33641,  44, 0, 2, 0, 430, 0, 0) /* HeavyWeapons */
+     , (33641,  45, 0, 2, 0, 430, 0, 0) /* LightWeapons */
+     , (33641,  46, 0, 2, 0, 467, 0, 0) /* FinesseWeapons */
+     , (33641,  47, 0, 2, 0, 240, 0, 0) /* MissileWeapons */
+     , (33641,   6, 0, 2, 0, 399, 0, 0) /* MeleeDefense */
+     , (33641,   7, 0, 2, 0, 468, 0, 0) /* MissileDefense */
+     , (33641,  15, 0, 2, 0, 347, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/33642 Sodden Undead Ruschk.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/33642 Sodden Undead Ruschk.sql
@@ -58,8 +58,7 @@ VALUES (33642,   1,       5) /* HeartbeatInterval */
      , (33642,  74,     0.5) /* ResistManaDrain */
      , (33642,  75,       1) /* ResistManaBoost */
      , (33642, 104,      10) /* ObviousRadarRange */
-     , (33642, 125,     0.5) /* ResistHealthDrain */
-     , (33642, 166,     0.2) /* ResistNether */;
+     , (33642, 125,     0.5) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33642,   1, 'Sodden Undead Ruschk') /* Name */;
@@ -86,41 +85,33 @@ VALUES (33642,   1,   850, 0, 0, 980) /* MaxHealth */
      , (33642,   3,  1000, 0, 0, 1260) /* MaxStamina */
      , (33642,   5,   200, 0, 0, 415) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33642,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (33642,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
-     , (33642, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33642, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
-     , (33642, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33642, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (33642, 32, 0, 3, 0, 275, 0, 0) /* ItemEnchantment     Specialized */
-     , (33642, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (33642, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (33642, 45, 0, 3, 0, 385, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33642,  0,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33642,  1,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33642,  2,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33642,  3,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33642,  4,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33642,  5,  4, 60,  0.5,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33642,  6,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33642,  7,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33642,  8,  4, 50,  0.4,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33642,  2074,   2.02)  /* Gossamer Flesh */
-     , (33642,  2136,   2.02)  /* Icy Torment */
-     , (33642,  2168,   2.02)  /* Gelidite's Gift */;
+VALUES (33642,  0,  4,  0,    0,  350,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33642,  1,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33642,  2,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33642,  3,  4,  0,    0,  300,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33642,  4,  4,  0,    0,  300,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33642,  5,  4, 60,  0.5,  350,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33642,  6,  4,  0,    0,  350,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33642,  7,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33642,  8,  4, 50,  0.4,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (33642, 2, 48585,  1, 0, 0, False) /* Create Frozen Dagger (48585) for Wield */
-     , (33642, 2, 48588,  1, 0, 0, False) /* Create Glacial Blade (48588) for Wield */
-     , (33642, 2, 48584,  1, 0, 0, False) /* Create Icy Club (48584) for Wield */
-     , (33642, 2, 48587,  1, 0, 0, False) /* Create Frigid Splinter (48587) for Wield */
-     , (33642, 2, 48586,  1, 0, 0, False) /* Create Ice Shard (48586) for Wield */
-     , (33642, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (33642, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (33642, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (33642, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (33642, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (33642, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33642, 10, 48585,  1, 0, 0.2, False) /* Create Frozen Dagger (48585) for WieldTreasure */
+     , (33642, 10, 48588,  1, 0, 0.2, False) /* Create Glacial Blade (48588) for WieldTreasure */
+     , (33642, 10, 48584,  1, 0, 0.2, False) /* Create Icy Club (48584) for WieldTreasure */
+     , (33642, 10, 48587,  1, 0, 0.2, False) /* Create Frigid Splinter (48587) for WieldTreasure */
+     , (33642, 10, 48586,  1, 0, 0.2, False) /* Create Ice Shard (48586) for WieldTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33642,  44, 0, 2, 0, 505, 0, 0) /* HeavyWeapons */
+     , (33642,  45, 0, 2, 0, 505, 0, 0) /* LightWeapons */
+     , (33642,  46, 0, 2, 0, 542, 0, 0) /* FinesseWeapons */
+     , (33642,  47, 0, 2, 0, 310, 0, 0) /* MissileWeapons */
+     , (33642,   6, 0, 2, 0, 472, 0, 0) /* MeleeDefense */
+     , (33642,   7, 0, 2, 0, 504, 0, 0) /* MissileDefense */
+     , (33642,  15, 0, 2, 0, 400, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/33734 Sodden Undead Ruschk.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/33734 Sodden Undead Ruschk.sql
@@ -61,8 +61,7 @@ VALUES (33734,   1,       5) /* HeartbeatInterval */
      , (33734,  74,     0.5) /* ResistManaDrain */
      , (33734,  75,       1) /* ResistManaBoost */
      , (33734, 104,      10) /* ObviousRadarRange */
-     , (33734, 125,     0.5) /* ResistHealthDrain */
-     , (33734, 166,     0.2) /* ResistNether */;
+     , (33734, 125,     0.5) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33734,   1, 'Sodden Undead Ruschk') /* Name */;
@@ -89,33 +88,16 @@ VALUES (33734,   1,   850, 0, 0, 980) /* MaxHealth */
      , (33734,   3,  1000, 0, 0, 1260) /* MaxStamina */
      , (33734,   5,   200, 0, 0, 415) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33734,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (33734,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
-     , (33734, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33734, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
-     , (33734, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33734, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (33734, 32, 0, 3, 0, 275, 0, 0) /* ItemEnchantment     Specialized */
-     , (33734, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (33734, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (33734, 45, 0, 3, 0, 385, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33734,  0,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33734,  1,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33734,  2,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33734,  3,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33734,  4,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33734,  5,  4, 60,  0.5,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33734,  6,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33734,  7,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33734,  8,  4, 50,  0.4,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33734,  2074,   2.02)  /* Gossamer Flesh */
-     , (33734,  2136,   2.02)  /* Icy Torment */
-     , (33734,  2168,   2.02)  /* Gelidite's Gift */;
+VALUES (33734,  0,  4,  0,    0,  350,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33734,  1,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33734,  2,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33734,  3,  4,  0,    0,  300,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33734,  4,  4,  0,    0,  300,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33734,  5,  4, 60,  0.5,  350,  405,  270,  495,  360,  248,  450,  360,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33734,  6,  4,  0,    0,  350,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33734,  7,  4,  0,    0,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33734,  8,  4, 50,  0.4,  390,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33734,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -126,15 +108,24 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (33734, 2, 48585,  1, 0, 0, False) /* Create Frozen Dagger (48585) for Wield */
-     , (33734, 2, 48588,  1, 0, 0, False) /* Create Glacial Blade (48588) for Wield */
-     , (33734, 2, 48584,  1, 0, 0, False) /* Create Icy Club (48584) for Wield */
-     , (33734, 2, 48587,  1, 0, 0, False) /* Create Frigid Splinter (48587) for Wield */
-     , (33734, 2, 48586,  1, 0, 0, False) /* Create Ice Shard (48586) for Wield */
-     , (33734, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (33734, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (33734, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (33734, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (33734, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (33734, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33734, 10, 48585,  1, 0, 0.2, False) /* Create Frozen Dagger (48585) for WieldTreasure */
+     , (33734, 10, 48588,  1, 0, 0.2, False) /* Create Glacial Blade (48588) for WieldTreasure */
+     , (33734, 10, 48584,  1, 0, 0.2, False) /* Create Icy Club (48584) for WieldTreasure */
+     , (33734, 10, 48587,  1, 0, 0.2, False) /* Create Frigid Splinter (48587) for WieldTreasure */
+     , (33734, 10, 48586,  1, 0, 0.2, False) /* Create Ice Shard (48586) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33734, -1, 33641, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Sodden Ruschk Chieftain (33641) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33734,  44, 0, 2, 0, 505, 0, 0) /* HeavyWeapons */
+     , (33734,  45, 0, 2, 0, 505, 0, 0) /* LightWeapons */
+     , (33734,  46, 0, 2, 0, 542, 0, 0) /* FinesseWeapons */
+     , (33734,  47, 0, 2, 0, 310, 0, 0) /* MissileWeapons */
+     , (33734,   6, 0, 2, 0, 472, 0, 0) /* MeleeDefense */
+     , (33734,   7, 0, 2, 0, 504, 0, 0) /* MissileDefense */
+     , (33734,  15, 0, 2, 0, 400, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/33735 Shambling Undead Ruschk.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/33735 Shambling Undead Ruschk.sql
@@ -38,7 +38,7 @@ VALUES (33735,   1,       5) /* HeartbeatInterval */
      , (33735,  12,       0) /* Shade */
      , (33735,  13,     0.9) /* ArmorModVsSlash */
      , (33735,  14,     0.6) /* ArmorModVsPierce */
-     , (33735,  15,     1.1) /* ArmorModVsBludgeon */
+     , (33735,  15,       1) /* ArmorModVsBludgeon */
      , (33735,  16,     0.8) /* ArmorModVsCold */
      , (33735,  17,    0.55) /* ArmorModVsFire */
      , (33735,  18,       1) /* ArmorModVsAcid */
@@ -48,21 +48,20 @@ VALUES (33735,   1,       5) /* HeartbeatInterval */
      , (33735,  36,       1) /* ChargeSpeed */
      , (33735,  39,       1) /* DefaultScale */
      , (33735,  43,       4) /* GeneratorRadius */
-     , (33735,  64,     0.1) /* ResistSlash */
-     , (33735,  65,     0.1) /* ResistPierce */
-     , (33735,  66,     0.3) /* ResistBludgeon */
-     , (33735,  67,     0.3) /* ResistFire */
-     , (33735,  68,     0.1) /* ResistCold */
-     , (33735,  69,     0.2) /* ResistAcid */
-     , (33735,  70,     0.1) /* ResistElectric */
+     , (33735,  64,     0.4) /* ResistSlash */
+     , (33735,  65,    0.75) /* ResistPierce */
+     , (33735,  66,     0.4) /* ResistBludgeon */
+     , (33735,  67,    0.75) /* ResistFire */
+     , (33735,  68,     0.2) /* ResistCold */
+     , (33735,  69,     0.4) /* ResistAcid */
+     , (33735,  70,     0.4) /* ResistElectric */
      , (33735,  71,       1) /* ResistHealthBoost */
      , (33735,  72,     0.5) /* ResistStaminaDrain */
      , (33735,  73,       1) /* ResistStaminaBoost */
      , (33735,  74,     0.5) /* ResistManaDrain */
      , (33735,  75,       1) /* ResistManaBoost */
      , (33735, 104,      10) /* ObviousRadarRange */
-     , (33735, 125,     0.5) /* ResistHealthDrain */
-     , (33735, 166,     0.2) /* ResistNether */;
+     , (33735, 125,     0.5) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33735,   1, 'Shambling Undead Ruschk') /* Name */;
@@ -89,18 +88,6 @@ VALUES (33735,   1,   740, 0, 0, 860) /* MaxHealth */
      , (33735,   3,   800, 0, 0, 1040) /* MaxStamina */
      , (33735,   5,   200, 0, 0, 410) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33735,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (33735,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
-     , (33735, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (33735, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
-     , (33735, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (33735, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (33735, 32, 0, 3, 0, 275, 0, 0) /* ItemEnchantment     Specialized */
-     , (33735, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (33735, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (33735, 45, 0, 3, 0, 385, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (33735,  0,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (33735,  1,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
@@ -112,11 +99,6 @@ VALUES (33735,  0,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,
      , (33735,  7,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (33735,  8,  4, 50,  0.4,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (33735,  2074,   2.02)  /* Gossamer Flesh */
-     , (33735,  2136,   2.02)  /* Icy Torment */
-     , (33735,  2168,   2.02)  /* Gelidite's Gift */;
-
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33735,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
@@ -126,15 +108,24 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (33735, 2, 48633,  1, 0, 0, False) /* Create Glacial Blade (48633) for Wield */
-     , (33735, 2, 48630,  1, 0, 0, False) /* Create Frozen Dagger (48630) for Wield */
-     , (33735, 2, 48631,  1, 0, 0, False) /* Create Ice Shard (48631) for Wield */
-     , (33735, 2, 48632,  1, 0, 0, False) /* Create Tursh's Spear (48632) for Wield */
-     , (33735, 2, 48629,  1, 0, 0, False) /* Create Icy Club (48629) for Wield */
-     , (33735, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (33735, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (33735, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (33735, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (33735, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (33735, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (33735, 10, 48633,  1, 0, 0.2, False) /* Create Glacial Blade (48633) for WieldTreasure */
+     , (33735, 10, 48630,  1, 0, 0.2, False) /* Create Frozen Dagger (48630) for WieldTreasure */
+     , (33735, 10, 48631,  1, 0, 0.2, False) /* Create Ice Shard (48631) for WieldTreasure */
+     , (33735, 10, 48632,  1, 0, 0.2, False) /* Create Frigid Splinter (48632) for WieldTreasure */
+     , (33735, 10, 48629,  1, 0, 0.2, False) /* Create Icy Club (48629) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (33735, -1, 33639, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Shambling Ruschk Chieftain (33639) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (33735,  44, 0, 2, 0, 430, 0, 0) /* HeavyWeapons */
+     , (33735,  45, 0, 2, 0, 430, 0, 0) /* LightWeapons */
+     , (33735,  46, 0, 2, 0, 466, 0, 0) /* FinesseWeapons */
+     , (33735,  47, 0, 2, 0, 196, 0, 0) /* MissileWeapons */
+     , (33735,   6, 0, 2, 0, 456, 0, 0) /* MeleeDefense */
+     , (33735,   7, 0, 2, 0, 500, 0, 0) /* MissileDefense */
+     , (33735,  15, 0, 2, 0, 400, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/34973 Falatacot Consort.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/34973 Falatacot Consort.sql
@@ -81,31 +81,16 @@ VALUES (34973,   1,   829, 0, 0, 934) /* MaxHealth */
      , (34973,   3,   800, 0, 0, 1010) /* MaxStamina */
      , (34973,   5,   300, 0, 0, 540) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (34973,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (34973,  7, 0, 3, 0, 405, 0, 0) /* MissileDefense      Specialized */
-     , (34973, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
-     , (34973, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
-     , (34973, 20, 0, 3, 0,  90, 0, 0) /* Deception           Specialized */
-     , (34973, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (34973, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (34973, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (34973, 44, 0, 3, 0, 375, 0, 0) /* HeavyWeapons        Specialized */
-     , (34973, 45, 0, 3, 0, 375, 0, 0) /* LightWeapons        Specialized */
-     , (34973, 46, 0, 3, 0, 375, 0, 0) /* FinesseWeapons      Specialized */
-     , (34973, 47, 0, 3, 0, 175, 0, 0) /* MissileWeapons      Specialized */
-     , (34973, 48, 0, 3, 0, 300, 0, 0) /* Shield              Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (34973,  0,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (34973,  1,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (34973,  2,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (34973,  3,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (34973,  4,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (34973,  5,  4,  5, 0.75,  625,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (34973,  6,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (34973,  7,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (34973,  8,  4,  5, 0.75,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (34973,  0,  4,  0,    0,  360,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (34973,  1,  4,  0,    0,  370,  625,  813,  625,  813,  625,  625,  750,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (34973,  2,  4,  0,    0,  370,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (34973,  3,  4,  0,    0,  380,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (34973,  4,  4,  0,    0,  400,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (34973,  5,  4,  5, 0.75,  380,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (34973,  6,  4,  0,    0,  370,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (34973,  7,  4,  0,    0,  400,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (34973,  8,  4,  5, 0.75,  380,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (34973,   176,   2.02)  /* Fester Other VI */
@@ -125,11 +110,22 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Im vaik av tiu ikni liViliakti.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (34973, 2, 48100,  1, 0, 0, False) /* Create Khopesh (48100) for Wield */
-     , (34973, 2, 48101,  1, 0, 0, False) /* Create Sickle (48101) for Wield */
-     , (34973, 2, 48102,  1, 0, 0, False) /* Create Khopesh (48102) for Wield */
-     , (34973, 2, 48103,  1, 0, 0, False) /* Create Sickle (48103) for Wield */
-     , (34973, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (34973, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (34973, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (34973, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (34973, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (34973, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (34973, 10, 48100,  1, 0, 0.25, False) /* Create Khopesh (48100) for WieldTreasure */
+     , (34973, 10, 48101,  1, 0, 0.25, False) /* Create Sickle (48101) for WieldTreasure */
+     , (34973, 10, 48102,  1, 0, 0.25, False) /* Create Khopesh (48102) for WieldTreasure */
+     , (34973, 10, 48103,  1, 0, 0.25, False) /* Create Sickle (48103) for WieldTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (34973,  34, 0, 2, 0, 134, 0, 0) /* WarMagic */
+     , (34973,  33, 0, 2, 0, 134, 0, 0) /* LifeMagic */
+     , (34973,  31, 0, 2, 0, 134, 0, 0) /* CreatureEnchantment */
+     , (34973,  44, 0, 2, 0, 383, 0, 0) /* HeavyWeapons */
+     , (34973,  45, 0, 2, 0, 383, 0, 0) /* LightWeapons */
+     , (34973,  46, 0, 2, 0, 391, 0, 0) /* FinesseWeapons */
+     , (34973,   6, 0, 2, 0, 408, 0, 0) /* MeleeDefense */
+     , (34973,   7, 0, 2, 0, 227, 0, 0) /* MissileDefense */
+     , (34973,  15, 0, 2, 0, 356, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/38593 Falatacot Consort.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/38593 Falatacot Consort.sql
@@ -87,31 +87,16 @@ VALUES (38593,   1,  1650, 0, 0, 1800) /* MaxHealth */
      , (38593,   3,  2000, 0, 0, 2300) /* MaxStamina */
      , (38593,   5,  1000, 0, 0, 1360) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (38593,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (38593,  7, 0, 3, 0, 405, 0, 0) /* MissileDefense      Specialized */
-     , (38593, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
-     , (38593, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
-     , (38593, 20, 0, 3, 0,  90, 0, 0) /* Deception           Specialized */
-     , (38593, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (38593, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (38593, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (38593, 44, 0, 3, 0, 375, 0, 0) /* HeavyWeapons        Specialized */
-     , (38593, 45, 0, 3, 0, 375, 0, 0) /* LightWeapons        Specialized */
-     , (38593, 46, 0, 3, 0, 375, 0, 0) /* FinesseWeapons      Specialized */
-     , (38593, 47, 0, 3, 0, 175, 0, 0) /* MissileWeapons      Specialized */
-     , (38593, 48, 0, 3, 0, 300, 0, 0) /* Shield              Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (38593,  0,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (38593,  1,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (38593,  2,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (38593,  3,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (38593,  4,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (38593,  5,  4,  5, 0.75,  625,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (38593,  6,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (38593,  7,  4,  0,    0,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (38593,  8,  4,  5, 0.75,  625,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (38593,  0,  4,  0,    0,  360,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (38593,  1,  4,  0,    0,  370,  625,  813,  625,  813,  625,  625,  750,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (38593,  2,  4,  0,    0,  370,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (38593,  3,  4,  0,    0,  380,  625,  813,  625,  813,  625,  625,  750,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (38593,  4,  4,  0,    0,  400,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (38593,  5,  4,  5, 0.75,  380,  625,  813,  625,  813,  625,  625,  750,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (38593,  6,  4,  0,    0,  370,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (38593,  7,  4,  0,    0,  400,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (38593,  8,  4,  5, 0.75,  380,  625,  813,  625,  813,  625,  625,  750,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (38593,   176,   2.02)  /* Fester Other VI */
@@ -132,12 +117,23 @@ VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'Im vaik av tiu ikni liViliak
      , (@parent_id,  1,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (38593, 2, 48100,  1, 0, 0, False) /* Create Khopesh (48100) for Wield */
-     , (38593, 2, 48101,  1, 0, 0, False) /* Create Sickle (48101) for Wield */
-     , (38593, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (38593, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (38593, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (38593, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (38593, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (38593, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (38593, 10, 48100,  1, 0, 0.5, False) /* Create Khopesh (48100) for WieldTreasure */
+     , (38593, 10, 48101,  1, 0, 0.5, False) /* Create Sickle (48101) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (38593, -1, 38594, 0, 1, 1, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Falatacot Blood Prophetess (38594) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (38593,  34, 0, 2, 0, 71, 0, 0) /* WarMagic */
+     , (38593,  33, 0, 2, 0, 71, 0, 0) /* LifeMagic */
+     , (38593,  31, 0, 2, 0, 71, 0, 0) /* CreatureEnchantment */
+     , (38593,  44, 0, 2, 0, 320, 0, 0) /* HeavyWeapons */
+     , (38593,  45, 0, 2, 0, 320, 0, 0) /* LightWeapons */
+     , (38593,  46, 0, 2, 0, 331, 0, 0) /* FinesseWeapons */
+     , (38593,   6, 0, 2, 0, 348, 0, 0) /* MeleeDefense */
+     , (38593,   7, 0, 2, 0, 191, 0, 0) /* MissileDefense */
+     , (38593,  15, 0, 2, 0, 320, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/38594 Falatacot Blood Prophetess.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/38594 Falatacot Blood Prophetess.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 38594;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (38594, 'ace38594-falatacotbloodprophetess', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (38594, 'ace38594-falatacotbloodprophetess', 10, '2023-05-15 04:36:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (38594,   1,         16) /* ItemType - Creature */
@@ -88,45 +88,41 @@ VALUES (38594,   1,  2800, 0, 0, 3010) /* MaxHealth */
      , (38594,   5,  3080, 0, 0, 3570) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (38594,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (38594,  7, 0, 3, 0, 405, 0, 0) /* MissileDefense      Specialized */
-     , (38594, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
-     , (38594, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
-     , (38594, 20, 0, 3, 0,  90, 0, 0) /* Deception           Specialized */
-     , (38594, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (38594, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (38594, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (38594, 44, 0, 3, 0, 375, 0, 0) /* HeavyWeapons        Specialized */
-     , (38594, 45, 0, 3, 0, 375, 0, 0) /* LightWeapons        Specialized */
-     , (38594, 46, 0, 3, 0, 375, 0, 0) /* FinesseWeapons      Specialized */
-     , (38594, 47, 0, 3, 0, 175, 0, 0) /* MissileWeapons      Specialized */
-     , (38594, 48, 0, 3, 0, 300, 0, 0) /* Shield              Specialized */;
+VALUES (38594,  6, 0, 2, 0, 375, 0, 0) /* MeleeDefense        Trained */
+     , (38594,  7, 0, 2, 0, 405, 0, 0) /* MissileDefense      Trained */
+     , (38594, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
+     , (38594, 31, 0, 2, 0,  78, 0, 0) /* CreatureEnchantment Trained */
+     , (38594, 33, 0, 2, 0,  78, 0, 0) /* LifeMagic           Trained */
+     , (38594, 34, 0, 2, 0,  78, 0, 0) /* WarMagic            Trained */
+     , (38594, 44, 0, 2, 0, 290, 0, 0) /* HeavyWeapons        Trained */
+     , (38594, 45, 0, 2, 0, 290, 0, 0) /* LightWeapons        Trained */
+     , (38594, 46, 0, 2, 0, 303, 0, 0) /* FinesseWeapons      Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (38594,  0,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (38594,  1,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (38594,  2,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (38594,  3,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (38594,  4,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (38594,  5,  4,  5, 0.75,  425,  425,  553,  425,  553,  425,  425,  510,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (38594,  6,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (38594,  7,  4,  0,    0,  425,  425,  553,  425,  553,  425,  425,  510,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (38594,  8,  4,  5, 0.75,  425,  425,  553,  425,  553,  425,  425,  510,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (38594,  0,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (38594,  1,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (38594,  2,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (38594,  3,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (38594,  4,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (38594,  5,  4,  5, 0.75,  425,  212,  212,  212,  212,  212,  212,  212,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (38594,  6,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (38594,  7,  4,  0,    0,  425,  212,  212,  212,  212,  212,  212,  212,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (38594,  8,  4,  5, 0.75,  425,  212,  212,  212,  212,  212,  212,  212,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (38594,  2144,   2.02)  /* Crushing Shame */
-     , (38594,  2170,   2.02)  /* Inferno's Gift */
-     , (38594,  3882,   2.02)  /* Incendiary Ring */
-     , (38594,  4441,   2.02)  /* Incantation of Flame Volley */;
+VALUES (38594,  2144,   2.05)  /* Crushing Shame */
+     , (38594,  2170,   2.05)  /* Inferno's Gift */
+     , (38594,  3882,   2.06)  /* Incendiary Ring */
+     , (38594,  4441,   2.06)  /* Incantation of Flame Volley */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (38594, 2, 48101,  1, 0, 0, False) /* Create Sickle (48101) for Wield */
-     , (38594, 2, 48103,  1, 0, 0, False) /* Create Sickle (48103) for Wield */
-     , (38594, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (38594, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (38594, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (38594, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
      , (38594, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
-     , (38594, 9, 38614,  1, 0, 1, False) /* Create Falatacot Battle Report (38614) for ContainTreasure */;
+     , (38594, 9, 38614,  1, 0, 1, False) /* Create Falatacot Battle Report (38614) for ContainTreasure */
+     , (38594, 10, 48101,  1, 0, 0.5, False) /* Create Sickle (48101) for WieldTreasure */
+     , (38594, 10, 48103,  1, 0, 0.5, False) /* Create Sickle (48103) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (38594, -1, 34973, 4, 2, 2, 1, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Falatacot Consort (34973) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/40287 Shambling Undead Ruschk.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/40287 Shambling Undead Ruschk.sql
@@ -36,7 +36,7 @@ VALUES (40287,   1,       5) /* HeartbeatInterval */
      , (40287,  12,       0) /* Shade */
      , (40287,  13,     0.9) /* ArmorModVsSlash */
      , (40287,  14,     0.6) /* ArmorModVsPierce */
-     , (40287,  15,     1.1) /* ArmorModVsBludgeon */
+     , (40287,  15,       1) /* ArmorModVsBludgeon */
      , (40287,  16,     0.8) /* ArmorModVsCold */
      , (40287,  17,    0.55) /* ArmorModVsFire */
      , (40287,  18,       1) /* ArmorModVsAcid */
@@ -45,21 +45,20 @@ VALUES (40287,   1,       5) /* HeartbeatInterval */
      , (40287,  34,       1) /* PowerupTime */
      , (40287,  36,       1) /* ChargeSpeed */
      , (40287,  39,       1) /* DefaultScale */
-     , (40287,  64,     0.1) /* ResistSlash */
-     , (40287,  65,     0.1) /* ResistPierce */
-     , (40287,  66,     0.3) /* ResistBludgeon */
-     , (40287,  67,     0.3) /* ResistFire */
-     , (40287,  68,     0.1) /* ResistCold */
-     , (40287,  69,     0.2) /* ResistAcid */
-     , (40287,  70,     0.1) /* ResistElectric */
+     , (40287,  64,     0.4) /* ResistSlash */
+     , (40287,  65,    0.75) /* ResistPierce */
+     , (40287,  66,     0.4) /* ResistBludgeon */
+     , (40287,  67,    0.75) /* ResistFire */
+     , (40287,  68,     0.2) /* ResistCold */
+     , (40287,  69,     0.4) /* ResistAcid */
+     , (40287,  70,     0.4) /* ResistElectric */
      , (40287,  71,       1) /* ResistHealthBoost */
      , (40287,  72,     0.5) /* ResistStaminaDrain */
      , (40287,  73,       1) /* ResistStaminaBoost */
      , (40287,  74,     0.5) /* ResistManaDrain */
      , (40287,  75,       1) /* ResistManaBoost */
      , (40287, 104,      10) /* ObviousRadarRange */
-     , (40287, 125,     0.5) /* ResistHealthDrain */
-     , (40287, 166,     0.2) /* ResistNether */;
+     , (40287, 125,     0.5) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (40287,   1, 'Shambling Undead Ruschk') /* Name */;
@@ -86,18 +85,6 @@ VALUES (40287,   1,   740, 0, 0, 860) /* MaxHealth */
      , (40287,   3,   800, 0, 0, 1040) /* MaxStamina */
      , (40287,   5,   200, 0, 0, 410) /* MaxMana */;
 
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40287,  6, 0, 3, 0, 375, 0, 0) /* MeleeDefense        Specialized */
-     , (40287,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
-     , (40287, 14, 0, 3, 0,  70, 0, 0) /* ArcaneLore          Specialized */
-     , (40287, 15, 0, 3, 0, 400, 0, 0) /* MagicDefense        Specialized */
-     , (40287, 20, 0, 3, 0,  50, 0, 0) /* Deception           Specialized */
-     , (40287, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (40287, 32, 0, 3, 0, 275, 0, 0) /* ItemEnchantment     Specialized */
-     , (40287, 33, 0, 3, 0, 275, 0, 0) /* LifeMagic           Specialized */
-     , (40287, 34, 0, 3, 0, 290, 0, 0) /* WarMagic            Specialized */
-     , (40287, 45, 0, 3, 0, 385, 0, 0) /* LightWeapons        Specialized */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (40287,  0,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (40287,  1,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
@@ -109,18 +96,22 @@ VALUES (40287,  0,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,
      , (40287,  7,  4,  0,    0,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (40287,  8,  4, 50,  0.4,  450,  405,  270,  495,  360,  248,  450,  360,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (40287,  2074,   2.02)  /* Gossamer Flesh */
-     , (40287,  2136,   2.02)  /* Icy Torment */
-     , (40287,  2168,   2.02)  /* Gelidite's Gift */;
-
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (40287, 2, 48633,  1, 0, 0, False) /* Create Glacial Blade (48633) for Wield */
-     , (40287, 2, 48630,  1, 0, 0, False) /* Create Frozen Dagger (48630) for Wield */
-     , (40287, 2, 48631,  1, 0, 0, False) /* Create Ice Shard (48631) for Wield */
-     , (40287, 2, 48632,  1, 0, 0, False) /* Create Tursh's Spear (48632) for Wield */
-     , (40287, 2, 48629,  1, 0, 0, False) /* Create Icy Club (48629) for Wield */
-     , (40287, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
+VALUES (40287, 9, 41979,  1, 0, 0.02, False) /* Create Shattered Mana Forge Key (41979) for ContainTreasure */
      , (40287, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
      , (40287, 9, 34277,  1, 0, 0.02, False) /* Create Ancient Falatacot Trinket (34277) for ContainTreasure */
-     , (40287, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (40287, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (40287, 10, 48633,  1, 0, 0.2, False) /* Create Glacial Blade (48633) for WieldTreasure */
+     , (40287, 10, 48630,  1, 0, 0.2, False) /* Create Frozen Dagger (48630) for WieldTreasure */
+     , (40287, 10, 48631,  1, 0, 0.2, False) /* Create Ice Shard (48631) for WieldTreasure */
+     , (40287, 10, 48632,  1, 0, 0.2, False) /* Create Frigid Splinter (48632) for WieldTreasure */
+     , (40287, 10, 48629,  1, 0, 0.2, False) /* Create Icy Club (48629) for WieldTreasure */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (40287,  44, 0, 2, 0, 430, 0, 0) /* HeavyWeapons */
+     , (40287,  45, 0, 2, 0, 430, 0, 0) /* LightWeapons */
+     , (40287,  46, 0, 2, 0, 466, 0, 0) /* FinesseWeapons */
+     , (40287,  47, 0, 2, 0, 196, 0, 0) /* MissileWeapons */
+     , (40287,   6, 0, 2, 0, 456, 0, 0) /* MeleeDefense */
+     , (40287,   7, 0, 2, 0, 500, 0, 0) /* MissileDefense */
+     , (40287,  15, 0, 2, 0, 400, 0, 0) /* MagicDefense */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/48630 Frozen Dagger.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/48630 Frozen Dagger.sql
@@ -1,0 +1,43 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48630;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48630, 'ace48630-frozendagger', 6, '2019-02-10 00:00:00') /* MeleeWeapon */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48630,   1,          1) /* ItemType - MeleeWeapon */
+     , (48630,   5,        135) /* EncumbranceVal */
+     , (48630,   8,         90) /* Mass */
+     , (48630,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (48630,  16,          1) /* ItemUseable - No */
+     , (48630,  19,         40) /* Value */
+     , (48630,  33,         -2) /* Bonded - Destroy */
+     , (48630,  44,        195) /* Damage */
+     , (48630,  45,          8) /* DamageType - Cold */
+     , (48630,  46,          2) /* DefaultCombatStyle - OneHanded */
+     , (48630,  47,          6) /* AttackType - Thrust, Slash */
+     , (48630,  48,         46) /* WeaponSkill - FinesseWeapons */
+     , (48630,  49,         20) /* WeaponTime */
+     , (48630,  51,          1) /* CombatUse - Melee */
+     , (48630,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48630, 150,        103) /* HookPlacement - Hook */
+     , (48630, 151,          2) /* HookType - Wall */
+     , (48630, 353,          6) /* WeaponType - Dagger */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48630,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48630,  21,     0.5) /* WeaponLength */
+     , (48630,  22,     0.5) /* DamageVariance */
+     , (48630,  29,       1) /* WeaponDefense */
+     , (48630,  62,       1) /* WeaponOffense */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48630,   1, 'Frozen Dagger') /* Name */
+     , (48630,  16, 'The dagger glistens with destruction as if mirroring the will of the wielder.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48630,   1, 0x02001344) /* Setup */
+     , (48630,   3, 0x20000014) /* SoundTable */
+     , (48630,   8, 0x06005AF3) /* Icon */
+     , (48630,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/48632 Frigid Splinter.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/48632 Frigid Splinter.sql
@@ -1,48 +1,44 @@
 DELETE FROM `weenie` WHERE `class_Id` = 48632;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (48632, 'ace48632-turshsspear', 6, '2021-11-01 00:00:00') /* MeleeWeapon */;
+VALUES (48632, 'ace48632-frigidsplinter', 6, '2019-02-10 00:00:00') /* MeleeWeapon */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (48632,   1,          1) /* ItemType - MeleeWeapon */
      , (48632,   5,        700) /* EncumbranceVal */
+     , (48632,   8,        140) /* Mass */
      , (48632,   9,    1048576) /* ValidLocations - MeleeWeapon */
      , (48632,  16,          1) /* ItemUseable - No */
-     , (48632,  18,       2048) /* UiEffects - Piercing */
+     , (48632,  19,        170) /* Value */
      , (48632,  33,         -2) /* Bonded - Destroy */
-     , (48632,  37,        500) /* ResistItemAppraisal */
-     , (48632,  44,         90) /* Damage */
-     , (48632,  45,          2) /* DamageType - Pierce */
+     , (48632,  44,        195) /* Damage */
+     , (48632,  45,          8) /* DamageType - Cold */
      , (48632,  46,          2) /* DefaultCombatStyle - OneHanded */
-     , (48632,  47,          2) /* AttackType - Thrust */
+     , (48632,  47,          6) /* AttackType - Thrust, Slash */
      , (48632,  48,         45) /* WeaponSkill - LightWeapons */
-     , (48632,  49,         -1) /* WeaponTime */
+     , (48632,  49,         30) /* WeaponTime */
      , (48632,  51,          1) /* CombatUse - Melee */
      , (48632,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (48632, 151,          2) /* HookType - Wall */
      , (48632, 353,          5) /* WeaponType - Spear */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
-VALUES (48632,  13, True ) /* Ethereal */
-     , (48632,  19, True ) /* Attackable */
-     , (48632,  22, True ) /* Inscribable */;
+VALUES (48632,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (48632,  21,       2) /* WeaponLength */
-     , (48632,  22,    0.65) /* DamageVariance */
+VALUES (48632,  21,       0) /* WeaponLength */
+     , (48632,  22,     0.5) /* DamageVariance */
+     , (48632,  26,       0) /* MaximumVelocity */
      , (48632,  29,       1) /* WeaponDefense */
      , (48632,  62,       1) /* WeaponOffense */
      , (48632,  63,       1) /* DamageMod */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (48632,   1, 'Tursh''s Spear') /* Name */;
+VALUES (48632,   1, 'Frigid Splinter') /* Name */
+     , (48632,  16, 'The spear glistens with destruction as if mirroring the will of the wielder.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (48632,   1, 0x02001308) /* Setup */
      , (48632,   3, 0x20000014) /* SoundTable */
      , (48632,   8, 0x06005AEE) /* Icon */
      , (48632,  22, 0x3400002B) /* PhysicsEffectTable */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (48632,  2096,    2.1)  /* Aura of Infected Caress */
-     , (48632,  2116,    2.1)  /* Aura of Atlan's Alacrity */
-     , (48632,  2184,    2.1)  /* Hydra's Head */;

--- a/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/48631 Ice Shard.sql
+++ b/Database/Patches/9 WeenieDefaults/Missile/MissileWeapon/48631 Ice Shard.sql
@@ -1,0 +1,51 @@
+DELETE FROM `weenie` WHERE `class_Id` = 48631;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (48631, 'ace48631-iceshard', 4, '2019-02-10 00:00:00') /* Missile */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (48631,   1,        256) /* ItemType - MissileWeapon */
+     , (48631,   5,         15) /* EncumbranceVal */
+     , (48631,   8,          8) /* Mass */
+     , (48631,   9,    4194304) /* ValidLocations - MissileWeapon */
+     , (48631,  11,        100) /* MaxStackSize */
+     , (48631,  12,          1) /* StackSize */
+     , (48631,  13,         15) /* StackUnitEncumbrance */
+     , (48631,  14,          8) /* StackUnitMass */
+     , (48631,  15,          4) /* StackUnitValue */
+     , (48631,  16,          1) /* ItemUseable - No */
+     , (48631,  19,          4) /* Value */
+     , (48631,  33,         -2) /* Bonded - Destroy */
+     , (48631,  44,        195) /* Damage */
+     , (48631,  45,          8) /* DamageType - Cold */
+     , (48631,  46,        128) /* DefaultCombatStyle - ThrownWeapon */
+     , (48631,  48,         47) /* WeaponSkill - MissileWeapons */
+     , (48631,  49,         15) /* WeaponTime */
+     , (48631,  51,          2) /* CombatUse - Missile */
+     , (48631,  93,     132116) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, Inelastic */
+     , (48631, 150,        103) /* HookPlacement - Hook */
+     , (48631, 151,          2) /* HookType - Wall */
+     , (48631, 353,         10) /* WeaponType - Thrown */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (48631,  17, True ) /* Inelastic */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (48631,  21,       0) /* WeaponLength */
+     , (48631,  22,     0.5) /* DamageVariance */
+     , (48631,  26,    27.2) /* MaximumVelocity */
+     , (48631,  29,       1) /* WeaponDefense */
+     , (48631,  62,       1) /* WeaponOffense */
+     , (48631,  63,       1) /* DamageMod */
+     , (48631,  78,       1) /* Friction */
+     , (48631,  79,       0) /* Elasticity */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (48631,   1, 'Ice Shard') /* Name */
+     , (48631,  16, 'A shard of ice, forged to steel-like density by the Ruschk.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (48631,   1, 0x02001341) /* Setup */
+     , (48631,   3, 0x20000014) /* SoundTable */
+     , (48631,   8, 0x06005A14) /* Icon */
+     , (48631,  22, 0x3400002B) /* PhysicsEffectTable */;


### PR DESCRIPTION
Revises skills (based on pcap skill estimates) and resistances (based on available video) of Dark Isle creatures. In general, their magic skills were too high. In some cases, melee and missile were too low. 

Adds missing shadow types (those that look like a viamontian and a royal knight).

Corrects weapon profiles for ruschk, and adds missing weapons. 