### PR TITLE
Fix Apostate Finale portal restrictions

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/70346 Scintillating Apostate Nexus.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/70346 Scintillating Apostate Nexus.sql
@@ -7,9 +7,9 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (70346,   1,      65536) /* ItemType - Portal */
      , (70346,   3,         21) /* PaletteTemplate - Gold */
      , (70346,  16,         32) /* ItemUseable - Remote */
-     , (70346,  86,        150) /* MinLevel */
+     , (70346,  86,        120) /* MinLevel */
      , (70346,  93,       2052) /* PhysicsState - Ethereal, LightingOn */
-     , (70346, 111,          1) /* PortalBitmask - Unrestricted */
+     , (70346, 111,         49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
      , (70346, 133,          4) /* ShowableOnRadar - ShowAlways */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/70347 Shimmering Apostate Nexus.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/70347 Shimmering Apostate Nexus.sql
@@ -7,9 +7,9 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (70347,   1,      65536) /* ItemType - Portal */
      , (70347,   3,         21) /* PaletteTemplate - Gold */
      , (70347,  16,         32) /* ItemUseable - Remote */
-     , (70347,  86,        150) /* MinLevel */
+     , (70347,  86,        120) /* MinLevel */
      , (70347,  93,       2052) /* PhysicsState - Ethereal, LightingOn */
-     , (70347, 111,          1) /* PortalBitmask - Unrestricted */
+     , (70347, 111,         49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
      , (70347, 133,          4) /* ShowableOnRadar - ShowAlways */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/70380 Heart of the Apostate Nexi.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/70380 Heart of the Apostate Nexi.sql
@@ -7,9 +7,9 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (70380,   1,      65536) /* ItemType - Portal */
      , (70380,   3,         21) /* PaletteTemplate - Gold */
      , (70380,  16,         32) /* ItemUseable - Remote */
-     , (70380,  86,        150) /* MinLevel */
+     , (70380,  86,        120) /* MinLevel */
      , (70380,  93,       2052) /* PhysicsState - Ethereal, LightingOn */
-     , (70380, 111,          1) /* PortalBitmask - Unrestricted */
+     , (70380, 111,         49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
      , (70380, 133,          4) /* ShowableOnRadar - ShowAlways */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)


### PR DESCRIPTION
Correction for the summoned portals on the Apostate Finale quest taken from PCAP 
PCAP Part 1\AC1Live-The-Ripley-Collection-part01\AC1Live-The-Ripley-Collection\aclog pcaps\pkt_2017-1-28_1485659343_log.pcap 
Namely changes PORTAL_BITMASK_INT to 49 (no summon/recall) and MIN_LEVEL_INT to 120. I don't know why the min level is 120 since the first portal in the chain is 150+, but that's what the PCAP says so that's what it is I guess.