### PR TITLE
Update 0031 Surface.sql portal for Creepy Canyons

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/0031.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0031.sql
@@ -77,8 +77,8 @@ VALUES (0x70031002, 31314, 0x003102FC, 151.119, -198.619, -29.995, -0.324846, 0,
 /* @teleloc 0x003102FC [151.119003 -198.619003 -29.995001] -0.324846 0.000000 0.000000 -0.945767 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70031003, 31314, 0x00310106, 193.641, -151.292, -90.063, 0, 0, -0.707107, 0.707107, False, '2021-11-01 00:00:00'); /* Surface */
-/* @teleloc 0x00310106 [193.641006 -151.292007 -90.063004] 0.000000 0.000000 -0.707107 0.707107 */
+VALUES (0x70031003, 31314, 0x00310106, 193.639526, -151.292969, -90, 1, 0, 0, 0, False, '2024-04-28 00:00:00'); /* Surface */
+/* @teleloc 0x00310106 [193.639526 -151.292969 -90] 1 0 0 0 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x70031004, 31422, 0x003102FA, 149.438, -178.349, -29.695, -0.187513, 0, 0, 0.982262,  True, '2021-11-01 00:00:00'); /* Stomper */


### PR DESCRIPTION
Database/Patches/6 LandBlockExtendedData/0031.sql

Update 0031 Surface .sql portal for Creepy Canyons Surface portal was failing to spawn
AddWorldObjectInternal: couldn't spawn 0x70031003:Surface [31314 - Portal] at 0x00310106 [193.641006 -151.292007 -90.063004] 0 0 -0.707107 0.707107

Using vloc2loc data, nudged surface portal to
@teleloc 0x00310106 [193.639526 -151.292969 -90] 1 0 0 0