### PR TITLE
Update 90130 90131 E3D5 E3D6 Olthoi Tunnel Final 2 Portals

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/E3D5.sql
+++ b/Database/Patches/6 LandBlockExtendedData/E3D5.sql
@@ -1,0 +1,5 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xE3D5;
+
+INSERT INTO `landblock_instance`(`weenie_Class_Id`,`obj_Cell_Id`,`origin_X`,`origin_Y`,`origin_Z`,`angles_W`,`angles_X`,`angles_Y`,`angles_Z`,`is_Link_Child`,`last_Modified`)
+VALUES(90131, 0xE3D50001, 8.941406, 11.824219, 0, 1, 0, 0, 0, False, '2024-04-28 00:00:00'); /* Olthoi Tunnel */
+/* @teleloc 0xE3D50001 [8.941406 11.824219 0] 1 0 0 0 */

--- a/Database/Patches/6 LandBlockExtendedData/E3D6.sql
+++ b/Database/Patches/6 LandBlockExtendedData/E3D6.sql
@@ -1,0 +1,5 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0xE3D6;
+
+INSERT INTO `landblock_instance`(`weenie_Class_Id`,`obj_Cell_Id`,`origin_X`,`origin_Y`,`origin_Z`,`angles_W`,`angles_X`,`angles_Y`,`angles_Z`,`is_Link_Child`,`last_Modified`)
+VALUES(90130, 0xE3D60032, 157.371094, 37.128906, 0, 1, 0, 0, 0, False, '2024-04-28 00:00:00'); /* Olthoi Tunnel */
+/* @teleloc 0xE3D60032 [157.371094 37.128906 0] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/90130 Olthoi Tunnel.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/90130 Olthoi Tunnel.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 90130;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (90130, 'ace90130-olthoitunnel', 7, '2024-03-25 20:00:00') /* Portal */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (90130,   1,      65536) /* ItemType - Portal */
+     , (90130,  16,         32) /* ItemUseable - Remote */
+     , (90130,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
+     , (90130, 111,        829) /* PortalBitmask - Unrestricted, NoPKLite, NoNPK, NoSummon, NoRecall, NoVitae, NoNewAccounts */
+     , (90130, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (90130,   1, True ) /* Stuck */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (90130,  54,    -0.1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (90130,   1, 'Olthoi Tunnel') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (90130,   1, 0x020001B3) /* Setup */
+     , (90130,   2, 0x09000003) /* MotionTable */
+     , (90130,   6, 0x040001FA) /* PaletteBase */
+     , (90130,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (90130, 2, 0xC7EA0100, 12, 36, -0.904248, 1, 0, 0, 0); /* Destination (85.4N, 57.3E) */
+/* @teleloc 0xC7EA0100 [12 36 -0.904248] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/90131 Olthoi Tunnel.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/90131 Olthoi Tunnel.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 90131;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (90131, 'ace90131-olthoitunnel', 7, '2024-03-25 20:00:00') /* Portal */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (90131,   1,      65536) /* ItemType - Portal */
+     , (90131,  16,         32) /* ItemUseable - Remote */
+     , (90131,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
+     , (90131, 111,        829) /* PortalBitmask - Unrestricted, NoPKLite, NoNPK, NoSummon, NoRecall, NoVitae, NoNewAccounts */
+     , (90131, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (90131,   1, True ) /* Stuck */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (90131,  54,    -0.1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (90131,   1, 'Olthoi Tunnel') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (90131,   1, 0x020001B3) /* Setup */
+     , (90131,   2, 0x09000003) /* MotionTable */
+     , (90131,   6, 0x040001FA) /* PaletteBase */
+     , (90131,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (90131, 2, 0x2E110006, 12, 131.99853, 56.006001, 1, 0, 0, 0); /* Destination (87.8S, 65.1W) */
+/* @teleloc 0x2E110006 [12 131.998535 56.006001] 1 0 0 0 */


### PR DESCRIPTION
Database/Patches/9 WeenieDefaults/Portal/Portal/90130 Olthoi Tunnel.sql 
Database/Patches/9 WeenieDefaults/Portal/Portal/90131 Olthoi Tunnel.sql 
Database/Patches/6 LandBlockExtendedData/E3D5.sql
Database/Patches/6 LandBlockExtendedData/E3D6.sql

https://asheron.fandom.com/wiki/Olthoi_Island
Of the twelve pair (24 total) of Olthoi Tunnels, we have 22 weenies, we are missing 2. Requested and received approval for 2 new weenies: 90130 & 90131.

-- Dark Isle Pair:
90130 (new) Olthoi Tunnel Source 69.4N, 80.3E
Destination 85.4N, 57.3E
Note: ace43705-olthoitunnel is existing return portal ---

-- Candeth Keep Pair:
90131 (new) Olthoi Tunnel Source 68.5N, 79.7E
Destination 87.7S, 65.1W
Note: ace43559-olthoitunnel is existing return portal