### PR TITLE
Fix GY colo timers

### DIFF
--- a/Database/Patches/8 QuestDefDB/GYColoRewardGiverInProgress.sql
+++ b/Database/Patches/8 QuestDefDB/GYColoRewardGiverInProgress.sql
@@ -1,4 +1,4 @@
 DELETE FROM `quest` WHERE `name` = 'GYColoRewardGiverInProgress';
 
 INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('GYColoRewardGiverInProgress', 300, -1, 'Shade of Lord Cynreft Spawned', '2021-11-01 00:00:00');
+VALUES ('GYColoRewardGiverInProgress', 175, -1, 'Shade of Lord Cynreft Spawned', '2021-11-01 00:00:00');

--- a/Database/Patches/8 QuestDefDB/GYColoWinRewardReceived.sql
+++ b/Database/Patches/8 QuestDefDB/GYColoWinRewardReceived.sql
@@ -1,4 +1,4 @@
 DELETE FROM `quest` WHERE `name` = 'GYColoWinRewardReceived';
 
 INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
-VALUES ('GYColoWinRewardReceived', 300, -1, 'Received Reward from GY Colo', '2021-11-01 00:00:00');
+VALUES ('GYColoWinRewardReceived', 190, -1, 'Received Reward from GY Colo', '2021-11-01 00:00:00');


### PR DESCRIPTION
Lowers the timer of the reward NPC (wcid 35401) on GY colo from 5 to 3 minutes based off PCAPs: 
PCAP Part 1\Callaway-1-25-2017-RadiantManaInfusion-GraveyardCol\pkt_2017-1-25_1485399800_log.pcap 
PCAP Part 1\Callaway-01-10-2017-MountLetheGraveyard\pkt_2017-1-9_1484006624_log.pcap 
PCAP Part 1\CatDevnull-01-30-2017-GY-Colo\pkt_2017-1-30_1485831256_log.pcap 

Offsets the NPC duration by 5 seconds to (mostly) account for the heartbeat interval used to despawn it. Also offsets the quest timer to fix an exploit where a player could get rewarded at the beginning of the NPC's duration and again at the end due to delay-induced overlap in the timers (which was the reason I looked into this in the first place).