### PR TITLE
Fix Red Rune Silveran Mace TurnIn

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Human/32992 Eddred the Wolf.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/32992 Eddred the Wolf.sql
@@ -284,7 +284,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'WeaponTrading', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (32992,  6 /* Give */,      1, 87534 /* Binding Realm */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (32992,  6 /* Give */,      1, 87555 /* Red Rune Silveran Mace */, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/32992.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/32992.es
@@ -127,7 +127,7 @@ Give: 33126
 Give: 41083
     - Goto: WeaponTrading
     
-Give: 87534
+Give: 87555
     - Goto: WeaponTrading
     
 Gotoset: WhisperingBladeToken

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/33015 Meerana du Renari.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/33015 Meerana du Renari.sql
@@ -287,7 +287,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'WeaponTrading', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (33015,  6 /* Give */,      1, 87534 /* Binding Realm */, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (33015,  6 /* Give */,      1, 87555 /* Red Rune Silveran Mace */, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/33015.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/33015.es
@@ -130,7 +130,7 @@ Give: 33126
 Give: 41083
     - Goto: WeaponTrading
     
-Give: 87534
+Give: 87555
     - Goto: WeaponTrading
     
 Gotoset: RossuMortaToken


### PR DESCRIPTION
Fixes the red rune silveran weapon turn-in to accept the mace instead of the Binding Realm portal.