### PR TITLE
Update Nexus

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/0110.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0110.sql
@@ -49,63 +49,63 @@ VALUES (0x70110015,  2131, 0x01100133, 43, -133, -65.995, 1, 0, 0, 0,  True, '20
 /* @teleloc 0x01100133 [43.000000 -133.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110019,  4065, 0x01100192, 40, -130.016, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110019,  24170, 0x01100192, 40, -130.016, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [40.000000 -130.016006 -44.893299] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110019, 0x7011000D, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001A,  4065, 0x01100192, 40.034, -129.345, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011001A,  24170, 0x01100192, 40.034, -129.345, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [40.034000 -129.345001 -44.893299] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011001A, 0x7011000F, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001B,  4065, 0x01100192, 39.9759, -130.588, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011001B,  24170, 0x01100192, 39.9759, -130.588, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [39.975899 -130.587997 -44.893299] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011001B, 0x7011000E, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001C,  4065, 0x01100192, 39.29, -129.963, -44.8933, 0.998344, 0, 0, 0.057524, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011001C,  24170, 0x01100192, 39.29, -129.963, -44.8933, 0.998344, 0, 0, 0.057524, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [39.290001 -129.962997 -44.893299] 0.998344 0.000000 0.000000 0.057524 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011001C, 0x70110011, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001D,  4065, 0x01100192, 40.7154, -129.94, -44.8933, 0.772458, 0, 0, -0.635065, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011001D,  24170, 0x01100192, 40.7154, -129.94, -44.8933, 0.772458, 0, 0, -0.635065, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [40.715401 -129.940002 -44.893299] 0.772458 0.000000 0.000000 -0.635065 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011001D, 0x70110010, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001E,  4065, 0x01100192, 39.5244, -129.596, -44.8988, -0.950789, 0, 0, -0.309839, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011001E,  24170, 0x01100192, 39.5244, -129.596, -44.8988, -0.950789, 0, 0, -0.309839, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [39.524399 -129.595993 -44.898800] -0.950789 0.000000 0.000000 -0.309839 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011001E, 0x70110012, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001F,  4065, 0x01100192, 40.4433, -129.546, -44.9122, -0.95998, 0, 0, 0.280069, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011001F,  24170, 0x01100192, 40.4433, -129.546, -44.9122, -0.95998, 0, 0, 0.280069, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [40.443298 -129.546005 -44.912201] -0.959980 0.000000 0.000000 0.280069 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011001F, 0x70110013, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110020,  4065, 0x01100192, 39.4785, -130.359, -44.8854, -0.919601, 0, 0, 0.392854, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110020,  24170, 0x01100192, 39.4785, -130.359, -44.8854, -0.919601, 0, 0, 0.392854, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [39.478500 -130.358994 -44.885399] -0.919601 0.000000 0.000000 0.392854 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110020, 0x70110014, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110021,  4065, 0x01100192, 40.4672, -130.328, -44.9122, -0.663864, 0, 0, 0.747854, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110021,  24170, 0x01100192, 40.4672, -130.328, -44.9122, -0.663864, 0, 0, 0.747854, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100192 [40.467201 -130.328003 -44.912201] -0.663864 0.000000 0.000000 0.747854 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -148,63 +148,63 @@ VALUES (0x7011002B,  2131, 0x011001BD, 43, -133, -35.995, 1, 0, 0, 0,  True, '20
 /* @teleloc 0x011001BD [43.000000 -133.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110036,  4065, 0x01100215, 39.2522, -130.101, -17.9178, 0.999834, 0, 0, -0.01822, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110036,  24170, 0x01100215, 39.2522, -130.101, -17.9178, 0.999834, 0, 0, -0.01822, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [39.252201 -130.100998 -17.917801] 0.999834 0.000000 0.000000 -0.018220 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110036, 0x70110027, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110037,  4065, 0x01100215, 39.8198, -130.915, -17.9177, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110037,  24170, 0x01100215, 39.8198, -130.915, -17.9177, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [39.819801 -130.914993 -17.917700] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110037, 0x70110024, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110038,  4065, 0x01100215, 39.9794, -130.222, -17.8642, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110038,  24170, 0x01100215, 39.9794, -130.222, -17.8642, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [39.979401 -130.222000 -17.864201] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110038, 0x70110023, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110039,  4065, 0x01100215, 40.0704, -129.438, -17.8509, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110039,  24170, 0x01100215, 40.0704, -129.438, -17.8509, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [40.070400 -129.438004 -17.850901] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110039, 0x70110025, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003A,  4065, 0x01100215, 40.6287, -130.139, -17.8117, 0.999834, 0, 0, -0.01822, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011003A,  24170, 0x01100215, 40.6287, -130.139, -17.8117, 0.999834, 0, 0, -0.01822, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [40.628700 -130.139008 -17.811701] 0.999834 0.000000 0.000000 -0.018220 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011003A, 0x70110026, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003B,  4065, 0x01100215, 39.5626, -129.621, -17.927, -0.964117, 0, 0, -0.265476, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011003B,  24170, 0x01100215, 39.5626, -129.621, -17.927, -0.964117, 0, 0, -0.265476, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [39.562599 -129.621002 -17.927000] -0.964117 0.000000 0.000000 -0.265476 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011003B, 0x7011002A, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003C,  4065, 0x01100215, 40.5074, -129.705, -17.8468, -0.501663, 0, 0, 0.865063, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011003C,  24170, 0x01100215, 40.5074, -129.705, -17.8468, -0.501663, 0, 0, 0.865063, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [40.507401 -129.705002 -17.846800] -0.501663 0.000000 0.000000 0.865063 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011003C, 0x70110028, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003D,  4065, 0x01100215, 40.4308, -130.656, -17.9003, 0.542407, 0, 0, 0.840116, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011003D,  24170, 0x01100215, 40.4308, -130.656, -17.9003, 0.542407, 0, 0, 0.840116, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [40.430801 -130.656006 -17.900299] 0.542407 0.000000 0.000000 0.840116 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011003D, 0x70110029, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003E,  4065, 0x01100215, 39.4119, -130.618, -17.8334, 0.762212, 0, 0, 0.647327, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011003E,  24170, 0x01100215, 39.4119, -130.618, -17.8334, 0.762212, 0, 0, 0.647327, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100215 [39.411900 -130.617996 -17.833401] 0.762212 0.000000 0.000000 0.647327 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -251,63 +251,63 @@ VALUES (0x7011004F,  2131, 0x01100268, 43, -133, -5.995, 1, 0, 0, 0,  True, '200
 /* @teleloc 0x01100268 [43.000000 -133.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110053,  4065, 0x01100284, 39.5402, -129.845, 9.59375, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110053,  24170, 0x01100284, 39.5402, -129.845, 9.59375, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [39.540199 -129.845001 9.593750] 0.999999 0.000000 0.000000 -0.001398 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110053, 0x70110047, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110054,  4065, 0x01100284, 40.8459, -129.942, 9.52688, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110054,  24170, 0x01100284, 40.8459, -129.942, 9.52688, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [40.845901 -129.942001 9.526880] 0.999999 0.000000 0.000000 -0.001398 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110054, 0x7011004A, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110055,  4065, 0x01100284, 40.1783, -129.271, 9.52688, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110055,  24170, 0x01100284, 40.1783, -129.271, 9.52688, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [40.178299 -129.270996 9.526880] 0.999999 0.000000 0.000000 -0.001398 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110055, 0x70110049, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110056,  4065, 0x01100284, 40.1067, -130.45, 9.567, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110056,  24170, 0x01100284, 40.1067, -130.45, 9.567, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [40.106701 -130.449997 9.567000] 0.999999 0.000000 0.000000 -0.001398 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110056, 0x70110048, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110057,  4065, 0x01100284, 40.148, -129.789, 9.62049, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110057,  24170, 0x01100284, 40.148, -129.789, 9.62049, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [40.147999 -129.789001 9.620490] 0.999999 0.000000 0.000000 -0.001398 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110057, 0x7011004B, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110058,  4065, 0x01100284, 39.6945, -129.489, 9.55944, 0.941437, 0, 0, 0.33719, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110058,  24170, 0x01100284, 39.6945, -129.489, 9.55944, 0.941437, 0, 0, 0.33719, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [39.694500 -129.488998 9.559440] 0.941437 0.000000 0.000000 0.337190 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110058, 0x7011004C, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110059,  4065, 0x01100284, 40.7073, -129.495, 9.62631, 0.904038, 0, 0, -0.427453, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x70110059,  24170, 0x01100284, 40.7073, -129.495, 9.62631, 0.904038, 0, 0, -0.427453, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [40.707298 -129.494995 9.626310] 0.904038 0.000000 0.000000 -0.427453 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x70110059, 0x7011004D, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011005A,  4065, 0x01100284, 39.6107, -130.237, 9.62632, 0.894133, 0, 0, -0.447801, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011005A,  24170, 0x01100284, 39.6107, -130.237, 9.62632, 0.894133, 0, 0, -0.447801, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [39.610699 -130.237000 9.626320] 0.894133 0.000000 0.000000 -0.447801 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7011005A, 0x7011004E, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011005B,  4065, 0x01100284, 40.5949, -130.257, 9.63969, 0.657206, 0, 0, -0.753711, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+VALUES (0x7011005B,  24170, 0x01100284, 40.5949, -130.257, 9.63969, 0.657206, 0, 0, -0.753711, False, '2005-02-09 10:00:00'); /* Lightning Trap */
 /* @teleloc 0x01100284 [40.594898 -130.257004 9.639690] 0.657206 0.000000 0.000000 -0.753711 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/0110.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0110.sql
@@ -1,308 +1,611 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x0110;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110000,  6796, 0x011002E2, 40, -270, 24.005, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Surface Portal */
-/* @teleloc 0x011002E2 [40.000000 -270.000000 24.004999] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x70110004,   278, 0x01100125, 40, -34.75, -66, 0, 0, 0, -1, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0x01100125 [40.000000 -34.750000 -66.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110001,   278, 0x011002C6, 40.01, -145, 24.005, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x011002C6 [40.009998 -145.000000 24.004999] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x70110008,   278, 0x01100129, 40, -74.75, -66, 0, 0, 0, -1, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0x01100129 [40.000000 -74.750000 -66.000000] 0.000000 0.000000 0.000000 -1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110002,   278, 0x011002DE, 40, -225, 24.005, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x011002DE [40.000000 -225.000000 24.004999] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x70110009,   278, 0x0110012C, 40, -95.25, -66, 1, 0, 0, 0, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0x0110012C [40.000000 -95.250000 -66.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110003,  3954, 0x011002DD, 40, -212.087, 24.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Item Gen (15 min.) */
-/* @teleloc 0x011002DD [40.000000 -212.087006 24.004999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x7011000D,  2131, 0x01100133, 40, -130, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [40.000000 -130.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011000E,  2131, 0x01100133, 40, -126.5, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [40.000000 -126.500000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011000F,  2131, 0x01100133, 40, -133.5, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [40.000000 -133.500000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110010,  2131, 0x01100133, 43, -130, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [43.000000 -130.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110011,  2131, 0x01100133, 37, -130, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [37.000000 -130.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110012,  2131, 0x01100133, 37, -127, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [37.000000 -127.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110013,  2131, 0x01100133, 43, -127, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [43.000000 -127.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110014,  2131, 0x01100133, 37, -133, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [37.000000 -133.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110015,  2131, 0x01100133, 43, -133, -65.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100133 [43.000000 -133.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110019,  4065, 0x01100192, 40, -130.016, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [40.000000 -130.016006 -44.893299] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x70110003, 0x70110004, '2021-11-01 00:00:00') /* Adventurer's warning (6812) */;
+VALUES (0x70110019, 0x7011000D, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110004,  6812, 0x011002E0, 37.3208, -239.608, 24.079, -0.982428, 0, 0, 0.186643,  True, '2021-11-01 00:00:00'); /* Adventurer's warning */
+VALUES (0x7011001A,  4065, 0x01100192, 40.034, -129.345, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [40.034000 -129.345001 -44.893299] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011001A, 0x7011000F, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011001B,  4065, 0x01100192, 39.9759, -130.588, -44.8933, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [39.975899 -130.587997 -44.893299] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011001B, 0x7011000E, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011001C,  4065, 0x01100192, 39.29, -129.963, -44.8933, 0.998344, 0, 0, 0.057524, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [39.290001 -129.962997 -44.893299] 0.998344 0.000000 0.000000 0.057524 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011001C, 0x70110011, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011001D,  4065, 0x01100192, 40.7154, -129.94, -44.8933, 0.772458, 0, 0, -0.635065, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [40.715401 -129.940002 -44.893299] 0.772458 0.000000 0.000000 -0.635065 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011001D, 0x70110010, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011001E,  4065, 0x01100192, 39.5244, -129.596, -44.8988, -0.950789, 0, 0, -0.309839, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [39.524399 -129.595993 -44.898800] -0.950789 0.000000 0.000000 -0.309839 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011001E, 0x70110012, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011001F,  4065, 0x01100192, 40.4433, -129.546, -44.9122, -0.95998, 0, 0, 0.280069, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [40.443298 -129.546005 -44.912201] -0.959980 0.000000 0.000000 0.280069 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011001F, 0x70110013, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110020,  4065, 0x01100192, 39.4785, -130.359, -44.8854, -0.919601, 0, 0, 0.392854, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [39.478500 -130.358994 -44.885399] -0.919601 0.000000 0.000000 0.392854 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110020, 0x70110014, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110021,  4065, 0x01100192, 40.4672, -130.328, -44.9122, -0.663864, 0, 0, 0.747854, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100192 [40.467201 -130.328003 -44.912201] -0.663864 0.000000 0.000000 0.747854 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110021, 0x70110015, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110023,  2131, 0x011001BD, 40, -130, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [40.000000 -130.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110024,  2131, 0x011001BD, 40, -127, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [40.000000 -127.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110025,  2131, 0x011001BD, 40, -133, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [40.000000 -133.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110026,  2131, 0x011001BD, 37, -130, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [37.000000 -130.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110027,  2131, 0x011001BD, 43, -130, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [43.000000 -130.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110028,  2131, 0x011001BD, 37, -127, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [37.000000 -127.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110029,  2131, 0x011001BD, 43, -127, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [43.000000 -127.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011002A,  2131, 0x011001BD, 37, -133, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [37.000000 -133.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011002B,  2131, 0x011001BD, 43, -133, -35.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011001BD [43.000000 -133.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110036,  4065, 0x01100215, 39.2522, -130.101, -17.9178, 0.999834, 0, 0, -0.01822, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [39.252201 -130.100998 -17.917801] 0.999834 0.000000 0.000000 -0.018220 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110036, 0x70110027, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110037,  4065, 0x01100215, 39.8198, -130.915, -17.9177, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [39.819801 -130.914993 -17.917700] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110037, 0x70110024, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110038,  4065, 0x01100215, 39.9794, -130.222, -17.8642, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [39.979401 -130.222000 -17.864201] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110038, 0x70110023, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110039,  4065, 0x01100215, 40.0704, -129.438, -17.8509, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [40.070400 -129.438004 -17.850901] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110039, 0x70110025, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011003A,  4065, 0x01100215, 40.6287, -130.139, -17.8117, 0.999834, 0, 0, -0.01822, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [40.628700 -130.139008 -17.811701] 0.999834 0.000000 0.000000 -0.018220 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011003A, 0x70110026, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011003B,  4065, 0x01100215, 39.5626, -129.621, -17.927, -0.964117, 0, 0, -0.265476, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [39.562599 -129.621002 -17.927000] -0.964117 0.000000 0.000000 -0.265476 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011003B, 0x7011002A, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011003C,  4065, 0x01100215, 40.5074, -129.705, -17.8468, -0.501663, 0, 0, 0.865063, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [40.507401 -129.705002 -17.846800] -0.501663 0.000000 0.000000 0.865063 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011003C, 0x70110028, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011003D,  4065, 0x01100215, 40.4308, -130.656, -17.9003, 0.542407, 0, 0, 0.840116, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [40.430801 -130.656006 -17.900299] 0.542407 0.000000 0.000000 0.840116 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011003D, 0x70110029, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011003E,  4065, 0x01100215, 39.4119, -130.618, -17.8334, 0.762212, 0, 0, 0.647327, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100215 [39.411900 -130.617996 -17.833401] 0.762212 0.000000 0.000000 0.647327 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011003E, 0x7011002B, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110044,  6796, 0x0110025F, 40, -30, -6.063, 1, 0, 0, 0, False, '2019-02-10 00:00:00'); /* Surface Portal */
+/* @teleloc 0x0110025F [40.000000 -30.000000 -6.063000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110047,  2131, 0x01100268, 40, -130, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [40.000000 -130.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110048,  2131, 0x01100268, 40, -127, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [40.000000 -127.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110049,  2131, 0x01100268, 40, -133, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [40.000000 -133.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011004A,  2131, 0x01100268, 37, -130, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [37.000000 -130.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011004B,  2131, 0x01100268, 43, -130, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [43.000000 -130.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011004C,  2131, 0x01100268, 37, -127, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [37.000000 -127.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011004D,  2131, 0x01100268, 43, -127, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [43.000000 -127.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011004E,  2131, 0x01100268, 37, -133, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [37.000000 -133.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011004F,  2131, 0x01100268, 43, -133, -5.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x01100268 [43.000000 -133.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110053,  4065, 0x01100284, 39.5402, -129.845, 9.59375, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [39.540199 -129.845001 9.593750] 0.999999 0.000000 0.000000 -0.001398 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110053, 0x70110047, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110054,  4065, 0x01100284, 40.8459, -129.942, 9.52688, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [40.845901 -129.942001 9.526880] 0.999999 0.000000 0.000000 -0.001398 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110054, 0x7011004A, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110055,  4065, 0x01100284, 40.1783, -129.271, 9.52688, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [40.178299 -129.270996 9.526880] 0.999999 0.000000 0.000000 -0.001398 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110055, 0x70110049, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110056,  4065, 0x01100284, 40.1067, -130.45, 9.567, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [40.106701 -130.449997 9.567000] 0.999999 0.000000 0.000000 -0.001398 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110056, 0x70110048, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110057,  4065, 0x01100284, 40.148, -129.789, 9.62049, 0.999999, 0, 0, -0.001398, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [40.147999 -129.789001 9.620490] 0.999999 0.000000 0.000000 -0.001398 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110057, 0x7011004B, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110058,  4065, 0x01100284, 39.6945, -129.489, 9.55944, 0.941437, 0, 0, 0.33719, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [39.694500 -129.488998 9.559440] 0.941437 0.000000 0.000000 0.337190 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110058, 0x7011004C, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110059,  4065, 0x01100284, 40.7073, -129.495, 9.62631, 0.904038, 0, 0, -0.427453, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [40.707298 -129.494995 9.626310] 0.904038 0.000000 0.000000 -0.427453 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70110059, 0x7011004D, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011005A,  4065, 0x01100284, 39.6107, -130.237, 9.62632, 0.894133, 0, 0, -0.447801, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [39.610699 -130.237000 9.626320] 0.894133 0.000000 0.000000 -0.447801 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011005A, 0x7011004E, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011005B,  4065, 0x01100284, 40.5949, -130.257, 9.63969, 0.657206, 0, 0, -0.753711, False, '2005-02-09 10:00:00'); /* Lightning Trap */
+/* @teleloc 0x01100284 [40.594898 -130.257004 9.639690] 0.657206 0.000000 0.000000 -0.753711 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011005B, 0x7011004F, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011005C,  6122, 0x0110028A, 40, -140, 12, 1, 0, 0, 0, False, '2019-02-10 00:00:00'); /* Acid */
+/* @teleloc 0x0110028A [40.000000 -140.000000 12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011005D,  6122, 0x0110028B, 40, -220, 12, 1, 0, 0, 0, False, '2019-02-10 00:00:00'); /* Acid */
+/* @teleloc 0x0110028B [40.000000 -220.000000 12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011006B,   278, 0x011002C6, 40.01, -145, 24, 0, 0, 0, -1, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0x011002C6 [40.009998 -145.000000 24.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70110078,   278, 0x011002DE, 40, -225, 24, 0, 0, 0, -1, False, '2019-02-10 00:00:00'); /* Door */
+/* @teleloc 0x011002DE [40.000000 -225.000000 24.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011007A,  6796, 0x011002E2, 40, -270, 23.937, 0.707107, 0, 0, -0.707107, False, '2019-02-10 00:00:00'); /* Surface Portal */
+/* @teleloc 0x011002E2 [40.000000 -270.000000 23.937000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701100B6,  5085, 0x011002E0, 37.3208, -239.608, 24.079, -0.982428, 0, 0, 0.186643, False, '2019-02-10 00:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x011002E0 [37.320801 -239.608002 24.079000] -0.982428 0.000000 0.000000 0.186643 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x701100B6, 0x701100B7, '2019-02-10 00:00:00') /* Adventurer's warning (6812) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701100B7,  6812, 0x011002E0, 37.3208, -239.608, 24.079, -0.982428, 0, 0, 0.186643,  True, '2019-02-10 00:00:00'); /* Adventurer's warning */
 /* @teleloc 0x011002E0 [37.320801 -239.608002 24.079000] -0.982428 0.000000 0.000000 0.186643 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110005,   278, 0x01100129, 40, -74.75, -65.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x01100129 [40.000000 -74.750000 -65.995003] 0.000000 0.000000 0.000000 -1.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110006,   278, 0x0110012C, 40, -95.25, -65.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x0110012C [40.000000 -95.250000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110007,  6796, 0x0110025F, 40, -30, -5.995, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Surface Portal */
-/* @teleloc 0x0110025F [40.000000 -30.000000 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110008,  6122, 0x0110028A, 40, -140, 12.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0110028A [40.000000 -140.000000 12.005000] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110009,  6122, 0x0110028B, 40, -220, 12.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Acid */
-/* @teleloc 0x0110028B [40.000000 -220.000000 12.005000] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011000A, 40810, 0x0110028A, 40, -140, 12.005, -1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Apostate Nexus Gateway */
-/* @teleloc 0x0110028A [40.000000 -140.000000 12.005000] -1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011000B,  7924, 0x011002DD, 40, -210, 24.005, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
-/* @teleloc 0x011002DD [40.000000 -210.000000 24.004999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x701100B8,  7924, 0x011002D7, 38.313, -189.462, 24.055, -0.180305, 0, 0, 0.983611, False, '2024-01-08 11:46:19'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x011002D7 [38.313000 -189.462006 24.055000] -0.180305 0.000000 0.000000 0.983611 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x7011000B, 0x7011000C, '2021-11-01 00:00:00') /* Nexus Commander (32301) */
-     , (0x7011000B, 0x7011000D, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x7011000E, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x7011000F, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110010, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110011, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110012, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110013, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110014, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110015, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110016, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110017, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110018, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110019, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011001A, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x7011001B, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011001C, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011001D, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011001E, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011001F, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110020, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110021, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110022, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110023, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110024, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110025, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110026, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110027, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110028, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110029, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011002A, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x7011002B, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x7011002C, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011002D, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x7011002E, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011002F, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110030, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110031, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110032, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110033, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110034, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x70110035, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110036, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110037, '2021-11-01 00:00:00') /* Royal Thaumaturge (29303) */
-     , (0x7011000B, 0x70110038, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x70110039, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011003A, '2021-11-01 00:00:00') /* Viamontian Tribune (28652) */
-     , (0x7011000B, 0x7011003B, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011003C, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
-     , (0x7011000B, 0x7011003D, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */;
+VALUES (0x701100B8, 0x701100B9, '2024-01-08 11:47:47') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100BA, '2024-01-08 11:49:22') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100BB, '2024-01-08 11:49:38') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100BC, '2024-01-08 11:49:53') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100BD, '2024-01-08 11:50:10') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100BE, '2024-01-08 11:50:25') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100BF, '2024-01-08 11:50:39') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100C1, '2024-01-08 11:51:05') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100C2, '2024-01-08 11:51:18') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100C3, '2024-01-08 11:51:33') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100C4, '2024-01-08 11:51:54') /* Apostate Nexus Gateway (40810) */
+     , (0x701100B8, 0x701100C5, '2024-01-08 11:52:41') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100C6, '2024-01-08 11:52:57') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100C8, '2024-01-08 11:55:31') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100C9, '2024-01-08 11:55:47') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100CA, '2024-01-08 11:56:00') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100CB, '2024-01-08 11:56:14') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100CC, '2024-01-08 11:56:27') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100CD, '2024-01-08 11:56:39') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100CE, '2024-01-08 11:57:15') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100CF, '2024-01-08 11:57:38') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100D0, '2024-01-08 11:57:59') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100D1, '2024-01-08 11:58:13') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100D2, '2024-01-08 11:58:26') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100D3, '2024-01-08 11:58:41') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100D4, '2024-01-08 11:58:55') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100D5, '2024-01-08 11:59:08') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100D6, '2024-01-08 11:59:22') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100D7, '2024-01-08 11:59:35') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100D8, '2024-01-08 11:59:48') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100D9, '2024-01-08 12:00:01') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100DA, '2024-01-08 12:00:13') /* Royal Thaumaturge (30297) */
+     , (0x701100B8, 0x701100DB, '2024-01-08 12:00:26') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100DC, '2024-01-08 12:00:39') /* Viamontian Tribune (30291) */
+     , (0x701100B8, 0x701100DD, '2024-01-08 12:00:53') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100DE, '2024-01-08 12:01:06') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100DF, '2024-01-08 12:01:18') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100E0, '2024-01-08 12:01:32') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100E1, '2024-01-08 12:01:44') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100E2, '2024-01-08 12:01:57') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100E3, '2024-01-08 12:02:11') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100E4, '2024-01-08 12:02:23') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100E5, '2024-01-08 12:02:37') /* Abhorrent Eater (28641) */
+     , (0x701100B8, 0x701100E6, '2024-01-08 12:02:51') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100E7, '2024-01-08 12:03:04') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100E8, '2024-01-08 12:03:18') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100E9, '2024-01-08 12:03:32') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100EA, '2024-01-08 12:03:45') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100EB, '2024-01-08 12:03:59') /* Royal Thaumaturge (29303) */
+     , (0x701100B8, 0x701100EC, '2024-01-08 12:04:12') /* Nexus Commander (32301) */
+     , (0x701100B8, 0x701100ED, '2024-01-08 12:04:26') /* Viamontian Tribune (28652) */
+     , (0x701100B8, 0x701100EE, '2024-01-08 12:04:39') /* Royal Thaumaturge (29303) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011000C, 32301, 0x01100127, 36.2196, -50.3426, -65.995, 0.999786, 0, 0, -0.020676,  True, '2021-11-01 00:00:00'); /* Nexus Commander */
-/* @teleloc 0x01100127 [36.219601 -50.342602 -65.995003] 0.999786 0.000000 0.000000 -0.020676 */
+VALUES (0x701100B9, 30291, 0x011002D7, 38.313, -189.462, 24.0068, -0.180305, 0, 0, 0.983611,  True, '2024-01-08 11:47:47'); /* Viamontian Tribune */
+/* @teleloc 0x011002D7 [38.313000 -189.462006 24.006800] -0.180305 0.000000 0.000000 0.983611 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011000D, 29303, 0x01100107, 20.11, -117.68, -65.995, -0.04, 0, 0, -1,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100107 [20.110001 -117.680000 -65.995003] -0.040000 0.000000 0.000000 -1.000000 */
+VALUES (0x701100BA, 30297, 0x011002D7, 40.4423, -190.006, 24.005, -0.004204, 0, 0, 0.999991,  True, '2024-01-08 11:49:22'); /* Royal Thaumaturge */
+/* @teleloc 0x011002D7 [40.442299 -190.005997 24.004999] -0.004204 0.000000 0.000000 0.999991 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011000E, 29303, 0x01100127, 40.54, -54.89, -65.9949, -0.019996, 0, 0, 0.9998,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100127 [40.540001 -54.889999 -65.994904] -0.019996 0.000000 0.000000 0.999800 */
+VALUES (0x701100BB, 30291, 0x011002D7, 42.8069, -188.402, 24.0068, 0.062161, 0, 0, 0.998066,  True, '2024-01-08 11:49:38'); /* Viamontian Tribune */
+/* @teleloc 0x011002D7 [42.806900 -188.401993 24.006800] 0.062161 0.000000 0.000000 0.998066 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011000F, 28652, 0x01100127, 41.37, -49.141, -65.995, -0.999513, 0, 0, 0.031212,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x01100127 [41.369999 -49.140999 -65.995003] -0.999513 0.000000 0.000000 0.031212 */
+VALUES (0x701100BC, 30297, 0x011002B2, 30.57, -180.849, 24.005, -0.357547, 0, 0, 0.933895,  True, '2024-01-08 11:49:53'); /* Royal Thaumaturge */
+/* @teleloc 0x011002B2 [30.570000 -180.848999 24.004999] -0.357547 0.000000 0.000000 0.933895 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110010, 28652, 0x011002D7, 37.8538, -189.636, 24.005, 0.068802, 0, 0, -0.99763,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x011002D7 [37.853802 -189.636002 24.004999] 0.068802 0.000000 0.000000 -0.997630 */
+VALUES (0x701100BD, 30297, 0x011002F0, 50, -180, 24.005, 0.04578, 0, 0, 0.998952,  True, '2024-01-08 11:50:10'); /* Royal Thaumaturge */
+/* @teleloc 0x011002F0 [50.000000 -180.000000 24.004999] 0.045780 0.000000 0.000000 0.998952 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110011, 28652, 0x011002D7, 40.39, -190.11, 24.005, -0.01, 0, 0, 0.99995,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x011002D7 [40.389999 -190.110001 24.004999] -0.010000 0.000000 0.000000 0.999950 */
+VALUES (0x701100BE, 30291, 0x011002D2, 37.4811, -179.509, 24.0068, 0.697564, 0, 0, 0.716523,  True, '2024-01-08 11:50:25'); /* Viamontian Tribune */
+/* @teleloc 0x011002D2 [37.481098 -179.509003 24.006800] 0.697564 0.000000 0.000000 0.716523 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110012, 28652, 0x011002D7, 42.68, -188.31, 24.005, -0.029987, 0, 0, 0.99955,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x011002D7 [42.680000 -188.309998 24.004999] -0.029987 0.000000 0.000000 0.999550 */
+VALUES (0x701100BF, 30291, 0x011002D2, 41.8841, -179.321, 24.0068, -0.677953, 0, 0, 0.735106,  True, '2024-01-08 11:50:39'); /* Viamontian Tribune */
+/* @teleloc 0x011002D2 [41.884102 -179.320999 24.006800] -0.677953 0.000000 0.000000 0.735106 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110013, 29303, 0x011002B2, 30.74, -180.59, 24.005, 0.140021, 0, 0, 0.990149,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x011002B2 [30.740000 -180.589996 24.004999] 0.140021 0.000000 0.000000 0.990149 */
+VALUES (0x701100C1, 28641, 0x011002CD, 39.5014, -169.622, 24, 0.038796, 0, 0, 0.999247,  True, '2024-01-08 11:51:05'); /* Abhorrent Eater */
+/* @teleloc 0x011002CD [39.501400 -169.621994 24.000000] 0.038796 0.000000 0.000000 0.999247 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110014, 28641, 0x011002D2, 37.64, -179.62, 24.005, 0.510077, 0, 0, 0.860129,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002D2 [37.639999 -179.619995 24.004999] 0.510077 0.000000 0.000000 0.860129 */
+VALUES (0x701100C2, 28641, 0x011002AA, 29.4467, -160.265, 24, 0.527992, 0, 0, -0.849249,  True, '2024-01-08 11:51:18'); /* Abhorrent Eater */
+/* @teleloc 0x011002AA [29.446699 -160.264999 24.000000] 0.527992 0.000000 0.000000 -0.849249 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110015, 28641, 0x011002D2, 41.91, -179.04, 24.005, 0, 0, 0, 1,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002D2 [41.910000 -179.039993 24.004999] 0.000000 0.000000 0.000000 1.000000 */
+VALUES (0x701100C3, 28641, 0x011002E8, 50.8609, -159.053, 24, 0.128104, 0, 0, -0.991761,  True, '2024-01-08 11:51:33'); /* Abhorrent Eater */
+/* @teleloc 0x011002E8 [50.860901 -159.052994 24.000000] 0.128104 0.000000 0.000000 -0.991761 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110016, 28641, 0x011002F0, 48.55, -178.9, 24.005, 0, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002F0 [48.549999 -178.899994 24.004999] 0.000000 0.000000 0.000000 0.000000 */
+VALUES (0x701100C4, 40810, 0x0110028A, 40, -140, 12.055, 1, 0, 0, 0,  True, '2024-01-08 11:51:54'); /* Apostate Nexus Gateway */
+/* @teleloc 0x0110028A [40.000000 -140.000000 12.055000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110017, 29303, 0x011002F0, 50.42, -178.68, 24.005, 0, 0, 0, 1,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x011002F0 [50.419998 -178.679993 24.004999] 0.000000 0.000000 0.000000 1.000000 */
+VALUES (0x701100C5, 28641, 0x01100297, 41.6938, -91.0367, 18, 0.393769, 0, 0, 0.91921,  True, '2024-01-08 11:52:41'); /* Abhorrent Eater */
+/* @teleloc 0x01100297 [41.693802 -91.036697 18.000000] 0.393769 0.000000 0.000000 0.919210 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110018, 29303, 0x011002CD, 39.56, -169.54, 24.005, 0, 0, 0, 1,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x011002CD [39.560001 -169.539993 24.004999] 0.000000 0.000000 0.000000 1.000000 */
+VALUES (0x701100C6, 28641, 0x01100294, 36.9159, -90.741, 18, -0.454727, 0, 0, 0.890631,  True, '2024-01-08 11:52:57'); /* Abhorrent Eater */
+/* @teleloc 0x01100294 [36.915901 -90.740997 18.000000] -0.454727 0.000000 0.000000 0.890631 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110019, 28641, 0x011002EC, 50.3, -167.54, 24.005, 0, 0, 0, 1,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002EC [50.299999 -167.539993 24.004999] 0.000000 0.000000 0.000000 1.000000 */
+VALUES (0x701100C8, 28641, 0x01100270, 48.9603, -131.455, -6, 0.799056, 0, 0, 0.601256,  True, '2024-01-08 11:55:31'); /* Abhorrent Eater */
+/* @teleloc 0x01100270 [48.960300 -131.455002 -6.000000] 0.799056 0.000000 0.000000 0.601256 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001A, 29303, 0x011002E8, 52.33, -159.58, 24.005, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x011002E8 [52.330002 -159.580002 24.004999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x701100C9, 28641, 0x01100252, 31.7062, -130.472, -6, 0.683415, 0, 0, -0.73003,  True, '2024-01-08 11:55:47'); /* Abhorrent Eater */
+/* @teleloc 0x01100252 [31.706200 -130.472000 -6.000000] 0.683415 0.000000 0.000000 -0.730030 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001B, 28641, 0x011002E8, 48.82, -160.61, 24.005, 0.649967, 0, 0, 0.759962,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002E8 [48.820000 -160.610001 24.004999] 0.649967 0.000000 0.000000 0.759962 */
+VALUES (0x701100CA, 29303, 0x01100272, 57.2669, -130.226, -5.995, -0.728724, 0, 0, -0.684808,  True, '2024-01-08 11:56:00'); /* Royal Thaumaturge */
+/* @teleloc 0x01100272 [57.266899 -130.225998 -5.995000] -0.728724 0.000000 0.000000 -0.684808 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001C, 28641, 0x011002C8, 38.69, -159.01, 24.005, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002C8 [38.689999 -159.009995 24.004999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x701100CB, 28641, 0x01100269, 41.4296, -141.041, -6, 0.999714, 0, 0, -0.023925,  True, '2024-01-08 11:56:14'); /* Abhorrent Eater */
+/* @teleloc 0x01100269 [41.429600 -141.041000 -6.000000] 0.999714 0.000000 0.000000 -0.023925 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001D, 28641, 0x011002C7, 40.17, -151.62, 24.005, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002C7 [40.169998 -151.619995 24.004999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x701100CC, 29303, 0x0110024A, 21.1292, -129.876, -5.995, 0.705786, 0, 0, -0.708425,  True, '2024-01-08 11:56:27'); /* Royal Thaumaturge */
+/* @teleloc 0x0110024A [21.129200 -129.876007 -5.995000] 0.705786 0.000000 0.000000 -0.708425 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001E, 28641, 0x011002AA, 29.27, -160.5, 24.005, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002AA [29.270000 -160.500000 24.004999] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x701100CD, 29303, 0x0110026A, 40.0441, -147.515, -5.995, -0.997888, 0, 0, 0.064955,  True, '2024-01-08 11:56:39'); /* Royal Thaumaturge */
+/* @teleloc 0x0110026A [40.044102 -147.514999 -5.995000] -0.997888 0.000000 0.000000 0.064955 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011001F, 28641, 0x011002A4, 49.85, -100.19, 18.005, 0.99955, 0, 0, 0.029987,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002A4 [49.849998 -100.190002 18.004999] 0.999550 0.000000 0.000000 0.029987 */
+VALUES (0x701100CE, 29303, 0x01100266, 40, -108.692, -5.995, 0.664098, 0, 0, -0.747645,  True, '2024-01-08 11:57:15'); /* Royal Thaumaturge */
+/* @teleloc 0x01100266 [40.000000 -108.692001 -5.995000] 0.664098 0.000000 0.000000 -0.747645 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110020, 28641, 0x011002A4, 50.18, -103.3, 18.005, -0.999201, 0, 0, -0.039968,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011002A4 [50.180000 -103.300003 18.004999] -0.999201 0.000000 0.000000 -0.039968 */
+VALUES (0x701100CF, 28652, 0x0110022D, 70.4896, -158.949, -17.9932, 0.780707, 0, 0, 0.624897,  True, '2024-01-08 11:57:38'); /* Viamontian Tribune */
+/* @teleloc 0x0110022D [70.489601 -158.949005 -17.993200] 0.780707 0.000000 0.000000 0.624897 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110021, 29303, 0x011002A5, 49.98, -106.33, 18.005, -0.998205, 0, 0, 0.059892,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x011002A5 [49.980000 -106.330002 18.004999] -0.998205 0.000000 0.000000 0.059892 */
+VALUES (0x701100D0, 29303, 0x0110022D, 69.9719, -160.601, -17.995, 0.714421, 0, 0, 0.699716,  True, '2024-01-08 11:57:59'); /* Royal Thaumaturge */
+/* @teleloc 0x0110022D [69.971901 -160.600998 -17.995001] 0.714421 0.000000 0.000000 0.699716 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110022, 28641, 0x0110028F, 29.97, -96.62, 18.005, 0.99955, 0, 0, 0.029987,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x0110028F [29.969999 -96.620003 18.004999] 0.999550 0.000000 0.000000 0.029987 */
+VALUES (0x701100D1, 28652, 0x01100228, 69.4387, -100.542, -17.9932, -0.004204, 0, 0, -0.999991,  True, '2024-01-08 11:58:13'); /* Viamontian Tribune */
+/* @teleloc 0x01100228 [69.438698 -100.542000 -17.993200] -0.004204 0.000000 0.000000 -0.999991 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110023, 28641, 0x0110028F, 30.1, -100.37, 18.005, 0.998752, 0, 0, 0.049938,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x0110028F [30.100000 -100.370003 18.004999] 0.998752 0.000000 0.000000 0.049938 */
+VALUES (0x701100D2, 29303, 0x01100228, 71.0139, -100.093, -17.995, 0.04578, 0, 0, 0.998952,  True, '2024-01-08 11:58:26'); /* Royal Thaumaturge */
+/* @teleloc 0x01100228 [71.013901 -100.093002 -17.995001] 0.045780 0.000000 0.000000 0.998952 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110024, 29303, 0x0110028F, 29.79, -104.51, 18.005, 0.99955, 0, 0, 0.029987,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x0110028F [29.790001 -104.510002 18.004999] 0.999550 0.000000 0.000000 0.029987 */
+VALUES (0x701100D3, 28652, 0x011001FE, 10.8548, -160.022, -17.9932, 1, 0, 0, 0,  True, '2024-01-08 11:58:41'); /* Viamontian Tribune */
+/* @teleloc 0x011001FE [10.854800 -160.022003 -17.993200] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110025, 29303, 0x01100253, 34.39, -135.29, -5.995, -0.947681, 0, 0, 0.319219,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100253 [34.389999 -135.289993 -5.995000] -0.947681 0.000000 0.000000 0.319219 */
+VALUES (0x701100D4, 29303, 0x011001FE, 8.98182, -160.147, -17.995, 1, 0, 0, 0,  True, '2024-01-08 11:58:55'); /* Royal Thaumaturge */
+/* @teleloc 0x011001FE [8.981820 -160.147003 -17.995001] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110026, 28641, 0x01100252, 32.1, -130.54, -5.995, -0.686916, 0, 0, 0.726737,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100252 [32.099998 -130.539993 -5.995000] -0.686916 0.000000 0.000000 0.726737 */
+VALUES (0x701100D5, 30291, 0x011001DE, 26.6026, -127.206, -23.9932, -0.499702, 0, 0, 0.866198,  True, '2024-01-08 11:59:08'); /* Viamontian Tribune */
+/* @teleloc 0x011001DE [26.602600 -127.206001 -23.993200] -0.499702 0.000000 0.000000 0.866198 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110027, 28641, 0x01100267, 43.88, -121.08, -5.995, -0.348937, 0, 0, -0.937146,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100267 [43.880001 -121.080002 -5.995000] -0.348937 0.000000 0.000000 -0.937146 */
+VALUES (0x701100D6, 30291, 0x011001DE, 27.5245, -132.608, -23.9932, -0.912694, 0, 0, 0.408644,  True, '2024-01-08 11:59:22'); /* Viamontian Tribune */
+/* @teleloc 0x011001DE [27.524500 -132.608002 -23.993200] -0.912694 0.000000 0.000000 0.408644 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110028, 29303, 0x01100270, 47.84, -125.16, -5.995, -0.529101, 0, 0, -0.848559,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100270 [47.840000 -125.160004 -5.995000] -0.529101 0.000000 0.000000 -0.848559 */
+VALUES (0x701100D7, 30297, 0x011001E4, 37.003, -139.056, -23.995, 0.974794, 0, 0, -0.223107,  True, '2024-01-08 11:59:35'); /* Royal Thaumaturge */
+/* @teleloc 0x011001E4 [37.002998 -139.056000 -23.995001] 0.974794 0.000000 0.000000 -0.223107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110029, 28641, 0x01100270, 48.45, -131.61, -5.995, 0.808304, 0, 0, 0.588765,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100270 [48.450001 -131.610001 -5.995000] 0.808304 0.000000 0.000000 0.588765 */
+VALUES (0x701100D8, 30297, 0x011001E4, 42.7158, -138.545, -23.995, 0.999688, 0, 0, 0.024997,  True, '2024-01-08 11:59:48'); /* Royal Thaumaturge */
+/* @teleloc 0x011001E4 [42.715801 -138.544998 -23.995001] 0.999688 0.000000 0.000000 0.024997 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011002A, 29303, 0x01100271, 45.26, -135.68, -5.995, -0.962651, 0, 0, -0.270746,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100271 [45.259998 -135.679993 -5.995000] -0.962651 0.000000 0.000000 -0.270746 */
+VALUES (0x701100D9, 30297, 0x011001E2, 42.6779, -120.755, -23.995, 0.046919, 0, 0, -0.998899,  True, '2024-01-08 12:00:01'); /* Royal Thaumaturge */
+/* @teleloc 0x011001E2 [42.677898 -120.754997 -23.995001] 0.046919 0.000000 0.000000 -0.998899 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011002B, 28652, 0x01100269, 42.71, -137.21, -5.995, -0.962651, 0, 0, -0.270746,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x01100269 [42.709999 -137.210007 -5.995000] -0.962651 0.000000 0.000000 -0.270746 */
+VALUES (0x701100DA, 30297, 0x011001E2, 36.9556, -121.169, -23.995, 0.540302, 0, 0, -0.841471,  True, '2024-01-08 12:00:13'); /* Royal Thaumaturge */
+/* @teleloc 0x011001E2 [36.955601 -121.168999 -23.995001] 0.540302 0.000000 0.000000 -0.841471 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011002C, 28641, 0x01100269, 36.25, -137.43, -5.995, 0.957276, 0, 0, -0.289177,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100269 [36.250000 -137.429993 -5.995000] 0.957276 0.000000 0.000000 -0.289177 */
+VALUES (0x701100DB, 30291, 0x011001E8, 53.0872, -132.276, -23.9932, 0.62161, 0, 0, 0.783327,  True, '2024-01-08 12:00:26'); /* Viamontian Tribune */
+/* @teleloc 0x011001E8 [53.087200 -132.276001 -23.993200] 0.621610 0.000000 0.000000 0.783327 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011002D, 28652, 0x011001E0, 34.29, -147.73, -23.995, -0.360994, 0, 0, 0.932568,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x011001E0 [34.290001 -147.729996 -23.995001] -0.360994 0.000000 0.000000 0.932568 */
+VALUES (0x701100DC, 30291, 0x011001E8, 52.6045, -127.299, -23.9932, 0.852525, 0, 0, 0.522687,  True, '2024-01-08 12:00:39'); /* Viamontian Tribune */
+/* @teleloc 0x011001E8 [52.604500 -127.299004 -23.993200] 0.852525 0.000000 0.000000 0.522687 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011002E, 28641, 0x011001E5, 44.07, -147.16, -23.995, 0.498284, 0, 0, 0.867014,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011001E5 [44.070000 -147.160004 -23.995001] 0.498284 0.000000 0.000000 0.867014 */
+VALUES (0x701100DD, 28641, 0x011001BE, 39.7742, -139.427, -36, 0.99994, 0, 0, -0.010924,  True, '2024-01-08 12:00:53'); /* Abhorrent Eater */
+/* @teleloc 0x011001BE [39.774200 -139.427002 -36.000000] 0.999940 0.000000 0.000000 -0.010924 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011002F, 28652, 0x011001E7, 53.03, -123.13, -23.995, -0.390293, 0, 0, 0.920691,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x011001E7 [53.029999 -123.129997 -23.995001] -0.390293 0.000000 0.000000 0.920691 */
+VALUES (0x701100DE, 28641, 0x0110029A, 39.9923, -114.361, 18, -0.979135, 0, 0, -0.203209,  True, '2024-01-08 12:01:06'); /* Abhorrent Eater */
+/* @teleloc 0x0110029A [39.992298 -114.361000 18.000000] -0.979135 0.000000 0.000000 -0.203209 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110030, 29303, 0x011001DD, 31.45, -117.77, -23.995, 0.91707, 0, 0, -0.398726,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x011001DD [31.450001 -117.769997 -23.995001] 0.917070 0.000000 0.000000 -0.398726 */
+VALUES (0x701100DF, 29303, 0x011001F9, 9.73189, -100.633, -17.995, -0.638782, 0, 0, 0.769388,  True, '2024-01-08 12:01:18'); /* Royal Thaumaturge */
+/* @teleloc 0x011001F9 [9.731890 -100.633003 -17.995001] -0.638782 0.000000 0.000000 0.769388 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110031, 28641, 0x011001D8, 24.02, -135.94, -23.995, 0.888358, 0, 0, 0.459151,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x011001D8 [24.020000 -135.940002 -23.995001] 0.888358 0.000000 0.000000 0.459151 */
+VALUES (0x701100E0, 28652, 0x011001F9, 9.69023, -99.3078, -17.9932, 0.731689, 0, 0, -0.681639,  True, '2024-01-08 12:01:32'); /* Viamontian Tribune */
+/* @teleloc 0x011001F9 [9.690230 -99.307800 -17.993200] 0.731689 0.000000 0.000000 -0.681639 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110032, 28641, 0x01100133, 43.41, -132.76, -65.995, 0.929164, 0, 0, 0.369667,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100133 [43.410000 -132.759995 -65.995003] 0.929164 0.000000 0.000000 0.369667 */
+VALUES (0x701100E1, 28641, 0x011001CA, 57.7352, -130.126, -36, 0.748499, 0, 0, 0.663136,  True, '2024-01-08 12:01:44'); /* Abhorrent Eater */
+/* @teleloc 0x011001CA [57.735199 -130.126007 -36.000000] 0.748499 0.000000 0.000000 0.663136 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110033, 28641, 0x01100133, 43.75, -126.1, -65.995, 0.490737, 0, 0, 0.871308,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100133 [43.750000 -126.099998 -65.995003] 0.490737 0.000000 0.000000 0.871308 */
+VALUES (0x701100E2, 28641, 0x011001AF, 21.0246, -129.592, -36, 0.659287, 0, 0, -0.751891,  True, '2024-01-08 12:01:57'); /* Abhorrent Eater */
+/* @teleloc 0x011001AF [21.024599 -129.591995 -36.000000] 0.659287 0.000000 0.000000 -0.751891 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110034, 28641, 0x01100133, 36.1, -126.43, -65.995, 0.340136, 0, 0, -0.940376,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100133 [36.099998 -126.430000 -65.995003] 0.340136 0.000000 0.000000 -0.940376 */
+VALUES (0x701100E3, 28641, 0x011001BB, 39.7933, -112.777, -36, 0.023572, 0, 0, 0.999722,  True, '2024-01-08 12:02:11'); /* Abhorrent Eater */
+/* @teleloc 0x011001BB [39.793301 -112.777000 -36.000000] 0.023572 0.000000 0.000000 0.999722 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110035, 29303, 0x01100130, 39.91, -122.25, -65.995, -0.009999, 0, 0, -0.99995,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100130 [39.910000 -122.250000 -65.995003] -0.009999 0.000000 0.000000 -0.999950 */
+VALUES (0x701100E4, 28641, 0x01100134, 40, -142.012, -66, 1, 0, 0, 0,  True, '2024-01-08 12:02:23'); /* Abhorrent Eater */
+/* @teleloc 0x01100134 [40.000000 -142.011993 -66.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110036, 28652, 0x01100145, 47.24, -129.97, -65.995, -0.726737, 0, 0, -0.686916,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x01100145 [47.240002 -129.970001 -65.995003] -0.726737 0.000000 0.000000 -0.686916 */
+VALUES (0x701100E5, 28641, 0x01100130, 40.296, -116.329, -66, 0.013505, 0, 0, -0.999909,  True, '2024-01-08 12:02:37'); /* Abhorrent Eater */
+/* @teleloc 0x01100130 [40.296001 -116.329002 -66.000000] 0.013505 0.000000 0.000000 -0.999909 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110037, 29303, 0x01100134, 39.84, -136.69, -65.995, -0.99995, 0, 0, -0.009999,  True, '2021-11-01 00:00:00'); /* Royal Thaumaturge */
-/* @teleloc 0x01100134 [39.840000 -136.690002 -65.995003] -0.999950 0.000000 0.000000 -0.009999 */
+VALUES (0x701100E6, 29303, 0x0110012C, 41.0885, -98.4165, -65.995, -0.004204, 0, 0, -0.999991,  True, '2024-01-08 12:02:51'); /* Royal Thaumaturge */
+/* @teleloc 0x0110012C [41.088501 -98.416496 -65.995003] -0.004204 0.000000 0.000000 -0.999991 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110038, 28652, 0x0110011E, 32.4394, -129.842, -65.995, 0.671176, 0, 0, -0.741298,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x0110011E [32.439400 -129.841995 -65.995003] 0.671176 0.000000 0.000000 -0.741298 */
+VALUES (0x701100E7, 28652, 0x0110010A, 21.7351, -130.374, -65.9932, 0.692983, 0, 0, -0.720954,  True, '2024-01-08 12:03:04'); /* Viamontian Tribune */
+/* @teleloc 0x0110010A [21.735100 -130.373993 -65.993202] 0.692983 0.000000 0.000000 -0.720954 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70110039, 28641, 0x01100139, 39.92, -146.7, -65.995, -0.99995, 0, 0, -0.009999,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x01100139 [39.919998 -146.699997 -65.995003] -0.999950 0.000000 0.000000 -0.009999 */
+VALUES (0x701100E8, 28652, 0x01100156, 56.3243, -129.475, -65.9932, 0.764842, 0, 0, 0.644218,  True, '2024-01-08 12:03:18'); /* Viamontian Tribune */
+/* @teleloc 0x01100156 [56.324299 -129.475006 -65.993202] 0.764842 0.000000 0.000000 0.644218 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003A, 28652, 0x01100124, 31, -149.9, -65.995, -0.721988, 0, 0, 0.691905,  True, '2021-11-01 00:00:00'); /* Viamontian Tribune */
-/* @teleloc 0x01100124 [31.000000 -149.899994 -65.995003] -0.721988 0.000000 0.000000 0.691905 */
+VALUES (0x701100E9, 28652, 0x01100124, 31.0397, -150, -65.9932, 0.939373, 0, 0, -0.342898,  True, '2024-01-08 12:03:32'); /* Viamontian Tribune */
+/* @teleloc 0x01100124 [31.039700 -150.000000 -65.993202] 0.939373 0.000000 0.000000 -0.342898 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003B, 28641, 0x0110010A, 22.97, -130.07, -65.995, -0.671176, 0, 0, 0.741298,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x0110010A [22.969999 -130.070007 -65.995003] -0.671176 0.000000 0.000000 0.741298 */
+VALUES (0x701100EA, 28652, 0x0110014B, 50.5167, -150.781, -65.9932, 0.939373, 0, 0, 0.342898,  True, '2024-01-08 12:03:45'); /* Viamontian Tribune */
+/* @teleloc 0x0110014B [50.516701 -150.781006 -65.993202] 0.939373 0.000000 0.000000 0.342898 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003C, 28641, 0x0110012D, 39.8, -112.78, -65.995, -0.019996, 0, 0, 0.9998,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x0110012D [39.799999 -112.779999 -65.995003] -0.019996 0.000000 0.000000 0.999800 */
+VALUES (0x701100EB, 29303, 0x01100127, 43.9382, -49.0327, -65.995, -0.148245, 0, 0, -0.988951,  True, '2024-01-08 12:03:59'); /* Royal Thaumaturge */
+/* @teleloc 0x01100127 [43.938202 -49.032700 -65.995003] -0.148245 0.000000 0.000000 -0.988951 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003D, 28641, 0x0110014B, 54.62, -150.23, -65.995, 0.691905, 0, 0, 0.721988,  True, '2021-11-01 00:00:00'); /* Abhorrent Eater */
-/* @teleloc 0x0110014B [54.619999 -150.229996 -65.995003] 0.691905 0.000000 0.000000 0.721988 */
+VALUES (0x701100EC, 32301, 0x01100127, 39.7144, -49.1646, -65.9932, -0.023791, 0, 0, -0.999717,  True, '2024-01-08 12:04:12'); /* Nexus Commander */
+/* @teleloc 0x01100127 [39.714401 -49.164600 -65.993202] -0.023791 0.000000 0.000000 -0.999717 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7011003E,   278, 0x01100125, 40, -34.75, -65.995, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Door */
-/* @teleloc 0x01100125 [40.000000 -34.750000 -65.995003] 0.000000 0.000000 0.000000 -1.000000 */
+VALUES (0x701100ED, 28652, 0x01100127, 40.8672, -50.9412, -65.9932, -0.023791, 0, 0, -0.999717,  True, '2024-01-08 12:04:26'); /* Viamontian Tribune */
+/* @teleloc 0x01100127 [40.867199 -50.941200 -65.993202] -0.023791 0.000000 0.000000 -0.999717 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x701100EE, 29303, 0x01100116, 32.4014, -49.9557, -65.995, 0.212008, 0, 0, -0.977268,  True, '2024-01-08 12:04:39'); /* Royal Thaumaturge */
+/* @teleloc 0x01100116 [32.401402 -49.955700 -65.995003] 0.212008 0.000000 0.000000 -0.977268 */

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32301 Nexus Commander.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32301 Nexus Commander.sql
@@ -19,7 +19,8 @@ VALUES (32301,   1,         16) /* ItemType - Creature */
      , (32301, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (32301, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (32301, 140,          1) /* AiOptions - CanOpenDoors */
-     , (32301, 146,     125000) /* XpOverride */;
+     , (32301, 146,     125000) /* XpOverride */
+     , (32301, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32301,   1, True ) /* Stuck */


### PR DESCRIPTION
Updates the Nexus landblock 0110 to match the pcap and retail video by Tzepesh. This corrects spawn placement, and adds the missing traps (present in the original landblock from world DB, and seen in the video, meaning they were not removed). Also adds damage rating to Nexus Commander (as in the video).

https://www.youtube.com/watch?v=0W13OWw8SkU