### PR TITLE
Fix Swamp Cavern gen

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Generic/None/87321 Putrid Moar Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87321 Putrid Moar Generator.sql
@@ -25,5 +25,5 @@ VALUES (87321,   1, 0x0200026B) /* Setup */
      , (87321,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87321, 0.03, 87319, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spiketooth (87319) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87321, 0.97, 87318, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Putrid Moar (87318) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87321, 0.03, 87319, 0, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Spiketooth (87319) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87321, 0.97, 87318, 0, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Putrid Moar (87318) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;


### PR DESCRIPTION
Putrid moar generator has a 900 delay and 300 regen interval, causing all moars to respawn as the rare Spiketooth spawn. A bit humorous, but probably not intended (or accurate). 