### PR TITLE
Update Shroud Cabal and Others

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/00EC.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00EC.sql
@@ -9,7 +9,7 @@ VALUES (0x700EC043, 37107, 0x00EC026C, 480, -10, 17.937, 0.707107, 0, 0, -0.7071
 /* @teleloc 0x00EC026C [480.000000 -10.000000 17.937000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EC044,  4219, 0x00EC0154, 290.254, -119.443, 0.005, 0.764842, 0, 0, 0.644218, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+VALUES (0x700EC044,  7924, 0x00EC0154, 290.254, -119.443, 0.005, 0.764842, 0, 0, 0.644218, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x00EC0154 [290.253998 -119.443001 0.005000] 0.764842 0.000000 0.000000 0.644218 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -198,7 +198,7 @@ VALUES (0x700EC069, 87471, 0x00EC0216, -0.055633, -40.0143, 17.937, 0.707107, 0,
 /* @teleloc 0x00EC0216 [-0.055633 -40.014301 17.937000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700EC06A,  4219, 0x00EC0120, 114.014, -206.253, 0.055, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 7 Min.) */
+VALUES (0x700EC06A,  7924, 0x00EC0120, 114.014, -206.253, 0.055, 0.707107, 0, 0, -0.707107, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x00EC0120 [114.014000 -206.253006 0.055000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/9 WeenieDefaults/Book/Writable/37102 Ley-Leech's Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Writable/37102 Ley-Leech's Orders.sql
@@ -7,6 +7,7 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37102,   1,       8192) /* ItemType - Writable */
      , (37102,   5,          5) /* EncumbranceVal */
      , (37102,  16,          8) /* ItemUseable - Contained */
+     , (37102,  19,          0) /* Value */
      , (37102,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Book/Writable/37103 Node-Leech's Orders.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Writable/37103 Node-Leech's Orders.sql
@@ -7,6 +7,7 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37103,   1,       8192) /* ItemType - Writable */
      , (37103,   5,          5) /* EncumbranceVal */
      , (37103,  16,          8) /* ItemUseable - Contained */
+     , (37103,  19,          0) /* Value */
      , (37103,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/37089 Nomendar al-Rakh.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/37089 Nomendar al-Rakh.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 37089;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (37089, 'ace37089-nomendaralrakh', 10, '2022-08-22 03:09:27') /* Creature */;
+VALUES (37089, 'ace37089-nomendaralrakh', 10, '2024-02-05 10:03:19') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37089,   1,         16) /* ItemType - Creature */
@@ -98,10 +98,11 @@ SET @parent_id = LAST_INSERT_ID();
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Very interesting! This medallion can actually be used to directly siphon mana out of a node between ley lines, if one possesses the geomantic skill necessary... Not useful to one such as yourself, you understand, but I have colleagues who would find this medallion to be valuable and informative. All I can do is thank you with some practical experience...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 12000000, NULL, NULL, NULL, False, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  31 /* EraseQuest */, 0, 1, NULL, 'NorthernResonatingCrystalFlag', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  22 /* StampQuest */, 0, 1, NULL, 'NorthernShroudCabalComplete_0511', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5, 102 /* InqQuestBitsOn */, 0, 1, NULL, '50to11BrokerContractsB', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 256, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  2,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, -2147483648, 12000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  31 /* EraseQuest */, 0, 1, NULL, 'NorthernResonatingCrystalFlag', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'NorthernShroudCabalComplete_0511', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  6, 102 /* InqQuestBitsOn */, 0, 1, NULL, '50to11BrokerContractsB@5', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 256, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (37089,  6 /* Give */,      1, 37093 /* Ley Leech's Medallion */, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -111,10 +112,11 @@ SET @parent_id = LAST_INSERT_ID();
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Very interesting! This medallion can actually be used to directly siphon mana out of a node between ley lines, if one possesses the geomantic skill necessary... Not useful to one such as yourself, you understand, but I have colleagues who would find this medallion to be valuable and informative. All I can do is thank you with some practical experience...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  2,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 5000000, NULL, NULL, NULL, False, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  3,  31 /* EraseQuest */, 0, 1, NULL, 'SouthernResonatingCrystalFlag', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  4,  22 /* StampQuest */, 0, 1, NULL, 'SouthernShroudCabalComplete_0511', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  5, 102 /* InqQuestBitsOn */, 0, 1, NULL, '50to11BrokerContractsB@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 512, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  2,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, -2147483648, 5000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4,  31 /* EraseQuest */, 0, 1, NULL, 'SouthernResonatingCrystalFlag', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  22 /* StampQuest */, 0, 1, NULL, 'SouthernShroudCabalComplete_0511', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  6, 102 /* InqQuestBitsOn */, 0, 1, NULL, '50to11BrokerContractsB@6', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 512, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (37089,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -128,7 +130,7 @@ VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NU
      , (@parent_id,  3,  22 /* StampQuest */, 0, 1, NULL, 'ShroudCabalSouthAccess0208', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37089, 13 /* QuestFailure */,      1, NULL, NULL, NULL, '50to11BrokerContractsB', NULL, NULL, NULL);
+VALUES (37089, 13 /* QuestFailure */,      1, NULL, NULL, NULL, '50to11BrokerContractsB@5', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -137,7 +139,7 @@ VALUES (@parent_id,  0, 106 /* SetQuestBitsOn */, 0, 1, NULL, '50to11BrokerContr
      , (@parent_id,  1,  22 /* StampQuest */, 0, 1, NULL, 'ContractQuestcounter_0511', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (37089, 13 /* QuestFailure */,      1, NULL, NULL, NULL, '50to11BrokerContractsB@2', NULL, NULL, NULL);
+VALUES (37089, 13 /* QuestFailure */,      1, NULL, NULL, NULL, '50to11BrokerContractsB@6', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/37089.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/37089.es
@@ -8,6 +8,7 @@ Give: Node Leech's Medallion (37092)
     - TurnToTarget
     - Tell: Very interesting! This medallion can actually be used to directly siphon mana out of a node between ley lines, if one possesses the geomantic skill necessary... Not useful to one such as yourself, you understand, but I have colleagues who would find this medallion to be valuable and informative. All I can do is thank you with some practical experience...
     - AwardLevelProportionalXP: 100%, Max: 12,000,000
+    - Give: Trade Note (250,000) (20630), 2
     - EraseQuest: NorthernResonatingCrystalFlag
     - StampQuest: NorthernShroudCabalComplete_0511
     - InqQuestBitsOn: 50to11BrokerContractsB, 0x100
@@ -19,6 +20,7 @@ Give: Ley Leech's Medallion (37093)
     - TurnToTarget
     - Tell: Very interesting! This medallion can actually be used to directly siphon mana out of a node between ley lines, if one possesses the geomantic skill necessary... Not useful to one such as yourself, you understand, but I have colleagues who would find this medallion to be valuable and informative. All I can do is thank you with some practical experience...
     - AwardLevelProportionalXP: 100%, Max: 5,000,000
+    - Give: Trade Note (250,000) (20630), 1
     - EraseQuest: SouthernResonatingCrystalFlag
     - StampQuest: SouthernShroudCabalComplete_0511
     - InqQuestBitsOn: 50to11BrokerContractsB, 0x200

--- a/Database/Patches/9 WeenieDefaults/Generic/Gem/24872 Golden Gromnie.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Gem/24872 Golden Gromnie.sql
@@ -1,0 +1,38 @@
+DELETE FROM `weenie` WHERE `class_Id` = 24872;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (24872, 'dollrewardgoldgromnie-ulgrimstuck', 1, '2005-02-09 10:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (24872,   1,       2048) /* ItemType - Gem */
+     , (24872,   3,         21) /* PaletteTemplate - Gold */
+     , (24872,   5,         10) /* EncumbranceVal */
+     , (24872,   8,         10) /* Mass */
+     , (24872,   9,          0) /* ValidLocations - None */
+     , (24872,  16,          1) /* ItemUseable - No */
+     , (24872,  19,         10) /* Value */
+     , (24872,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (24872,  94,         16) /* TargetType - Creature */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (24872,   1, True ) /* Stuck */
+     , (24872,  22, True ) /* Inscribable */
+     , (24872,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (24872,  12,     0.5) /* Shade */
+     , (24872,  39,     0.4) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (24872,   1, 'Golden Gromnie') /* Name */
+     , (24872,   7, 'This time Really no one will be taking my golden gromnie! Don''t Touch!') /* Inscription */
+     , (24872,   8, 'Ulgrim') /* ScribeName */
+     , (24872,  16, 'The gromnie appears to be nailed to the floor... twice.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (24872,   1, 0x02000037) /* Setup */
+     , (24872,   2, 0x090000B2) /* MotionTable */
+     , (24872,   6, 0x040001BB) /* PaletteBase */
+     , (24872,   7, 0x100002CB) /* ClothingBase */
+     , (24872,   8, 0x0600201A) /* Icon */
+     , (24872,  22, 0x3400001C) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/32967 Reflective Shard.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/32967 Reflective Shard.sql
@@ -27,5 +27,6 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (32967,   1, 0x02000C02) /* Setup */
      , (32967,   3, 0x20000014) /* SoundTable */
      , (32967,   6, 0x04000F68) /* PaletteBase */
+     , (32967,   7, 0x10000363) /* ClothingBase */
      , (32967,   8, 0x060063E5) /* Icon */
      , (32967,  22, 0x3400002B) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37092 Node Leech's Medallion.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37092 Node Leech's Medallion.sql
@@ -7,6 +7,7 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37092,   1,        128) /* ItemType - Misc */
      , (37092,   5,         50) /* EncumbranceVal */
      , (37092,  16,          1) /* ItemUseable - No */
+     , (37092,  19,          0) /* Value */
      , (37092,  33,          1) /* Bonded - Bonded */
      , (37092,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37092, 114,          1) /* Attuned - Attuned */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/37093 Ley Leech's Medallion.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/37093 Ley Leech's Medallion.sql
@@ -7,6 +7,7 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (37093,   1,        128) /* ItemType - Misc */
      , (37093,   5,         50) /* EncumbranceVal */
      , (37093,  16,          1) /* ItemUseable - No */
+     , (37093,  19,          0) /* Value */
      , (37093,  33,          1) /* Bonded - Bonded */
      , (37093,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (37093, 114,          1) /* Attuned - Attuned */;
@@ -16,6 +17,7 @@ VALUES (37093,  22, True ) /* Inscribable */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (37093,   1, 'Ley Leech''s Medallion') /* Name */
+     , (37093,  16, 'This medallion was taken from a Shroud Cabal Node Leech. It may be useful to a geomancer.') /* LongDesc */
      , (37093,  33, 'LeyLeechsMedallion_Pickup') /* Quest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)


### PR DESCRIPTION
Adds missing properties to Shroud Cabal quest items (value, description), and MMD reward to this quest.

Adds missing clothing base to Reflective Shard (from low Harbinger quest) to match retail screenshot.

https://asheron.fandom.com/wiki/Reflective_Shard

Corrects clothing base on Golden Gromnie (item in Ulgrim's basement) to match retail screenshot (i.e., so gromnie is actually gold, not blue). The wrong clothing base appears in World DB, and this appears to have been corrected at some point in retail.

https://asheron.fandom.com/wiki/Golden_Gromnie_(Object)