### PR TITLE
Fix Spectral Blade and Claws Contract

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/46749 Contract for Kill_ Spectral Blades and Claws.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/46749 Contract for Kill_ Spectral Blades and Claws.sql
@@ -18,7 +18,7 @@ VALUES (46749,   1,       2048) /* ItemType - Gem */
      , (46749,  94,         16) /* TargetType - Creature */
      , (46749, 114,          1) /* Attuned - Attuned */
      , (46749, 280,        100) /* SharedCooldown */
-     , (46749, 349,        236) /* UseCreatesContractId - Contract_236_Kill__Spectral_Archers */;
+     , (46749, 349,        242) /* UseCreatesContractId - Contract_242_Kill__Spectral_Blades_and_Claws */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (46749,   1, False) /* Stuck */


### PR DESCRIPTION
Fixes the Kill: Spectral Blade and Claws contract to point to the right contract (242) instead of the Archers one (236).