### PR TITLE
Misc Fixes

### DIFF
--- a/Database/Patches/4 CraftTable/05303 Composite Crossbow with Fine Handle.sql
+++ b/Database/Patches/4 CraftTable/05303 Composite Crossbow with Fine Handle.sql
@@ -17,5 +17,5 @@ VALUES (@parent_id, 3,  25, NULL, 4, 0) /* On Player.SuccessResult CopyFromSourc
 DELETE FROM `cook_book` WHERE `recipe_Id` = 5303;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (5303, 33984 /* Fine Bone Handle */,  6963 /* Composite Bow */, '2022-07-02 15:33:11')
+VALUES (5303, 33984 /* Fine Bone Handle */,  7035 /* Composite Crossbow */, '2022-07-02 15:33:11')
      , (5303, 33984 /* Fine Bone Handle */, 33999 /* Composite Crossbow with Handle */, '2022-07-02 15:33:11');

--- a/Database/Patches/4 CraftTable/05304 Composite Crossbow with Superb Handle.sql
+++ b/Database/Patches/4 CraftTable/05304 Composite Crossbow with Superb Handle.sql
@@ -17,6 +17,6 @@ VALUES (@parent_id, 3,  25, NULL, 4, 0) /* On Player.SuccessResult CopyFromSourc
 DELETE FROM `cook_book` WHERE `recipe_Id` = 5304;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (5304, 33983 /* Superb Bone Handle */,  6963 /* Composite Bow */, '2022-07-02 15:33:11')
+VALUES (5304, 33983 /* Superb Bone Handle */,  7035 /* Composite Crossbow */, '2022-07-02 15:33:11')
      , (5304, 33983 /* Superb Bone Handle */, 33999 /* Composite Crossbow with Handle */, '2022-07-02 15:33:11')
      , (5304, 33983 /* Superb Bone Handle */, 87751 /* Composite Crossbow with Fine Handle */, '2022-07-02 15:33:11');

--- a/Database/Patches/4 CraftTable/05305 Composite Crossbow with Exquisite Handle.sql
+++ b/Database/Patches/4 CraftTable/05305 Composite Crossbow with Exquisite Handle.sql
@@ -17,7 +17,7 @@ VALUES (@parent_id, 3,  25, NULL, 4, 0) /* On Player.SuccessResult CopyFromSourc
 DELETE FROM `cook_book` WHERE `recipe_Id` = 5305;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (5305, 33982 /* Exquisite Bone Handle */,  6963 /* Composite Bow */, '2022-07-02 15:33:11')
+VALUES (5305, 33982 /* Exquisite Bone Handle */,  7035 /* Composite Crossbow */, '2022-07-02 15:33:11')
      , (5305, 33982 /* Exquisite Bone Handle */, 33993 /* Composite Crossbow with Superb Handle */, '2022-07-02 15:33:11')
      , (5305, 33982 /* Exquisite Bone Handle */, 33999 /* Composite Crossbow with Handle */, '2022-07-02 15:33:11')
      , (5305, 33982 /* Exquisite Bone Handle */, 87751 /* Composite Crossbow with Fine Handle */, '2022-07-02 15:33:11');

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/33539 Decaying Ruschk Laktar.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/33539 Decaying Ruschk Laktar.sql
@@ -37,7 +37,7 @@ VALUES (33539,   1,       5) /* HeartbeatInterval */
      , (33539,  13,     0.9) /* ArmorModVsSlash */
      , (33539,  14,     0.7) /* ArmorModVsPierce */
      , (33539,  15,     1.1) /* ArmorModVsBludgeon */
-     , (33539,  16,     0.9) /* ArmorModVsCold */
+     , (33539,  16,     0.8) /* ArmorModVsCold */
      , (33539,  17,     0.6) /* ArmorModVsFire */
      , (33539,  18,       1) /* ArmorModVsAcid */
      , (33539,  19,     0.8) /* ArmorModVsElectric */
@@ -45,21 +45,20 @@ VALUES (33539,   1,       5) /* HeartbeatInterval */
      , (33539,  34,       1) /* PowerupTime */
      , (33539,  36,       1) /* ChargeSpeed */
      , (33539,  39,     1.2) /* DefaultScale */
-     , (33539,  64,     0.1) /* ResistSlash */
-     , (33539,  65,     0.1) /* ResistPierce */
-     , (33539,  66,     0.3) /* ResistBludgeon */
-     , (33539,  67,     0.3) /* ResistFire */
-     , (33539,  68,     0.1) /* ResistCold */
-     , (33539,  69,     0.2) /* ResistAcid */
-     , (33539,  70,     0.1) /* ResistElectric */
+     , (33539,  64,     0.7) /* ResistSlash */
+     , (33539,  65,     0.7) /* ResistPierce */
+     , (33539,  66,     0.5) /* ResistBludgeon */
+     , (33539,  67,     0.8) /* ResistFire */
+     , (33539,  68,     0.5) /* ResistCold */
+     , (33539,  69,     0.4) /* ResistAcid */
+     , (33539,  70,     0.4) /* ResistElectric */
      , (33539,  71,       1) /* ResistHealthBoost */
      , (33539,  72,     0.5) /* ResistStaminaDrain */
      , (33539,  73,       1) /* ResistStaminaBoost */
      , (33539,  74,     0.5) /* ResistManaDrain */
      , (33539,  75,       1) /* ResistManaBoost */
      , (33539, 104,      10) /* ObviousRadarRange */
-     , (33539, 125,     0.5) /* ResistHealthDrain */
-     , (33539, 166,     0.2) /* ResistNether */;
+     , (33539, 125,     0.5) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (33539,   1, 'Decaying Ruschk Laktar') /* Name */;

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/46392 Shadowfire Isparian Spear.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/46392 Shadowfire Isparian Spear.sql
@@ -16,7 +16,7 @@ VALUES (46392,   1,          1) /* ItemType - MeleeWeapon */
      , (46392,  44,         72) /* Damage */
      , (46392,  45,         16) /* DamageType - Fire */
      , (46392,  46,          2) /* DefaultCombatStyle - OneHanded */
-     , (46392,  47,          6) /* AttackType - Thrust, Slash */
+     , (46392,  47,          2) /* AttackType - Thrust */
      , (46392,  48,         45) /* WeaponSkill - LightWeapons */
      , (46392,  49,          1) /* WeaponTime */
      , (46392,  51,          1) /* CombatUse - Melee */

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/87751 Composite Crossbow with Fine Handle.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/87751 Composite Crossbow with Fine Handle.sql
@@ -6,7 +6,7 @@ VALUES (87751, 'ace87751-compositecrossbowwithfinehandle', 3, '2022-06-21 15:22:
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (87751,   1,        256) /* ItemType - MissileWeapon */
      , (87751,   3,         20) /* PaletteTemplate - Silver */
-     , (87751,   5,       1200) /* EncumbranceVal */
+     , (87751,   5,       1500) /* EncumbranceVal */
      , (87751,   9,    4194304) /* ValidLocations - MissileWeapon */
      , (87751,  16,          1) /* ItemUseable - No */
      , (87751,  18,          1) /* UiEffects - Magical */
@@ -16,22 +16,22 @@ VALUES (87751,   1,        256) /* ItemType - MissileWeapon */
      , (87751,  45,          0) /* DamageType - Undef */
      , (87751,  46,         32) /* DefaultCombatStyle - Crossbow */
      , (87751,  48,         47) /* WeaponSkill - MissileWeapons */
-     , (87751,  49,         60) /* WeaponTime */
+     , (87751,  49,         80) /* WeaponTime */
      , (87751,  50,          2) /* AmmoType - Bolt */
      , (87751,  51,          2) /* CombatUse - Missile */
      , (87751,  52,          2) /* ParentLocation - LeftHand */
      , (87751,  53,          3) /* PlacementPosition - LeftHand */
      , (87751,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
-     , (87751, 106,        400) /* ItemSpellcraft */
-     , (87751, 107,          0) /* ItemCurMana */
-     , (87751, 108,       1000) /* ItemMaxMana */
-     , (87751, 109,        225) /* ItemDifficulty */
+     , (87751, 106,        313) /* ItemSpellcraft */
+     , (87751, 107,        800) /* ItemCurMana */
+     , (87751, 108,        800) /* ItemMaxMana */
+     , (87751, 109,        190) /* ItemDifficulty */
      , (87751, 114,          1) /* Attuned - Attuned */
      , (87751, 150,        103) /* HookPlacement - Hook */
      , (87751, 151,          2) /* HookType - Wall */
      , (87751, 158,          2) /* WieldRequirements - RawSkill */
      , (87751, 159,         47) /* WieldSkillType - MissileWeapons */
-     , (87751, 160,        335) /* WieldDifficulty */
+     , (87751, 160,        305) /* WieldDifficulty */
      , (87751, 353,          9) /* WeaponType - Crossbow */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -43,7 +43,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (87751,   5,   -0.05) /* ManaRate */
      , (87751,  12,     0.5) /* Shade */
      , (87751,  26,    27.3) /* MaximumVelocity */
-     , (87751,  29,    1.15) /* WeaponDefense */
+     , (87751,  29,   1.135) /* WeaponDefense */
      , (87751,  62,     1.1) /* WeaponOffense */
      , (87751,  63,    2.75) /* DamageMod */
      , (87751, 136,       3) /* CriticalMultiplier */
@@ -63,7 +63,7 @@ VALUES (87751,   1, 0x02000874) /* Setup */
      , (87751,  55,       2100) /* ProcSpell - Tattercoat */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (87751,  1605,      2)  /* Aura of Defender Self VI */
+VALUES (87751,  2101,      2)  /* Aura of Cragstone's Will */
      , (87751,  2058,      2)  /* Boon of Refinement */
      , (87751,  2096,      2)  /* Aura of Infected Caress */
      , (87751,  2116,      2)  /* Aura of Atlan's Alacrity */


### PR DESCRIPTION
Corrects composite crossbow with handle recipes to use the crossbow (not bow) as the base. 

Removes nether resistance from Decaying Ruschk Laktar, and sets other resistances to be similar to other undead Ruschk. 

Sets attack type to thrust for 46392 Shadowfire Isparian Spear.

Corrects stats on Composite Crossbow with Fine Handle based on what's listed on both wikis.