### PR TITLE
Update Passage to Olthoi Island 43536 43580 are not yet implemented

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/43536 Passage to Olthoi Island.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/43536 Passage to Olthoi Island.sql
@@ -29,3 +29,7 @@ VALUES (43536,   1, 0x020001B3) /* Setup */
      , (43536,   2, 0x09000003) /* MotionTable */
      , (43536,   6, 0x040001FA) /* PaletteBase */
      , (43536,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`,`position_Type`,`obj_Cell_Id`,`origin_X`,`origin_Y`,`origin_Z`,`angles_W`,`angles_X`,`angles_Y`,`angles_Z`)
+VALUES (43536, 2, 0xE4D60014, 60, 83.996094, 8.006001, 1, 0, 0, 0); /* Destination (69.6N, 80.7E)*/
+/* @teleloc 0xE4D60014 [60 83.996094 8.006001] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/43580 Passage to Olthoi Island.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/43580 Passage to Olthoi Island.sql
@@ -29,3 +29,7 @@ VALUES (43580,   1, 0x020001B3) /* Setup */
      , (43580,   2, 0x09000003) /* MotionTable */
      , (43580,   6, 0x040001FA) /* PaletteBase */
      , (43580,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`,`position_Type`,`obj_Cell_Id`,`origin_X`,`origin_Y`,`origin_Z`,`angles_W`,`angles_X`,`angles_Y`,`angles_Z`)
+VALUES (43580, 2, 0xE8D2002B, 132, 60, 42.006001, 1, 0, 0, 0); /* Destination (66.3N, 84.2E)*/
+/* @teleloc 0xE8D2002B [132 60 42.006001] 1 0 0 0 */


### PR DESCRIPTION
Database/Patches/9 WeenieDefaults/Portal/Portal/43536 Passage to Olthoi Island.sql Database/Patches/9 WeenieDefaults/Portal/Portal/43580 Passage to Olthoi Island.sql

43536-43580 Passage to Olthoi Island - portal ID 43536 & 43580 not yet implemented! -- https://asheron.fandom.com/wiki/Passage_to_Olthoi_Island?so=search

43580
-- Portal 1 source 63.1N, 76.4E
-- Portal 1 drops at 66.3N, 84.2E
world_objects db confirms destination as
34257	14	DECE003B	76.37	63.12	0.01	Passage to Olthoi Island	Passage to Olthoi Island (66.3N, 84.2E). 
-- @teleloc 0xE8D2002B [132 60 42.006001] 1 0 0 0

43536
-- Portal 2 source 63.7N, 75.6E
-- Portal 2 drops at 69.6N, 80.7E
world_objects db shows this
34256	14	DDCF0039	75.58	63.7	0.01	Passage to Olthoi Island	Passage to Olthoi Island (69.6N, 80.7E). 
-- @teleloc 0xE4D60014 [60 83.996094 8.006001] 1 0 0 0