### PR TITLE
Update 37585 Soul Bound Staff.sql

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Caster/Caster/37585 Soul Bound Staff.sql
+++ b/Database/Patches/9 WeenieDefaults/Caster/Caster/37585 Soul Bound Staff.sql
@@ -39,10 +39,10 @@ VALUES (37585,   5,   -0.05) /* ManaRate */
      , (37585,  29,     1.2) /* WeaponDefense */
      , (37585,  39,     0.7) /* DefaultScale */
      , (37585,  76,     0.7) /* Translucency */
-     , (37585, 136,       2) /* CriticalMultiplier */
+     , (37585, 136,     3.5) /* CriticalMultiplier */
      , (37585, 138,     1.5) /* SlayerDamageBonus */
      , (37585, 144,    0.15) /* ManaConversionMod */
-     , (37585, 147,     0.3) /* CriticalFrequency */
+     , (37585, 147,    0.15) /* CriticalFrequency */
      , (37585, 152,     1.2) /* ElementalDamageMod */
      , (37585, 157,       1) /* ResistanceModifier */;
 


### PR DESCRIPTION
Adjusts critical multiplier and critical frequency on the SB staff for a closer match to retail.

Based on a retail video of Berek fighting Aerbax, with pierce vul 8, the average on normal hits was 1317 (based on 66 shots). The critical average was 4432 (based on 11 shots).

Without pierce vul (only on the staff's pierce rend), the normal hit average is 1031 (total 40 shots) and 3506 on criticals (total 10 shots).

Either way, criticals are about 3.5 more damage than normal hits. Also, out of the 149 shots in the video, 25 were criticals, which is a .1677 rate. Subtracting 1% for eye of remorseless aug, and rounding down to be more conservative, gives 15% chance to critical.