### PR TITLE
Remove Swarm Demon Life Immunity

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Olthoi/35151 Swarm Demon.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Olthoi/35151 Swarm Demon.sql
@@ -21,8 +21,7 @@ INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (35151,   1, True ) /* Stuck */
      , (35151,  12, True ) /* ReportCollisions */
      , (35151,  14, True ) /* GravityStatus */
-     , (35151,  19, True ) /* Attackable */
-     , (35151, 103, True ) /* NonProjectileMagicImmune */;
+     , (35151,  19, True ) /* Attackable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35151,   1,       5) /* HeartbeatInterval */


### PR DESCRIPTION
Removes the NonProjectileMagicImmune property from Swarm Demons based off retail video https://youtu.be/6aSxe8gFhAM?t=2113