### PR TITLE
Fix Mobs in Bulb of Mornings

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/88084 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/88084 Spectral Archer.sql
@@ -14,6 +14,7 @@ VALUES (88084,   1,         16) /* ItemType - Creature */
      , (88084,  48,         47) /* WeaponSkill - MissileWeapons */
      , (88084,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
      , (88084,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (88084, 101,     524288) /* AiAllowedCombatStyle - StubbornMissile */
      , (88084, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (88084, 146,    1850000) /* XpOverride */
      , (88084, 307,         10) /* DamageRating */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/87589 Mu-miyah Vizier.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/87589 Mu-miyah Vizier.sql
@@ -64,7 +64,8 @@ VALUES (87589,   1,       5) /* HeartbeatInterval */
      , (87589, 166,     1.1) /* ResistNether */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (87589,   1, 'Mu-miyah Vizier') /* Name */;
+VALUES (87589,   1, 'Mu-miyah Vizier') /* Name */
+     , (87589,  45, 'SanctumGuardianKillTask') /* KillQuest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (87589,   1, 0x02000001) /* Setup */

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/88228 Seed of Essence.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/88228 Seed of Essence.sql
@@ -26,4 +26,4 @@ VALUES (88228,   1, 'Seed of Essence') /* Name */
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (88228,   1, 0x02001BA5) /* Setup */
      , (88228,   7, 0x10000841) /* ClothingBase */
-     , (88228,   8, 0x060073EF) /* Icon */;
+     , (88228,   8, 0x060073F4) /* Icon */;


### PR DESCRIPTION
Adds missing kill task stamp to a Vizier and missing stubborn missile to a Spectral Archer.