### PR TITLE
40250, 40485, 71390 Fixed 'detected bad quaternion' errors in server log

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/40250 Entrance to the pyramid.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/40250 Entrance to the pyramid.sql
@@ -31,5 +31,5 @@ VALUES (40250,   1, 0x02001698) /* Setup */
      , (40250,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (40250, 2, 0x00CB0100, 0, 0, -29.995, 0.020795, 0, 0, -1) /* Destination */
-/* @teleloc 0x00CB0100 [0.000000 0.000000 -29.995001] 0.020795 0.000000 0.000000 -1.000000 */;
+VALUES (40250, 2, 0x00CB0100, 0, 0, -29.995001, 0.020791, 0, 0, -0.999784) /* Destination */
+/* @teleloc 0x00CB0100 [0.000000 0.000000 -29.995001] 0.020791 0.000000 0.000000 -0.999784 */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/40250 Entrance to the pyramid.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/40250 Entrance to the pyramid.sql
@@ -31,5 +31,5 @@ VALUES (40250,   1, 0x02001698) /* Setup */
      , (40250,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (40250, 2, 0x00CB0100, 0, 0, -29.995001, 0.020791, 0, 0, -0.999784) /* Destination */
-/* @teleloc 0x00CB0100 [0.000000 0.000000 -29.995001] 0.020791 0.000000 0.000000 -0.999784 */;
+VALUES (40250, 2, 0x00CB0100, 0, 0, -29.995, 0, 0, 0, 1) /* Destination */
+/* @teleloc 0x00CB0100 [0.000000 0.000000 -29.995001] 0.000000 0.000000 0.000000 1.000000 */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/40485 Crystalline Portal.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/40485 Crystalline Portal.sql
@@ -26,5 +26,5 @@ VALUES (40485,   1, 0x020001B3) /* Setup */
      , (40485,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (40485, 2, 0x870401F6, 120.05, -134.69, -155.99, -0.005, 0, 0, 0.99) /* Destination */
-/* @teleloc 0x870401F6 [120.050003 -134.690002 -155.990005] -0.005000 0.000000 0.000000 0.990000 */;
+VALUES (40485, 2, 0x870401F6, 120.050003, -134.690002, -155.990005, -0.005050, 0, 0, 0.999987) /* Destination */
+/* @teleloc 0x870401F6 [120.050003 -134.690002 -155.990005] -0.005050 0.000000 0.000000 0.999987 */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/40485 Crystalline Portal.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/40485 Crystalline Portal.sql
@@ -26,5 +26,5 @@ VALUES (40485,   1, 0x020001B3) /* Setup */
      , (40485,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (40485, 2, 0x870401F6, 120.050003, -134.690002, -155.990005, -0.005050, 0, 0, 0.999987) /* Destination */
-/* @teleloc 0x870401F6 [120.050003 -134.690002 -155.990005] -0.005050 0.000000 0.000000 0.999987 */;
+VALUES (40485, 2, 0x870401F6, 120.05, -134.69, -155.99, 0, 0, 0, 1) /* Destination */
+/* @teleloc 0x870401F6 [120.050003 -134.690002 -155.990005] 0.000000 0.000000 0.000000 1.000000 */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/71390 Catacombs.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/71390 Catacombs.sql
@@ -30,5 +30,5 @@ VALUES (71390,   1, 0x020001B3) /* Setup */
      , (71390,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (71390, 2, 0x57540264, 99.951202, -2.459900, 0.006000, 0.042789, 0, 0, 0.999084) /* Destination */
-/* @teleloc 0x57540264 [99.951202 -2.459900 0.006000] 0.042789 0.000000 0.000000 0.999084 */;
+VALUES (71390, 2, 0x57540264, 99.9512, -2.4599, 0.006, 0, 0, 0, 1) /* Destination */
+/* @teleloc 0x57540264 [99.951202 -2.459900 0.006000] 0.000000 0.000000 0.000000 1.000000 */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/71390 Catacombs.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/71390 Catacombs.sql
@@ -30,5 +30,5 @@ VALUES (71390,   1, 0x020001B3) /* Setup */
      , (71390,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (71390, 2, 0x57540264, 99.9512, -2.4599, 0.006, 0.0424, 0, 0, 0.99) /* Destination */
-/* @teleloc 0x57540264 [99.951202 -2.459900 0.006000] 0.042400 0.000000 0.000000 0.990000 */;
+VALUES (71390, 2, 0x57540264, 99.951202, -2.459900, 0.006000, 0.042789, 0, 0, 0.999084) /* Destination */
+/* @teleloc 0x57540264 [99.951202 -2.459900 0.006000] 0.042789 0.000000 0.000000 0.999084 */;


### PR DESCRIPTION
Nudge these three portal destinations to remove error messages from our ACEmulator server log. 

[37] WARN  (ACE.Server.Entity.PositionExtensions) detected bad quaternion x y z w for Entrance to the pyramid (0x773C8002) | WCID: 40250 | WeenieType: Portal | PositionType: Destination [37] WARN  (ACE.Server.Entity.PositionExtensions) before fix: 0x00CB0100 [0.000000 0.000000 -29.995001] 0.020795 0.000000 0.000000 -1.000000 [37] WARN  (ACE.Server.Entity.PositionExtensions)  after fix: 0x00CB0100 [0.000000 0.000000 -29.995001] 0.020791 0.000000 0.000000 -0.999784

[26] WARN  (ACE.Server.Entity.PositionExtensions) detected bad quaternion x y z w for Crystalline Portal (0x788031B8) | WCID: 40485 | WeenieType: Portal | PositionType: Destination
[26] WARN  (ACE.Server.Entity.PositionExtensions) before fix: 0x870401F6 [120.050003 -134.690002 -155.990005] -0.005000 0.000000 0.000000 0.990000
[26] WARN  (ACE.Server.Entity.PositionExtensions)  after fix: 0x870401F6 [120.050003 -134.690002 -155.990005] -0.005050 0.000000 0.000000 0.999987

[7] WARN  (ACE.Server.Entity.PositionExtensions) detected bad quaternion x y z w for Catacombs (0x7575414C) | WCID: 71390 | WeenieType: Portal | PositionType: Destination
[7] WARN  (ACE.Server.Entity.PositionExtensions) before fix: 0x57540264 [99.951202 -2.459900 0.006000] 0.042400 0.000000 0.000000 0.990000
[7] WARN  (ACE.Server.Entity.PositionExtensions)  after fix: 0x57540264 [99.951202 -2.459900 0.006000] 0.042789 0.000000 0.000000 0.999084