### PR TITLE
Update Bloodstone Wand

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/43813 Sturdy Bloodstone Wand.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/43813 Sturdy Bloodstone Wand.sql
@@ -35,7 +35,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (43813,   5,   -0.03) /* ManaRate */
      , (43813,  29,    1.15) /* WeaponDefense */
      , (43813, 144,     0.2) /* ManaConversionMod */
-     , (43813, 147,    0.06) /* CriticalFrequency */
+     , (43813, 147,    0.25) /* CriticalFrequency */
      , (43813, 152,     1.1) /* ElementalDamageMod */
      , (43813, 157,       1) /* ResistanceModifier */;
 

--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/43814 Delicate Bloodstone Wand.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/43814 Delicate Bloodstone Wand.sql
@@ -38,7 +38,7 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (43814,   5,   -0.03) /* ManaRate */
      , (43814,  29,    1.15) /* WeaponDefense */
      , (43814, 144,     0.2) /* ManaConversionMod */
-     , (43814, 147,    0.06) /* CriticalFrequency */
+     , (43814, 147,    0.25) /* CriticalFrequency */
      , (43814, 152,     1.1) /* ElementalDamageMod */
      , (43814, 157,       1) /* ResistanceModifier */;
 


### PR DESCRIPTION
Increased critical frequency to 0.25 from 0.06. This is a wand from a level 200 quest, and should be on the upper end for quest critical frequencies (for example, in the world db, the singularity scepte has a critical frequency of 0.25).