### PR TITLE
Stormwood Staff Spell Fix

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/53314 Stormwood Staff.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/53314 Stormwood Staff.sql
@@ -59,5 +59,5 @@ VALUES (53314,  4395,      2)  /* Aura of Incantation of Blood Drinker Self */
      , (53314,  4400,      2)  /* Aura of Incantation of Defender Self */
      , (53314,  4405,      2)  /* Aura of Incantation of Heart Seeker Self */
      , (53314,  4417,      2)  /* Aura of Incantation of Swift Killer Self */
-     , (53314,  4624,      2)  /* Incantation of Heavy Weapon Mastery Self */
+     , (53314,  4518,      2)  /* Incantation of Light Weapon Mastery Self */
      , (53314,  6043,      2)  /* Legendary Light Weapon Aptitude */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/72005 Stormwood Staff.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/72005 Stormwood Staff.sql
@@ -61,6 +61,6 @@ VALUES (72005,  4395,      2)  /* Aura of Incantation of Blood Drinker Self */
      , (72005,  4400,      2)  /* Aura of Incantation of Defender Self */
      , (72005,  4405,      2)  /* Aura of Incantation of Heart Seeker Self */
      , (72005,  4417,      2)  /* Aura of Incantation of Swift Killer Self */
-     , (72005,  4624,      2)  /* Incantation of Heavy Weapon Mastery Self */
+     , (72005,  4518,      2)  /* Incantation of Light Weapon Mastery Self */
      , (72005,  6043,      2)  /* Legendary Light Weapon Aptitude */
      , (72005,  6089,      2)  /* Legendary Blood Thirst */;


### PR DESCRIPTION
Changes stormwood staves to cast LW Mastery 8 instead of HW Mastery 8 (as PCAPed for 53314)