### PR TITLE
Portal Updates 35038 33035 87641 009D 0030 0043 0049 004D

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/0030.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0030.sql
@@ -37,7 +37,7 @@ VALUES (0x70030001, 31293, 0x003001AE, 8.70818, -128.822, 0.005, -0.926105, 0, 0
 /* @teleloc 0x003001AE [8.708180 -128.822006 0.005000] -0.926105 0.000000 0.000000 -0.377266 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70030002, 19131, 0x00300186, 120.762, -0.903507, -5.995, -0.352254, 0, 0, 0.935904, False, '2021-11-01 00:00:00'); /* Portal to Fort Tethana */
+VALUES (0x70030002, 19131, 0x00300186, 120.762, -0.903507, -5.995, -0.352254, 0, 0, 0.935904, False, '2024-04-13 00:00:00'); /* Portal to Fort Tethana */
 /* @teleloc 0x00300186 [120.762001 -0.903507 -5.995000] -0.352254 0.000000 0.000000 0.935904 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/0030.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0030.sql
@@ -37,7 +37,7 @@ VALUES (0x70030001, 31293, 0x003001AE, 8.70818, -128.822, 0.005, -0.926105, 0, 0
 /* @teleloc 0x003001AE [8.708180 -128.822006 0.005000] -0.926105 0.000000 0.000000 -0.377266 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70030002, 31293, 0x00300186, 120.762, -0.903507, -5.995, -0.352254, 0, 0, 0.935904, False, '2021-11-01 00:00:00'); /* Surface */
+VALUES (0x70030002, 19131, 0x00300186, 120.762, -0.903507, -5.995, -0.352254, 0, 0, 0.935904, False, '2021-11-01 00:00:00'); /* Portal to Fort Tethana */
 /* @teleloc 0x00300186 [120.762001 -0.903507 -5.995000] -0.352254 0.000000 0.000000 0.935904 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/0043.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0043.sql
@@ -84,8 +84,8 @@ VALUES (0x700433E8, 0x700433EA, '2021-11-01 00:00:00') /* Viamontian Lord (28656
      , (0x700433E8, 0x70043437, '2021-11-01 00:00:00') /* Master Versario (32230) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700433E9, 32240, 0x00430101, 0.085737, -325.252, -18.0627, -0.999718, 0, 0, -0.023732,  True, '2021-11-01 00:00:00'); /* Surface */
-/* @teleloc 0x00430101 [0.085737 -325.252014 -18.062700] -0.999718 0.000000 0.000000 -0.023732 */
+VALUES (0x700433E9, 32240, 0x00430101, 0, -328.000977, -18, 1, 0, 0, 0,  False, '2024-04-13 20:00:00'); /* Surface */
+/* @teleloc 0x00430101 [0 -328.000977 -18] 1 0 0 0 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700433EA, 28656, 0x0043010F, 25.0251, -359.211, -17.9936, -0.537582, 0, 0, 0.843211,  True, '2021-11-01 00:00:00'); /* Viamontian Lord */
@@ -392,8 +392,8 @@ VALUES (0x70043435, 35131, 0x0043032D, 257.103, -96.039, 0.006899, 0.999672, 0, 
 /* @teleloc 0x0043032D [257.102997 -96.039001 0.006899] 0.999672 0.000000 0.000000 -0.025619 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70043436, 32240, 0x0043031B, 249.938, -7.58789, -0.062694, 0.999583, 0, 0, 0.028871,  True, '2021-11-01 00:00:00'); /* Surface */
-/* @teleloc 0x0043031B [249.938004 -7.587890 -0.062694] 0.999583 0.000000 0.000000 0.028871 */
+VALUES (0x70043436, 32240, 0x0043031B, 249.999390, -8.000977, 0, 1, 0, 0, 0,  False, '2024-04-13 20:00:00'); /* Surface */
+/* @teleloc @teleloc 0x0043031B [249.999390 -8.000977 0] 1 0 0 0 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x70043437, 32230, 0x0043010F, 27.1586, -360.402, -17.9926, -0.919448, 0, 0, 0.393211,  True, '2021-11-01 00:00:00'); /* Master Versario */

--- a/Database/Patches/6 LandBlockExtendedData/0049.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0049.sql
@@ -114,3 +114,7 @@ VALUES (0x70049016, 70753, 0x00490101, 122.407, -261.031, -23.9937, -0.696329, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x70049017, 70754, 0x00490105, 120.113, -296.184, -24.063, -0.011627, 0, 0, -0.999932, False, '2021-11-01 00:00:00'); /* Surface */
 /* @teleloc 0x00490105 [120.112999 -296.183990 -24.063000] -0.011627 0.000000 0.000000 -0.999932 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70049018, 70754, 0x004901AF, 49.998779, -0.000977, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000, False, '2024-04-13 20:00:00'); /* Surface */
+/* @teleloc 0x004901AF [49.998779 -0.000977 0.000000] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/6 LandBlockExtendedData/004D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/004D.sql
@@ -870,3 +870,15 @@ VALUES (0x7004D176, 0x7004D177, '2023-05-15 03:25:02') /* Pressure Plate (2131) 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7004D177,  2131, 0x004D02D2, 94.9939, -359.827, -42, -0.710071, 0, 0, -0.70413,  True, '2023-05-15 03:25:02'); /* Pressure Plate */
 /* @teleloc 0x004D02D2 [94.993896 -359.826996 -42.000000] -0.710071 0.000000 0.000000 -0.704130 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7004D179, 33295, 0x004D03D6, 61.631470, -58.274414, -18, 1, 0, 0, 0, False, '2024-04-13 20:00:00'); /* Temple of N'cthail */
+/* @teleloc 0x004D03D6 [61.631470 -58.274414 -18] 1 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7004D180, 33295, 0x004D049E, 90, -360, -18, 1, 0, 0, 0, False, '2024-04-13 20:00:00'); /* Temple of N'cthail */
+/* @teleloc 0x004D049E [90 -360 -18] 1 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7004D178, 33295, 0x004D0131, 79.425659, -319.461914, -78, 1, 0, 0, 0, False, '2024-04-13 20:00:00'); /* Temple of N'cthail */
+/* @teleloc 0x004D0131 [79.425659 -319.461914 -78] 1 0 0 0 */

--- a/Database/Patches/6 LandBlockExtendedData/009D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/009D.sql
@@ -121,5 +121,9 @@ VALUES (0x7009D01D, 87321, 0x009D018C, 75.9264, 0.591573, -23.945, -0.030943, 0,
 /* @teleloc 0x009D018C [75.926399 0.591573 -23.945000] -0.030943 0.000000 0.000000 -0.999521 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7009D01E, 87322, 0x009D013C, 94.24, -69.9733, -30.2098, -0.691955, 0, 0, -0.72194, False, '2021-11-01 00:00:00'); /* Cavern Exit */
-/* @teleloc 0x009D013C [94.239998 -69.973297 -30.209801] -0.691955 0.000000 0.000000 -0.721940 */
+VALUES (0x7009D01E, 87322, 0x009D0147, 99.999390, -70, -30, 1, 0, 0, 0, False, '2024-04-12 00:00:00'); /* Cavern Exit */
+/* @teleloc 0x009D0147 [99.999390 -70 -30] 1 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7009D01F, 87322, 0x009D02D2, 78.621826, -68.693359, 0, 1, 0, 0, 0, False, '2024-04-12 20:00:00'); /* Cavern Exit */
+/* @teleloc 0x009D02D2 [78.621826 -68.693359 0] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/33035 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/33035 Surface.sql
@@ -28,3 +28,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (33035,   1, 0x020001B3) /* Setup */
      , (33035,   2, 0x09000003) /* MotionTable */
      , (33035,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (33035, 2, 0xBAED003D, 187.038147, 114.089066, 26.528265, -0.100658, 0.000000, 0.000000, 0.994921); /* Destination */
+/* @teleloc 0xBAED003D [187.038147 114.089066 26.528265] -0.100658 0.000000 0.000000 0.994921 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/35038 Bur Catacombs.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/35038 Bur Catacombs.sql
@@ -28,3 +28,8 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (35038,   1, 0x02001699) /* Setup */
      , (35038,   2, 0x09000172) /* MotionTable */
      , (35038,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (35038, 2, 0x00D40535, 120.000000, -210.000000, -11.985000, 1.000000, 0.000000, 0.000000, 0.000000) /* Destination */;
+/* @teleloc 0x00D40535 [120.000000 -210.000000 -11.985000] 1.000000 0.000000 0.000000 0.000000 */
+

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/87641 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/87641 Surface.sql
@@ -25,5 +25,5 @@ VALUES (87641,   1, 0x020001B3) /* Setup */
      , (87641,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87641, 2, 0x007B011D, 40, -200, 0.005, 1, 0, 0, 0) /* Destination */
-/* @teleloc 0x007B011D [40.000000 -200.000000 0.005000] 1.000000 0.000000 0.000000 0.000000 */;
+VALUES (87641, 2, 0xB82A0013, 60.53906, 57.126953, 0.000000, 1.000000, 0.000000, 0.000000, 0.000000); /* Destination Surface (67.9S, 45.4E) */
+/* @teleloc 0xB82A0013 [60.539062 57.126953 0.000000] 1.000000 0.000000 0.000000 0.000000 */


### PR DESCRIPTION
Contributing Portal Updates 
per PCAPS google sheet, vloc2loc dungeon data.
and (virindi) world objects database sources

Database/Patches/9 WeenieDefaults/Portal/Portal/35038 Bur Catacombs.sql
Database/Patches/9 WeenieDefaults/Portal/Portal/33035 Surface.sql (Ancient Masonry)
Database/Patches/9 WeenieDefaults/Portal/Portal/87641 Surface.sql (Tanada House of Storms Exit Portal)
Database/Patches/6 LandBlockExtendedData/009D.sql (Swamp Temple Cavern Exit)
Database/Patches/6 LandBlockExtendedData/0030.sql (Renegade Incursion Change Exit Portal to Fort Tethana)
Database/Patches/6 LandBlockExtendedData/0043.sql (Master_Vaserio's_Dig Surface Portal)
Database/Patches/6 LandBlockExtendedData/0049.sql (Camp Entemarre Surface Portal)
Database/Patches/6 LandBlockExtendedData/004D.sql (Temple Catacacombs Temple of N'cthail Portals)