### PR TITLE
hosh infiltration portal fix

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/46590 Great Hall.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/46590 Great Hall.sql
@@ -7,6 +7,7 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46590,   1,      65536) /* ItemType - Portal */
      , (46590,  16,         32) /* ItemUseable - Remote */
      , (46590,  93,       1036) /* PhysicsState - Ethereal, ReportCollisions, Gravity */
+	 , (46590, 111,         49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
      , (46590, 133,          4) /* ShowableOnRadar - ShowAlways */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)


### PR DESCRIPTION
currently when you go thru the great hall portal you are able to recall. which allows you skip half the quest.