### PR TITLE
Update 00B5 Mosswart Worship Cavern

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/00B5.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00B5.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x00B5;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700B5000, 87733, 0x00B50129, 159.877, -48.4272, -23.9934, -0.022454, 0, 0, -0.999748, False, '2021-11-17 16:56:08'); /* Ahumba */
-/* @teleloc 0x00B50129 [159.876999 -48.427200 -23.993401] -0.022454 0.000000 0.000000 -0.999748 */
+VALUES (0x700B5000, 87733, 0x00B50129, 159.999390, -48, -24, 1, 0, 0, 0, False, '2024-04-28 12:00:00'); /* Ahumba */
+/* @teleloc 0x00B50129 [159.999390 -48 -24] 1 0 0 0 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700B5001, 87736, 0x00B5014F, 10.2489, -139.917, -5.945, 0.377102, 0, 0, -0.926172, False, '2021-11-17 16:56:08'); /* Mosswart Worship Cavern Generator */
@@ -87,3 +87,12 @@ VALUES (0x700B5014, 87736, 0x00B501D0, 129.888, -116.11, -5.945, 0.406319, 0, 0,
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700B5015, 87736, 0x00B501E2, 145.159, -69.9845, -5.945, -0.349515, 0, 0, -0.936931, False, '2021-11-17 16:56:08'); /* Mosswart Worship Cavern Generator */
 /* @teleloc 0x00B501E2 [145.158997 -69.984497 -5.945000] -0.349515 0.000000 0.000000 -0.936931 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700B5016, 278, 0x00B5012B, 159.949951, -65.351562, -24, 1, 0, 0, 0, False, '2024-04-28 12:00:08'); /* Door */
+/* @teleloc 0x00B5012B [159.949951 -65.351562 -24] 1 0 0 0 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700B5017, 90273, 0x00B50200, 9.992065, -195.851562, 0, 1, 0, 0, 0, False, '2024-04-28 12:00:08'); /* Surface */
+/* @teleloc 0x00B50200 [9.992065 -195.851562 0] 1 0 0 0 */
+

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/90273 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/90273 Surface.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 90273;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (90273, 'ace90273-surface', 7, '2024-04-28 12:00:00') /* Portal */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (90273,   1,      65536) /* ItemType - Portal */
+     , (90273,  16,         32) /* ItemUseable - Remote */
+     , (90273,  86,         80) /* MinLevel */
+     , (90273,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
+     , (90273, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (90273,   1, True ) /* Stuck */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (90273,  54,    -0.1) /* UseRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (90273,   1, 'Surface') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (90273,   1, 0x020005D5) /* Setup */
+     , (90273,   2, 0x09000003) /* MotionTable */
+     , (90273,   8, 0x0600106B) /* Icon */;
+
+INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (90273, 2, 0x424C0019, 83.999023, 12, 7.005837, 1, 0, 0, 0) /* Destination */
+/* @teleloc 0x424C0019 [83.999023 12 7.005837] 1 0 0 0 */

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/90273 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/90273 Surface.sql
@@ -25,5 +25,5 @@ VALUES (90273,   1, 0x020005D5) /* Setup */
      , (90273,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (90273, 2, 0x424C0019, 83.999023, 12, 7.005837, 1, 0, 0, 0) /* Destination */
+VALUES (90273, 2, 0x424C0019, 83.999023, 12, 7.005837, 1, 0, 0, 0); /* Destination */
 /* @teleloc 0x424C0019 [83.999023 12 7.005837] 1 0 0 0 */


### PR DESCRIPTION
Database/Patches/9 WeenieDefaults/Portal/Portal/ace90273 Surface.sql 
Database/Patches/6 LandBlockExtendedData/00B5.sql

Mosswart Worship Cavern
Using vloc2loc data on 00B5, we are missing a door 
Door - @teleloc 0x00B5012B [159.949951 -65.351562 -24] 1 0 0 0

Using vloc2loc data on 00B5, we are missing a Surface portal
Surface - @teleloc 0x00B50200 [9.992065 -195.851562 0] 1 0 0 0

Requested and received permission for new weenie
ace90273-surface

Destination of portal using world_objects data is here: exit - Surface (41.1S, 48.8W).
@teleloc 0x424C0019 [83.999023 12 7.005837] 1 0 0 0

Using vloc2loc data on 00B5, Ahumba (npc) should be 'nudged' into proper position behind the altar 
Ahumba - @teleloc 0x00B50129 [159.999390 -48 -24] 1 0 0 0