### PR TITLE
Add ProcSpellRate to Clubs of Cunning

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/37402 Club of Surprising Cunning.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/37402 Club of Surprising Cunning.sql
@@ -44,7 +44,8 @@ VALUES (37402,   5,  -0.033) /* ManaRate */
      , (37402,  62,     1.1) /* WeaponOffense */
      , (37402,  63,       1) /* DamageMod */
      , (37402, 136,     1.2) /* CriticalMultiplier */
-     , (37402, 147,    0.28) /* CriticalFrequency */;
+     , (37402, 147,    0.28) /* CriticalFrequency */
+     , (37402, 156,    0.05) /* ProcSpellRate */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37402,   1, 'Club of Surprising Cunning') /* Name */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/87477 Club of Remarkable Cunning.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/87477 Club of Remarkable Cunning.sql
@@ -44,7 +44,8 @@ VALUES (87477,   5,  -0.033) /* ManaRate */
      , (87477,  62,    1.15) /* WeaponOffense */
      , (87477,  63,       1) /* DamageMod */
      , (87477, 136,    1.24) /* CriticalMultiplier */
-     , (87477, 147,    0.31) /* CriticalFrequency */;
+     , (87477, 147,    0.31) /* CriticalFrequency */
+     , (87477, 156,     0.1) /* ProcSpellRate */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (87477,   1, 'Club of Remarkable Cunning') /* Name */


### PR DESCRIPTION
Adds missing ProcSpellRate to clubs of cunning. Rates themselves are admittedly asspulls, just based them off the ones for Princely/Royal Runed weapons. 