### PR TITLE
Various Bug Fixes

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/C4F2.sql
+++ b/Database/Patches/6 LandBlockExtendedData/C4F2.sql
@@ -671,3 +671,7 @@ VALUES (0x7C4F2118, 40271, 0xC4F203F9, 166.836, 212.514, -9.93046, -0.886302, 0,
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7C4F2119, 40090, 0xC4F2012A, 197.509, 211.539, -50.9798, 0.99506, 0, 0, -0.099272,  True, '2023-05-15 03:25:02'); /* Radiant Mana Infusion */
 /* @teleloc 0xC4F2012A [197.509003 211.539001 -50.979801] 0.995060 0.000000 0.000000 -0.099272 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7C4F211A, 73167, 0xC4F20128, 194.617, 218.25, -51.125, 1, 0, 0, 0, False, '2024-05-21 09:38:59'); /* Ley Line */
+/* @teleloc 0xC4F20128 [194.617004 218.250000 -51.125000] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35888 Paradox-touched Olthoi Queen.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35888 Paradox-touched Olthoi Queen.sql
@@ -77,17 +77,13 @@ VALUES (35888,   1, 199600, 0, 0, 200000) /* MaxHealth */
      , (35888,   5, 199200, 0, 0, 200000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35888,  6, 0, 2, 0, 260, 0, 0) /* MeleeDefense        Trained */
-     , (35888,  7, 0, 2, 0, 520, 0, 0) /* MissileDefense      Trained */
-     , (35888, 15, 0, 2, 0, 240, 0, 0) /* MagicDefense        Trained */
-     , (35888, 16, 0, 2, 0, 200, 0, 0) /* ManaConversion      Trained */
-     , (35888, 31, 0, 2, 0, 400, 0, 0) /* CreatureEnchantment Trained */
-     , (35888, 33, 0, 2, 0, 400, 0, 0) /* LifeMagic           Trained */
-     , (35888, 34, 0, 2, 0, 400, 0, 0) /* WarMagic            Trained */
-     , (35888, 41, 0, 2, 0, 140, 0, 0) /* TwoHandedCombat     Trained */
-     , (35888, 44, 0, 2, 0, 940, 0, 0) /* HeavyWeapons        Trained */
-     , (35888, 45, 0, 2, 0, 250, 0, 0) /* LightWeapons        Trained */
-     , (35888, 46, 0, 2, 0, 140, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35888,  6, 0, 2, 0, 120, 0, 0) /* MeleeDefense        Trained */
+     , (35888,  7, 0, 2, 0, 340, 0, 0) /* MissileDefense      Trained */
+     , (35888, 15, 0, 2, 0, 200, 0, 0) /* MagicDefense        Trained */
+     , (35888, 31, 0, 2, 0,  65, 0, 0) /* CreatureEnchantment Trained */
+     , (35888, 33, 0, 2, 0,  65, 0, 0) /* LifeMagic           Trained */
+     , (35888, 34, 0, 2, 0,  65, 0, 0) /* WarMagic            Trained */
+     , (35888, 45, 0, 2, 0,  50, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35888,  0,  2, 450, 0.75,  700,  805,  770,  770,  875,  875,  875,  875,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/35100 Grave Rat.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/35100 Grave Rat.sql
@@ -62,7 +62,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (35100,   1, 0x0200003D) /* Setup */
      , (35100,   2, 0x0900000E) /* MotionTable */
      , (35100,   3, 0x2000000F) /* SoundTable */
-     , (35100,   4, 0x30000009) /* CombatTable */
+     , (35100,   4, 0x30000013) /* CombatTable */
      , (35100,   6, 0x040001B4) /* PaletteBase */
      , (35100,   7, 0x100004FA) /* ClothingBase */
      , (35100,   8, 0x0600103B) /* Icon */
@@ -84,10 +84,10 @@ VALUES (35100,   1,  1200, 0, 0, 1350) /* MaxHealth */
      , (35100,   5,     0, 0, 0, 190) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35100,  6, 0, 2, 0, 522, 0, 0) /* MeleeDefense        Trained */
-     , (35100,  7, 0, 2, 0, 149, 0, 0) /* MissileDefense      Trained */
-     , (35100, 15, 0, 2, 0, 170, 0, 0) /* MagicDefense        Trained */
-     , (35100, 45, 0, 2, 0, 553, 0, 0) /* LightWeapons        Trained */;
+VALUES (35100,  6, 0, 2, 0, 330, 0, 0) /* MeleeDefense        Trained */
+     , (35100,  7, 0, 2, 0, 480, 0, 0) /* MissileDefense      Trained */
+     , (35100, 15, 0, 2, 0, 300, 0, 0) /* MagicDefense        Trained */
+     , (35100, 45, 0, 2, 0, 380, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (35100,  0,  2, 120, 0.75,  430,  421,  421,  280,  421,  421,  421,  280,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/36172 Blood Curse Rat.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/36172 Blood Curse Rat.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 36172;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36172, 'ace36172-bloodcurserat', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (36172, 'ace36172-bloodcurserat', 10, '2024-05-21 09:06:53') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (36172,   1,         16) /* ItemType - Creature */
@@ -18,6 +18,7 @@ VALUES (36172,   1,         16) /* ItemType - Creature */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (36172,   1, True ) /* Stuck */
+     , (36172,   6, True ) /* AiUsesMana */
      , (36172,  11, False) /* IgnoreCollisions */
      , (36172,  12, True ) /* ReportCollisions */
      , (36172,  13, False) /* Ethereal */
@@ -54,18 +55,17 @@ VALUES (36172,   1,       5) /* HeartbeatInterval */
      , (36172, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (36172,   1, 'Blood Curse Rat') /* Name */
-     , (36172,  45, 'KilltaskGraveyardGraveRat_1107') /* KillQuest */;
+VALUES (36172,   1, 'Blood Curse Rat') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (36172,   1, 0x0200003D) /* Setup */
      , (36172,   2, 0x0900019C) /* MotionTable */
      , (36172,   3, 0x2000000F) /* SoundTable */
-     , (36172,   4, 0x30000009) /* CombatTable */
+     , (36172,   4, 0x30000013) /* CombatTable */
      , (36172,   7, 0x1000022E) /* ClothingBase */
      , (36172,   8, 0x0600103B) /* Icon */
      , (36172,  22, 0x340000C1) /* PhysicsEffectTable */
-     , (36172,  30,         86) /* PhysicsScript - BreatheAcid */
+     , (36172,  30,         84) /* PhysicsScript - BreatheFlame */
      , (36172,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -82,23 +82,19 @@ VALUES (36172,   1,  1200, 0, 0, 1350) /* MaxHealth */
      , (36172,   5,  5000, 0, 0, 5190) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36172,  6, 0, 2, 0, 360, 0, 0) /* MeleeDefense        Trained */
-     , (36172,  7, 0, 2, 0, 256, 0, 0) /* MissileDefense      Trained */
-     , (36172, 15, 0, 2, 0, 156, 0, 0) /* MagicDefense        Trained */
-     , (36172, 16, 0, 2, 0, 165, 0, 0) /* ManaConversion      Trained */
-     , (36172, 31, 0, 2, 0, 198, 0, 0) /* CreatureEnchantment Trained */
-     , (36172, 33, 0, 2, 0, 198, 0, 0) /* LifeMagic           Trained */
-     , (36172, 34, 0, 2, 0, 198, 0, 0) /* WarMagic            Trained */
-     , (36172, 44, 0, 2, 0, 575, 0, 0) /* HeavyWeapons        Trained */
-     , (36172, 45, 0, 2, 0, 575, 0, 0) /* LightWeapons        Trained */
-     , (36172, 46, 0, 2, 0, 575, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (36172,  6, 0, 2, 0, 330, 0, 0) /* MeleeDefense        Trained */
+     , (36172,  7, 0, 2, 0, 480, 0, 0) /* MissileDefense      Trained */
+     , (36172, 15, 0, 2, 0, 300, 0, 0) /* MagicDefense        Trained */
+     , (36172, 33, 0, 2, 0, 450, 0, 0) /* LifeMagic           Trained */
+     , (36172, 45, 0, 2, 0, 380, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (36172,  0,  2, 180, 0.75,  430,  421,  421,  310,  421,  421,  421,  310,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */
-     , (36172, 16,  4, 180, 0.75,  430,  421,  421,  310,  421,  421,  421,  310,    0, 2, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75) /* Torso */
-     , (36172, 17,  4, 180,    0,  430,  421,  421,  310,  421,  421,  421,  310,    0, 3,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25) /* Tail */
-     , (36172, 22, 32, 180,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+VALUES (36172,  0,  2, 180, 0.75,  430,  215,  215,  215,  215,  215,  215,  215,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */
+     , (36172, 16,  4, 180, 0.75,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75) /* Torso */
+     , (36172, 17,  4, 180,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25) /* Tail */
+     , (36172, 22, 16, 180,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (36172,  2074,   2.99)  /* Gossamer Flesh */
-     , (36172,  2178,   2.99)  /* Decrepitude's Grasp */;
+VALUES (36172,  2074,   2.25)  /* Gossamer Flesh */
+     , (36172,  2070,   2.33)  /* Heart Rend */
+     , (36172,  2178,    2.5)  /* Decrepitude's Grasp */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/36173 DeathTail.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/36173 DeathTail.sql
@@ -9,7 +9,7 @@ VALUES (36173,   1,         16) /* ItemType - Creature */
      , (36173,   6,         -1) /* ItemsCapacity */
      , (36173,   7,         -1) /* ContainersCapacity */
      , (36173,  16,          1) /* ItemUseable - No */
-     , (36173,  25,        135) /* Level */
+     , (36173,  25,        300) /* Level */
      , (36173,  40,          2) /* CombatMode - Melee */
      , (36173,  68,          5) /* TargetingTactic - Random, LastDamager */
      , (36173,  81,          8) /* MaxGeneratedObjects */
@@ -65,10 +65,10 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (36173,   1, 0x0200003D) /* Setup */
      , (36173,   2, 0x0900019C) /* MotionTable */
      , (36173,   3, 0x2000000F) /* SoundTable */
-     , (36173,   4, 0x30000009) /* CombatTable */
+     , (36173,   4, 0x30000013) /* CombatTable */
      , (36173,   8, 0x0600103B) /* Icon */
      , (36173,  22, 0x34000023) /* PhysicsEffectTable */
-     , (36173,  30,         86) /* PhysicsScript - BreatheAcid */
+     , (36173,  30,         85) /* PhysicsScript - BreatheFrost */
      , (36173,  35,       1000) /* DeathTreasureType - Loot Tier: 7 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
@@ -85,18 +85,16 @@ VALUES (36173,   1, 200000, 0, 0, 200250) /* MaxHealth */
      , (36173,   5,  3500, 0, 0, 3690) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36173,  6, 0, 2, 0, 360, 0, 0) /* MeleeDefense        Trained */
-     , (36173,  7, 0, 2, 0, 256, 0, 0) /* MissileDefense      Trained */
-     , (36173, 15, 0, 2, 0, 156, 0, 0) /* MagicDefense        Trained */
-     , (36173, 44, 0, 2, 0, 650, 0, 0) /* HeavyWeapons        Trained */
-     , (36173, 45, 0, 2, 0, 650, 0, 0) /* LightWeapons        Trained */
-     , (36173, 46, 0, 2, 0, 650, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (36173,  6, 0, 2, 0, 330, 0, 0) /* MeleeDefense        Trained */
+     , (36173,  7, 0, 2, 0, 480, 0, 0) /* MissileDefense      Trained */
+     , (36173, 15, 0, 2, 0, 300, 0, 0) /* MagicDefense        Trained */
+     , (36173, 45, 0, 2, 0, 380, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (36173,  0,  2, 320, 0.75,  430,  417,  413,  335,  413,  417,  417,  353,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */
      , (36173, 16,  4, 320, 0.75,  430,  417,  413,  335,  413,  417,  417,  353,    0, 2, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75) /* Torso */
      , (36173, 17,  4, 300,    0,  430,  417,  413,  335,  413,  417,  417,  353,    0, 3,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25) /* Tail */
-     , (36173, 22, 32, 300,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
+     , (36173, 22,  8, 300,  0.5,    0,    0,    0,    0,    0,    0,    0,    0,    0, 0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (36173, 9, 36171,  0, 0, 0, False) /* Create DeathTail's Fang (36171) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/37456 Grave Rat.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/37456 Grave Rat.sql
@@ -62,7 +62,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (37456,   1, 0x0200003D) /* Setup */
      , (37456,   2, 0x0900000E) /* MotionTable */
      , (37456,   3, 0x2000000F) /* SoundTable */
-     , (37456,   4, 0x30000009) /* CombatTable */
+     , (37456,   4, 0x30000013) /* CombatTable */
      , (37456,   6, 0x040001B4) /* PaletteBase */
      , (37456,   7, 0x100004FA) /* ClothingBase */
      , (37456,   8, 0x0600103B) /* Icon */
@@ -84,10 +84,10 @@ VALUES (37456,   1,  1200, 0, 0, 1350) /* MaxHealth */
      , (37456,   5,     0, 0, 0, 190) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (37456,  6, 0, 2, 0, 522, 0, 0) /* MeleeDefense        Trained */
-     , (37456,  7, 0, 2, 0, 149, 0, 0) /* MissileDefense      Trained */
-     , (37456, 15, 0, 2, 0, 170, 0, 0) /* MagicDefense        Trained */
-     , (37456, 45, 0, 2, 0, 553, 0, 0) /* LightWeapons        Trained */;
+VALUES (37456,  6, 0, 2, 0, 330, 0, 0) /* MeleeDefense        Trained */
+     , (37456,  7, 0, 2, 0, 480, 0, 0) /* MissileDefense      Trained */
+     , (37456, 15, 0, 2, 0, 300, 0, 0) /* MagicDefense        Trained */
+     , (37456, 45, 0, 2, 0, 380, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (37456,  0,  2, 120, 0.75,  430,  421,  421,  280,  421,  421,  421,  280,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/43166 Grave Rat.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/43166 Grave Rat.sql
@@ -61,7 +61,7 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (43166,   1, 0x0200003D) /* Setup */
      , (43166,   2, 0x0900000E) /* MotionTable */
      , (43166,   3, 0x2000000F) /* SoundTable */
-     , (43166,   4, 0x30000009) /* CombatTable */
+     , (43166,   4, 0x30000013) /* CombatTable */
      , (43166,   6, 0x040001B4) /* PaletteBase */
      , (43166,   7, 0x100004FA) /* ClothingBase */
      , (43166,   8, 0x0600103B) /* Icon */
@@ -83,10 +83,10 @@ VALUES (43166,   1,  1200, 0, 0, 1350) /* MaxHealth */
      , (43166,   5,     0, 0, 0, 190) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (43166,  6, 0, 2, 0, 522, 0, 0) /* MeleeDefense        Trained */
-     , (43166,  7, 0, 2, 0, 149, 0, 0) /* MissileDefense      Trained */
-     , (43166, 15, 0, 2, 0, 170, 0, 0) /* MagicDefense        Trained */
-     , (43166, 45, 0, 2, 0, 553, 0, 0) /* LightWeapons        Trained */;
+VALUES (43166,  6, 0, 2, 0, 330, 0, 0) /* MeleeDefense        Trained */
+     , (43166,  7, 0, 2, 0, 480, 0, 0) /* MissileDefense      Trained */
+     , (43166, 15, 0, 2, 0, 300, 0, 0) /* MagicDefense        Trained */
+     , (43166, 45, 0, 2, 0, 380, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (43166,  0,  2, 120, 0.75,  430,  421,  421,  280,  421,  421,  421,  280,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/34947 Rock.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/34947 Rock.sql
@@ -13,7 +13,9 @@ VALUES (34947,   1,         16) /* ItemType - Creature */
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (34947,   1, True ) /* Stuck */
-     , (34947,  19, False) /* Attackable */;
+     , (34947,  19, False) /* Attackable */
+     , (34947,  52, True ) /* AiImmobile */
+     , (34947,  83, True ) /* NpcLooksLikeObject */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (34947,  39,     1.2) /* DefaultScale */
@@ -69,4 +71,4 @@ VALUES (34947, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'BurunLiberator_
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'Nothing Happens.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You examine the rock but find nothing out of the ordinary.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/34947.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/34947.es
@@ -9,4 +9,4 @@ Use:
                     - DirectBroadcast: This must be the rock that Tmauruk told you about! You move it aside and swiftly enter the passage behind. The rock rolls back into place behind you.
                     - CastSpellInstant: 4064
                 QuestFailure:
-                    - DirectBroadcast: Nothing Happens.
+                    - DirectBroadcast: You examine the rock but find nothing out of the ordinary.

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72142 Rynthid Platforms 1 Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72142 Rynthid Platforms 1 Gen.sql
@@ -14,7 +14,7 @@ VALUES (72142,   1, True ) /* Stuck */
      , (72142,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72142,  41,     180) /* RegenerationInterval */
+VALUES (72142,  41,     600) /* RegenerationInterval */
      , (72142,  43,       5) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Generic/None/72143 Rynthid Platforms 2 Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/72143 Rynthid Platforms 2 Gen.sql
@@ -14,7 +14,7 @@ VALUES (72143,   1, True ) /* Stuck */
      , (72143,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (72143,  41,     180) /* RegenerationInterval */
+VALUES (72143,  41,     600) /* RegenerationInterval */
      , (72143,  43,       5) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Scroll/Writable/53369 Scroll of Radiant Blood Recall.sql
+++ b/Database/Patches/9 WeenieDefaults/Scroll/Writable/53369 Scroll of Radiant Blood Recall.sql
@@ -8,7 +8,9 @@ VALUES (53369,   1,       8192) /* ItemType - Writable */
      , (53369,   5,         50) /* EncumbranceVal */
      , (53369,  16,          8) /* ItemUseable - Contained */
      , (53369,  19,          5) /* Value */
-     , (53369,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+     , (53369,  33,          1) /* Bonded - Bonded */
+     , (53369,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (53369, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (53369,   1, False) /* Stuck */

--- a/Database/Patches/9 WeenieDefaults/Scroll/Writable/87875 Scroll of Celestial Hand Recall.sql
+++ b/Database/Patches/9 WeenieDefaults/Scroll/Writable/87875 Scroll of Celestial Hand Recall.sql
@@ -8,7 +8,9 @@ VALUES (87875,   1,       8192) /* ItemType - Writable */
      , (87875,   5,         50) /* EncumbranceVal */
      , (87875,  16,          8) /* ItemUseable - Contained */
      , (87875,  19,          5) /* Value */
-     , (87875,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+     , (87875,  33,          1) /* Bonded - Bonded */
+     , (87875,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (87875, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (87875,   1, False) /* Stuck */

--- a/Database/Patches/9 WeenieDefaults/Scroll/Writable/88053 Scroll of Eldrytch Web Recall.sql
+++ b/Database/Patches/9 WeenieDefaults/Scroll/Writable/88053 Scroll of Eldrytch Web Recall.sql
@@ -8,7 +8,9 @@ VALUES (88053,   1,       8192) /* ItemType - Writable */
      , (88053,   5,         50) /* EncumbranceVal */
      , (88053,  16,          8) /* ItemUseable - Contained */
      , (88053,  19,          5) /* Value */
-     , (88053,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+     , (88053,  33,          1) /* Bonded - Bonded */
+     , (88053,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (88053, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (88053,   1, False) /* Stuck */


### PR DESCRIPTION
Adds attuned, bonded to society recall spell scrolls. 
Fixes graveyard rat breath attacks and sets skills from pcaps. 
Sets Rynthid platforms generator respawn to 10 min (timed from a Loud Lou retail video). It was previously 3 min. 
Adds NPC looks like object to a rock on Bur.
Adds leyline hotspot to Radiant Blood Infusion quest dungeon.