### PR TITLE
Updated Cells of the Black Book Portals 32674, 32675, 32676, 32677, 32678, 0089

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/0089.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0089.sql
@@ -173,3 +173,7 @@ VALUES (0x7008903B, 32751, 0x008902BD, 260, -260, -6, 1, 0, 0, 0,  True, '2021-1
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7008903C, 32751, 0x00890262, 160, -260, -6, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Black Book of Salt and Ash */
 /* @teleloc 0x00890262 [160.000000 -260.000000 -6.000000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7008903D, 32678, 0x00890113, 67.000122, -240, -12, 1, 0, 0, 0, False, '2024-04-13 20:00:00'); /* Surface (West)*/
+/* @teleloc 0x00890113 [67.000122 -240 -12] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/32674 Cells of the Black Book.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/32674 Cells of the Black Book.sql
@@ -33,5 +33,5 @@ VALUES (32674,   1, 0x020005D4) /* Setup */
      , (32674,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (32674, 2, 0x008902FF, 220, 0, 0, 0, 0, 0, -1) /* Destination */
-/* @teleloc 0x008902FF [220.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */;
+VALUES (32674, 2, 0x008902DC, 0, -200, -0.087583, 0.707107, 0, 0, -0.707107); /* Destination West */
+/* @teleloc 0x008902DC [0 -200 -0.087583] 0.707107 0 0 -0.707107  */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/32675 Cells of the Black Book.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/32675 Cells of the Black Book.sql
@@ -33,5 +33,5 @@ VALUES (32675,   1, 0x020005D4) /* Setup */
      , (32675,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (32675, 2, 0x008902FF, 220, 0, 0, 0, 0, 0, -1) /* Destination */
-/* @teleloc 0x008902FF [220.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */;
+VALUES (32675, 2, 0x008902F5, 200, -420, -0.375722, 1, 0, 0, 0); /* Destination South */
+/* @teleloc 0x008902F5 [200 -420 -0.375722] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/32676 Cells of the Black Book.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/32676 Cells of the Black Book.sql
@@ -33,5 +33,5 @@ VALUES (32676,   1, 0x020005D4) /* Setup */
      , (32676,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (32676, 2, 0x008902FF, 220, 0, 0, 0, 0, 0, -1) /* Destination */
-/* @teleloc 0x008902FF [220.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */;
+VALUES (32676, 2, 0x008902FF, 220, 0, 0, 0, 0, 0, -1); /* Destination North */
+/* @teleloc 0x008902FF [220 0 0] 0 0 0 -1 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/32677 Cells of the Black Book.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/32677 Cells of the Black Book.sql
@@ -33,5 +33,5 @@ VALUES (32677,   1, 0x020005D4) /* Setup */
      , (32677,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (32677, 2, 0x008902FF, 220, 0, 0, 0, 0, 0, -1) /* Destination */
-/* @teleloc 0x008902FF [220.000000 0.000000 0.000000] 0.000000 0.000000 0.000000 -1.000000 */;
+VALUES (32677, 2, 0x00890318, 420, -220, 0, -0.707107, 0, 0, -0.707107); /* Destination East */
+/* @teleloc 0x00890318 [420 -220 0] -0.707107 0 0 -0.707107 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/32678 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/32678 Surface.sql
@@ -28,3 +28,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (32678,   1, 0x020001B3) /* Setup */
      , (32678,   2, 0x09000003) /* MotionTable */
      , (32678,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (32678, 2,  0xBE720015, 60, 107.998047, 6.006000, 1, 0, 0, 0); /* Destination Surface (10.3S, 50.3E)*/
+/* @teleloc  0xBE720015 [60 107.998047 6.006000] 1 0 0 0 */


### PR DESCRIPTION
Database/Patches/6 LandBlockExtendedData/0089.sql (Cells of the Black Book Surface Portal) 
Database/Patches/9 WeenieDefaults/Portal/Portal/32674 Cells of the Black Book.sql 
Database/Patches/9 WeenieDefaults/Portal/Portal/32675 Cells of the Black Book.sql 
Database/Patches/9 WeenieDefaults/Portal/Portal/32676 Cells of the Black Book.sql 
Database/Patches/9 WeenieDefaults/Portal/Portal/32677 Cells of the Black Book.sql 
Database/Patches/9 WeenieDefaults/Portal/Portal/32678 Surface.sql (Cells of the Black Book Surface Portal)

32674, 32675, 32676, 32677 Cells of the Black Book Portal drops Updated portal destinations for Cells of the Black Book portals to match Landblocks Google Sheets PCAPS.

PCAP Data (from Landblocks Google Sheet) shows four entrances Cells of the Black Book (Entrance 1) - 32674
0x008902DC 0 -200 -0.087583 0.707107 0 0 -0.707107 Cells of the Black Book (Entrance 2) - 32675
0x008902F5 200 -420 -0.375722 1 0 0 0
Cells of the Black Book (Entrance 3) - 32676
0x008902FF 220 0 0 0 0 0 -1
Cells of the Black Book (Entrance 4) - 32677
0x00890318 420 -220 0 -0.707107 0 0 -0.707107

Previously all portals were mistakenly set to the same drop point (North side) Now updated to 4 different drops W, S, N, E.

--
Updated 0089.sql Add 4th Surface Portal to Cells of the Black Book @teleloc 0x00890113 [67.000122 -240 -12] 1 0 0 0

From vloc2loc data (0089)
Surface - @teleloc 0x00890150 [180 -67 -12] 1 0 0 0 Surface - @teleloc 0x008901E7 [240 -353 -12] 1 0 0 0 Surface - @teleloc 0x00890224 [352.999878 -180 -12] 1 0 0 0 (MISSING) Surface - @teleloc 0x00890113 [67.000122 -240 -12] 1 0 0 0

From world_objects (landcell '89%')
37576	14	890150		-101.2	7.37	-0.05	Surface (10.3S, 50.3E). 37826	14	89010000000	-100.95	6.18	-0.05	Surface (10.3S, 50.3E). 37854	14	890224		-100.48	6.9	-0.05	Surface	(10.3S, 50.3E). (MISSING) 38026	14	890113	-101.67	6.65	-0.05	Surface (10.3S, 50.3E).

--
32678 Cells of the Black Book Surface Portal NOT YET IMPLEMENTED Update Cells of the Black Book Surface Portal(s) to deposit you outside the bunker. /* @teleloc  0xBE720015 [60.000000 107.998047 6.006000] 1 0 0 0 */ /* this matches world_objects exit portal data for landcell 89.. that shows "Surface (10.3S, 50.3E)"

From world_objects (landcell '89%')
37576	14	890150		-101.2	7.37	-0.05	Surface (10.3S, 50.3E). 37826	14	89010000000	-100.95	6.18	-0.05	Surface (10.3S, 50.3E). 37854	14	890224		-100.48	6.9	-0.05	Surface	(10.3S, 50.3E). 38026	14	890113		-101.67	6.65	-0.05	Surface (10.3S, 50.3E).