### PR TITLE
Harlune's Diplomacy

### DIFF
--- a/Database/Patches/9 WeenieDefaults/PressurePlate/Misc/87841 Large Pressure Plate.sql
+++ b/Database/Patches/9 WeenieDefaults/PressurePlate/Misc/87841 Large Pressure Plate.sql
@@ -16,7 +16,7 @@ INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (87841,   1, True ) /* Stuck */
      , (87841,  11, False) /* IgnoreCollisions */
      , (87841,  12, True ) /* ReportCollisions */
-     , (87841,  13, False) /* Ethereal */
+     , (87841,  13, True ) /* Ethereal */
      , (87841,  14, False) /* GravityStatus */
      , (87841,  18, True ) /* Visibility */;
 

--- a/Database/Patches/9 WeenieDefaults/PressurePlate/Misc/87843 Large Pressure Plate.sql
+++ b/Database/Patches/9 WeenieDefaults/PressurePlate/Misc/87843 Large Pressure Plate.sql
@@ -16,7 +16,7 @@ INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (87843,   1, True ) /* Stuck */
      , (87843,  11, False) /* IgnoreCollisions */
      , (87843,  12, True ) /* ReportCollisions */
-     , (87843,  13, False) /* Ethereal */
+     , (87843,  13, True ) /* Ethereal */
      , (87843,  14, False) /* GravityStatus */
      , (87843,  18, True ) /* Visibility */;
 


### PR DESCRIPTION
Fixed a pair of Pressure Plates that were not triggering since they were not ethereal, meaning the quest could never be completed.