### PR TITLE
Fix spells on Seasoned Explorer Nether Staff

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/45956 Seasoned Explorer Nether Staff.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/45956 Seasoned Explorer Nether Staff.sql
@@ -55,4 +55,4 @@ VALUES (45956,  2560,      2)  /* Minor Mana Conversion Prowess */
      , (45956,  1605,      2)  /* Aura of Defender Self VI */
      , (45956,   664,      2)  /* Mana Conversion Mastery Other VI */
      , (45956,  5427,      2)  /* Minor Void Magic Aptitude */
-     , (45956,  2158,      2)  /* Storm's Boon */;
+     , (45956,  3258,      2)  /* Aura of Spirit Drinker Self VI */;


### PR DESCRIPTION
Changes Storm's Boon to Aura of Spirit Drinker Self VI on Seasoned Explorer Nether Staff to match PCAP.