### PR TITLE
Fix Littoral Siraluun Hoeroa for MOA

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/29912 Littoral Siraluun Hoeroa.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/29912 Littoral Siraluun Hoeroa.sql
@@ -56,6 +56,6 @@ VALUES (29912,   1, 0x02001242) /* Setup */
      , (29912,  37,         10) /* ItemSkillLimit - Staff */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (29912,   390,      2)  /* Light Weapon Mastery Other III */
+VALUES (29912,   414,      2)  /* Heavy Weapon Mastery Other III */
      , (29912,  1589,      2)  /* Aura of Heart Seeker Self III */
      , (29912,  1613,      2)  /* Aura of Blood Drinker Self III */;


### PR DESCRIPTION
Update spell from staff mastery (LW) to HW to match weapon type