### PR TITLE
Neftet Skill Rebalance

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/44031 Dust Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/44031 Dust Golem.sql
@@ -17,6 +17,7 @@ VALUES (44031,   1,         16) /* ItemType - Creature */
      , (44031, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (44031, 146,    4000000) /* XpOverride */
      , (44031, 307,         10) /* DamageRating */
+     , (44031, 315,       9999) /* CritResistRating */
      , (44031, 332,        300) /* LuminanceAward */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -88,15 +89,13 @@ VALUES (44031,   1,  9815, 0, 0, 10000) /* MaxHealth */
      , (44031,   5,  5000, 0, 0, 5260) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44031,  6, 0, 2, 0, 425, 0, 0) /* MeleeDefense        Trained */
+VALUES (44031,  6, 0, 2, 0, 525, 0, 0) /* MeleeDefense        Trained */
      , (44031,  7, 0, 2, 0, 450, 0, 0) /* MissileDefense      Trained */
-     , (44031, 13, 0, 3, 0, 490, 0, 0) /* UnarmedCombat       Specialized */
      , (44031, 15, 0, 2, 0, 390, 0, 0) /* MagicDefense        Trained */
      , (44031, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (44031, 33, 0, 2, 0, 350, 0, 0) /* LifeMagic           Trained */
-     , (44031, 34, 0, 2, 0, 350, 0, 0) /* WarMagic            Trained */
-     , (44031, 45, 0, 3, 0, 480, 0, 0) /* LightWeapons        Specialized */
-     , (44031, 46, 0, 3, 0, 480, 0, 0) /* FinesseWeapons      Specialized */;
+     , (44031, 33, 0, 2, 0, 330, 0, 0) /* LifeMagic           Trained */
+     , (44031, 34, 0, 2, 0, 330, 0, 0) /* WarMagic            Trained */
+     , (44031, 45, 0, 3, 0, 615, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (44031,  0,  4,  0,    0,  490,  490,  441,  490,  294,  490,  490,  490,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/44032 Dust Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/44032 Dust Golem.sql
@@ -85,15 +85,13 @@ VALUES (44032,   1,  9815, 0, 0, 10000) /* MaxHealth */
      , (44032,   5,  5000, 0, 0, 5260) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44032,  6, 0, 2, 0, 425, 0, 0) /* MeleeDefense        Trained */
+VALUES (44032,  6, 0, 2, 0, 525, 0, 0) /* MeleeDefense        Trained */
      , (44032,  7, 0, 2, 0, 450, 0, 0) /* MissileDefense      Trained */
-     , (44032, 13, 0, 3, 0, 490, 0, 0) /* UnarmedCombat       Specialized */
      , (44032, 15, 0, 2, 0, 390, 0, 0) /* MagicDefense        Trained */
      , (44032, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (44032, 33, 0, 2, 0, 350, 0, 0) /* LifeMagic           Trained */
-     , (44032, 34, 0, 2, 0, 350, 0, 0) /* WarMagic            Trained */
-     , (44032, 45, 0, 3, 0, 480, 0, 0) /* LightWeapons        Specialized */
-     , (44032, 46, 0, 3, 0, 480, 0, 0) /* FinesseWeapons      Specialized */;
+     , (44032, 33, 0, 2, 0, 330, 0, 0) /* LifeMagic           Trained */
+     , (44032, 34, 0, 2, 0, 330, 0, 0) /* WarMagic            Trained */
+     , (44032, 45, 0, 3, 0, 615, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (44032,  0,  4,  0,    0,  490,  490,  490,  196,  196,  392,  328,  392,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/44033 Burning Sands Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/44033 Burning Sands Golem.sql
@@ -19,6 +19,7 @@ VALUES (44033,   1,         16) /* ItemType - Creature */
      , (44033, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (44033, 146,    4000000) /* XpOverride */
      , (44033, 307,         10) /* DamageRating */
+     , (44033, 315,       9999) /* CritResistRating */
      , (44033, 332,        300) /* LuminanceAward */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -91,14 +92,13 @@ VALUES (44033,   1,  9815, 0, 0, 10000) /* MaxHealth */
      , (44033,   5,  5000, 0, 0, 5260) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44033,  6, 0, 2, 0, 425, 0, 0) /* MeleeDefense        Trained */
-     , (44033,  7, 0, 2, 0, 450, 0, 0) /* MissileDefense      Trained */
-     , (44033, 15, 0, 2, 0, 415, 0, 0) /* MagicDefense        Trained */
-     , (44033, 24, 0, 2, 0, 300, 0, 0) /* Run                 Trained */
-     , (44033, 33, 0, 2, 0, 400, 0, 0) /* LifeMagic           Trained */
-     , (44033, 34, 0, 2, 0, 400, 0, 0) /* WarMagic            Trained */
-     , (44033, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */
-     , (44033, 46, 0, 3, 0, 500, 0, 0) /* FinesseWeapons      Specialized */;
+VALUES (44033,  6, 0, 3, 0, 575, 0, 0) /* MeleeDefense        Trained */
+     , (44033,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Trained */
+     , (44033, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Trained */
+     , (44033, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
+     , (44033, 33, 0, 3, 0, 330, 0, 0) /* LifeMagic           Trained */
+     , (44033, 34, 0, 3, 0, 330, 0, 0) /* WarMagic            Trained */
+     , (44033, 45, 0, 3, 0, 615, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (44033,  0,  4,  0,    0,  500,  500,  450,  375,  500,  500,  335,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/44034 Burning Sands Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/44034 Burning Sands Golem.sql
@@ -85,14 +85,13 @@ VALUES (44034,   1,  9815, 0, 0, 10000) /* MaxHealth */
      , (44034,   5,  5000, 0, 0, 5260) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44034,  6, 0, 2, 0, 425, 0, 0) /* MeleeDefense        Trained */
-     , (44034,  7, 0, 2, 0, 450, 0, 0) /* MissileDefense      Trained */
-     , (44034, 15, 0, 2, 0, 415, 0, 0) /* MagicDefense        Trained */
-     , (44034, 24, 0, 2, 0, 300, 0, 0) /* Run                 Trained */
-     , (44034, 33, 0, 2, 0, 400, 0, 0) /* LifeMagic           Trained */
-     , (44034, 34, 0, 2, 0, 400, 0, 0) /* WarMagic            Trained */
-     , (44034, 45, 0, 3, 0, 500, 0, 0) /* LightWeapons        Specialized */
-     , (44034, 46, 0, 3, 0, 500, 0, 0) /* FinesseWeapons      Specialized */;
+VALUES (44034,  6, 0, 3, 0, 575, 0, 0) /* MeleeDefense        Trained */
+     , (44034,  7, 0, 3, 0, 440, 0, 0) /* MissileDefense      Trained */
+     , (44034, 15, 0, 3, 0, 415, 0, 0) /* MagicDefense        Trained */
+     , (44034, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
+     , (44034, 33, 0, 3, 0, 330, 0, 0) /* LifeMagic           Trained */
+     , (44034, 34, 0, 3, 0, 330, 0, 0) /* WarMagic            Trained */
+     , (44034, 45, 0, 3, 0, 615, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (44034,  0,  4,  0,    0,  500,  500,  500,  200,  200,  400,  335,  400,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44039 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44039 Mu-miyah Lord.sql
@@ -97,7 +97,7 @@ VALUES (44039,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
      , (44039,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
      , (44039, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (44039, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44039, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (44039, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
      , (44039, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
      , (44039, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (44039, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44039 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44039 Mu-miyah Lord.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44039;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44039, 'ace44039-mumiyahlord', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (44039, 'ace44039-mumiyahlord', 10, '2024-03-09 03:28:17') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44039,   1,         16) /* ItemType - Creature */
@@ -93,40 +93,49 @@ VALUES (44039,   1,  6870, 0, 0, 7000) /* MaxHealth */
      , (44039,   5,  2000, 0, 0, 2370) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44039,  6, 0, 2, 0, 470, 0, 0) /* MeleeDefense        Trained */
-     , (44039,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (44039, 15, 0, 2, 0, 450, 0, 0) /* MagicDefense        Trained */
+VALUES (44039,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
+     , (44039,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
+     , (44039, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (44039, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44039, 31, 0, 2, 0, 500, 0, 0) /* CreatureEnchantment Trained */
-     , (44039, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (44039, 34, 0, 2, 0, 525, 0, 0) /* WarMagic            Trained */
+     , (44039, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (44039, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (44039, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (44039, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */
      , (44039, 46, 0, 3, 0, 600, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (44039,  0,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (44039,  1,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (44039,  2,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (44039,  3,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (44039,  4,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (44039,  5,  4, 550, 0.75,  470,  315,  423,  353,  470,  315,  315,  470,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (44039,  6,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (44039,  7,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (44039,  8,  4, 550, 0.75,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (44039,  0,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (44039,  1,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (44039,  2,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (44039,  3,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (44039,  4,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (44039,  5,  4, 550, 0.75,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (44039,  6,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (44039,  7,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (44039,  8,  4, 550, 0.75,  470,  235,  235,  235,  235,  235,  235,  235,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (44039,  1832,   2.06)  /* Torrential Acid */
-     , (44039,  1841,   2.06)  /* Slithering Flames */
-     , (44039,  2042,   2.06)  /* Demon's Tongues */
-     , (44039,  2123,   2.06)  /* Celdiseth's Searing */
-     , (44039,  2130,   2.06)  /* Infernae */
-     , (44039,  2710,   2.06)  /* Volcanic Blast */
-     , (44039,  3119,   2.06)  /* Sear Flesh */
-     , (44039,  3883,   2.06)  /* Pyroclastic Explosion */
-     , (44039,  3886,   2.08)  /* Magic Disarmament */
+VALUES (44039,  1832,   2.04)  /* Torrential Acid */
+     , (44039,  1841,   2.03)  /* Slithering Flames */
+     , (44039,  2042,   2.04)  /* Demon's Tongues */
+     , (44039,  2123,   2.03)  /* Celdiseth's Searing */
+     , (44039,  2130,   2.03)  /* Infernae */
+     , (44039,  2710,   2.05)  /* Volcanic Blast */
+     , (44039,  3119,   2.05)  /* Sear Flesh */
+     , (44039,  3883,   2.05)  /* Pyroclastic Explosion */
+     , (44039,  3886,   2.06)  /* Magic Disarmament */
      , (44039,  3905,   2.06)  /* Essence's Fury */
      , (44039,  3908,   2.06)  /* Mana Blast */
-     , (44039,  5532,   2.06)  /* Incantation of Bloodstone Bolt */;
+     , (44039,  5532,   2.08)  /* Incantation of Bloodstone Bolt */
+     , (44039,  4421,   2.07)  /* Incantation of Acid Arc */
+     , (44039,  4423,   2.08)  /* Incantation of Flame Arc */
+     , (44039,  4431,   2.07)  /* Incantation of Acid Blast */
+     , (44039,  4433,   2.07)  /* Incantation of Acid Stream */
+     , (44039,  4434,   2.08)  /* Incantation of Acid Volley */
+     , (44039,  4438,   2.08)  /* Incantation of Flame Blast */
+     , (44039,  4441,   2.09)  /* Incantation of Flame Volley */
+     , (44039,  4473,    2.1)  /* Incantation of Acid Vulnerability Other */
+     , (44039,  4481,   2.11)  /* Incantation of Fire Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44039, 9, 44240,  1, 0, 0.1, False) /* Create A'nekshay Token (44240) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44040 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44040 Mu-miyah Lord.sql
@@ -92,13 +92,13 @@ VALUES (44040,   1,  6870, 0, 0, 7000) /* MaxHealth */
      , (44040,   5,  2000, 0, 0, 2370) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44040,  6, 0, 2, 0, 470, 0, 0) /* MeleeDefense        Trained */
-     , (44040,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (44040, 15, 0, 2, 0, 450, 0, 0) /* MagicDefense        Trained */
+VALUES (44040,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
+     , (44040,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
+     , (44040, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (44040, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44040, 31, 0, 2, 0, 500, 0, 0) /* CreatureEnchantment Trained */
-     , (44040, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (44040, 34, 0, 2, 0, 525, 0, 0) /* WarMagic            Trained */
+     , (44040, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (44040, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (44040, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (44040, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */
      , (44040, 46, 0, 3, 0, 600, 0, 0) /* FinesseWeapons      Specialized */;
 
@@ -114,18 +114,27 @@ VALUES (44040,  0,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,
      , (44040,  8,  4, 550, 0.75,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (44040,  1832,   2.06)  /* Torrential Acid */
-     , (44040,  1841,   2.06)  /* Slithering Flames */
-     , (44040,  2042,   2.06)  /* Demon's Tongues */
-     , (44040,  2123,   2.06)  /* Celdiseth's Searing */
-     , (44040,  2130,   2.06)  /* Infernae */
-     , (44040,  2710,   2.06)  /* Volcanic Blast */
-     , (44040,  3119,   2.06)  /* Sear Flesh */
-     , (44040,  3883,   2.06)  /* Pyroclastic Explosion */
-     , (44040,  3886,   2.08)  /* Magic Disarmament */
+VALUES (44040,  1832,   2.04)  /* Torrential Acid */
+     , (44040,  1841,   2.03)  /* Slithering Flames */
+     , (44040,  2042,   2.04)  /* Demon's Tongues */
+     , (44040,  2123,   2.03)  /* Celdiseth's Searing */
+     , (44040,  2130,   2.03)  /* Infernae */
+     , (44040,  2710,   2.05)  /* Volcanic Blast */
+     , (44040,  3119,   2.05)  /* Sear Flesh */
+     , (44040,  3883,   2.05)  /* Pyroclastic Explosion */
+     , (44040,  3886,   2.06)  /* Magic Disarmament */
      , (44040,  3905,   2.06)  /* Essence's Fury */
      , (44040,  3908,   2.06)  /* Mana Blast */
-     , (44040,  5532,   2.06)  /* Incantation of Bloodstone Bolt */;
+     , (44040,  5532,   2.08)  /* Incantation of Bloodstone Bolt */
+     , (44040,  4421,   2.07)  /* Incantation of Acid Arc */
+     , (44040,  4423,   2.08)  /* Incantation of Flame Arc */
+     , (44040,  4431,   2.07)  /* Incantation of Acid Blast */
+     , (44040,  4433,   2.07)  /* Incantation of Acid Stream */
+     , (44040,  4434,   2.08)  /* Incantation of Acid Volley */
+     , (44040,  4438,   2.08)  /* Incantation of Flame Blast */
+     , (44040,  4441,   2.09)  /* Incantation of Flame Volley */
+     , (44040,  4473,    2.1)  /* Incantation of Acid Vulnerability Other */
+     , (44040,  4481,   2.11)  /* Incantation of Fire Vulnerability Other */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (44040,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44040 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44040 Mu-miyah Lord.sql
@@ -96,7 +96,7 @@ VALUES (44040,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
      , (44040,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
      , (44040, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (44040, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44040, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (44040, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
      , (44040, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
      , (44040, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (44040, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44045 Mu-miyah Vizier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44045 Mu-miyah Vizier.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 44045;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (44045, 'ace44045-mumiyahvizier', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (44045, 'ace44045-mumiyahvizier', 10, '2024-03-09 03:56:23') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (44045,   1,         16) /* ItemType - Creature */
@@ -93,32 +93,34 @@ VALUES (44045,   1,  4490, 0, 0, 4600) /* MaxHealth */
      , (44045,   5,  1550, 0, 0, 1880) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44045,  6, 0, 2, 0, 450, 0, 0) /* MeleeDefense        Trained */
+VALUES (44045,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
      , (44045,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (44045, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
+     , (44045, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
      , (44045, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44045, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (44045, 34, 0, 2, 0, 480, 0, 0) /* WarMagic            Trained */
-     , (44045, 45, 0, 3, 0, 550, 0, 0) /* LightWeapons        Specialized */
-     , (44045, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */;
+     , (44045, 33, 0, 2, 0, 240, 0, 0) /* LifeMagic           Trained */
+     , (44045, 34, 0, 2, 0, 240, 0, 0) /* WarMagic            Trained */
+     , (44045, 45, 0, 3, 0, 610, 0, 0) /* LightWeapons        Specialized */
+     , (44045, 46, 0, 3, 0, 610, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (44045,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (44045,  1,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (44045,  2,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (44045,  3,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (44045,  4,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (44045,  5,  4, 450, 0.75,  460,  308,  414,  345,  460,  308,  308,  460,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (44045,  6,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (44045,  7,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (44045,  8,  4, 400, 0.75,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (44045,  0,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (44045,  1,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (44045,  2,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (44045,  3,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (44045,  4,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (44045,  5,  4, 450, 0.75,  460,  230,  230,  230,  230,  230,  230,  230,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (44045,  6,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (44045,  7,  4,  0,    0,  460,  230,  230,  230,  230,  230,  230,  230,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (44045,  8,  4, 400, 0.75,  460,  230,  230,  230,  230,  230,  230,  230,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (44045,  2174,   2.06)  /* Archer's Gift */
+VALUES (44045,  4477,   2.04)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (44045,  4485,   2.04)  /* Incantation of Piercing Vulnerability Other */
+     , (44045,  4443,   2.05)  /* Incantation of Force Bolt */
      , (44045,  4424,   2.06)  /* Incantation of Force Arc */
      , (44045,  4442,   2.06)  /* Incantation of Force Blast */
-     , (44045,  4489,   2.06)  /* Incantation of Fester Other */
-     , (44045,  6192,   2.06)  /* Nuhmudira's Spines II */;
+     , (44045,  4489,   2.05)  /* Incantation of Fester Other */
+     , (44045,  1786,   2.05)  /* Nuhmudira's Spines */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44045, 9, 44240,  1, 0, 0.1, False) /* Create A'nekshay Token (44240) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44046 Mu-miyah Vizier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44046 Mu-miyah Vizier.sql
@@ -92,14 +92,14 @@ VALUES (44046,   1,  4490, 0, 0, 4600) /* MaxHealth */
      , (44046,   5,  1550, 0, 0, 1880) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44046,  6, 0, 2, 0, 450, 0, 0) /* MeleeDefense        Trained */
+VALUES (44046,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
      , (44046,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (44046, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
+     , (44046, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
      , (44046, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44046, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (44046, 34, 0, 2, 0, 480, 0, 0) /* WarMagic            Trained */
-     , (44046, 45, 0, 3, 0, 550, 0, 0) /* LightWeapons        Specialized */
-     , (44046, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */;
+     , (44046, 33, 0, 2, 0, 240, 0, 0) /* LifeMagic           Trained */
+     , (44046, 34, 0, 2, 0, 240, 0, 0) /* WarMagic            Trained */
+     , (44046, 45, 0, 3, 0, 610, 0, 0) /* LightWeapons        Specialized */
+     , (44046, 46, 0, 3, 0, 610, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (44046,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -113,11 +113,13 @@ VALUES (44046,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,
      , (44046,  8,  4, 400, 0.75,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (44046,  2174,   2.06)  /* Archer's Gift */
+VALUES (44046,  4477,   2.04)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (44046,  4485,   2.04)  /* Incantation of Piercing Vulnerability Other */
+     , (44046,  4443,   2.05)  /* Incantation of Force Bolt */
      , (44046,  4424,   2.06)  /* Incantation of Force Arc */
      , (44046,  4442,   2.06)  /* Incantation of Force Blast */
-     , (44046,  4489,   2.06)  /* Incantation of Fester Other */
-     , (44046,  6192,   2.06)  /* Nuhmudira's Spines II */;
+     , (44046,  4489,   2.05)  /* Incantation of Fester Other */
+     , (44046,  1786,   2.05)  /* Nuhmudira's Spines */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (44046,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44093 Mu-miyah Vizier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44093 Mu-miyah Vizier.sql
@@ -93,14 +93,14 @@ VALUES (44093,   1,  4490, 0, 0, 4600) /* MaxHealth */
      , (44093,   5,  1550, 0, 0, 1880) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44093,  6, 0, 2, 0, 450, 0, 0) /* MeleeDefense        Trained */
+VALUES (44093,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
      , (44093,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (44093, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
+     , (44093, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
      , (44093, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44093, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (44093, 34, 0, 2, 0, 480, 0, 0) /* WarMagic            Trained */
-     , (44093, 45, 0, 3, 0, 550, 0, 0) /* LightWeapons        Specialized */
-     , (44093, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */;
+     , (44093, 33, 0, 2, 0, 240, 0, 0) /* LifeMagic           Trained */
+     , (44093, 34, 0, 2, 0, 240, 0, 0) /* WarMagic            Trained */
+     , (44093, 45, 0, 3, 0, 610, 0, 0) /* LightWeapons        Specialized */
+     , (44093, 46, 0, 3, 0, 610, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (44093,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -114,11 +114,13 @@ VALUES (44093,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,
      , (44093,  8,  4, 400, 0.75,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (44093,  2174,   2.06)  /* Archer's Gift */
+VALUES (44093,  4477,   2.04)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (44093,  4485,   2.04)  /* Incantation of Piercing Vulnerability Other */
+     , (44093,  4443,   2.05)  /* Incantation of Force Bolt */
      , (44093,  4424,   2.06)  /* Incantation of Force Arc */
      , (44093,  4442,   2.06)  /* Incantation of Force Blast */
-     , (44093,  4489,   2.06)  /* Incantation of Fester Other */
-     , (44093,  6192,   2.06)  /* Nuhmudira's Spines II */;
+     , (44093,  4489,   2.05)  /* Incantation of Fester Other */
+     , (44093,  1786,   2.05)  /* Nuhmudira's Spines */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44093, 9, 44240,  1, 0, 0.1, False) /* Create A'nekshay Token (44240) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44096 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44096 Mu-miyah Lord.sql
@@ -93,13 +93,13 @@ VALUES (44096,   1,  6870, 0, 0, 7000) /* MaxHealth */
      , (44096,   5,  2000, 0, 0, 2370) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44096,  6, 0, 2, 0, 470, 0, 0) /* MeleeDefense        Trained */
-     , (44096,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (44096, 15, 0, 2, 0, 450, 0, 0) /* MagicDefense        Trained */
+VALUES (44096,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
+     , (44096,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
+     , (44096, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (44096, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44096, 31, 0, 2, 0, 500, 0, 0) /* CreatureEnchantment Trained */
-     , (44096, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (44096, 34, 0, 2, 0, 525, 0, 0) /* WarMagic            Trained */
+     , (44096, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (44096, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (44096, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (44096, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */
      , (44096, 46, 0, 3, 0, 600, 0, 0) /* FinesseWeapons      Specialized */;
 
@@ -115,18 +115,27 @@ VALUES (44096,  0,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,
      , (44096,  8,  4, 550, 0.75,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (44096,  1832,   2.06)  /* Torrential Acid */
-     , (44096,  1841,   2.06)  /* Slithering Flames */
-     , (44096,  2042,   2.06)  /* Demon's Tongues */
-     , (44096,  2123,   2.06)  /* Celdiseth's Searing */
-     , (44096,  2130,   2.06)  /* Infernae */
-     , (44096,  2710,   2.06)  /* Volcanic Blast */
-     , (44096,  3119,   2.06)  /* Sear Flesh */
-     , (44096,  3883,   2.06)  /* Pyroclastic Explosion */
-     , (44096,  3886,   2.08)  /* Magic Disarmament */
+VALUES (44096,  1832,   2.04)  /* Torrential Acid */
+     , (44096,  1841,   2.03)  /* Slithering Flames */
+     , (44096,  2042,   2.04)  /* Demon's Tongues */
+     , (44096,  2123,   2.03)  /* Celdiseth's Searing */
+     , (44096,  2130,   2.03)  /* Infernae */
+     , (44096,  2710,   2.05)  /* Volcanic Blast */
+     , (44096,  3119,   2.05)  /* Sear Flesh */
+     , (44096,  3883,   2.05)  /* Pyroclastic Explosion */
+     , (44096,  3886,   2.06)  /* Magic Disarmament */
      , (44096,  3905,   2.06)  /* Essence's Fury */
      , (44096,  3908,   2.06)  /* Mana Blast */
-     , (44096,  5532,   2.06)  /* Incantation of Bloodstone Bolt */;
+     , (44096,  5532,   2.08)  /* Incantation of Bloodstone Bolt */
+     , (44096,  4421,   2.07)  /* Incantation of Acid Arc */
+     , (44096,  4423,   2.08)  /* Incantation of Flame Arc */
+     , (44096,  4431,   2.07)  /* Incantation of Acid Blast */
+     , (44096,  4433,   2.07)  /* Incantation of Acid Stream */
+     , (44096,  4434,   2.08)  /* Incantation of Acid Volley */
+     , (44096,  4438,   2.08)  /* Incantation of Flame Blast */
+     , (44096,  4441,   2.09)  /* Incantation of Flame Volley */
+     , (44096,  4473,    2.1)  /* Incantation of Acid Vulnerability Other */
+     , (44096,  4481,   2.11)  /* Incantation of Fire Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44096, 9, 44240,  1, 0, 0.1, False) /* Create A'nekshay Token (44240) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44096 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44096 Mu-miyah Lord.sql
@@ -97,7 +97,7 @@ VALUES (44096,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
      , (44096,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
      , (44096, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (44096, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (44096, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (44096, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
      , (44096, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
      , (44096, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (44096, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/71388 Mu-miyah Vizier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/71388 Mu-miyah Vizier.sql
@@ -90,14 +90,14 @@ VALUES (71388,   1,  4490, 0, 0, 4600) /* MaxHealth */
      , (71388,   5,  1550, 0, 0, 1880) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (71388,  6, 0, 2, 0, 450, 0, 0) /* MeleeDefense        Trained */
+VALUES (71388,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
      , (71388,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (71388, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
+     , (71388, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
      , (71388, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (71388, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (71388, 34, 0, 2, 0, 480, 0, 0) /* WarMagic            Trained */
-     , (71388, 45, 0, 3, 0, 550, 0, 0) /* LightWeapons        Specialized */
-     , (71388, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */;
+     , (71388, 33, 0, 2, 0, 240, 0, 0) /* LifeMagic           Trained */
+     , (71388, 34, 0, 2, 0, 240, 0, 0) /* WarMagic            Trained */
+     , (71388, 45, 0, 3, 0, 610, 0, 0) /* LightWeapons        Specialized */
+     , (71388, 46, 0, 3, 0, 610, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (71388,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -111,11 +111,13 @@ VALUES (71388,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,
      , (71388,  8,  4, 400, 0.75,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (71388,  4442,   2.06)  /* Incantation of Force Blast */
+VALUES (71388,  4477,   2.04)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (71388,  4485,   2.04)  /* Incantation of Piercing Vulnerability Other */
+     , (71388,  4443,   2.05)  /* Incantation of Force Bolt */
      , (71388,  4424,   2.06)  /* Incantation of Force Arc */
-     , (71388,  6192,   2.06)  /* Nuhmudira's Spines II */
-     , (71388,  2174,   2.06)  /* Archer's Gift */
-     , (71388,  4489,   2.06)  /* Incantation of Fester Other */;
+     , (71388,  4442,   2.06)  /* Incantation of Force Blast */
+     , (71388,  4489,   2.05)  /* Incantation of Fester Other */
+     , (71388,  1786,   2.05)  /* Nuhmudira's Spines */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (71388, 9, 71355,  1, 0, 1, False) /* Create Mu-Miyah Sacrificial Dagger (71355) for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/87589 Mu-miyah Vizier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/87589 Mu-miyah Vizier.sql
@@ -91,14 +91,14 @@ VALUES (87589,   1,  4490, 0, 0, 4600) /* MaxHealth */
      , (87589,   5,  1550, 0, 0, 1880) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (87589,  6, 0, 2, 0, 450, 0, 0) /* MeleeDefense        Trained */
+VALUES (87589,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
      , (87589,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (87589, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
+     , (87589, 15, 0, 2, 0, 320, 0, 0) /* MagicDefense        Trained */
      , (87589, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (87589, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (87589, 34, 0, 2, 0, 480, 0, 0) /* WarMagic            Trained */
-     , (87589, 45, 0, 3, 0, 550, 0, 0) /* LightWeapons        Specialized */
-     , (87589, 46, 0, 3, 0, 450, 0, 0) /* FinesseWeapons      Specialized */;
+     , (87589, 33, 0, 2, 0, 240, 0, 0) /* LifeMagic           Trained */
+     , (87589, 34, 0, 2, 0, 240, 0, 0) /* WarMagic            Trained */
+     , (87589, 45, 0, 3, 0, 610, 0, 0) /* LightWeapons        Specialized */
+     , (87589, 46, 0, 3, 0, 610, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (87589,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
@@ -112,11 +112,13 @@ VALUES (87589,  0,  4,  0,    0,  460,  308,  414,  345,  460,  308,  308,  460,
      , (87589,  8,  4, 400, 0.75,  460,  308,  414,  345,  460,  308,  308,  460,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (87589,  2174,   2.06)  /* Archer's Gift */
+VALUES (87589,  4477,   2.04)  /* Incantation of Bludgeoning Vulnerability Other */
+     , (87589,  4485,   2.04)  /* Incantation of Piercing Vulnerability Other */
+     , (87589,  4443,   2.05)  /* Incantation of Force Bolt */
      , (87589,  4424,   2.06)  /* Incantation of Force Arc */
      , (87589,  4442,   2.06)  /* Incantation of Force Blast */
-     , (87589,  4489,   2.06)  /* Incantation of Fester Other */
-     , (87589,  6192,   2.06)  /* Nuhmudira's Spines II */;
+     , (87589,  4489,   2.05)  /* Incantation of Fester Other */
+     , (87589,  1786,   2.05)  /* Nuhmudira's Spines */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (87589, 9, 44240,  1, 0, 0.1, False) /* Create A'nekshay Token (44240) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/87848 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/87848 Mu-miyah Lord.sql
@@ -92,13 +92,13 @@ VALUES (87848,   1,  6870, 0, 0, 7000) /* MaxHealth */
      , (87848,   5,  2000, 0, 0, 2370) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (87848,  6, 0, 2, 0, 470, 0, 0) /* MeleeDefense        Trained */
-     , (87848,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (87848, 15, 0, 2, 0, 450, 0, 0) /* MagicDefense        Trained */
+VALUES (87848,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
+     , (87848,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
+     , (87848, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (87848, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (87848, 31, 0, 2, 0, 500, 0, 0) /* CreatureEnchantment Trained */
-     , (87848, 33, 0, 2, 0, 500, 0, 0) /* LifeMagic           Trained */
-     , (87848, 34, 0, 2, 0, 525, 0, 0) /* WarMagic            Trained */
+     , (87848, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (87848, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (87848, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (87848, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */
      , (87848, 46, 0, 3, 0, 600, 0, 0) /* FinesseWeapons      Specialized */;
 
@@ -114,18 +114,27 @@ VALUES (87848,  0,  4,  0,    0,  470,  315,  423,  353,  470,  315,  315,  470,
      , (87848,  8,  4, 550, 0.75,  470,  315,  423,  353,  470,  315,  315,  470,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (87848,  1832,   2.06)  /* Torrential Acid */
-     , (87848,  1841,   2.06)  /* Slithering Flames */
-     , (87848,  2042,   2.06)  /* Demon's Tongues */
-     , (87848,  2123,   2.06)  /* Celdiseth's Searing */
-     , (87848,  2130,   2.06)  /* Infernae */
-     , (87848,  2710,   2.06)  /* Volcanic Blast */
-     , (87848,  3119,   2.06)  /* Sear Flesh */
-     , (87848,  3883,   2.06)  /* Pyroclastic Explosion */
-     , (87848,  3886,   2.08)  /* Magic Disarmament */
+VALUES (87848,  1832,   2.04)  /* Torrential Acid */
+     , (87848,  1841,   2.03)  /* Slithering Flames */
+     , (87848,  2042,   2.04)  /* Demon's Tongues */
+     , (87848,  2123,   2.03)  /* Celdiseth's Searing */
+     , (87848,  2130,   2.03)  /* Infernae */
+     , (87848,  2710,   2.05)  /* Volcanic Blast */
+     , (87848,  3119,   2.05)  /* Sear Flesh */
+     , (87848,  3883,   2.05)  /* Pyroclastic Explosion */
+     , (87848,  3886,   2.06)  /* Magic Disarmament */
      , (87848,  3905,   2.06)  /* Essence's Fury */
      , (87848,  3908,   2.06)  /* Mana Blast */
-     , (87848,  5532,   2.06)  /* Incantation of Bloodstone Bolt */;
+     , (87848,  5532,   2.08)  /* Incantation of Bloodstone Bolt */
+     , (87848,  4421,   2.07)  /* Incantation of Acid Arc */
+     , (87848,  4423,   2.08)  /* Incantation of Flame Arc */
+     , (87848,  4431,   2.07)  /* Incantation of Acid Blast */
+     , (87848,  4433,   2.07)  /* Incantation of Acid Stream */
+     , (87848,  4434,   2.08)  /* Incantation of Acid Volley */
+     , (87848,  4438,   2.08)  /* Incantation of Flame Blast */
+     , (87848,  4441,   2.09)  /* Incantation of Flame Volley */
+     , (87848,  4473,    2.1)  /* Incantation of Acid Vulnerability Other */
+     , (87848,  4481,   2.11)  /* Incantation of Fire Vulnerability Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (87848, 9, 44240,  1, 0, 0.1, False) /* Create A'nekshay Token (44240) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/87848 Mu-miyah Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/87848 Mu-miyah Lord.sql
@@ -96,7 +96,7 @@ VALUES (87848,  6, 0, 2, 0, 500, 0, 0) /* MeleeDefense        Trained */
      , (87848,  7, 0, 2, 0, 460, 0, 0) /* MissileDefense      Trained */
      , (87848, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
      , (87848, 24, 0, 2, 0, 255, 0, 0) /* Run                 Trained */
-     , (87848, 31, 0, 2, 0, 200, 0, 0) /* CreatureEnchantment Trained */
+     , (87848, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
      , (87848, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
      , (87848, 34, 0, 2, 0, 270, 0, 0) /* WarMagic            Trained */
      , (87848, 45, 0, 3, 0, 600, 0, 0) /* LightWeapons        Specialized */


### PR DESCRIPTION
Updated skill levels for Neftet golems and mummies based on pcaps. Also corrected some spellbooks. In general, magic skills were too high, while some melee skills were too low.