### PR TITLE
Update Major Atlan Stone Quests

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/0117.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0117.sql
@@ -1,0 +1,498 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x0117;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117000, 24322, 0x01170104, 152.033, -159.497, -35.9925, -0.701969, 0, 0, -0.712208,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170104 [152.033005 -159.496994 -35.992500] -0.701969 0.000000 0.000000 -0.712208 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117001, 24322, 0x01170104, 151.401, -160.85, -35.9925, -0.627359, 0, 0, -0.77873,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170104 [151.401001 -160.850006 -35.992500] -0.627359 0.000000 0.000000 -0.778730 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117002, 24322, 0x01170104, 152.429, -160.626, -35.9925, -0.627359, 0, 0, -0.77873,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170104 [152.429001 -160.626007 -35.992500] -0.627359 0.000000 0.000000 -0.778730 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117003, 24320, 0x01170105, 159.427, -133.086, -35.9917, 0.137722, 0, 0, 0.990471,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170105 [159.427002 -133.085999 -35.991699] 0.137722 0.000000 0.000000 0.990471 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117004, 24320, 0x01170105, 161.409, -134.017, -35.945, -0.202104, 0, 0, 0.979364,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170105 [161.408997 -134.016998 -35.945000] -0.202104 0.000000 0.000000 0.979364 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117005, 24320, 0x01170105, 161.036, -132.781, -35.945, 0.109206, 0, 0, 0.994019,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170105 [161.035995 -132.781006 -35.945000] 0.109206 0.000000 0.000000 0.994019 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117006, 24322, 0x01170109, 159.92, -150.153, -35.9925, 0.046963, 0, 0, 0.998897,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170109 [159.919998 -150.153000 -35.992500] 0.046963 0.000000 0.000000 0.998897 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117007, 24322, 0x01170109, 161.125, -152.115, -35.9925, 0.135908, 0, 0, 0.990721,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170109 [161.125000 -152.115005 -35.992500] 0.135908 0.000000 0.000000 0.990721 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117008, 24319, 0x01170114, 176.58, -118.337, -35.9917, 0.502673, 0, 0, 0.864477,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170114 [176.580002 -118.336998 -35.991699] 0.502673 0.000000 0.000000 0.864477 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117009, 24319, 0x01170114, 177.886, -117.5, -35.9917, 0.402841, 0, 0, 0.91527,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170114 [177.886002 -117.500000 -35.991699] 0.402841 0.000000 0.000000 0.915270 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011700A, 24320, 0x01170127, 100.702, -160.907, -23.9918, -0.673463, 0, 0, -0.739221,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170127 [100.702003 -160.906998 -23.991800] -0.673463 0.000000 0.000000 -0.739221 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011700B, 24320, 0x01170127, 100.788, -159.695, -23.9918, -0.987714, 0, 0, -0.15627,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170127 [100.788002 -159.695007 -23.991800] -0.987714 0.000000 0.000000 -0.156270 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011700C, 24322, 0x01170127, 99.2069, -159.203, -23.9925, -0.999072, 0, 0, 0.043074,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170127 [99.206902 -159.203003 -23.992500] -0.999072 0.000000 0.000000 0.043074 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011700D, 24322, 0x01170127, 99.7196, -160.362, -23.9925, -0.743897, 0, 0, -0.668294,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170127 [99.719597 -160.362000 -23.992500] -0.743897 0.000000 0.000000 -0.668294 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011700E, 24320, 0x0117013F, 207.846, -87.5312, -23.9918, 0.475722, 0, 0, 0.879596,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x0117013F [207.845993 -87.531197 -23.991800] 0.475722 0.000000 0.000000 0.879596 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011700F, 24319, 0x0117013F, 208.499, -87.104, -23.9918, 0.475722, 0, 0, 0.879596,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117013F [208.498993 -87.103996 -23.991800] 0.475722 0.000000 0.000000 0.879596 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117010, 24322, 0x0117014D, 20.6835, -108.897, -17.9925, 0.997565, 0, 0, 0.069743,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x0117014D [20.683500 -108.897003 -17.992500] 0.997565 0.000000 0.000000 0.069743 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117011, 24322, 0x0117014D, 19.6192, -110.081, -17.9925, 0.994686, 0, 0, 0.102951,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x0117014D [19.619200 -110.081001 -17.992500] 0.994686 0.000000 0.000000 0.102951 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117012, 24322, 0x01170150, 20.4534, -106.406, -17.9925, 0.999586, 0, 0, 0.028771,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170150 [20.453400 -106.405998 -17.992500] 0.999586 0.000000 0.000000 0.028771 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117013, 24320, 0x0117015B, 31.8303, -113.175, -17.9918, -0.258744, 0, 0, -0.965946,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x0117015B [31.830299 -113.175003 -17.991800] -0.258744 0.000000 0.000000 -0.965946 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117014, 24322, 0x0117015C, 27.1457, -120.727, -17.9925, -0.710307, 0, 0, -0.703892,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x0117015C [27.145700 -120.726997 -17.992500] -0.710307 0.000000 0.000000 -0.703892 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117015, 24322, 0x0117015C, 27.9018, -118.161, -17.9925, -0.44549, 0, 0, -0.895287,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x0117015C [27.901800 -118.161003 -17.992500] -0.445490 0.000000 0.000000 -0.895287 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117016, 24320, 0x01170175, 39.4592, -136.494, -17.9918, 0.99875, 0, 0, 0.049979,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170175 [39.459202 -136.494003 -17.991800] 0.998750 0.000000 0.000000 0.049979 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117017, 24320, 0x01170175, 40.5941, -135.609, -17.9918, 0.994562, 0, 0, 0.104146,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170175 [40.594101 -135.608994 -17.991800] 0.994562 0.000000 0.000000 0.104146 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117018, 24322, 0x01170191, 58.5868, -93.5577, -17.9925, 0.941545, 0, 0, 0.336888,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170191 [58.586800 -93.557701 -17.992500] 0.941545 0.000000 0.000000 0.336888 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117019, 24322, 0x01170191, 60.3686, -92.9003, -17.9925, 0.962971, 0, 0, 0.269604,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170191 [60.368599 -92.900299 -17.992500] 0.962971 0.000000 0.000000 0.269604 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011701A, 24322, 0x01170192, 58.0903, -89.7663, -17.945, 0.911869, 0, 0, 0.410481,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170192 [58.090302 -89.766296 -17.945000] 0.911869 0.000000 0.000000 0.410481 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011701B, 24320, 0x01170198, 60.0243, -106.652, -17.9918, 0.994982, 0, 0, 0.100056,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170198 [60.024300 -106.652000 -17.991800] 0.994982 0.000000 0.000000 0.100056 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011701C, 24320, 0x01170198, 59.2487, -110.733, -17.9918, 0.31589, 0, 0, 0.948796,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170198 [59.248699 -110.733002 -17.991800] 0.315890 0.000000 0.000000 0.948796 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011701D, 24320, 0x011701AC, 61.0403, -158.011, -17.9918, -0.997504, 0, 0, 0.070607,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701AC [61.040298 -158.011002 -17.991800] -0.997504 0.000000 0.000000 0.070607 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011701E, 24320, 0x011701AC, 58.2815, -157.159, -17.945, -0.99616, 0, 0, -0.087556,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701AC [58.281502 -157.158997 -17.945000] -0.996160 0.000000 0.000000 -0.087556 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011701F, 24320, 0x011701BC, 66.2109, -140.007, -17.9918, 0.60258, 0, 0, 0.798058,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701BC [66.210899 -140.007004 -17.991800] 0.602580 0.000000 0.000000 0.798058 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117020, 24320, 0x011701BC, 65.7164, -141.291, -17.9918, 0.60258, 0, 0, 0.798058,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701BC [65.716400 -141.291000 -17.991800] 0.602580 0.000000 0.000000 0.798058 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117021, 24320, 0x011701C3, 78.5166, -115.846, -17.945, 0.11267, 0, 0, -0.993632,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701C3 [78.516602 -115.846001 -17.945000] 0.112670 0.000000 0.000000 -0.993632 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117022, 24322, 0x011701C3, 81.1943, -116.827, -17.9925, -0.0388, 0, 0, -0.999247,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701C3 [81.194298 -116.827003 -17.992500] -0.038800 0.000000 0.000000 -0.999247 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117023, 24322, 0x011701C9, 79.0231, -134.453, -17.945, 0.999821, 0, 0, 0.018945,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701C9 [79.023102 -134.453003 -17.945000] 0.999821 0.000000 0.000000 0.018945 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117024, 24322, 0x011701C9, 80.9079, -135.001, -17.9925, 0.994382, 0, 0, -0.105855,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701C9 [80.907898 -135.001007 -17.992500] 0.994382 0.000000 0.000000 -0.105855 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117025, 24322, 0x011701CD, 79.0748, -135.816, -17.9925, 0.996717, 0, 0, -0.080965,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701CD [79.074799 -135.815994 -17.992500] 0.996717 0.000000 0.000000 -0.080965 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117026, 24320, 0x011701D5, 88.4183, -117.181, -17.9918, -0.994433, 0, 0, 0.105372,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701D5 [88.418297 -117.181000 -17.991800] -0.994433 0.000000 0.000000 0.105372 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117027, 24320, 0x011701D5, 94.0515, -119.273, -17.945, -0.603504, 0, 0, 0.79736,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701D5 [94.051498 -119.273003 -17.945000] -0.603504 0.000000 0.000000 0.797360 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117028, 24320, 0x011701D5, 91.5185, -122.871, -17.9918, 0.156879, 0, 0, 0.987618,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701D5 [91.518501 -122.871002 -17.991800] 0.156879 0.000000 0.000000 0.987618 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117029, 24320, 0x011701E9, 99.0459, -131.019, -17.9918, -0.706268, 0, 0, -0.707945,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011701E9 [99.045898 -131.018997 -17.991800] -0.706268 0.000000 0.000000 -0.707945 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011702A, 24322, 0x011701F4, 108.902, -102.873, -17.9925, 0.999722, 0, 0, 0.023578,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701F4 [108.902000 -102.873001 -17.992500] 0.999722 0.000000 0.000000 0.023578 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011702B, 24322, 0x011701F6, 110.566, -105.358, -17.945, 0.99799, 0, 0, -0.063373,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701F6 [110.566002 -105.358002 -17.945000] 0.997990 0.000000 0.000000 -0.063373 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011702C, 24322, 0x011701F6, 109.037, -105.751, -17.9925, 0.998678, 0, 0, -0.051397,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x011701F6 [109.037003 -105.750999 -17.992500] 0.998678 0.000000 0.000000 -0.051397 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011702D, 24319, 0x01170283, 100.922, -81.298, -11.9917, -0.828286, 0, 0, 0.560305,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170283 [100.921997 -81.297997 -11.991700] -0.828286 0.000000 0.000000 0.560305 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011702E, 24319, 0x01170283, 101.492, -79.4623, -11.9917, -0.89168, 0, 0, 0.452667,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170283 [101.491997 -79.462303 -11.991700] -0.891680 0.000000 0.000000 0.452667 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011702F,   278, 0x01170285, 100.013, -75.249, -12, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01170285 [100.013000 -75.249001 -12.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117030, 24319, 0x01170299, 118.371, -96.5339, -11.9917, 0.973025, 0, 0, -0.230699,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170299 [118.371002 -96.533897 -11.991700] 0.973025 0.000000 0.000000 -0.230699 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117031, 24319, 0x01170299, 117.942, -97.4085, -11.9917, 0.993139, 0, 0, 0.116936,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170299 [117.942001 -97.408501 -11.991700] 0.993139 0.000000 0.000000 0.116936 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117032, 24319, 0x0117029D, 125.647, -70.5852, -11.945, -0.224195, 0, 0, 0.974544,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117029D [125.647003 -70.585197 -11.945000] -0.224195 0.000000 0.000000 0.974544 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117033, 24319, 0x011702AE, 154.228, -108.698, -11.9917, -0.646812, 0, 0, 0.76265,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702AE [154.227997 -108.697998 -11.991700] -0.646812 0.000000 0.000000 0.762650 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117034, 24319, 0x011702AE, 152.076, -108.019, -11.945, -0.525579, 0, 0, 0.850745,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702AE [152.076004 -108.018997 -11.945000] -0.525579 0.000000 0.000000 0.850745 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117035, 24319, 0x011702AE, 151.841, -105.935, -11.9917, -0.52558, 0, 0, 0.850744,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702AE [151.841003 -105.934998 -11.991700] -0.525580 0.000000 0.000000 0.850744 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117036, 24319, 0x011702C1, 213.212, -110.13, -11.9917, -0.829164, 0, 0, 0.559005,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702C1 [213.212006 -110.129997 -11.991700] -0.829164 0.000000 0.000000 0.559005 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117037, 24319, 0x011702C1, 211.814, -109.602, -11.9917, -0.842879, 0, 0, 0.538103,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702C1 [211.813995 -109.601997 -11.991700] -0.842879 0.000000 0.000000 0.538103 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117038, 24319, 0x011702C5, 220.168, -78.8694, -11.9917, 0.999484, 0, 0, -0.032119,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702C5 [220.167999 -78.869400 -11.991700] 0.999484 0.000000 0.000000 -0.032119 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117039, 24320, 0x011702C5, 219.071, -78.8059, -11.9917, 0.99569, 0, 0, 0.092742,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011702C5 [219.070999 -78.805901 -11.991700] 0.995690 0.000000 0.000000 0.092742 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011703A, 24320, 0x011702D0, 34.5643, -50.7519, -5.945, -0.924792, 0, 0, 0.380473,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011702D0 [34.564301 -50.751900 -5.945000] -0.924792 0.000000 0.000000 0.380473 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011703B, 24320, 0x011702D4, 35.8524, -49.4514, -5.99175, -0.924792, 0, 0, 0.380473,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x011702D4 [35.852402 -49.451401 -5.991750] -0.924792 0.000000 0.000000 0.380473 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011703C,  6398, 0x011702F0, 123.08, -10.0368, -4.203, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x011702F0 [123.080002 -10.036800 -4.203000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011703D,   286, 0x01170308, 152.974, -74.3705, -4.34578, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01170308 [152.973999 -74.370499 -4.345780] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011703E,  2180, 0x0117030B, 154.75, -70, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0117030B [154.750000 -70.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011703E, 0x7011703D, '2005-02-09 10:00:00') /* Lever (286) */
+     , (0x7011703E, 0x7011703F, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011703F,   286, 0x01170319, 184.392, -87.0805, -4.51346, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01170319 [184.391998 -87.080498 -4.513460] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117040,   278, 0x0117031C, 180, -85.25, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0117031C [180.000000 -85.250000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117041, 24322, 0x01170331, 61.844, -33.4015, 0.0075, -0.86298, 0, 0, 0.505238,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170331 [61.844002 -33.401501 0.007500] -0.862980 0.000000 0.000000 0.505238 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117042, 24322, 0x01170331, 62.6838, -31.9041, 0.0075, -0.875503, 0, 0, 0.483213,  True, '2005-02-09 10:00:00'); /* Undead Lieutenant */
+/* @teleloc 0x01170331 [62.683800 -31.904100 0.007500] -0.875503 0.000000 0.000000 0.483213 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117043,  2179, 0x01170340, 97.57, -30, 0, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01170340 [97.570000 -30.000000 0.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70117043, 0x70117044, '2005-02-09 10:00:00') /* Lever (286) */
+     , (0x70117043, 0x70117046, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117044,   286, 0x01170340, 101.5, -31.548, 1.5, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01170340 [101.500000 -31.548000 1.500000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117045,   286, 0x01170340, 101.5, -28.448, 1.5, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01170340 [101.500000 -28.448000 1.500000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117046,   286, 0x01170348, 110.025, -44.8536, 1.6441, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Lever */
+/* @teleloc 0x01170348 [110.025002 -44.853600 1.644100] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117047, 24319, 0x0117034F, 122.616, -0.295794, 0.00825, 0.004517, 0, 0, -0.99999,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117034F [122.615997 -0.295794 0.008250] 0.004517 0.000000 0.000000 -0.999990 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117048, 24319, 0x0117034F, 117.388, -0.16314, 0.00825, -0.127237, 0, 0, -0.991872,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117034F [117.388000 -0.163140 0.008250] -0.127237 0.000000 0.000000 -0.991872 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117049, 24319, 0x0117034F, 119.897, -0.477385, 0.00825, 0.06404, 0, 0, -0.997947,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117034F [119.897003 -0.477385 0.008250] 0.064040 0.000000 0.000000 -0.997947 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011704A,  6411, 0x0117034F, 123.073, 1.898, 0.079, 0.172952, 0, 0, -0.98493,  True, '2005-02-09 10:00:00'); /* Elaborate Scroll */
+/* @teleloc 0x0117034F [123.072998 1.898000 0.079000] 0.172952 0.000000 0.000000 -0.984930 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011704B,  6123, 0x0117034F, 117.178, 2.37459, 0.016501, 0.195662, 0, 0, -0.980671,  True, '2005-02-09 10:00:00'); /* Major Shivering Stone */
+/* @teleloc 0x0117034F [117.178001 2.374590 0.016501] 0.195662 0.000000 0.000000 -0.980671 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011704C, 24320, 0x0117034F, 119.605, -3.44416, 0.00825, -0.000826, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x0117034F [119.605003 -3.444160 0.008250] -0.000826 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011704D,  2180, 0x01170351, 120, -24.75, 0, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01170351 [120.000000 -24.750000 0.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011704D, 0x70117045, '2005-02-09 10:00:00') /* Lever (286) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011704F,  7923, 0x01170140, -1.896, -100.029, -17.995, 0, 0, 0, 1, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x01170140 [-1.896000 -100.028999 -17.995001] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011704F, 0x70117000, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117001, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117002, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117003, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117004, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117005, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117006, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117007, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117008, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117009, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x7011700A, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011700B, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011700C, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011700D, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011700E, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011700F, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117010, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117011, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117012, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117013, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117014, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117015, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117016, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117017, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117018, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117019, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011701A, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011701B, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011701C, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011701D, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011701E, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011701F, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117020, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117021, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117022, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117023, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117024, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117025, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117026, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117027, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117028, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117029, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011702A, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011702B, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011702C, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x7011702D, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x7011702E, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117030, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117031, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117032, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117033, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117034, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117035, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117036, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117037, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117038, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117039, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011703A, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011703B, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117041, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117042, '2005-02-09 10:00:00') /* Undead Lieutenant (24322) */
+     , (0x7011704F, 0x70117047, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117048, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117049, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x7011704C, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117051, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117052, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117053, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x70117054, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117055, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117056, '2005-02-09 10:00:00') /* Dark Master (46281) */
+     , (0x7011704F, 0x70117057, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117058, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x70117059, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x7011705A, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011705B, '2005-02-09 10:00:00') /* Great Revenant (24320) */
+     , (0x7011704F, 0x7011705C, '2005-02-09 10:00:00') /* Dark Master (24319) */
+     , (0x7011704F, 0x7011705D, '2005-02-09 10:00:00') /* Dark Master (46281) */
+     , (0x7011704F, 0x7011705E, '2005-02-09 10:00:00') /* Dark Master (46281) */
+     , (0x7011704F, 0x7011705F, '2005-02-09 10:00:00') /* Dark Master (46281) */
+     , (0x7011704F, 0x70117060, '2005-02-09 10:00:00') /* Dark Master (46281) */
+     , (0x7011704F, 0x70117061, '2005-02-09 10:00:00') /* Dark Master (46281) */
+     , (0x7011704F, 0x70117062, '2005-02-09 10:00:00') /* Dark Master (46281) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117050,  5085, 0x01170140, 0, -100, -17.995, -0.184337, 0, 0, -0.982863, False, '2005-02-09 10:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x01170140 [0.000000 -100.000000 -17.995001] -0.184337 0.000000 0.000000 -0.982863 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70117050, 0x7011704A, '2005-02-09 10:00:00') /* Elaborate Scroll (6411) */
+     , (0x70117050, 0x7011704B, '2005-02-09 10:00:00') /* Major Shivering Stone (6123) */
+     , (0x70117050, 0x70117063, '2005-02-09 10:00:00') /* Textbook (6407) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117051, 24319, 0x01170269, 30.3132, -121.584, -11.9917, -0.999998, 0, 0, -0.001982,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170269 [30.313200 -121.584000 -11.991700] -0.999998 0.000000 0.000000 -0.001982 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117052, 24320, 0x01170273, 48.8496, -102.16, -11.9917, 0.999998, 0, 0, 0.002102,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170273 [48.849602 -102.160004 -11.991700] 0.999998 0.000000 0.000000 0.002102 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117053, 24320, 0x01170273, 50.6862, -102.153, -11.9917, 0.999998, 0, 0, 0.002102,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170273 [50.686199 -102.153000 -11.991700] 0.999998 0.000000 0.000000 0.002102 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117054, 24319, 0x0117027C, 66.485, -98.0652, -11.9917, 0.892096, 0, 0, -0.451847,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117027C [66.485001 -98.065201 -11.991700] 0.892096 0.000000 0.000000 -0.451847 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117055, 24319, 0x0117027C, 65.0051, -100.063, -11.9917, 0.892096, 0, 0, -0.451847,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117027C [65.005096 -100.063004 -11.991700] 0.892096 0.000000 0.000000 -0.451847 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117056, 46281, 0x011702B9, 184.689, -89.3936, -11.945, -0.376049, 0, 0, 0.9266,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702B9 [184.688995 -89.393600 -11.945000] -0.376049 0.000000 0.000000 0.926600 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117057, 24319, 0x011702EA, 110.424, -60.366, -5.99175, 0.692897, 0, 0, -0.721036,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x011702EA [110.424004 -60.366001 -5.991750] 0.692897 0.000000 0.000000 -0.721036 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117058, 24319, 0x01170314, 169.085, -79.7191, -5.99175, -0.999805, 0, 0, -0.01973,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170314 [169.085007 -79.719101 -5.991750] -0.999805 0.000000 0.000000 -0.019730 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117059, 24319, 0x01170314, 170.892, -79.6477, -5.99175, -0.999805, 0, 0, -0.01973,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170314 [170.891998 -79.647697 -5.991750] -0.999805 0.000000 0.000000 -0.019730 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011705A, 24320, 0x01170319, 179.371, -92.9254, -5.99175, 0.716706, 0, 0, 0.697375,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170319 [179.371002 -92.925400 -5.991750] 0.716706 0.000000 0.000000 0.697375 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011705B, 24320, 0x01170319, 178.346, -89.4431, -5.99175, 0.988277, 0, 0, -0.152672,  True, '2005-02-09 10:00:00'); /* Great Revenant */
+/* @teleloc 0x01170319 [178.345993 -89.443100 -5.991750] 0.988277 0.000000 0.000000 -0.152672 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011705C, 24319, 0x01170319, 181.575, -89.9453, -5.99175, 0.992972, 0, 0, 0.118352,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170319 [181.574997 -89.945297 -5.991750] 0.992972 0.000000 0.000000 0.118352 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011705D, 46281, 0x0117034C, 110.907, -71.4195, 0.00825, -0.031187, 0, 0, 0.999514,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117034C [110.906998 -71.419502 0.008250] -0.031187 0.000000 0.000000 0.999514 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011705E, 46281, 0x0117034C, 109.32, -71.5186, 0.00825, -0.031187, 0, 0, 0.999514,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x0117034C [109.320000 -71.518600 0.008250] -0.031187 0.000000 0.000000 0.999514 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011705F, 46281, 0x01170356, 120.987, -69.635, 0.00825, 0.012935, 0, 0, -0.999916,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170356 [120.987000 -69.635002 0.008250] 0.012935 0.000000 0.000000 -0.999916 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117060, 46281, 0x01170356, 119.518, -69.673, 0.00825, 0.012935, 0, 0, -0.999916,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170356 [119.517998 -69.672997 0.008250] 0.012935 0.000000 0.000000 -0.999916 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117061, 46281, 0x01170359, 131.004, -69.8097, 0.00825, 0.008644, 0, 0, -0.999963,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170359 [131.003998 -69.809700 0.008250] 0.008644 0.000000 0.000000 -0.999963 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117062, 46281, 0x01170359, 129.534, -69.8351, 0.00825, 0.008644, 0, 0, -0.999963,  True, '2005-02-09 10:00:00'); /* Dark Master */
+/* @teleloc 0x01170359 [129.533997 -69.835098 0.008250] 0.008644 0.000000 0.000000 -0.999963 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70117063,  6407, 0x0117034F, 120.021, 2.66111, 0.06954, 0.659983, 0, 0, 0.75128,  True, '2005-02-09 10:00:00'); /* Textbook */
+/* @teleloc 0x0117034F [120.021004 2.661110 0.069540] 0.659983 0.000000 0.000000 0.751280 */

--- a/Database/Patches/6 LandBlockExtendedData/0119.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0119.sql
@@ -1,0 +1,417 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x0119;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119000, 25596, 0x01190101, 9.00524, -13.9875, -77.995, 0.988589, 0, 0, -0.150639,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190101 [9.005240 -13.987500 -77.995003] 0.988589 0.000000 0.000000 -0.150639 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119001, 25596, 0x01190103, 19.5191, -0.693483, -77.995, 0.915634, 0, 0, -0.402013,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190103 [19.519100 -0.693483 -77.995003] 0.915634 0.000000 0.000000 -0.402013 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119002, 25596, 0x01190103, 15.359, -0.370727, -77.995, 0.966059, 0, 0, 0.258322,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190103 [15.359000 -0.370727 -77.995003] 0.966059 0.000000 0.000000 0.258322 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119003,  6390, 0x01190104, 20, -12.975, -78, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01190104 [20.000000 -12.975000 -78.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119004,  7095, 0x01190104, 20, -10, -77.9915, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190104 [20.000000 -10.000000 -77.991501] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119005,   278, 0x01190106, 20, -5.25, -78, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190106 [20.000000 -5.250000 -78.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119006, 25596, 0x01190109, 27.4334, -18.459, -77.995, 0.651462, 0, 0, 0.758681,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190109 [27.433399 -18.459000 -77.995003] 0.651462 0.000000 0.000000 0.758681 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119007,  7924, 0x0119010B, 39.9494, -12.4832, -77.995, 0.989437, 0, 0, -0.144966, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x0119010B [39.949402 -12.483200 -77.995003] 0.989437 0.000000 0.000000 -0.144966 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70119007, 0x70119000, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119001, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119002, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119006, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119008, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119010, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119011, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119013, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119017, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x7011901E, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119023, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119027, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x7011902F, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119031, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x70119007, 0x70119039, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119008, 25596, 0x0119010B, 39.2059, -14.2103, -77.995, 0.080239, 0, 0, 0.996776,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x0119010B [39.205898 -14.210300 -77.995003] 0.080239 0.000000 0.000000 0.996776 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119009,  5085, 0x01190113, 111.495, -39.7096, -78, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x01190113 [111.495003 -39.709599 -78.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70119009, 0x7011900A, '2005-02-09 10:00:00') /* Gem (280) */
+     , (0x70119009, 0x7011900B, '2005-02-09 10:00:00') /* Ruby (2411) */
+     , (0x70119009, 0x7011900C, '2005-02-09 10:00:00') /* Sapphire (2412) */
+     , (0x70119009, 0x7011900D, '2005-02-09 10:00:00') /* Malachite (2416) */
+     , (0x70119009, 0x7011900E, '2005-02-09 10:00:00') /* Major Sparking Stone (6125) */
+     , (0x70119009, 0x70119057, '2005-02-09 10:00:00') /* Textbook (6407) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011900A,   280, 0x01190113, 107.076, -40.3499, -78, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Gem */
+/* @teleloc 0x01190113 [107.075996 -40.349899 -78.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011900B,  2411, 0x01190113, 106.314, -41.0897, -78, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Ruby */
+/* @teleloc 0x01190113 [106.314003 -41.089699 -78.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011900C,  2412, 0x01190113, 107.586, -39.3125, -78, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Sapphire */
+/* @teleloc 0x01190113 [107.585999 -39.312500 -78.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011900D,  2416, 0x01190113, 106.629, -39.5793, -78, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Malachite */
+/* @teleloc 0x01190113 [106.628998 -39.579300 -78.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011900E,  6125, 0x01190113, 107.498, -39.9438, -77.9835, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Major Sparking Stone */
+/* @teleloc 0x01190113 [107.498001 -39.943802 -77.983498] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011900F,  7095, 0x01190113, 110.319, -44.8324, -77.945, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190113 [110.319000 -44.832401 -77.945000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119010, 25596, 0x01190113, 109.204, -41.5828, -77.995, 0.04578, 0, 0, 0.998952,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190113 [109.204002 -41.582802 -77.995003] 0.045780 0.000000 0.000000 0.998952 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119011, 25596, 0x01190113, 112.105, -41.8492, -77.995, 0.04578, 0, 0, 0.998952,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190113 [112.105003 -41.849201 -77.995003] 0.045780 0.000000 0.000000 0.998952 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119012,  7924, 0x01190114, 110.011, -49.993, -78, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x01190114 [110.011002 -49.993000 -78.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x70119012, 0x70119004, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x70119012, 0x7011900F, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x70119012, 0x70119015, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x70119012, 0x70119019, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x70119012, 0x7011901B, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x7011901D, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x7011901F, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119021, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119025, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119026, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119029, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x7011902A, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x7011902B, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x7011902C, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x70119012, 0x7011902E, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119030, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119032, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119033, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119034, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119035, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x70119036, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x70119012, 0x70119037, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x70119012, 0x7011903A, '2005-02-09 10:00:00') /* Voltarc (21170) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119013, 25596, 0x01190114, 111.628, -49.8979, -77.995, 0.696331, 0, 0, 0.717721,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190114 [111.627998 -49.897900 -77.995003] 0.696331 0.000000 0.000000 0.717721 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119014,   568, 0x01190122, 10, -35.25, -72, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190122 [10.000000 -35.250000 -72.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119015,  7095, 0x01190123, 10, -50, -71.9915, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190123 [10.000000 -50.000000 -71.991501] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119016,   568, 0x01190126, 10, -45.25, -72, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190126 [10.000000 -45.250000 -72.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119017, 25596, 0x0119013F, 20, -30, -71.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x0119013F [20.000000 -30.000000 -71.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119018,   568, 0x01190146, 20, -35.25, -72, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190146 [20.000000 -35.250000 -72.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119019,  7095, 0x01190147, 20, -50, -71.9915, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190147 [20.000000 -50.000000 -71.991501] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011901A,   568, 0x01190149, 20, -45.25, -72, -1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190149 [20.000000 -45.250000 -72.000000] -1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011901B, 21170, 0x0119015B, 20, -110, -71.9935, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x0119015B [20.000000 -110.000000 -71.993500] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011901C,   568, 0x01190169, 30, -34.75, -72, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190169 [30.000000 -34.750000 -72.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011901D, 21170, 0x01190174, 30, -90, -71.9935, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190174 [30.000000 -90.000000 -71.993500] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011901E, 25596, 0x0119017A, 30, -140, -71.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x0119017A [30.000000 -140.000000 -71.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011901F, 21170, 0x01190185, 40, -70, -71.9935, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190185 [40.000000 -70.000000 -71.993500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119020,   568, 0x01190187, 44.7775, -89.9998, -72, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190187 [44.777500 -89.999802 -72.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119021, 21170, 0x01190194, 40.007, -156.07, -71.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190194 [40.007000 -156.070007 -71.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119022,   568, 0x0119019E, 50, -84.765, -72, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x0119019E [50.000000 -84.764999 -72.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119023, 25596, 0x0119019F, 50, -90, -71.995, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x0119019F [50.000000 -90.000000 -71.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119024,   568, 0x011901A0, 50, -95.239, -72, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011901A0 [50.000000 -95.238998 -72.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119025, 21170, 0x011901A0, 50, -100, -71.9935, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901A0 [50.000000 -100.000000 -71.993500] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119026, 21170, 0x011901A7, 50, -140, -71.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901A7 [50.000000 -140.000000 -71.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119027, 25596, 0x011901B0, 56.8717, -70.2179, -71.995, -0.702713, 0, 0, 0.711473,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x011901B0 [56.871700 -70.217903 -71.995003] -0.702713 0.000000 0.000000 0.711473 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119028,   568, 0x011901B1, 55.2442, -90.0049, -72, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011901B1 [55.244202 -90.004898 -72.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119029, 21170, 0x011901B1, 60, -90, -71.9935, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901B1 [60.000000 -90.000000 -71.993500] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011902A, 21170, 0x011901C6, 70, -100, -71.9935, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901C6 [70.000000 -100.000000 -71.993500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011902B, 21170, 0x011901C8, 70, -120, -71.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901C8 [70.000000 -120.000000 -71.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011902C,  7095, 0x011901CD, 80, -30, -71.9915, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x011901CD [80.000000 -30.000000 -71.991501] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011902D,   568, 0x011901CF, 80, -34.75, -72, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011901CF [80.000000 -34.750000 -72.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011902E, 21170, 0x011901D9, 80, -70, -71.9935, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901D9 [80.000000 -70.000000 -71.993500] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011902F, 25596, 0x011901DB, 81.9598, -82.6136, -71.995, 0.397766, 0, 0, 0.917487,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x011901DB [81.959801 -82.613602 -71.995003] 0.397766 0.000000 0.000000 0.917487 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119030, 21170, 0x011901F1, 89.9621, -70.4656, -71.9935, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901F1 [89.962097 -70.465599 -71.993500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119031, 25596, 0x011901F6, 89.0282, -93.1792, -71.995, -0.359552, 0, 0, 0.933125,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x011901F6 [89.028198 -93.179199 -71.995003] -0.359552 0.000000 0.000000 0.933125 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119032, 21170, 0x011901FF, 90, -130, -71.9935, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011901FF [90.000000 -130.000000 -71.993500] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119033, 21170, 0x01190209, 110, -80, -71.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190209 [110.000000 -80.000000 -71.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119034, 21170, 0x0119020C, 110, -110, -71.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x0119020C [110.000000 -110.000000 -71.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119035, 21170, 0x01190225, 80, -30, -65.9935, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190225 [80.000000 -30.000000 -65.993500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119036,  7095, 0x01190236, 110, -60, -65.9915, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190236 [110.000000 -60.000000 -65.991501] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119037, 21170, 0x0119023D, 130, -40, -65.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x0119023D [130.000000 -40.000000 -65.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119038,  6390, 0x01190242, 50, -90, -60, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01190242 [50.000000 -90.000000 -60.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119039, 25596, 0x01190249, 50, -80, -53.995, -0.202788, 0, 0, 0.979223,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190249 [50.000000 -80.000000 -53.994999] -0.202788 0.000000 0.000000 0.979223 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011903A, 21170, 0x0119024B, 50, -100, -53.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x0119024B [50.000000 -100.000000 -53.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011903B,  7924, 0x01190256, 30, -110, -48, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x01190256 [30.000000 -110.000000 -48.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011903B, 0x7011903C, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x7011903D, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x7011903B, 0x7011903E, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x7011903B, 0x7011903F, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x70119040, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x70119041, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x70119042, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x7011903B, 0x70119043, '2005-02-09 10:00:00') /* Scathisa (7095) */
+     , (0x7011903B, 0x70119044, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x70119046, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x70119047, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x70119048, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x70119049, '2005-02-09 10:00:00') /* Voltarc (21170) */
+     , (0x7011903B, 0x7011904A, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x7011904C, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x7011904D, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x7011904E, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x7011904F, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x70119050, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */
+     , (0x7011903B, 0x70119052, '2005-02-09 10:00:00') /* Amethyst Gromnie (25596) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011903C, 21170, 0x01190256, 30, -110, -47.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190256 [30.000000 -110.000000 -47.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011903D,  7095, 0x01190259, 40, -80, -47.9915, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190259 [40.000000 -80.000000 -47.991501] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011903E,  7095, 0x01190266, 60, -80, -47.9915, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x01190266 [60.000000 -80.000000 -47.991501] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011903F, 21170, 0x01190286, 80, -120, -41.9935, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190286 [80.000000 -120.000000 -41.993500] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119040, 21170, 0x0119028F, 40, -90, -35.9935, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x0119028F [40.000000 -90.000000 -35.993500] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119041, 21170, 0x01190298, 60, -100, -35.9935, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190298 [60.000000 -100.000000 -35.993500] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119042,  7095, 0x011902C8, 60, -80, -23.9915, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x011902C8 [60.000000 -80.000000 -23.991501] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119043,  7095, 0x011902CB, 60, -100, -23.9915, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Scathisa */
+/* @teleloc 0x011902CB [60.000000 -100.000000 -23.991501] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119044, 21170, 0x011902DE, 20, -90, -11.9935, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011902DE [20.000000 -90.000000 -11.993500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119045,  6390, 0x011902E5, 50, -90, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x011902E5 [50.000000 -90.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119046, 21170, 0x011902E7, 50, -70, 0.0065, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011902E7 [50.000000 -70.000000 0.006500] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119047, 25596, 0x011902F4, 30, -90, 6.005, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x011902F4 [30.000000 -90.000000 6.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119048, 21170, 0x011902F8, 40, -80, 6.0065, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x011902F8 [40.000000 -80.000000 6.006500] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119049, 21170, 0x01190306, 60, -90, 6.0065, 0, 0, 0, -1,  True, '2005-02-09 10:00:00'); /* Voltarc */
+/* @teleloc 0x01190306 [60.000000 -90.000000 6.006500] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011904A, 25596, 0x01190310, 20, -80, 12.005, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190310 [20.000000 -80.000000 12.005000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011904B,  6390, 0x0119032E, 50, -90, 24, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x0119032E [50.000000 -90.000000 24.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011904C, 25596, 0x0119033C, 41.4002, -81.3217, 30.005, 1, 0, 0, 0,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x0119033C [41.400200 -81.321701 30.004999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011904D, 25596, 0x01190340, 40, -100, 30.005, -0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190340 [40.000000 -100.000000 30.004999] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011904E, 25596, 0x01190349, 59.6118, -81.6816, 30.005, 0.707107, 0, 0, -0.707107,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190349 [59.611801 -81.681602 30.004999] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011904F, 25596, 0x01190349, 59.6598, -78.0357, 30.005, -0.990674, 0, 0, -0.136255,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190349 [59.659801 -78.035698 30.004999] -0.990674 0.000000 0.000000 -0.136255 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119050, 25596, 0x0119034C, 58.3985, -98.3628, 30.005, 0.991129, 0, 0, -0.132905,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x0119034C [58.398499 -98.362801 30.004999] 0.991129 0.000000 0.000000 -0.132905 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119052, 25596, 0x01190364, 70, -60, 36.005, -0.718733, 0, 0, -0.695286,  True, '2005-02-09 10:00:00'); /* Amethyst Gromnie */
+/* @teleloc 0x01190364 [70.000000 -60.000000 36.005001] -0.718733 0.000000 0.000000 -0.695286 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119053,  6390, 0x01190366, 37.025, -110, 42, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x01190366 [37.025002 -110.000000 42.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119054,   278, 0x01190368, 44.75, -110, 42, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190368 [44.750000 -110.000000 42.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119056,   278, 0x01190373, 55.25, -110, 42, -0.707107, 0, 0, 0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x01190373 [55.250000 -110.000000 42.000000] -0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x70119057,  6407, 0x01190113, 108.815, -37.8449, -77.9305, -0.986156, 0, 0, -0.165823,  True, '2005-02-09 10:00:00'); /* Textbook */
+/* @teleloc 0x01190113 [108.815002 -37.844898 -77.930496] -0.986156 0.000000 0.000000 -0.165823 */

--- a/Database/Patches/6 LandBlockExtendedData/011A.sql
+++ b/Database/Patches/6 LandBlockExtendedData/011A.sql
@@ -1,0 +1,1101 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x011A;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A000,  6122, 0x011A0100, 60, -90, -24, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0100 [60.000000 -90.000000 -24.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A001, 46279, 0x011A0105, 70.4921, -108.261, -17.995, -0.98812, 0, 0, -0.153686,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0105 [70.492104 -108.261002 -17.995001] -0.988120 0.000000 0.000000 -0.153686 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A002, 46279, 0x011A0105, 70.6128, -110.903, -17.995, -0.47003, 0, 0, -0.882651,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0105 [70.612801 -110.903000 -17.995001] -0.470030 0.000000 0.000000 -0.882651 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A003, 46279, 0x011A010F, 84.3322, -100.091, -17.995, -0.650471, 0, 0, -0.759531,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A010F [84.332199 -100.091003 -17.995001] -0.650471 0.000000 0.000000 -0.759531 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A004, 46279, 0x011A0115, 79.8333, -121.233, -17.995, 0.639996, 0, 0, -0.768378,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0115 [79.833298 -121.233002 -17.995001] 0.639996 0.000000 0.000000 -0.768378 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A005, 46279, 0x011A0115, 77.8413, -118.387, -17.995, 0.722182, 0, 0, -0.691703,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0115 [77.841301 -118.387001 -17.995001] 0.722182 0.000000 0.000000 -0.691703 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A006,  6122, 0x011A0121, 90, -60, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0121 [90.000000 -60.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A007,  6122, 0x011A0122, 90, -70, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0122 [90.000000 -70.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A008,  6122, 0x011A0123, 90, -80, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0123 [90.000000 -80.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A009, 46279, 0x011A0124, 85.6435, -90.619, -17.995, 0.610542, 0, 0, 0.791984,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0124 [85.643501 -90.619003 -17.995001] 0.610542 0.000000 0.000000 0.791984 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A00A, 46279, 0x011A012C, 92.1287, -129.84, -17.995, 0.640538, 0, 0, -0.767927,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A012C [92.128700 -129.839996 -17.995001] 0.640538 0.000000 0.000000 -0.767927 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A00B, 46279, 0x011A0136, 90, -150, -17.995, 0.984727, 0, 0, -0.174108,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0136 [90.000000 -150.000000 -17.995001] 0.984727 0.000000 0.000000 -0.174108 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A00C, 46279, 0x011A0137, 93.8799, -150.233, -17.995, 0.951424, 0, 0, 0.307883,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0137 [93.879898 -150.233002 -17.995001] 0.951424 0.000000 0.000000 0.307883 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A00D,  6122, 0x011A0139, 100, -50, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0139 [100.000000 -50.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A00E,  6122, 0x011A013A, 100, -60, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A013A [100.000000 -60.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A00F,  6122, 0x011A013B, 100, -70, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A013B [100.000000 -70.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A010,  6122, 0x011A013C, 100, -80, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A013C [100.000000 -80.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A011,  6122, 0x011A013D, 100, -90, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A013D [100.000000 -90.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A012,  6122, 0x011A014B, 110, -50, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A014B [110.000000 -50.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A013,  6122, 0x011A014C, 110, -60, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A014C [110.000000 -60.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A014,  6122, 0x011A014D, 110, -70, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A014D [110.000000 -70.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A015,  6122, 0x011A014E, 110, -80, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A014E [110.000000 -80.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A016,  6122, 0x011A014F, 110, -90, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A014F [110.000000 -90.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A017, 46279, 0x011A0153, 107.303, -130.886, -17.995, 0.639208, 0, 0, -0.769034,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0153 [107.303001 -130.886002 -17.995001] 0.639208 0.000000 0.000000 -0.769034 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A018, 46279, 0x011A0153, 107.024, -128.407, -17.995, 0.531256, 0, 0, -0.847211,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0153 [107.024002 -128.406998 -17.995001] 0.531256 0.000000 0.000000 -0.847211 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A019,  6122, 0x011A015B, 120, -50, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A015B [120.000000 -50.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A01A,  6122, 0x011A015C, 120, -60, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A015C [120.000000 -60.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A01B,  6122, 0x011A015D, 120, -70, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A015D [120.000000 -70.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A01C,  6122, 0x011A015E, 120, -80, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A015E [120.000000 -80.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A01D,  6122, 0x011A015F, 120, -90, -18, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A015F [120.000000 -90.000000 -18.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A01E, 46279, 0x011A0167, 119.625, -140.715, -17.995, 0.702288, 0, 0, -0.711893,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0167 [119.625000 -140.714996 -17.995001] 0.702288 0.000000 0.000000 -0.711893 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A01F, 46279, 0x011A0167, 118.58, -137.764, -17.995, 0.546857, 0, 0, -0.837226,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0167 [118.580002 -137.764008 -17.995001] 0.546857 0.000000 0.000000 -0.837226 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A020,  6122, 0x011A0173, 60, -190, -12, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0173 [60.000000 -190.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A021,  6122, 0x011A0174, 60, -210, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0174 [60.000000 -210.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A022,  6122, 0x011A0175, 70, -140, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0175 [70.000000 -140.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A023,  6122, 0x011A0176, 70, -150, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0176 [70.000000 -150.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A024,  6122, 0x011A0177, 70, -160, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0177 [70.000000 -160.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A025,  6122, 0x011A0178, 70, -180, -12, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0178 [70.000000 -180.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A026,  6122, 0x011A0179, 70, -210, -12, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0179 [70.000000 -210.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A027,  6122, 0x011A017A, 80, -140, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A017A [80.000000 -140.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A028,  6122, 0x011A017B, 80, -150, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A017B [80.000000 -150.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A029,  6122, 0x011A017C, 80, -160, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A017C [80.000000 -160.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A02A,  6122, 0x011A017D, 80, -200, -12, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A017D [80.000000 -200.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A02B,  6122, 0x011A017E, 80, -210, -12, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A017E [80.000000 -210.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A02C,  6122, 0x011A017F, 80, -220, -12, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A017F [80.000000 -220.000000 -12.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A02D,  6122, 0x011A0183, 90, -130, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0183 [90.000000 -130.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A02E,  6122, 0x011A0184, 90, -140, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0184 [90.000000 -140.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A02F,  6122, 0x011A0185, 90, -150, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0185 [90.000000 -150.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A030,  6122, 0x011A0186, 90, -160, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0186 [90.000000 -160.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A031,  6122, 0x011A0187, 90, -180, -12, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0187 [90.000000 -180.000000 -12.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A032,  6122, 0x011A0188, 90, -210, -12, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0188 [90.000000 -210.000000 -12.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A033,  6122, 0x011A018E, 100, -130, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A018E [100.000000 -130.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A034,  6122, 0x011A018F, 100, -140, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A018F [100.000000 -140.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A035,  6122, 0x011A0195, 110, -130, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0195 [110.000000 -130.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A036,  6122, 0x011A0196, 110, -140, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A0196 [110.000000 -140.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A037,  6122, 0x011A019C, 120, -120, -11.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A019C [120.000000 -120.000000 -11.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A038,  6122, 0x011A019D, 120, -130, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A019D [120.000000 -130.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A039,  6122, 0x011A019E, 120, -140, -12, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Acid */
+/* @teleloc 0x011A019E [120.000000 -140.000000 -12.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A03A,  5627, 0x011A01A0, 4.35555, -310.085, -6, -0.66832, 0, 0, -0.743874, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A01A0 [4.355550 -310.084991 -6.000000] -0.668320 0.000000 0.000000 -0.743874 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A03B, 46279, 0x011A01A0, 2.9228, -309.267, -5.98831, -0.809693, 0, 0, 0.586853,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01A0 [2.922800 -309.266998 -5.988310] -0.809693 0.000000 0.000000 0.586853 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A03C, 46279, 0x011A01A0, 2.91344, -311.345, -5.97675, -0.736864, 0, 0, 0.676041,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01A0 [2.913440 -311.345001 -5.976750] -0.736864 0.000000 0.000000 0.676041 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A03D,  5627, 0x011A01A8, 19.9147, -264.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A01A8 [19.914700 -264.355988 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A03E, 46279, 0x011A01A8, 20.6827, -262.928, -5.99499, 0.015975, 0, 0, -0.999872,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01A8 [20.682699 -262.928009 -5.994990] 0.015975 0.000000 0.000000 -0.999872 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A03F, 46279, 0x011A01A8, 19.236, -262.947, -5.995, 0.154457, 0, 0, -0.987999,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01A8 [19.236000 -262.946991 -5.995000] 0.154457 0.000000 0.000000 -0.987999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A040,  5627, 0x011A01C6, 20.0853, -345.644, -6, 0.053425, 0, 0, -0.998572, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A01C6 [20.085300 -345.644012 -6.000000] 0.053425 0.000000 0.000000 -0.998572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A041, 46279, 0x011A01C6, 21.2643, -347.094, -5.96722, 0.995536, 0, 0, 0.094383,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01C6 [21.264299 -347.093994 -5.967220] 0.995536 0.000000 0.000000 0.094383 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A042, 46279, 0x011A01C6, 19.2916, -347.082, -5.98237, 0.998915, 0, 0, -0.046565,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01C6 [19.291599 -347.082001 -5.982370] 0.998915 0.000000 0.000000 -0.046565 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A043,  5627, 0x011A01C7, 34.3556, -90.0853, -6, -0.66832, 0, 0, -0.743874, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A01C7 [34.355598 -90.085297 -6.000000] -0.668320 0.000000 0.000000 -0.743874 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A044, 46279, 0x011A01C7, 32.8987, -91.2481, -5.95858, -0.837236, 0, 0, 0.546842,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01C7 [32.898701 -91.248100 -5.958580] -0.837236 0.000000 0.000000 0.546842 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A045, 46279, 0x011A01C7, 32.9193, -89.0852, -5.98403, -0.619469, 0, 0, 0.785021,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01C7 [32.919300 -89.085197 -5.984030] -0.619469 0.000000 0.000000 0.785021 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A046, 46279, 0x011A01C8, 25.9277, -269.869, -5.995, -0.697215, 0, 0, -0.716862,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01C8 [25.927700 -269.868988 -5.995000] -0.697215 0.000000 0.000000 -0.716862 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A047, 46279, 0x011A01EE, 40.6612, -119.281, -5.995, -0.951378, 0, 0, 0.308025,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01EE [40.661201 -119.280998 -5.995000] -0.951378 0.000000 0.000000 0.308025 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A048,  5627, 0x011A01FC, 40, -310, -6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A01FC [40.000000 -310.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A049, 46279, 0x011A01FC, 40.101, -307.379, -6, -0.021347, 0, 0, -0.999772,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A01FC [40.101002 -307.378998 -6.000000] -0.021347 0.000000 0.000000 -0.999772 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A04A,  5627, 0x011A020C, 54.3556, -180.085, -6, -0.66832, 0, 0, -0.743874, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A020C [54.355598 -180.085007 -6.000000] -0.668320 0.000000 0.000000 -0.743874 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A04B, 46279, 0x011A020C, 52.9634, -181.442, -5.995, -0.772989, 0, 0, 0.634419,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A020C [52.963402 -181.442001 -5.995000] -0.772989 0.000000 0.000000 0.634419 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A04C, 46279, 0x011A020C, 52.8981, -179.293, -5.95785, 0.656014, 0, 0, -0.754749,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A020C [52.898102 -179.292999 -5.957850] 0.656014 0.000000 0.000000 -0.754749 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A04D, 46279, 0x011A020D, 53.4764, -198.964, -5.96693, -0.716145, 0, 0, 0.697951,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A020D [53.476398 -198.964005 -5.966930] -0.716145 0.000000 0.000000 0.697951 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A04E, 46279, 0x011A020D, 53.597, -200.471, -5.995, 0.752031, 0, 0, -0.659127,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A020D [53.597000 -200.470993 -5.995000] 0.752031 0.000000 0.000000 -0.659127 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A04F,  5627, 0x011A0219, 54.3556, -310.085, -6, -0.66832, 0, 0, -0.743874, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0219 [54.355598 -310.084991 -6.000000] -0.668320 0.000000 0.000000 -0.743874 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A050, 46279, 0x011A0219, 53.2195, -311.18, -5.995, 0.774552, 0, 0, -0.632511,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0219 [53.219501 -311.179993 -5.995000] 0.774552 0.000000 0.000000 -0.632511 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A051, 46279, 0x011A0219, 52.9085, -309.774, -5.97059, 0.741971, 0, 0, -0.670432,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0219 [52.908501 -309.773987 -5.970590] 0.741971 0.000000 0.000000 -0.670432 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A052, 46279, 0x011A021A, 47.9239, -320.891, -5.995, 0.341009, 0, 0, -0.94006,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A021A [47.923901 -320.890991 -5.995000] 0.341009 0.000000 0.000000 -0.940060 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A053, 46279, 0x011A021D, 52.2408, -350.358, -5.995, -0.970426, 0, 0, -0.2414,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A021D [52.240799 -350.358002 -5.995000] -0.970426 0.000000 0.000000 -0.241400 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A054, 46279, 0x011A0221, 60.5136, -100.582, -5.995, 0.663374, 0, 0, -0.748288,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0221 [60.513599 -100.582001 -5.995000] 0.663374 0.000000 0.000000 -0.748288 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A055, 46279, 0x011A0221, 61.3986, -98.174, -5.995, 0.639821, 0, 0, -0.768524,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0221 [61.398602 -98.174004 -5.995000] 0.639821 0.000000 0.000000 -0.768524 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A056, 46279, 0x011A0225, 61.5379, -129.39, -5.995, -0.975353, 0, 0, -0.22065,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0225 [61.537899 -129.389999 -5.995000] -0.975353 0.000000 0.000000 -0.220650 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A057, 46279, 0x011A0226, 64.8867, -130.54, -5.995, -0.584476, 0, 0, 0.811411,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0226 [64.886703 -130.539993 -5.995000] -0.584476 0.000000 0.000000 0.811411 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A058, 46279, 0x011A022A, 59.883, -199.395, -5.995, -0.95139, 0, 0, 0.307989,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A022A [59.882999 -199.395004 -5.995000] -0.951390 0.000000 0.000000 0.307989 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A059, 46279, 0x011A022A, 63.6792, -200.216, -5.995, -0.75806, 0, 0, 0.652185,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A022A [63.679199 -200.216003 -5.995000] -0.758060 0.000000 0.000000 0.652185 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A05A,  5627, 0x011A022A, 55.0749, -199.832, -6, -0.66832, 0, 0, -0.743874, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A022A [55.074902 -199.832001 -6.000000] -0.668320 0.000000 0.000000 -0.743874 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A05B,  5627, 0x011A022C, 64.3556, -260.085, -6, -0.66832, 0, 0, -0.743874, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A022C [64.355598 -260.084991 -6.000000] -0.668320 0.000000 0.000000 -0.743874 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A05C, 46279, 0x011A022C, 63.1343, -259.221, -5.995, 0.662674, 0, 0, -0.748908,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A022C [63.134300 -259.221008 -5.995000] 0.662674 0.000000 0.000000 -0.748908 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A05D, 46279, 0x011A022C, 63.1951, -261.375, -5.995, 0.79825, 0, 0, -0.602326,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A022C [63.195099 -261.375000 -5.995000] 0.798250 0.000000 0.000000 -0.602326 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A05E,  5627, 0x011A022D, 59.9147, -274.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A022D [59.914700 -274.355988 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A05F, 46279, 0x011A022D, 58.9723, -272.9, -5.95954, -0.03357, 0, 0, 0.999436,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A022D [58.972301 -272.899994 -5.959540] -0.033570 0.000000 0.000000 0.999436 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A060, 46279, 0x011A022D, 60.5951, -272.906, -5.9679, -0.145923, 0, 0, -0.989296,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A022D [60.595100 -272.906006 -5.967900] -0.145923 0.000000 0.000000 -0.989296 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A061,  5627, 0x011A0232, 60, -290, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0232 [60.000000 -290.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A062, 46279, 0x011A0251, 69.4647, -119.215, -5.995, -0.711644, 0, 0, 0.70254,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0251 [69.464699 -119.214996 -5.995000] -0.711644 0.000000 0.000000 0.702540 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A063, 46279, 0x011A0259, 71.1201, -198.756, -5.995, 0.663619, 0, 0, -0.748071,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0259 [71.120102 -198.755997 -5.995000] 0.663619 0.000000 0.000000 -0.748071 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A064,  5627, 0x011A025B, 70, -260, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A025B [70.000000 -260.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A065, 46279, 0x011A0272, 69.9989, -332.494, -5.995, 0.453596, 0, 0, -0.891207,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0272 [69.998901 -332.493988 -5.995000] 0.453596 0.000000 0.000000 -0.891207 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A066,  5627, 0x011A0286, 70.0853, -365.644, -6, 0.053425, 0, 0, -0.998572, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0286 [70.085297 -365.644012 -6.000000] 0.053425 0.000000 0.000000 -0.998572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A067, 46279, 0x011A0286, 68.66, -367.101, -5.95886, 0.988771, 0, 0, -0.149438,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0286 [68.660004 -367.101013 -5.958860] 0.988771 0.000000 0.000000 -0.149438 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A068, 46279, 0x011A0286, 70.8553, -366.621, -5.995, 0.991906, 0, 0, 0.126973,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0286 [70.855301 -366.621002 -5.995000] 0.991906 0.000000 0.000000 0.126973 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A069,  5627, 0x011A028D, 79.9147, -174.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A028D [79.914703 -174.356003 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A06A, 46279, 0x011A028D, 79.1618, -172.943, -5.96398, -0.00312, 0, 0, 0.999995,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A028D [79.161797 -172.942993 -5.963980] -0.003120 0.000000 0.000000 0.999995 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A06B, 46279, 0x011A028D, 80.8664, -173.057, -5.991, 0.107325, 0, 0, 0.994224,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A028D [80.866402 -173.057007 -5.991000] 0.107325 0.000000 0.000000 0.994224 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A06C,  5627, 0x011A02BC, 85.6444, -99.9147, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02BC [85.644402 -99.914703 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A06D, 46279, 0x011A02BC, 87.0911, -99.8623, -5.9711, -0.662926, 0, 0, -0.748685,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02BC [87.091103 -99.862297 -5.971100] -0.662926 0.000000 0.000000 -0.748685 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A06E, 46279, 0x011A02BD, 92.8976, -118.044, -5.995, -0.693595, 0, 0, -0.720365,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02BD [92.897598 -118.043999 -5.995000] -0.693595 0.000000 0.000000 -0.720365 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A06F,  5627, 0x011A02C3, 89.9147, -194.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02C3 [89.914703 -194.356003 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A070, 46279, 0x011A02C3, 90.5741, -193.041, -5.96398, 0.100521, 0, 0, -0.994935,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02C3 [90.574097 -193.041000 -5.963980] 0.100521 0.000000 0.000000 -0.994935 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A071, 46279, 0x011A02C3, 89.3852, -193.334, -5.995, 0.133697, 0, 0, -0.991022,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02C3 [89.385201 -193.334000 -5.995000] 0.133697 0.000000 0.000000 -0.991022 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A072, 46279, 0x011A02C6, 93.5767, -220.417, -5.995, 0.733062, 0, 0, -0.680162,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02C6 [93.576698 -220.417007 -5.995000] 0.733062 0.000000 0.000000 -0.680162 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A073,  5627, 0x011A02C7, 89.9147, -234.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02C7 [89.914703 -234.356003 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A074, 46279, 0x011A02C7, 88.8597, -232.905, -5.96692, 0.00626, 0, 0, 0.99998,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02C7 [88.859703 -232.904999 -5.966920] 0.006260 0.000000 0.000000 0.999980 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A075, 46279, 0x011A02C7, 91.0145, -233.186, -5.995, 0.090924, 0, 0, 0.995858,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02C7 [91.014503 -233.186005 -5.995000] 0.090924 0.000000 0.000000 0.995858 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A076,  5627, 0x011A02C8, 90, -240, -6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02C8 [90.000000 -240.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A077, 46279, 0x011A02CB, 93.1794, -259.421, -5.995, 0.904296, 0, 0, -0.426906,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02CB [93.179398 -259.420990 -5.995000] 0.904296 0.000000 0.000000 -0.426906 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A078,  5627, 0x011A02CE, 90, -300, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02CE [90.000000 -300.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A079,  5627, 0x011A02D6, 85.6444, -339.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02D6 [85.644402 -339.915009 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A07A,  5627, 0x011A02D7, 90, -350, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02D7 [90.000000 -350.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A07B, 46279, 0x011A02D7, 92.4698, -350.044, -5.995, 0.705711, 0, 0, 0.7085,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02D7 [92.469803 -350.044006 -5.995000] 0.705711 0.000000 0.000000 0.708500 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A07C, 46279, 0x011A02DF, 101.112, -62.7511, -5.995, -0.003919, 0, 0, -0.999992,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02DF [101.112000 -62.751099 -5.995000] -0.003919 0.000000 0.000000 -0.999992 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A07D, 46279, 0x011A02E7, 100.386, -120.491, -5.995, -0.73011, 0, 0, -0.683329,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02E7 [100.386002 -120.490997 -5.995000] -0.730110 0.000000 0.000000 -0.683329 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A07E, 46279, 0x011A02EA, 101.856, -147.433, -5.995, -0.590343, 0, 0, 0.807152,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02EA [101.856003 -147.432999 -5.995000] -0.590343 0.000000 0.000000 0.807152 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A07F, 46279, 0x011A02EA, 102.763, -152.391, -5.995, -0.28703, 0, 0, -0.957922,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02EA [102.763000 -152.391006 -5.995000] -0.287030 0.000000 0.000000 -0.957922 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A080,  5627, 0x011A02EC, 99.9147, -174.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02EC [99.914703 -174.356003 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A081, 46279, 0x011A02EC, 98.783, -173.285, -5.995, 0.087156, 0, 0, -0.996195,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02EC [98.782997 -173.285004 -5.995000] 0.087156 0.000000 0.000000 -0.996195 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A082, 46279, 0x011A02EC, 100.218, -173.05, -5.995, -0.087156, 0, 0, -0.996195,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02EC [100.218002 -173.050003 -5.995000] -0.087156 0.000000 0.000000 -0.996195 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A083, 46279, 0x011A02EF, 101.04, -218.871, -5.995, 0.595647, 0, 0, -0.803246,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02EF [101.040001 -218.871002 -5.995000] 0.595647 0.000000 0.000000 -0.803246 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A084, 46279, 0x011A02EF, 100.214, -221.591, -5.995, 0.770269, 0, 0, -0.637719,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02EF [100.213997 -221.591003 -5.995000] 0.770269 0.000000 0.000000 -0.637719 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A085, 46279, 0x011A02F2, 103.885, -265.828, -5.995, 0.998316, 0, 0, 0.058002,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02F2 [103.885002 -265.828003 -5.995000] 0.998316 0.000000 0.000000 0.058002 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A086,  5627, 0x011A02F9, 95.6444, -309.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02F9 [95.644402 -309.915009 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A087, 46279, 0x011A02F9, 97.0232, -308.841, -5.995, 0.684759, 0, 0, 0.728769,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02F9 [97.023201 -308.841003 -5.995000] 0.684759 0.000000 0.000000 0.728769 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A088, 46279, 0x011A02F9, 97.0087, -310.575, -5.995, 0.815894, 0, 0, 0.578201,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02F9 [97.008698 -310.575012 -5.995000] 0.815894 0.000000 0.000000 0.578201 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A089,  5627, 0x011A02FA, 95.6444, -349.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02FA [95.644402 -349.915009 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A08A, 46279, 0x011A02FA, 97.0965, -349.918, -5.96442, 0.705711, 0, 0, 0.7085,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02FA [97.096497 -349.917999 -5.964420] 0.705711 0.000000 0.000000 0.708500 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A08B,  5627, 0x011A02FB, 109.915, -14.3556, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A02FB [109.915001 -14.355600 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A08C, 46279, 0x011A02FB, 109.93, -12.9149, -5.9786, 0.01721, 0, 0, 0.999852,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02FB [109.930000 -12.914900 -5.978600] 0.017210 0.000000 0.000000 0.999852 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A08D, 46279, 0x011A02FB, 111.304, -12.9282, -5.995, 0.120169, 0, 0, 0.992753,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02FB [111.304001 -12.928200 -5.995000] 0.120169 0.000000 0.000000 0.992753 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A08E, 46279, 0x011A02FB, 108.865, -13.0373, -5.995, -0.203666, 0, 0, 0.97904,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A02FB [108.864998 -13.037300 -5.995000] -0.203666 0.000000 0.000000 0.979040 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A08F,  6394, 0x011A02FC, 110.147, -18.6328, -5.995, 0.999938, 0, 0, -0.011175, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x011A02FC [110.147003 -18.632799 -5.995000] 0.999938 0.000000 0.000000 -0.011175 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A090, 46279, 0x011A0307, 108.843, -56.4277, -5.995, -0.284129, 0, 0, -0.958786,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0307 [108.843002 -56.427700 -5.995000] -0.284129 0.000000 0.000000 -0.958786 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A091, 46279, 0x011A030C, 108.981, -83.8682, -5.995, -0.041459, 0, 0, -0.99914,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A030C [108.981003 -83.868202 -5.995000] -0.041459 0.000000 0.000000 -0.999140 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A092, 46279, 0x011A030D, 109.363, -81.3636, -5.995, 0.202234, 0, 0, -0.979337,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A030D [109.362999 -81.363602 -5.995000] 0.202234 0.000000 0.000000 -0.979337 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A093,  5627, 0x011A0314, 110, -110, -6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0314 [110.000000 -110.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A094, 46279, 0x011A0314, 109.772, -108.396, -5.995, 0.042344, 0, 0, -0.999103,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0314 [109.772003 -108.396004 -5.995000] 0.042344 0.000000 0.000000 -0.999103 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A095, 46279, 0x011A0315, 108.771, -119.893, -5.995, -0.674413, 0, 0, -0.738354,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0315 [108.771004 -119.892998 -5.995000] -0.674413 0.000000 0.000000 -0.738354 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A096,  5627, 0x011A031A, 110, -190, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A031A [110.000000 -190.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A097, 46279, 0x011A031A, 112.321, -189.781, -5.995, -0.708254, 0, 0, -0.705957,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A031A [112.320999 -189.781006 -5.995000] -0.708254 0.000000 0.000000 -0.705957 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A098, 46279, 0x011A031A, 106.533, -190.211, -5.995, -0.724539, 0, 0, -0.689233,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A031A [106.532997 -190.210999 -5.995000] -0.724539 0.000000 0.000000 -0.689233 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A099,  5627, 0x011A0320, 110, -240, -6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0320 [110.000000 -240.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A09A, 46279, 0x011A0320, 109.521, -237.26, -5.995, -0.008538, 0, 0, -0.999964,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0320 [109.521004 -237.259995 -5.995000] -0.008538 0.000000 0.000000 -0.999964 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A09B, 46279, 0x011A0320, 110.428, -238.298, -5.995, 0.066413, 0, 0, -0.997792,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0320 [110.428001 -238.298004 -5.995000] 0.066413 0.000000 0.000000 -0.997792 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A09C, 46279, 0x011A0333, 119.534, -150.122, -5.995, 0.635559, 0, 0, -0.772052,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0333 [119.533997 -150.121994 -5.995000] 0.635559 0.000000 0.000000 -0.772052 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A09D, 46279, 0x011A0333, 118.986, -154.856, -5.995, 0.851252, 0, 0, -0.524757,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0333 [118.986000 -154.856003 -5.995000] 0.851252 0.000000 0.000000 -0.524757 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A09E, 46279, 0x011A0333, 124.211, -150.533, -5.995, 0.721107, 0, 0, -0.692823,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0333 [124.210999 -150.533005 -5.995000] 0.721107 0.000000 0.000000 -0.692823 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A09F,  5627, 0x011A0340, 115.644, -219.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0340 [115.643997 -219.914993 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A0, 46279, 0x011A0340, 117.03, -219.051, -5.995, 0.571455, 0, 0, 0.820634,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0340 [117.029999 -219.050995 -5.995000] 0.571455 0.000000 0.000000 0.820634 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A1, 46279, 0x011A0340, 116.862, -220.237, -5.995, -0.768321, 0, 0, -0.640065,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0340 [116.862000 -220.237000 -5.995000] -0.768321 0.000000 0.000000 -0.640065 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A2,  5627, 0x011A0341, 120, -260, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0341 [120.000000 -260.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A3, 46279, 0x011A0341, 122.419, -259.909, -5.995, 0.747309, 0, 0, 0.664477,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0341 [122.418999 -259.908997 -5.995000] 0.747309 0.000000 0.000000 0.664477 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A4,  5627, 0x011A0342, 115.644, -299.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0342 [115.643997 -299.915009 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A5, 46279, 0x011A0342, 117.042, -299.206, -5.995, 0.704413, 0, 0, 0.70979,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0342 [117.042000 -299.205994 -5.995000] 0.704413 0.000000 0.000000 0.709790 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A6, 46279, 0x011A0342, 117.102, -300.619, -5.95709, 0.649248, 0, 0, 0.760577,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0342 [117.101997 -300.618988 -5.957090] 0.649248 0.000000 0.000000 0.760577 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A7,  5627, 0x011A034D, 129.915, -164.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A034D [129.914993 -164.356003 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A8, 46279, 0x011A034D, 129.688, -163.34, -5.995, -0.074513, 0, 0, 0.99722,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A034D [129.688004 -163.339996 -5.995000] -0.074513 0.000000 0.000000 0.997220 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0A9,  5627, 0x011A0355, 125.644, -189.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0355 [125.643997 -189.914993 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0AA, 46279, 0x011A0355, 126.821, -188.701, -5.995, -0.65185, 0, 0, -0.758348,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0355 [126.820999 -188.701004 -5.995000] -0.651850 0.000000 0.000000 -0.758348 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0AB, 46279, 0x011A0355, 127.075, -190.672, -5.99113, 0.65256, 0, 0, 0.757737,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0355 [127.074997 -190.671997 -5.991130] 0.652560 0.000000 0.000000 0.757737 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0AC, 46279, 0x011A035A, 130.214, -209.897, -5.995, -0.912007, 0, 0, 0.410175,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A035A [130.214005 -209.897003 -5.995000] -0.912007 0.000000 0.000000 0.410175 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0AD,  5627, 0x011A035E, 130, -220, -6, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A035E [130.000000 -220.000000 -6.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0AE,  5627, 0x011A035F, 130.085, -225.644, -6, 0.053425, 0, 0, -0.998572, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A035F [130.085007 -225.643997 -6.000000] 0.053425 0.000000 0.000000 -0.998572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0AF, 46279, 0x011A035F, 131.085, -227.099, -5.9614, -0.999494, 0, 0, -0.031796,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A035F [131.085007 -227.098999 -5.961400] -0.999494 0.000000 0.000000 -0.031796 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B0, 46279, 0x011A035F, 129.404, -226.96, -5.995, -0.999067, 0, 0, 0.043185,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A035F [129.404007 -226.960007 -5.995000] -0.999067 0.000000 0.000000 0.043185 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B1,  5627, 0x011A0360, 125.644, -259.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0360 [125.643997 -259.915009 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B2, 46279, 0x011A0360, 127.072, -260.024, -5.995, 0.636338, 0, 0, 0.77141,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0360 [127.071999 -260.023987 -5.995000] 0.636338 0.000000 0.000000 0.771410 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B3,  5627, 0x011A0364, 140, -140, -6, 0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0364 [140.000000 -140.000000 -6.000000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B4, 46279, 0x011A0376, 154.538, -29.6668, -5.995, 0.690678, 0, 0, 0.723162,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0376 [154.537994 -29.666800 -5.995000] 0.690678 0.000000 0.000000 0.723162 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B5,  5627, 0x011A037C, 150, -150, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A037C [150.000000 -150.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B6, 46279, 0x011A037C, 150.097, -147.478, -5.995, -0.136624, 0, 0, -0.990623,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A037C [150.097000 -147.477997 -5.995000] -0.136624 0.000000 0.000000 -0.990623 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B7, 46279, 0x011A037C, 150.655, -145.491, -5.995, -0.136624, 0, 0, -0.990623,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A037C [150.654999 -145.490997 -5.995000] -0.136624 0.000000 0.000000 -0.990623 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B8, 46279, 0x011A0380, 154.328, -168.111, -5.995, 0.999963, 0, 0, -0.008654,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0380 [154.328003 -168.110992 -5.995000] 0.999963 0.000000 0.000000 -0.008654 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0B9, 46279, 0x011A038F, 158.385, -179.113, -5.995, 0.941096, 0, 0, -0.338139,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A038F [158.384995 -179.113007 -5.995000] 0.941096 0.000000 0.000000 -0.338139 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0BA, 46279, 0x011A039B, 169.616, -31.3858, -5.995, -0.986714, 0, 0, 0.162468,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A039B [169.615997 -31.385799 -5.995000] -0.986714 0.000000 0.000000 0.162468 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0BB,  2411, 0x011A039E, 169.036, -44.3718, -5.995, -0.416147, 0, 0, 0.909297,  True, '2005-02-09 10:00:00'); /* Ruby */
+/* @teleloc 0x011A039E [169.035995 -44.371799 -5.995000] -0.416147 0.000000 0.000000 0.909297 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0BC,  2414, 0x011A039E, 170.248, -43.564, -5.995, -0.881582, 0, 0, 0.47203,  True, '2005-02-09 10:00:00'); /* Azurite */
+/* @teleloc 0x011A039E [170.248001 -43.563999 -5.995000] -0.881582 0.000000 0.000000 0.472030 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0BD, 46279, 0x011A039E, 169.834, -42.7802, -5.995, 0.999977, 0, 0, -0.006802,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A039E [169.834000 -42.780201 -5.995000] 0.999977 0.000000 0.000000 -0.006802 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0BE,  6126, 0x011A039F, 170.135, -45.1932, -5.9835, -0.0292, 0, 0, 0.999574,  True, '2005-02-09 10:00:00'); /* Major Stinging Stone */
+/* @teleloc 0x011A039F [170.134995 -45.193199 -5.983500] -0.029200 0.000000 0.000000 0.999574 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0BF,  2415, 0x011A039F, 170.485, -45.1437, -5.995, -0.251475, 0, 0, 0.967864,  True, '2005-02-09 10:00:00'); /* Lapis Lazuli */
+/* @teleloc 0x011A039F [170.485001 -45.143700 -5.995000] -0.251475 0.000000 0.000000 0.967864 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C0,  2410, 0x011A039F, 169.368, -45.2068, -5.995, 0.989577, 0, 0, -0.144005,  True, '2005-02-09 10:00:00'); /* Emerald */
+/* @teleloc 0x011A039F [169.367996 -45.206799 -5.995000] 0.989577 0.000000 0.000000 -0.144005 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C1,  5627, 0x011A03BB, 170.085, -225.644, -6, 0.053425, 0, 0, -0.998572, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A03BB [170.085007 -225.643997 -6.000000] 0.053425 0.000000 0.000000 -0.998572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C2, 46279, 0x011A03BB, 170.967, -226.254, -5.995, 0.968912, 0, 0, 0.247404,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03BB [170.966995 -226.253998 -5.995000] 0.968912 0.000000 0.000000 0.247404 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C3, 46279, 0x011A03BB, 168.968, -227.001, -5.995, 0.995004, 0, 0, 0.099833,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03BB [168.968002 -227.001007 -5.995000] 0.995004 0.000000 0.000000 0.099833 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C4,  5627, 0x011A03BC, 179.915, -144.356, -6, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A03BC [179.914993 -144.356003 -6.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C5, 46279, 0x011A03BC, 181.487, -142.907, -5.96822, 0.004441, 0, 0, -0.99999,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03BC [181.487000 -142.906998 -5.968220] 0.004441 0.000000 0.000000 -0.999990 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C6, 46279, 0x011A03BC, 179.816, -142.897, -5.95682, 0.153828, 0, 0, -0.988098,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03BC [179.815994 -142.897003 -5.956820] 0.153828 0.000000 0.000000 -0.988098 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C7,  5627, 0x011A03C6, 180, -170, -6, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A03C6 [180.000000 -170.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C8,  5627, 0x011A03E2, 195.644, -169.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A03E2 [195.643997 -169.914993 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0C9, 46279, 0x011A03E2, 196.715, -169.155, -5.995, -0.711538, 0, 0, -0.702648,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03E2 [196.714996 -169.154999 -5.995000] -0.711538 0.000000 0.000000 -0.702648 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0CA, 46279, 0x011A03E2, 196.877, -170.758, -5.995, -0.598545, 0, 0, -0.801089,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03E2 [196.876999 -170.757996 -5.995000] -0.598545 0.000000 0.000000 -0.801089 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0CB,  5627, 0x011A03E3, 195.644, -189.915, -6, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A03E3 [195.643997 -189.914993 -6.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0CC, 46279, 0x011A03E3, 196.848, -188.503, -5.995, -0.527981, 0, 0, -0.849256,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03E3 [196.848007 -188.503006 -5.995000] -0.527981 0.000000 0.000000 -0.849256 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0CD, 46279, 0x011A03E3, 197.051, -191.24, -5.995, -0.730974, 0, 0, -0.682405,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A03E3 [197.050995 -191.240005 -5.995000] -0.730974 0.000000 0.000000 -0.682405 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0CE,  6394, 0x011A0404, 59.3586, -348.379, 0.005, -0.000225, 0, 0, 1, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x011A0404 [59.358601 -348.378998 0.005000] -0.000225 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0CF,  7923, 0x011A040C, 67.5558, -333.023, 0.024, -0.711106, 0, 0, -0.703085, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 3 Min.) */
+/* @teleloc 0x011A040C [67.555801 -333.023010 0.024000] -0.711106 0.000000 0.000000 -0.703085 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011A0CF, 0x7011A001, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A002, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A003, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A004, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A005, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A009, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A00A, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A00B, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A00C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A017, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A018, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A01E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A01F, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A03B, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A03C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A03E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A03F, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A041, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A042, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A044, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A045, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A046, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A047, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A049, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A04B, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A04C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A04D, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A04E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A050, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A051, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A052, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A053, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A054, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A055, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A056, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A057, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A058, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A059, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A05C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A05D, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A05F, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A060, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A062, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A063, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A065, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A067, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A068, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A06A, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A06B, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A06D, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A06E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A070, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A071, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A072, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A074, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A075, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A077, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A07B, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A07C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A07D, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A07E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A07F, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A081, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A082, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A083, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A084, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A085, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A087, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A088, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A08A, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A08C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A08D, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A08E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A090, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A091, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A092, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A094, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A095, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A097, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A098, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A09A, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A09B, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A09C, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A09D, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A09E, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0A0, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0A1, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0A3, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0A5, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0A6, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0A8, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0AA, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0AB, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0AC, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0AF, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B0, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B2, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B4, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B6, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B7, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B8, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0B9, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0BA, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0BD, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0C2, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0C3, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0C5, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0C6, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0C9, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0CA, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0CC, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0CD, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (46279) */
+     , (0x7011A0CF, 0x7011A0D2, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0D3, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0D4, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0D5, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0D6, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0D7, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0D9, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0DB, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0DC, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0DD, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0DE, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0DF, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E0, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E3, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E4, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E5, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E6, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E7, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E8, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0E9, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0EB, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */
+     , (0x7011A0CF, 0x7011A0ED, '2005-02-09 10:00:00') /* Olthoi Swarm Soldier (23989) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D0,  5085, 0x011A040C, 66.491, -333.023, 0.024, -0.711106, 0, 0, -0.703085, False, '2005-02-09 10:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x011A040C [66.490997 -333.023010 0.024000] -0.711106 0.000000 0.000000 -0.703085 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011A0D0, 0x7011A0BB, '2005-02-09 10:00:00') /* Ruby (2411) */
+     , (0x7011A0D0, 0x7011A0BC, '2005-02-09 10:00:00') /* Azurite (2414) */
+     , (0x7011A0D0, 0x7011A0BE, '2005-02-09 10:00:00') /* Major Stinging Stone (6126) */
+     , (0x7011A0D0, 0x7011A0BF, '2005-02-09 10:00:00') /* Lapis Lazuli (2415) */
+     , (0x7011A0D0, 0x7011A0C0, '2005-02-09 10:00:00') /* Emerald (2410) */
+     , (0x7011A0D0, 0x7011A0EE, '2005-02-09 10:00:00') /* Textbook (6407) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D1,  5627, 0x011A0435, 109.915, -34.3556, 0, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0435 [109.915001 -34.355598 0.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D2, 23989, 0x011A0435, 108.78, -33.2861, 0.005, -0.098625, 0, 0, 0.995125,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0435 [108.779999 -33.286098 0.005000] -0.098625 0.000000 0.000000 0.995125 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D3, 23989, 0x011A0435, 110.623, -32.9113, 0.025938, -0.073718, 0, 0, 0.997279,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0435 [110.623001 -32.911301 0.025938] -0.073718 0.000000 0.000000 0.997279 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D4, 23989, 0x011A0436, 109.459, -39.1473, 0.005, 0.101042, 0, 0, 0.994882,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0436 [109.459000 -39.147301 0.005000] 0.101042 0.000000 0.000000 0.994882 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D5, 23989, 0x011A0439, 109.901, -44.1694, 0.005, -0.023783, 0, 0, 0.999717,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0439 [109.901001 -44.169399 0.005000] -0.023783 0.000000 0.000000 0.999717 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D6, 23989, 0x011A043E, 110.757, -101.119, 0.005, -0.998655, 0, 0, 0.051846,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A043E [110.757004 -101.119003 0.005000] -0.998655 0.000000 0.000000 0.051846 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D7, 23989, 0x011A0441, 110.265, -96.2028, 0.005, -0.996293, 0, 0, -0.086029,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0441 [110.264999 -96.202797 0.005000] -0.996293 0.000000 0.000000 -0.086029 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D8,  5627, 0x011A0443, 110.085, -105.644, 0, 0.053425, 0, 0, -0.998572, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0443 [110.084999 -105.643997 0.000000] 0.053425 0.000000 0.000000 -0.998572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0D9, 23989, 0x011A0443, 110.417, -107.092, 0.030337, -0.989716, 0, 0, 0.143043,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0443 [110.417000 -107.092003 0.030337] -0.989716 0.000000 0.000000 0.143043 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0DA,  5627, 0x011A0455, 139.915, -4.35556, 0, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0455 [139.914993 -4.355560 0.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0DB, 23989, 0x011A0455, 140.25, -2.9001, 0.039733, -0.184157, 0, 0, -0.982897,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0455 [140.250000 -2.900100 0.039733] -0.184157 0.000000 0.000000 -0.982897 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0DC, 23989, 0x011A0459, 140.076, -14.437, 0.005, 0.001475, 0, 0, -0.999999,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0459 [140.076004 -14.437000 0.005000] 0.001475 0.000000 0.000000 -0.999999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0DD, 23989, 0x011A045A, 140.928, -7.92615, 0.005, 0.001475, 0, 0, -0.999999,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A045A [140.927994 -7.926150 0.005000] 0.001475 0.000000 0.000000 -0.999999 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0DE, 23989, 0x011A045E, 140.876, -50.361, 0.005, 0.999972, 0, 0, -0.007437,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A045E [140.876007 -50.361000 0.005000] 0.999972 0.000000 0.000000 -0.007437 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0DF, 23989, 0x011A0461, 140.777, -45.5162, 0.005, 0.999972, 0, 0, -0.007437,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0461 [140.776993 -45.516201 0.005000] 0.999972 0.000000 0.000000 -0.007437 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E0, 23989, 0x011A0462, 138.737, -52.9515, 0.005, 0.996289, 0, 0, -0.086067,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0462 [138.737000 -52.951500 0.005000] 0.996289 0.000000 0.000000 -0.086067 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E1,  5627, 0x011A0463, 140.085, -55.6444, 0, 0.053425, 0, 0, -0.998572, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0463 [140.085007 -55.644402 0.000000] 0.053425 0.000000 0.000000 -0.998572 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E2,  5627, 0x011A046F, 159.915, -14.3556, 0, 0.998572, 0, 0, 0.053425, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A046F [159.914993 -14.355600 0.000000] 0.998572 0.000000 0.000000 0.053425 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E3, 23989, 0x011A046F, 159.648, -12.9265, 0.007079, 0.004615, 0, 0, 0.999989,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A046F [159.647995 -12.926500 0.007079] 0.004615 0.000000 0.000000 0.999989 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E4, 23989, 0x011A0470, 157.042, -23.1081, 0.005, 0.629918, 0, 0, 0.776662,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0470 [157.042007 -23.108101 0.005000] 0.629918 0.000000 0.000000 0.776662 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E5, 23989, 0x011A0471, 157.279, -32.6284, 0.005, 0.709725, 0, 0, 0.704479,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0471 [157.279007 -32.628399 0.005000] 0.709725 0.000000 0.000000 0.704479 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E6, 23989, 0x011A0471, 157.336, -27.856, 0.005, 0.740542, 0, 0, 0.672011,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0471 [157.335999 -27.856001 0.005000] 0.740542 0.000000 0.000000 0.672011 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E7, 23989, 0x011A0472, 158.197, -36.8209, 0.005, 0.848832, 0, 0, 0.528663,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0472 [158.197006 -36.820900 0.005000] 0.848832 0.000000 0.000000 0.528663 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E8, 23989, 0x011A0478, 170.785, -29.5589, 0.005, -0.714396, 0, 0, -0.699742,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0478 [170.785004 -29.558901 0.005000] -0.714396 0.000000 0.000000 -0.699742 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0E9, 23989, 0x011A0478, 165.723, -30.1712, 0.005, 0.69727, 0, 0, 0.716809,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0478 [165.723007 -30.171200 0.005000] 0.697270 0.000000 0.000000 0.716809 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0EA,  5627, 0x011A0479, 165.644, -39.9147, 0, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A0479 [165.643997 -39.914700 0.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0EB, 23989, 0x011A0479, 167.088, -39.0868, 0.025502, 0.651096, 0, 0, 0.758996,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A0479 [167.087997 -39.086800 0.025502] 0.651096 0.000000 0.000000 0.758996 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0EC,  5627, 0x011A047D, 175.644, -29.9147, 0, 0.743874, 0, 0, -0.66832, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011A047D [175.643997 -29.914700 0.000000] 0.743874 0.000000 0.000000 -0.668320 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0ED, 23989, 0x011A047D, 177.1, -30.1517, 0.040348, -0.772919, 0, 0, -0.634505,  True, '2005-02-09 10:00:00'); /* Olthoi Swarm Soldier */
+/* @teleloc 0x011A047D [177.100006 -30.151699 0.040348] -0.772919 0.000000 0.000000 -0.634505 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011A0EE,  6407, 0x011A039F, 170.094, -46.365, -5.93046, -0.004204, 0, 0, -0.999991,  True, '2005-02-09 10:00:00'); /* Textbook */
+/* @teleloc 0x011A039F [170.093994 -46.365002 -5.930460] -0.004204 0.000000 0.000000 -0.999991 */

--- a/Database/Patches/6 LandBlockExtendedData/011B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/011B.sql
@@ -1,0 +1,437 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x011B;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B000, 11534, 0x011B0103, 68.6837, -40.55, -83.985, 0.711025, 0, 0, 0.703166,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0103 [68.683701 -40.549999 -83.985001] 0.711025 0.000000 0.000000 0.703166 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B001, 11534, 0x011B0103, 68.728, -36.5684, -83.985, 0.711025, 0, 0, 0.703166,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0103 [68.727997 -36.568401 -83.985001] 0.711025 0.000000 0.000000 0.703166 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B002,  7924, 0x011B0106, 71.787, -59.714, -83.995, 0.872637, 0, 0, 0.48837, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x011B0106 [71.787003 -59.714001 -83.995003] 0.872637 0.000000 0.000000 0.488370 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B002, 0x7011B000, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B001, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B003, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B004, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B005, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B002, 0x7011B006, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B007, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B009, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B015, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B01C, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B020, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B025, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B027, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B032, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B033, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B034, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B002, 0x7011B04E, '2005-02-09 10:00:00') /* Enku Zefir (11534) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B003, 11534, 0x011B0106, 70.6335, -61.154, -83.985, 0.689338, 0, 0, 0.72444,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0106 [70.633499 -61.153999 -83.985001] 0.689338 0.000000 0.000000 0.724440 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B004, 11534, 0x011B0106, 70.5021, -58.5093, -83.985, 0.689338, 0, 0, 0.72444,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0106 [70.502098 -58.509300 -83.985001] 0.689338 0.000000 0.000000 0.724440 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B005,  8405, 0x011B0113, 90.3462, -35.1972, -77.945, -0.98102, 0, 0, 0.193907,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0113 [90.346199 -35.197201 -77.945000] -0.981020 0.000000 0.000000 0.193907 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B006, 11534, 0x011B0117, 86.7339, -49.6422, -77.985, 0.73005, 0, 0, 0.683394,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0117 [86.733902 -49.642200 -77.985001] 0.730050 0.000000 0.000000 0.683394 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B007, 11534, 0x011B011C, 100.218, -22.4397, -77.985, 0.047711, 0, 0, 0.998861,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B011C [100.218002 -22.439699 -77.985001] 0.047711 0.000000 0.000000 0.998861 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B008,  8405, 0x011B0127, 100.881, -64.9035, -77.945, 0.90198, 0, 0, 0.431778,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0127 [100.880997 -64.903503 -77.945000] 0.901980 0.000000 0.000000 0.431778 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B009, 11534, 0x011B012C, 106.431, -49.8268, -77.985, 0.658177, 0, 0, 0.752863,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B012C [106.431000 -49.826801 -77.985001] 0.658177 0.000000 0.000000 0.752863 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B00A,  8405, 0x011B0137, 38.9438, -35.6878, -65.9935, 0.999999, 0, 0, -0.001503,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0137 [38.943802 -35.687801 -65.993500] 0.999999 0.000000 0.000000 -0.001503 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B00B,  3955, 0x011B0145, 78.0698, -41.9159, -65.995, 0.849302, 0, 0, -0.527907, False, '2005-02-09 10:00:00'); /* Linkable Monster Gen (15 min.) */
+/* @teleloc 0x011B0145 [78.069801 -41.915901 -65.995003] 0.849302 0.000000 0.000000 -0.527907 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B00B, 0x7011B008, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B00A, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B00F, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B013, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B014, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B016, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B00B, 0x7011B017, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B00B, 0x7011B018, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B00B, 0x7011B019, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B00B, 0x7011B01A, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B00B, 0x7011B01B, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B01D, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B01E, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B01F, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B021, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B022, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B026, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B03D, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B03F, '2005-02-09 10:00:00') /* Inferno (5712) */
+     , (0x7011B00B, 0x7011B042, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B043, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B044, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B046, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B048, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B050, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B051, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B00B, 0x7011B052, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B00B, 0x7011B053, '2005-02-09 10:00:00') /* Enku Zefir (11534) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B00C,  6396, 0x011B0145, 80, -40, -65.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x011B0145 [80.000000 -40.000000 -65.995003] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B00D,   278, 0x011B0147, 80, -44.75, -66, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011B0147 [80.000000 -44.750000 -66.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B00E,   278, 0x011B014D, 80, -55.25, -66, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011B014D [80.000000 -55.250000 -66.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B00F,  8405, 0x011B0153, 19.8589, -60.3247, -62.9935, -0.877141, 0, 0, 0.480232,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0153 [19.858900 -60.324699 -62.993500] -0.877141 0.000000 0.000000 0.480232 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B010,  7561, 0x011B0159, 50.6364, -51.1117, -57.4671, 0.405051, 0, 0, -0.914294, False, '2005-02-09 10:00:00'); /* Magic trap */
+/* @teleloc 0x011B0159 [50.636398 -51.111698 -57.467098] 0.405051 0.000000 0.000000 -0.914294 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B010, 0x7011B012, '2005-02-09 10:00:00') /* Pressure Plate (2131) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B011,  1947, 0x011B015A, 53.9251, -54.1731, -60, 0, 0, 0, -1, False, '2005-02-09 10:00:00'); /* Chest */
+/* @teleloc 0x011B015A [53.925098 -54.173100 -60.000000] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B012,  2131, 0x011B015B, 52.9239, -52.775, -59.995, 0.350679, 0, 0, -0.936496,  True, '2005-02-09 10:00:00'); /* Pressure Plate */
+/* @teleloc 0x011B015B [52.923901 -52.775002 -59.994999] 0.350679 0.000000 0.000000 -0.936496 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B013,  8405, 0x011B0161, 9.67514, -52.83, -53.9935, 0.997281, 0, 0, -0.073696,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0161 [9.675140 -52.830002 -53.993500] 0.997281 0.000000 0.000000 -0.073696 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B014,  8405, 0x011B0165, 33.6185, -22.1657, -53.945, 0.530136, 0, 0, 0.847913,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0165 [33.618500 -22.165701 -53.945000] 0.530136 0.000000 0.000000 0.847913 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B015, 11534, 0x011B0168, 33.3516, -48.1046, -53.985, -0.386268, 0, 0, 0.922387,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0168 [33.351601 -48.104599 -53.985001] -0.386268 0.000000 0.000000 0.922387 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B016, 24310, 0x011B016A, 31.0483, -68.9724, -53.988, 0.706786, 0, 0, 0.707428,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B016A [31.048300 -68.972397 -53.987999] 0.706786 0.000000 0.000000 0.707428 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B017, 24310, 0x011B016A, 31.5648, -70.557, -53.988, 0.706786, 0, 0, 0.707428,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B016A [31.564800 -70.556999 -53.987999] 0.706786 0.000000 0.000000 0.707428 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B018, 24310, 0x011B0174, 35.231, -69.792, -53.945, 0.706786, 0, 0, 0.707428,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0174 [35.230999 -69.792000 -53.945000] 0.706786 0.000000 0.000000 0.707428 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B019, 24310, 0x011B0174, 36.6068, -68.4441, -53.945, -0.991197, 0, 0, -0.132397,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0174 [36.606800 -68.444099 -53.945000] -0.991197 0.000000 0.000000 -0.132397 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B01A, 24310, 0x011B0174, 39.1617, -66.1229, -53.988, -0.912671, 0, 0, 0.408696,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0174 [39.161701 -66.122902 -53.987999] -0.912671 0.000000 0.000000 0.408696 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B01B,  8405, 0x011B017E, 60.2262, -27.2745, -53.9935, -0.019116, 0, 0, 0.999817,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B017E [60.226200 -27.274500 -53.993500] -0.019116 0.000000 0.000000 0.999817 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B01C, 11534, 0x011B017E, 60.1417, -28.0531, -53.985, 0.20052, 0, 0, -0.97969,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B017E [60.141701 -28.053101 -53.985001] 0.200520 0.000000 0.000000 -0.979690 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B01D, 11534, 0x011B017E, 60.5168, -29.679, -53.985, 0.898498, 0, 0, 0.438978,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B017E [60.516800 -29.679001 -53.985001] 0.898498 0.000000 0.000000 0.438978 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B01E, 11534, 0x011B0185, 30.4191, -36.3256, -47.985, -1, 0, 0, -0.00078,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0185 [30.419100 -36.325600 -47.985001] -1.000000 0.000000 0.000000 -0.000780 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B01F, 11534, 0x011B0185, 29.4166, -38.8785, -47.985, -0.998711, 0, 0, -0.050758,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0185 [29.416599 -38.878502 -47.985001] -0.998711 0.000000 0.000000 -0.050758 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B020, 11534, 0x011B018F, 50.0762, -19.8792, -47.985, -0.063585, 0, 0, -0.997976,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B018F [50.076199 -19.879200 -47.985001] -0.063585 0.000000 0.000000 -0.997976 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B021,  8405, 0x011B0199, 39.2711, -69.891, -41.9935, 0.999982, 0, 0, -0.006012,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0199 [39.271099 -69.890999 -41.993500] 0.999982 0.000000 0.000000 -0.006012 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B022,  8405, 0x011B019C, 49.6338, -9.38773, -44.9935, 0.203131, 0, 0, 0.979152,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B019C [49.633801 -9.387730 -44.993500] 0.203131 0.000000 0.000000 0.979152 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B025, 11534, 0x011B01A4, 29.776, -29.5432, -35.985, 0.010451, 0, 0, 0.999945,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01A4 [29.775999 -29.543200 -35.985001] 0.010451 0.000000 0.000000 0.999945 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B026,  8405, 0x011B01AC, 40.2428, -28.991, -35.9935, -0.015681, 0, 0, 0.999877,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B01AC [40.242802 -28.990999 -35.993500] -0.015681 0.000000 0.000000 0.999877 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B027, 11534, 0x011B01AD, 37.9042, -30.379, -35.945, 0.813017, 0, 0, 0.58224,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01AD [37.904202 -30.379000 -35.945000] 0.813017 0.000000 0.000000 0.582240 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B028,  7607, 0x011B01B3, -1.0758, -19.7778, -29.9915, 0.705619, 0, 0, -0.708592,  True, '2005-02-09 10:00:00'); /* Ember */
+/* @teleloc 0x011B01B3 [-1.075800 -19.777800 -29.991501] 0.705619 0.000000 0.000000 -0.708592 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B029,  7924, 0x011B01B3, -0.523423, -19.9624, -29.995, 0.66721, 0, 0, -0.74487, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x011B01B3 [-0.523423 -19.962400 -29.995001] 0.667210 0.000000 0.000000 -0.744870 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B029, 0x7011B028, '2005-02-09 10:00:00') /* Ember (7607) */
+     , (0x7011B029, 0x7011B02C, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B02D, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B02E, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B02F, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B030, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B037, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B038, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B039, '2005-02-09 10:00:00') /* Enku Zefir (11534) */
+     , (0x7011B029, 0x7011B03A, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B03B, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B03C, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B045, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B04B, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B04F, '2005-02-09 10:00:00') /* Flamma (8405) */
+     , (0x7011B029, 0x7011B054, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B055, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B029, 0x7011B056, '2005-02-09 10:00:00') /* Direland Rat (24310) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B02A,  5085, 0x011B01B3, -0.168678, -23.8992, -29.995, 0.178173, 0, 0, -0.983999, False, '2005-02-09 10:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x011B01B3 [-0.168678 -23.899200 -29.995001] 0.178173 0.000000 0.000000 -0.983999 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B02A, 0x7011B02B, '2005-02-09 10:00:00') /* Major Smoldering Stone (6124) */
+     , (0x7011B02A, 0x7011B058, '2005-02-09 10:00:00') /* Textbook (6407) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B02B,  6124, 0x011B01B3, -2.90107, -20.0789, -29.9835, -0.701702, 0, 0, -0.71247,  True, '2005-02-09 10:00:00'); /* Major Smoldering Stone */
+/* @teleloc 0x011B01B3 [-2.901070 -20.078899 -29.983500] -0.701702 0.000000 0.000000 -0.712470 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B02C, 11534, 0x011B01B3, 0.975327, -16.8783, -29.985, -0.561292, 0, 0, 0.827618,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01B3 [0.975327 -16.878300 -29.985001] -0.561292 0.000000 0.000000 0.827618 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B02D, 11534, 0x011B01B3, 0.413812, -20.3147, -29.985, -0.731791, 0, 0, 0.681529,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01B3 [0.413812 -20.314699 -29.985001] -0.731791 0.000000 0.000000 0.681529 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B02E, 11534, 0x011B01B3, 0.613328, -23.1163, -29.985, -0.731791, 0, 0, 0.681529,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01B3 [0.613328 -23.116301 -29.985001] -0.731791 0.000000 0.000000 0.681529 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B02F, 11534, 0x011B01B5, 7.42746, -19.8748, -29.975, -0.696814, 0, 0, 0.717252,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01B5 [7.427460 -19.874800 -29.975000] -0.696814 0.000000 0.000000 0.717252 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B030, 11534, 0x011B01B7, 16.8862, -20.179, -29.985, -0.751638, 0, 0, 0.659576,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01B7 [16.886200 -20.179001 -29.985001] -0.751638 0.000000 0.000000 0.659576 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B031,  6396, 0x011B01B8, 30, -10, -29.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Surface Portal */
+/* @teleloc 0x011B01B8 [30.000000 -10.000000 -29.995001] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B032, 11534, 0x011B01BD, 40.1564, -27.3318, -29.985, -0.013627, 0, 0, -0.999907,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01BD [40.156399 -27.331800 -29.985001] -0.013627 0.000000 0.000000 -0.999907 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B033, 11534, 0x011B01C0, 48.0198, -40.4472, -29.985, -0.459973, 0, 0, 0.887933,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01C0 [48.019798 -40.447201 -29.985001] -0.459973 0.000000 0.000000 0.887933 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B034, 11534, 0x011B01C0, 49.4102, -38.4782, -29.985, -0.274399, 0, 0, 0.961616,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01C0 [49.410198 -38.478199 -29.985001] -0.274399 0.000000 0.000000 0.961616 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B035, 24310, 0x011B01D7, 70.6579, -39.8578, -26.988, -0.013326, 0, 0, 0.999911,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B01D7 [70.657898 -39.857800 -26.988001] -0.013326 0.000000 0.000000 0.999911 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B036, 24310, 0x011B01D7, 69.248, -39.8954, -26.988, -0.013326, 0, 0, 0.999911,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B01D7 [69.248001 -39.895401 -26.988001] -0.013326 0.000000 0.000000 0.999911 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B037, 11534, 0x011B01DD, 47.2034, -59.3458, -17.985, -0.733128, 0, 0, 0.680091,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01DD [47.203400 -59.345798 -17.985001] -0.733128 0.000000 0.000000 0.680091 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B038, 11534, 0x011B01DD, 49.0204, -59.9554, -17.985, -0.715898, 0, 0, 0.698205,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01DD [49.020401 -59.955399 -17.985001] -0.715898 0.000000 0.000000 0.698205 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B039, 11534, 0x011B01DD, 47.3247, -60.9167, -17.938, -0.733128, 0, 0, 0.680091,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B01DD [47.324699 -60.916698 -17.938000] -0.733128 0.000000 0.000000 0.680091 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B03A, 24310, 0x011B01DE, 58.8718, -59.7088, -17.988, -0.715898, 0, 0, 0.698205,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B01DE [58.871799 -59.708801 -17.988001] -0.715898 0.000000 0.000000 0.698205 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B03B, 24310, 0x011B01DE, 57.2562, -58.9907, -17.988, -0.715898, 0, 0, 0.698205,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B01DE [57.256199 -58.990700 -17.988001] -0.715898 0.000000 0.000000 0.698205 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B03C, 24310, 0x011B01DE, 57.3072, -61.0284, -17.988, -0.715898, 0, 0, 0.698205,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B01DE [57.307201 -61.028400 -17.988001] -0.715898 0.000000 0.000000 0.698205 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B03D,  8405, 0x011B01E0, 70.3742, -48.3975, -17.9935, 0.04539, 0, 0, -0.998969,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B01E0 [70.374199 -48.397499 -17.993500] 0.045390 0.000000 0.000000 -0.998969 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B03E, 24310, 0x011B01E5, 79.8877, -39.754, -20.988, 0.690134, 0, 0, 0.723682,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B01E5 [79.887703 -39.754002 -20.988001] 0.690134 0.000000 0.000000 0.723682 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B03F,  5712, 0x011B01E6, 78.8776, -53.7595, -17.9915, 0.992131, 0, 0, -0.125207,  True, '2005-02-09 10:00:00'); /* Inferno */
+/* @teleloc 0x011B01E6 [78.877602 -53.759499 -17.991501] 0.992131 0.000000 0.000000 -0.125207 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B040,  5085, 0x011B01F3, 50.281, -49.2445, -11.995, 0.387404, 0, 0, -0.92191, False, '2005-02-09 10:00:00'); /* Linkable Item Gen - 25 seconds */
+/* @teleloc 0x011B01F3 [50.280998 -49.244499 -11.995000] 0.387404 0.000000 0.000000 -0.921910 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B040, 0x7011B041, '2005-02-09 10:00:00') /* Carefully Printed Note (6405) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B041,  6405, 0x011B01F5, 52.2553, -51.1787, -11.921, 0.387404, 0, 0, -0.92191,  True, '2005-02-09 10:00:00'); /* Carefully Printed Note */
+/* @teleloc 0x011B01F5 [52.255299 -51.178699 -11.921000] 0.387404 0.000000 0.000000 -0.921910 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B042, 11534, 0x011B020C, 91.3984, -46.8071, -13.0425, -0.318689, 0, 0, 0.947859,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B020C [91.398399 -46.807098 -13.042500] -0.318689 0.000000 0.000000 0.947859 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B043, 11534, 0x011B020C, 89.1168, -52.9749, -16.9346, 0.771208, 0, 0, 0.636583,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B020C [89.116798 -52.974899 -16.934601] 0.771208 0.000000 0.000000 0.636583 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B044, 11534, 0x011B020C, 86.6483, -51.6787, -17.985, -0.416385, 0, 0, -0.909189,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B020C [86.648300 -51.678699 -17.985001] -0.416385 0.000000 0.000000 -0.909189 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B045, 24310, 0x011B0210, 20.0507, -75.4232, -6.14369, 0.013413, 0, 0, 0.99991,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0210 [20.050699 -75.423203 -6.143690] 0.013413 0.000000 0.000000 0.999910 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B046,  8405, 0x011B0214, 43.5626, -61.1809, -5.9935, 0.322814, 0, 0, 0.946462,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0214 [43.562599 -61.180901 -5.993500] 0.322814 0.000000 0.000000 0.946462 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B047,   278, 0x011B0221, 65.25, -20, -6, -0.707107, 0, 0, -0.707107, False, '2005-02-09 10:00:00'); /* Door */
+/* @teleloc 0x011B0221 [65.250000 -20.000000 -6.000000] -0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B048,  8405, 0x011B0223, 70.4038, -50.4997, -8.9935, 0.968052, 0, 0, 0.250751,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0223 [70.403801 -50.499699 -8.993500] 0.968052 0.000000 0.000000 0.250751 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B049, 24310, 0x011B0227, 83.0989, -23.758, -5.988, 0.766189, 0, 0, 0.642615,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0227 [83.098900 -23.757999 -5.988000] 0.766189 0.000000 0.000000 0.642615 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B04A, 24310, 0x011B0227, 83.7793, -17.1764, -5.988, 0.642602, 0, 0, 0.7662,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0227 [83.779297 -17.176399 -5.988000] 0.642602 0.000000 0.000000 0.766200 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B04B, 24310, 0x011B0227, 83.0837, -19.6106, -5.988, 0.433065, 0, 0, 0.901363,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0227 [83.083702 -19.610600 -5.988000] 0.433065 0.000000 0.000000 0.901363 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B04C,  7924, 0x011B0227, 80, -18.6983, -5.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x011B0227 [80.000000 -18.698299 -5.995000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B04C, 0x7011B049, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B04C, 0x7011B04A, '2005-02-09 10:00:00') /* Direland Rat (24310) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B04D,  7924, 0x011B022F, 87.8986, -42.7884, -5.995, -0.997419, 0, 0, -0.071799, False, '2005-02-09 10:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x011B022F [87.898598 -42.788399 -5.995000] -0.997419 0.000000 0.000000 -0.071799 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x7011B04D, 0x7011B035, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B04D, 0x7011B036, '2005-02-09 10:00:00') /* Direland Rat (24310) */
+     , (0x7011B04D, 0x7011B03E, '2005-02-09 10:00:00') /* Direland Rat (24310) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B04E, 11534, 0x011B022F, 90.1956, -43.8154, -11.985, 0.022121, 0, 0, 0.999755,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B022F [90.195602 -43.815399 -11.985000] 0.022121 0.000000 0.000000 0.999755 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B04F,  8405, 0x011B0233, 29.2628, -9.66502, 0.0065, 0.695539, 0, 0, -0.718488,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B0233 [29.262800 -9.665020 0.006500] 0.695539 0.000000 0.000000 -0.718488 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B050,  8405, 0x011B023B, 29.6943, -70.3163, -2.9935, 0.711498, 0, 0, -0.702688,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B023B [29.694300 -70.316299 -2.993500] 0.711498 0.000000 0.000000 -0.702688 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B051,  8405, 0x011B024C, 51.4316, -60.2553, 0.0065, -0.706069, 0, 0, -0.708143,  True, '2005-02-09 10:00:00'); /* Flamma */
+/* @teleloc 0x011B024C [51.431599 -60.255299 0.006500] -0.706069 0.000000 0.000000 -0.708143 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B052, 11534, 0x011B0253, 70.4265, -41.0622, -2.945, 0.839618, 0, 0, 0.543177,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0253 [70.426498 -41.062199 -2.945000] 0.839618 0.000000 0.000000 0.543177 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B053, 11534, 0x011B0253, 70.9166, -39.3006, -2.945, 0.781197, 0, 0, 0.624285,  True, '2005-02-09 10:00:00'); /* Enku Zefir */
+/* @teleloc 0x011B0253 [70.916603 -39.300598 -2.945000] 0.781197 0.000000 0.000000 0.624285 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B054, 24310, 0x011B0256, 22.0695, -52.9266, 6.012, 0.282317, 0, 0, 0.959321,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0256 [22.069500 -52.926601 6.012000] 0.282317 0.000000 0.000000 0.959321 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B055, 24310, 0x011B0257, 19.8289, -63.8778, 0.78351, 0.009676, 0, 0, 0.999953,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B0257 [19.828899 -63.877800 0.783510] 0.009676 0.000000 0.000000 0.999953 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B056, 24310, 0x011B025A, 26.9846, -48.0645, 6.012, 0.394744, 0, 0, 0.918791,  True, '2005-02-09 10:00:00'); /* Direland Rat */
+/* @teleloc 0x011B025A [26.984600 -48.064499 6.012000] 0.394744 0.000000 0.000000 0.918791 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B057,  5489, 0x011B01A3, 10, -20, -35.995, 1, 0, 0, 0, False, '2005-02-09 10:00:00'); /* "Mag-Ma!" */
+/* @teleloc 0x011B01A3 [10.000000 -20.000000 -35.994999] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7011B058,  6407, 0x011B01B3, -2.95353, -23.6527, -29.9305, -0.004204, 0, 0, -0.999991,  True, '2005-02-09 10:00:00'); /* Textbook */
+/* @teleloc 0x011B01B3 [-2.953530 -23.652700 -29.930500] -0.004204 0.000000 0.000000 -0.999991 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Olthoi/46279 Olthoi Swarm Soldier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Olthoi/46279 Olthoi Swarm Soldier.sql
@@ -1,0 +1,123 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46279;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46279, 'ace46279-olthoiswarmsoldier', 10, '2020-07-23 03:33:54') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46279,   1,         16) /* ItemType - Creature */
+     , (46279,   2,          1) /* CreatureType - Olthoi */
+     , (46279,   6,         -1) /* ItemsCapacity */
+     , (46279,   7,         -1) /* ContainersCapacity */
+     , (46279,   8,       8000) /* Mass */
+     , (46279,  16,          1) /* ItemUseable - No */
+     , (46279,  25,        100) /* Level */
+     , (46279,  27,          0) /* ArmorType - None */
+     , (46279,  40,          2) /* CombatMode - Melee */
+     , (46279,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (46279,  72,         35) /* FriendType - OlthoiLarvae */
+     , (46279,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (46279, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (46279, 140,          1) /* AiOptions - CanOpenDoors */
+     , (46279, 146,      80000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46279,   1, True ) /* Stuck */
+     , (46279,  11, False) /* IgnoreCollisions */
+     , (46279,  12, True ) /* ReportCollisions */
+     , (46279,  13, False) /* Ethereal */
+     , (46279,  14, True ) /* GravityStatus */
+     , (46279,  19, True ) /* Attackable */
+     , (46279,  42, True ) /* AllowEdgeSlide */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46279,   1,       5) /* HeartbeatInterval */
+     , (46279,   2,       0) /* HeartbeatTimestamp */
+     , (46279,   3,    0.65) /* HealthRate */
+     , (46279,   4,       4) /* StaminaRate */
+     , (46279,   5,       2) /* ManaRate */
+     , (46279,  13,    0.66) /* ArmorModVsSlash */
+     , (46279,  14,     0.8) /* ArmorModVsPierce */
+     , (46279,  15,     0.6) /* ArmorModVsBludgeon */
+     , (46279,  16,       1) /* ArmorModVsCold */
+     , (46279,  17,       1) /* ArmorModVsFire */
+     , (46279,  18,     1.2) /* ArmorModVsAcid */
+     , (46279,  19,       1) /* ArmorModVsElectric */
+     , (46279,  31,      24) /* VisualAwarenessRange */
+     , (46279,  34,       1) /* PowerupTime */
+     , (46279,  36,       1) /* ChargeSpeed */
+     , (46279,  64,    0.75) /* ResistSlash */
+     , (46279,  65,       1) /* ResistPierce */
+     , (46279,  66,       1) /* ResistBludgeon */
+     , (46279,  67,    0.75) /* ResistFire */
+     , (46279,  68,    0.75) /* ResistCold */
+     , (46279,  69,    0.42) /* ResistAcid */
+     , (46279,  70,    0.25) /* ResistElectric */
+     , (46279,  71,       1) /* ResistHealthBoost */
+     , (46279,  72,       1) /* ResistStaminaDrain */
+     , (46279,  73,       1) /* ResistStaminaBoost */
+     , (46279,  74,       1) /* ResistManaDrain */
+     , (46279,  75,       1) /* ResistManaBoost */
+     , (46279,  77,       1) /* PhysicsScriptIntensity */
+     , (46279, 104,      10) /* ObviousRadarRange */
+     , (46279, 117,     0.8) /* FocusedProbability */
+     , (46279, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46279,   1, 'Olthoi Swarm Soldier') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46279,   1, 0x02000AAA) /* Setup */
+     , (46279,   2, 0x09000002) /* MotionTable */
+     , (46279,   3, 0x2000000D) /* SoundTable */
+     , (46279,   4, 0x3000001B) /* CombatTable */
+     , (46279,   8, 0x060010E7) /* Icon */
+     , (46279,  19, 0x00000056) /* ActivationAnimation */
+     , (46279,  22, 0x34000021) /* PhysicsEffectTable */
+     , (46279,  30,         86) /* PhysicsScript - BreatheAcid */
+     , (46279,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (46279,   1, 310, 0, 0) /* Strength */
+     , (46279,   2, 310, 0, 0) /* Endurance */
+     , (46279,   3, 140, 0, 0) /* Quickness */
+     , (46279,   4, 140, 0, 0) /* Coordination */
+     , (46279,   5, 110, 0, 0) /* Focus */
+     , (46279,   6,  60, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (46279,   1,   255, 0, 0, 410) /* MaxHealth */
+     , (46279,   3,   300, 0, 0, 610) /* MaxStamina */
+     , (46279,   5,     0, 0, 0, 60) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (46279,  6, 0, 3, 0, 305, 0, 0) /* MeleeDefense        Specialized */
+     , (46279,  7, 0, 3, 0, 370, 0, 0) /* MissileDefense      Specialized */
+     , (46279, 15, 0, 3, 0, 300, 0, 0) /* MagicDefense        Specialized */
+     , (46279, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
+     , (46279, 22, 0, 2, 0, 200, 0, 0) /* Jump                Trained */
+     , (46279, 24, 0, 2, 0,  60, 0, 0) /* Run                 Trained */
+     , (46279, 45, 0, 3, 0, 230, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (46279,  0,  4,  0,    0,  220,  145,  176,  132,  220,  220,  264,  220,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (46279, 16,  4,  0,    0,  220,  145,  176,  132,  220,  220,  264,  220,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (46279, 18,  4, 50,  0.5,  220,  145,  176,  132,  220,  220,  264,  220,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (46279, 19,  4,  0,    0,  220,  145,  176,  132,  220,  220,  264,  220,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (46279, 20,  2, 50, 0.75,  220,  145,  176,  132,  220,  220,  264,  220,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (46279, 22, 32, 45,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46279,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (46279,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/46281 Dark Master.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/46281 Dark Master.sql
@@ -1,0 +1,169 @@
+DELETE FROM `weenie` WHERE `class_Id` = 46281;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (46281, 'ace46281-darkmaster', 10, '2020-07-23 03:33:54') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (46281,   1,         16) /* ItemType - Creature */
+     , (46281,   2,         14) /* CreatureType - Undead */
+     , (46281,   3,         14) /* PaletteTemplate - Red */
+     , (46281,   6,         -1) /* ItemsCapacity */
+     , (46281,   7,         -1) /* ContainersCapacity */
+     , (46281,  16,          1) /* ItemUseable - No */
+     , (46281,  25,        100) /* Level */
+     , (46281,  27,          0) /* ArmorType - None */
+     , (46281,  40,          1) /* CombatMode - NonCombat */
+     , (46281,  68,          3) /* TargetingTactic - Random, Focused */
+     , (46281,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (46281, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
+     , (46281, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (46281, 140,          1) /* AiOptions - CanOpenDoors */
+     , (46281, 146,      80000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (46281,   1, True ) /* Stuck */
+     , (46281,   6, True ) /* AiUsesMana */
+     , (46281,  11, False) /* IgnoreCollisions */
+     , (46281,  12, True ) /* ReportCollisions */
+     , (46281,  13, False) /* Ethereal */
+     , (46281,  14, True ) /* GravityStatus */
+     , (46281,  19, True ) /* Attackable */
+     , (46281,  42, True ) /* AllowEdgeSlide */
+     , (46281,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (46281,   1,       5) /* HeartbeatInterval */
+     , (46281,   2,       0) /* HeartbeatTimestamp */
+     , (46281,   3,     0.8) /* HealthRate */
+     , (46281,   4,     0.5) /* StaminaRate */
+     , (46281,   5,       2) /* ManaRate */
+     , (46281,  12,     0.5) /* Shade */
+     , (46281,  13,       1) /* ArmorModVsSlash */
+     , (46281,  14,       1) /* ArmorModVsPierce */
+     , (46281,  15,       1) /* ArmorModVsBludgeon */
+     , (46281,  16,       1) /* ArmorModVsCold */
+     , (46281,  17,       1) /* ArmorModVsFire */
+     , (46281,  18,       1) /* ArmorModVsAcid */
+     , (46281,  19,       1) /* ArmorModVsElectric */
+     , (46281,  31,      18) /* VisualAwarenessRange */
+     , (46281,  34,       1) /* PowerupTime */
+     , (46281,  36,       1) /* ChargeSpeed */
+     , (46281,  39,     1.1) /* DefaultScale */
+     , (46281,  64,     0.9) /* ResistSlash */
+     , (46281,  65,    0.52) /* ResistPierce */
+     , (46281,  66,    0.75) /* ResistBludgeon */
+     , (46281,  67,     0.9) /* ResistFire */
+     , (46281,  68,     0.1) /* ResistCold */
+     , (46281,  69,    0.75) /* ResistAcid */
+     , (46281,  70,    0.86) /* ResistElectric */
+     , (46281,  71,       1) /* ResistHealthBoost */
+     , (46281,  72,       1) /* ResistStaminaDrain */
+     , (46281,  73,       1) /* ResistStaminaBoost */
+     , (46281,  74,       1) /* ResistManaDrain */
+     , (46281,  75,       1) /* ResistManaBoost */
+     , (46281,  80,       3) /* AiUseMagicDelay */
+     , (46281, 104,      10) /* ObviousRadarRange */
+     , (46281, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (46281,   1, 'Dark Master') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (46281,   1, 0x02000197) /* Setup */
+     , (46281,   2, 0x09000017) /* MotionTable */
+     , (46281,   3, 0x20000016) /* SoundTable */
+     , (46281,   4, 0x30000000) /* CombatTable */
+     , (46281,   6, 0x04000742) /* PaletteBase */
+     , (46281,   7, 0x10000492) /* ClothingBase */
+     , (46281,   8, 0x06001226) /* Icon */
+     , (46281,  22, 0x34000028) /* PhysicsEffectTable */
+     , (46281,  32,        291) /* WieldedTreasureType - 
+                                   # Set: 1
+                                   |  40.00% chance of 5x Frost Throwing Club (23663) | StackSizeVariance: 0.1
+                                   |  30.00% chance of 5x Throwing Club (23655) | StackSizeVariance: 0.1
+                                   |  30.00% chance of Yumi (23736)
+                                   |         with
+                                   |            100.00% chance of 16x to 18x Greater Arrow (5304) | StackSizeVariance: 0.1
+                                   # Set: 2
+                                   |  25.00% chance of Frost Yari (23728)
+                                   |  25.00% chance of Yari (23732)
+                                   |  15.00% chance of Frost Spear (23694)
+                                   |  15.00% chance of Spear (23698)
+                                   |  20.00% chance of Tachi (23702)
+                                   |   1.00% chance of nothing from this set */
+     , (46281,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (46281,   1, 130, 0, 0) /* Strength */
+     , (46281,   2, 130, 0, 0) /* Endurance */
+     , (46281,   3, 110, 0, 0) /* Quickness */
+     , (46281,   4, 160, 0, 0) /* Coordination */
+     , (46281,   5, 200, 0, 0) /* Focus */
+     , (46281,   6, 190, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (46281,   1,   375, 0, 0, 440) /* MaxHealth */
+     , (46281,   3,   450, 0, 0, 580) /* MaxStamina */
+     , (46281,   5,   250, 0, 0, 440) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (46281,  6, 0, 3, 0, 265, 0, 0) /* MeleeDefense        Specialized */
+     , (46281,  7, 0, 3, 0, 380, 0, 0) /* MissileDefense      Specialized */
+     , (46281, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
+     , (46281, 15, 0, 3, 0, 215, 0, 0) /* MagicDefense        Specialized */
+     , (46281, 20, 0, 3, 0,  90, 0, 0) /* Deception           Specialized */
+     , (46281, 31, 0, 3, 0, 120, 0, 0) /* CreatureEnchantment Specialized */
+     , (46281, 33, 0, 3, 0, 120, 0, 0) /* LifeMagic           Specialized */
+     , (46281, 34, 0, 3, 0, 120, 0, 0) /* WarMagic            Specialized */
+     , (46281, 44, 0, 3, 0, 280, 0, 0) /* HeavyWeapons        Specialized */
+     , (46281, 45, 0, 3, 0, 280, 0, 0) /* LightWeapons        Specialized */
+     , (46281, 46, 0, 3, 0, 280, 0, 0) /* FinesseWeapons      Specialized */
+     , (46281, 47, 0, 3, 0, 160, 0, 0) /* MissileWeapons      Specialized */
+     , (46281, 48, 0, 3, 0, 280, 0, 0) /* Shield              Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (46281,  0,  4,  0,    0,  410,  410,  410,  410,  410,  410,  410,  410,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (46281,  1,  4,  0,    0,  410,  410,  410,  410,  410,  410,  410,  410,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (46281,  2,  4,  0,    0,  410,  410,  410,  410,  410,  410,  410,  410,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (46281,  3,  4,  0,    0,  410,  410,  410,  410,  410,  410,  410,  410,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (46281,  4,  4,  0,    0,  410,  410,  410,  410,  410,  410,  410,  410,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (46281,  5,  4, 80, 0.75,  410,  410,  410,  410,  410,  410,  410,  410,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (46281,  6,  4,  0,    0,  420,  420,  420,  420,  420,  420,  420,  420,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (46281,  7,  4,  0,    0,  420,  420,  420,  420,  420,  420,  420,  420,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (46281,  8,  4, 80, 0.75,  420,  420,  420,  420,  420,  420,  420,  420,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (46281,    62,   2.01)  /* Acid Stream V */
+     , (46281,    68,   2.01)  /* Shock Wave V */
+     , (46281,    73,   2.01)  /* Frost Bolt V */
+     , (46281,    79,   2.01)  /* Lightning Bolt V */
+     , (46281,    84,   2.01)  /* Flame Bolt V */
+     , (46281,    90,   2.01)  /* Force Bolt V */
+     , (46281,    96,   2.01)  /* Whirling Blade V */
+     , (46281,   129,   2.01)  /* Acid Volley V */
+     , (46281,   137,   2.01)  /* Frost Volley V */
+     , (46281,   141,   2.01)  /* Lightning Volley V */
+     , (46281,   145,   2.01)  /* Flame Volley V */
+     , (46281,   169,  2.025)  /* Regeneration Self V */
+     , (46281,   175,  2.011)  /* Fester Other V */
+     , (46281,  1241,  2.025)  /* Drain Health Other V */
+     , (46281,  1253,  2.025)  /* Drain Stamina Other V */
+     , (46281,  1264,  2.025)  /* Drain Mana Other V */
+     , (46281,  1342,  2.011)  /* Weakness Other V */
+     , (46281,  1371,  2.011)  /* Frailty Other V */
+     , (46281,  1395,  2.011)  /* Clumsiness Other V */
+     , (46281,  1419,  2.011)  /* Slowness Other V */
+     , (46281,  1443,  2.011)  /* Bafflement Other V */
+     , (46281,  1467,  2.011)  /* Feeblemind Other V */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (46281, 9,  6876,  0, 0, 0.02, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */
+     , (46281, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (46281, 9, 24854,  0, 0, 0.03, False) /* Create Skull of a Dark Master (24854) for ContainTreasure */
+     , (46281, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */
+     , (46281, 9,  9310,  0, 0, 0.07, False) /* Create A Large Mnemosyne (9310) for ContainTreasure */
+     , (46281, 9,     0,  0, 0, 0.93, False) /* Create nothing for ContainTreasure */
+     , (46281, 9,  5873,  0, 0, 0.03, False) /* Create Seal (5873) for ContainTreasure */
+     , (46281, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */
+     , (46281, 9, 12225,  0, 0, 0.05, False) /* Create Zombie Head (12225) for ContainTreasure */
+     , (46281, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;


### PR DESCRIPTION
Updates the dungeons (jahannan, serac, amprehelion, and incunabula vault) to end of retail spawns based on the pcaps.

Adds two missing creatures (Dark Master and Olthoi Swarm Soldier, edge slide versions) found in the dungeons.
