### PR TITLE
Prismatic Armor Fixes

### DIFF
--- a/Database/Patches/4 CraftTable/07767 Decanter of Essence of Verdancy.sql
+++ b/Database/Patches/4 CraftTable/07767 Decanter of Essence of Verdancy.sql
@@ -6,4 +6,4 @@ VALUES (7767, 0, 0, 0, 0, 70988 /* Decanter of Essence of Verdancy */, 1, 'The C
 DELETE FROM `cook_book` WHERE `recipe_Id` = 7767;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (7767, 19483 /* Decanter of Essence */, 32748 /* Crystallized Essence of Verdancy */, '2021-11-01 00:00:00');
+VALUES (7767, 19482 /* Enchanted Decanter */, 32748 /* Crystallized Essence of Verdancy */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/07768 Decanter of Essence of Artifice.sql
+++ b/Database/Patches/4 CraftTable/07768 Decanter of Essence of Artifice.sql
@@ -6,4 +6,4 @@ VALUES (7768, 0, 0, 0, 0, 32730 /* Decanter of Essence of Artifice */, 1, 'The C
 DELETE FROM `cook_book` WHERE `recipe_Id` = 7768;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (7768, 19483 /* Decanter of Essence */, 32747 /* Crystallized Essence of Artifice */, '2021-11-01 00:00:00');
+VALUES (7768, 19482 /* Enchanted Decanter */, 32747 /* Crystallized Essence of Artifice */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/07769 Decanter of Essence of Enchantment.sql
+++ b/Database/Patches/4 CraftTable/07769 Decanter of Essence of Enchantment.sql
@@ -6,4 +6,4 @@ VALUES (7769, 0, 0, 0, 0, 32729 /* Decanter of Essence of Enchantment */, 1, 'Th
 DELETE FROM `cook_book` WHERE `recipe_Id` = 7769;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (7769, 19483 /* Decanter of Essence */, 32746 /* Crystallized Essence of Enchantment */, '2021-11-01 00:00:00');
+VALUES (7769, 19482 /* Enchanted Decanter */, 32746 /* Crystallized Essence of Enchantment */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/07770 Decanter of Essence of Strife.sql
+++ b/Database/Patches/4 CraftTable/07770 Decanter of Essence of Strife.sql
@@ -6,4 +6,4 @@ VALUES (7770, 0, 0, 0, 0, 32732 /* Decanter of Essence of Strife */, 1, 'The Cry
 DELETE FROM `cook_book` WHERE `recipe_Id` = 7770;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (7770, 19483 /* Decanter of Essence */, 32749 /* Crystallized Essence of Strife */, '2021-11-01 00:00:00');
+VALUES (7770, 19482 /* Enchanted Decanter */, 32749 /* Crystallized Essence of Strife */, '2021-11-01 00:00:00');

--- a/Database/Patches/9 WeenieDefaults/CraftTool/CraftAlchemyIntermediate/19482 Enchanted Decanter.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/CraftAlchemyIntermediate/19482 Enchanted Decanter.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 19482;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (19482, 'decanterenchanted', 44, '2005-02-09 10:00:00') /* CraftTool */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (19482,   1,   67108864) /* ItemType - CraftAlchemyIntermediate */
+     , (19482,   3,         82) /* PaletteTemplate - PinkPurple */
+     , (19482,   5,        150) /* EncumbranceVal */
+     , (19482,   8,         50) /* Mass */
+     , (19482,   9,          0) /* ValidLocations - None */
+     , (19482,  11,          1) /* MaxStackSize */
+     , (19482,  12,          1) /* StackSize */
+     , (19482,  13,        150) /* StackUnitEncumbrance */
+     , (19482,  14,         50) /* StackUnitMass */
+     , (19482,  15,          0) /* StackUnitValue */
+     , (19482,  16,    2097160) /* ItemUseable - SourceContainedTargetRemote */
+     , (19482,  19,          0) /* Value */
+     , (19482,  33,          1) /* Bonded - Bonded */
+     , (19482,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (19482,  94,       2176) /* TargetType - Misc, Gem */
+     , (19482, 114,          1) /* Attuned - Attuned */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (19482,  22, True ) /* Inscribable */
+     , (19482,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (19482,   1, 'Enchanted Decanter') /* Name */
+     , (19482,  14, 'This item can be used in crafting. Use this item on a source of pure mana to harvest the fluid.') /* Use */
+     , (19482,  15, 'An empty decanter, that shimmers in the light.') /* ShortDesc */
+     , (19482,  16, 'An empty decanter, that shimmers in the light.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (19482,   1, 0x020005FD) /* Setup */
+     , (19482,   3, 0x20000014) /* SoundTable */
+     , (19482,   6, 0x04000BEF) /* PaletteBase */
+     , (19482,   7, 0x10000166) /* ClothingBase */
+     , (19482,   8, 0x060025C9) /* Icon */
+     , (19482,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32746 Crystallized Essence of Enchantment.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32746 Crystallized Essence of Enchantment.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 32746;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (32746, 'ace32746-crystallizedessenceofenchantment', 1, '2021-11-01 00:00:00') /* Generic */;
+VALUES (32746, 'ace32746-crystallizedessenceofenchantment', 38, '2019-02-10 00:00:00') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32746,   1,       2048) /* ItemType - Gem */

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32747 Crystallized Essence of Artifice.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32747 Crystallized Essence of Artifice.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 32747;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (32747, 'ace32747-crystallizedessenceofartifice', 1, '2021-11-01 00:00:00') /* Generic */;
+VALUES (32747, 'ace32747-crystallizedessenceofartifice', 38, '2019-02-10 00:00:00') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32747,   1,       2048) /* ItemType - Gem */

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32748 Crystallized Essence of Verdancy.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32748 Crystallized Essence of Verdancy.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 32748;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (32748, 'ace32748-crystallizedessenceofverdancy', 1, '2021-11-01 00:00:00') /* Generic */;
+VALUES (32748, 'ace32748-crystallizedessenceofverdancy', 38, '2019-02-10 00:00:00') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32748,   1,       2048) /* ItemType - Gem */

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32749 Crystallized Essence of Strife.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32749 Crystallized Essence of Strife.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 32749;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (32749, 'ace32749-crystallizedessenceofstrife', 1, '2021-11-01 00:00:00') /* Generic */;
+VALUES (32749, 'ace32749-crystallizedessenceofstrife', 38, '2019-02-10 00:00:00') /* Gem */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32749,   1,       2048) /* ItemType - Gem */


### PR DESCRIPTION
The quest now correctly uses the empty Enchanted Decanters (19482) from the Arcanum Research Facility. 

Corrects properties on decanter and crystallized essence to match pcap and allow for crafting interaction.