### PR TITLE
Update Bur

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/009C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/009C.sql
@@ -42,8 +42,6 @@ VALUES (0x7009C043,  1154, 0x009C026D, 214.027, -86.7504, -18, 0.999242, 0, 0, -
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
 VALUES (0x7009C043, 0x7009C044, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
-     , (0x7009C043, 0x7009C045, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
-     , (0x7009C043, 0x7009C046, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C047, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C048, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C049, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
@@ -77,11 +75,8 @@ VALUES (0x7009C043, 0x7009C044, '2021-11-01 00:00:00') /* Baby Thrungus (34868) 
      , (0x7009C043, 0x7009C065, '2021-11-01 00:00:00') /* Pallid Moarsman (27859) */
      , (0x7009C043, 0x7009C066, '2021-11-01 00:00:00') /* Pallid Moar (34869) */
      , (0x7009C043, 0x7009C067, '2021-11-01 00:00:00') /* Pallid Moar (34869) */
-     , (0x7009C043, 0x7009C068, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
-     , (0x7009C043, 0x7009C069, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C06A, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C06B, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
-     , (0x7009C043, 0x7009C06C, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C06D, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C06E, '2021-11-01 00:00:00') /* Baby Thrungus (34868) */
      , (0x7009C043, 0x7009C06F, '2021-11-01 00:00:00') /* Pallid Moar (34869) */
@@ -90,14 +85,6 @@ VALUES (0x7009C043, 0x7009C044, '2021-11-01 00:00:00') /* Baby Thrungus (34868) 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7009C044, 34868, 0x009C026D, 214.027, -86.7504, -18, 0.999242, 0, 0, -0.038928,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
 /* @teleloc 0x009C026D [214.026993 -86.750397 -18.000000] 0.999242 0.000000 0.000000 -0.038928 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7009C045, 34868, 0x009C0275, 226.637, -95.5518, -18, -0.058206, 0, 0, -0.998305,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
-/* @teleloc 0x009C0275 [226.636993 -95.551804 -18.000000] -0.058206 0.000000 0.000000 -0.998305 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7009C046, 34868, 0x009C0159, 272.081, -74.4236, -24, -0.901371, 0, 0, -0.433048,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
-/* @teleloc 0x009C0159 [272.080994 -74.423599 -24.000000] -0.901371 0.000000 0.000000 -0.433048 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7009C047, 34868, 0x009C0144, 275.582, -102.793, -30, 0.041373, 0, 0, 0.999144,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
@@ -232,24 +219,12 @@ VALUES (0x7009C067, 34869, 0x009C0240, 30.5502, -79.392, -17.982, 0.889789, 0, 0
 /* @teleloc 0x009C0240 [30.550200 -79.391998 -17.982000] 0.889789 0.000000 0.000000 -0.456372 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7009C068, 34868, 0x009C0191, 325.812, -84.3765, -24, -0.940749, 0, 0, 0.339103,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
-/* @teleloc 0x009C0191 [325.812012 -84.376503 -24.000000] -0.940749 0.000000 0.000000 0.339103 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7009C069, 34868, 0x009C0190, 333.954, -74.7402, -24, -0.840955, 0, 0, -0.541104,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
-/* @teleloc 0x009C0190 [333.954010 -74.740196 -24.000000] -0.840955 0.000000 0.000000 -0.541104 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7009C06A, 34868, 0x009C0274, 226.546, -94.3666, -18, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
 /* @teleloc 0x009C0274 [226.546005 -94.366600 -18.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7009C06B, 34868, 0x009C0184, 323.418, -61.0306, -24, -0.873738, 0, 0, -0.486396,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
 /* @teleloc 0x009C0184 [323.417999 -61.030602 -24.000000] -0.873738 0.000000 0.000000 -0.486396 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7009C06C, 34868, 0x009C0193, 325.086, -85.0306, -24, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */
-/* @teleloc 0x009C0193 [325.085999 -85.030602 -24.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7009C06D, 34868, 0x009C0191, 333.732, -75.6611, -24, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Baby Thrungus */

--- a/Database/Patches/6 LandBlockExtendedData/00D2.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00D2.sql
@@ -1,8 +1,16 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x00D2;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2009, 34830, 0x00D201DF, 31.314, -301.708, -24.2098, 0.382683, 0, 0, -0.92388, False, '2021-11-01 00:00:00'); /* Northern Catacombs Exit */
-/* @teleloc 0x00D201DF [31.313999 -301.708008 -24.209801] 0.382683 0.000000 0.000000 -0.923880 */
+VALUES (0x700D2001, 34830, 0x00D20115, 70.4479, -159.911, -30.2098, 0.939373, 0, 0, -0.342898, False, '2021-11-01 00:00:00'); /* Northern Catacombs Exit */
+/* @teleloc 0x00D20115 [70.447899 -159.910995 -30.209801] 0.939373 0.000000 0.000000 -0.342898 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D2003, 87291, 0x00D2015B, 120, -124.732, -30.2098, 0, 0, 0, -1, False, '2021-11-01 00:00:00'); /* Humid Guruk Caverns */
+/* @teleloc 0x00D2015B [120.000000 -124.732002 -30.209801] 0.000000 0.000000 0.000000 -1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D2007, 34830, 0x00D201B8, 169.868, -159.664, -30.2098, 0.921061, 0, 0, 0.389418, False, '2021-11-01 00:00:00'); /* Northern Catacombs Exit */
+/* @teleloc 0x00D201B8 [169.867996 -159.664001 -30.209801] 0.921061 0.000000 0.000000 0.389418 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D2037, 34830, 0x00D20511, 111.579, -216.585, -12.2098, -0.923879, 0, 0, -0.382684, False, '2021-11-01 00:00:00'); /* Northern Catacombs Exit */
@@ -17,281 +25,277 @@ VALUES (0x700D203C, 34830, 0x00D20539, 118.502, -216.499, -12.2098, -0.34202, 0,
 /* @teleloc 0x00D20539 [118.501999 -216.498993 -12.209800] -0.342020 0.000000 0.000000 -0.939693 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21E4, 87285, 0x00D205F3, 185.76, -173.144, -11.945, -0.022954, 0, 0, 0.999737, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205F3 [185.759995 -173.143997 -11.945000] -0.022954 0.000000 0.000000 0.999737 */
+VALUES (0x700D204F, 35801, 0x00D2060F, 228.617, -81.2211, -12.063, -0.925411, 0, 0, 0.378964, False, '2021-11-01 00:00:00'); /* Temple of the Three, Ritual Chambers */
+/* @teleloc 0x00D2060F [228.617004 -81.221100 -12.063000] -0.925411 0.000000 0.000000 0.378964 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21E5, 87285, 0x00D2060E, 216.27, -205.875, -11.945, 0.932955, 0, 0, 0.359992, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2060E [216.270004 -205.875000 -11.945000] 0.932955 0.000000 0.000000 0.359992 */
+VALUES (0x700D2296, 87285, 0x00D205EC, 182.447, -233.84, -11.945, 0.95201, 0, 0, 0.306068, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205EC [182.447006 -233.839996 -11.945000] 0.952010 0.000000 0.000000 0.306068 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21E6, 87285, 0x00D205EC, 180.445, -230.467, -11.945, 0.941499, 0, 0, 0.337015, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205EC [180.445007 -230.466995 -11.945000] 0.941499 0.000000 0.000000 0.337015 */
+VALUES (0x700D2297, 87285, 0x00D2060D, 217.43, -203.992, -11.945, -0.701028, 0, 0, -0.713134, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2060D [217.429993 -203.992004 -11.945000] -0.701028 0.000000 0.000000 -0.713134 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21E7, 87285, 0x00D20495, 76.9859, -206.082, -11.945, 0.78848, 0, 0, 0.615061, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20495 [76.985901 -206.082001 -11.945000] 0.788480 0.000000 0.000000 0.615061 */
+VALUES (0x700D2298, 87285, 0x00D205E7, 184.809, -171.444, -11.945, -0.260278, 0, 0, 0.965534, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205E7 [184.809006 -171.444000 -11.945000] -0.260278 0.000000 0.000000 0.965534 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21E8, 87285, 0x00D20435, 43.5904, -237.682, -11.945, 0.969495, 0, 0, -0.24511, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20435 [43.590401 -237.682007 -11.945000] 0.969495 0.000000 0.000000 -0.245110 */
+VALUES (0x700D229A, 87285, 0x00D20495, 77.5686, -206.424, -11.945, 0.856562, 0, 0, 0.516044, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20495 [77.568604 -206.423996 -11.945000] 0.856562 0.000000 0.000000 0.516044 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21E9, 87285, 0x00D20419, 13.5526, -203.692, -11.945, 0.514956, 0, 0, -0.857217, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20419 [13.552600 -203.692001 -11.945000] 0.514956 0.000000 0.000000 -0.857217 */
+VALUES (0x700D229B, 87285, 0x00D20435, 42.2548, -238.64, -11.945, 0.944352, 0, 0, -0.328937, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20435 [42.254799 -238.639999 -11.945000] 0.944352 0.000000 0.000000 -0.328937 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21EA, 87285, 0x00D20444, 45.7792, -173.322, -11.945, 0.349343, 0, 0, 0.936995, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20444 [45.779202 -173.322006 -11.945000] 0.349343 0.000000 0.000000 0.936995 */
+VALUES (0x700D229C, 87285, 0x00D2041A, 11.8089, -205.235, -11.945, 0.707619, 0, 0, -0.706594, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2041A [11.808900 -205.235001 -11.945000] 0.707619 0.000000 0.000000 -0.706594 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21EB, 87285, 0x00D2043F, 49.9087, -139.896, -11.945, -0.999681, 0, 0, 0.02527, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2043F [49.908699 -139.895996 -11.945000] -0.999681 0.000000 0.000000 0.025270 */
+VALUES (0x700D229D, 87285, 0x00D20432, 43.615, -172.706, -11.945, 0.010168, 0, 0, -0.999948, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20432 [43.615002 -172.705994 -11.945000] 0.010168 0.000000 0.000000 -0.999948 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21EC, 87285, 0x00D20428, 25.7772, -115.843, -11.945, -0.952803, 0, 0, 0.30359, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20428 [25.777201 -115.843002 -11.945000] -0.952803 0.000000 0.000000 0.303590 */
+VALUES (0x700D229F, 87285, 0x00D20420, 23.9231, -118.79, -11.945, 0.985956, 0, 0, -0.167007, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20420 [23.923100 -118.790001 -11.945000] 0.985956 0.000000 0.000000 -0.167007 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21ED, 87285, 0x00D2044B, 58.0711, -84.2363, -11.945, 0.699489, 0, 0, 0.714643, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2044B [58.071098 -84.236298 -11.945000] 0.699489 0.000000 0.000000 0.714643 */
+VALUES (0x700D22A0, 87285, 0x00D20414, 1.4181, -85.3999, -11.945, 0.703565, 0, 0, -0.710631, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20414 [1.418100 -85.399902 -11.945000] 0.703565 0.000000 0.000000 -0.710631 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21EE, 87285, 0x00D20425, 25.4492, -52.4275, -11.945, 0.039491, 0, 0, -0.99922, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20425 [25.449200 -52.427502 -11.945000] 0.039491 0.000000 0.000000 -0.999220 */
+VALUES (0x700D22A1, 87285, 0x00D20425, 25.9497, -52.0979, -11.945, 0.007811, 0, 0, -0.999969, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20425 [25.949699 -52.097900 -11.945000] 0.007811 0.000000 0.000000 -0.999969 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21EF, 87285, 0x00D20414, 2.64063, -85.6371, -11.945, 0.707287, 0, 0, -0.706927, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20414 [2.640630 -85.637100 -11.945000] 0.707287 0.000000 0.000000 -0.706927 */
+VALUES (0x700D22A2, 87285, 0x00D2044B, 58.0569, -83.0979, -11.945, -0.693751, 0, 0, -0.720215, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2044B [58.056900 -83.097900 -11.945000] -0.693751 0.000000 0.000000 -0.720215 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F0, 87285, 0x00D2047F, 79.3744, -86.5344, -11.945, 0.997888, 0, 0, -0.064964, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2047F [79.374397 -86.534401 -11.945000] 0.997888 0.000000 0.000000 -0.064964 */
+VALUES (0x700D22A4, 87285, 0x00D20479, 80.7105, -34.9683, -11.945, -0.700354, 0, 0, 0.713796, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20479 [80.710503 -34.968300 -11.945000] -0.700354 0.000000 0.000000 0.713796 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F1, 87285, 0x00D204EF, 114.804, -65.004, -11.945, 0.999089, 0, 0, 0.042674, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D204EF [114.804001 -65.003998 -11.945000] 0.999089 0.000000 0.000000 0.042674 */
+VALUES (0x700D22A5, 87285, 0x00D204EA, 114.698, -1.02804, -11.945, 0.001506, 0, 0, 0.999999, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D204EA [114.697998 -1.028040 -11.945000] 0.001506 0.000000 0.000000 0.999999 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F2, 87285, 0x00D2047A, 81.653, -35.0141, -11.945, -0.699901, 0, 0, 0.71424, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2047A [81.653000 -35.014099 -11.945000] -0.699901 0.000000 0.000000 0.714240 */
+VALUES (0x700D22A6, 87285, 0x00D2058F, 148.11, -35.8981, -11.945, 0.721077, 0, 0, 0.692855, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2058F [148.110001 -35.898102 -11.945000] 0.721077 0.000000 0.000000 0.692855 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F3, 87285, 0x00D20512, 115.477, -2.2358, -11.945, 0.004544, 0, 0, 0.99999, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20512 [115.476997 -2.235800 -11.945000] 0.004544 0.000000 0.000000 0.999990 */
+VALUES (0x700D22A7, 87285, 0x00D20518, 123.425, -80.828, -11.945, -0.022498, 0, 0, 0.999747, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20518 [123.425003 -80.828003 -11.945000] -0.022498 0.000000 0.000000 0.999747 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F4, 87285, 0x00D2058E, 146.745, -34.0429, -11.945, 0.687055, 0, 0, 0.726606, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2058E [146.744995 -34.042900 -11.945000] 0.687055 0.000000 0.000000 0.726606 */
+VALUES (0x700D22A8, 87285, 0x00D204F0, 107.799, -82.9879, -11.945, -0.014802, 0, 0, 0.99989, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D204F0 [107.799004 -82.987900 -11.945000] -0.014802 0.000000 0.000000 0.999890 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F5, 87285, 0x00D20590, 149.152, -81.0617, -11.945, -0.019495, 0, 0, 0.99981, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20590 [149.151993 -81.061699 -11.945000] -0.019495 0.000000 0.000000 0.999810 */
+VALUES (0x700D22A9, 87285, 0x00D20451, 61.992, -122.576, -11.945, -0.567332, 0, 0, 0.823489, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20451 [61.992001 -122.575996 -11.945000] -0.567332 0.000000 0.000000 0.823489 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F6, 87285, 0x00D205C4, 171.239, -84.2544, -11.945, -0.707744, 0, 0, 0.706469, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205C4 [171.238998 -84.254402 -11.945000] -0.707744 0.000000 0.000000 0.706469 */
+VALUES (0x700D22AA, 87285, 0x00D20454, 60.9961, -148.639, -11.945, -0.909551, 0, 0, 0.415593, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20454 [60.996101 -148.639008 -11.945000] -0.909551 0.000000 0.000000 0.415593 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F7, 87285, 0x00D205F7, 204.922, -53.8724, -11.945, 0.005049, 0, 0, 0.999987, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205F7 [204.921997 -53.872398 -11.945000] 0.005049 0.000000 0.000000 0.999987 */
+VALUES (0x700D22AB, 87285, 0x00D204E8, 102.423, -188.321, -11.945, -0.951349, 0, 0, 0.308114, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D204E8 [102.422997 -188.320999 -11.945000] -0.951349 0.000000 0.000000 0.308114 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F8, 87285, 0x00D20610, 225.513, -85.4256, -11.945, -0.701442, 0, 0, -0.712727, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20610 [225.513000 -85.425598 -11.945000] -0.701442 0.000000 0.000000 -0.712727 */
+VALUES (0x700D22AC, 87285, 0x00D2055E, 126.666, -187.149, -11.945, -0.912322, 0, 0, -0.409473, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2055E [126.666000 -187.149002 -11.945000] -0.912322 0.000000 0.000000 -0.409473 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21F9, 87285, 0x00D20604, 205.814, -116.177, -11.945, -0.999959, 0, 0, 0.009026, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20604 [205.813995 -116.177002 -11.945000] -0.999959 0.000000 0.000000 0.009026 */
+VALUES (0x700D22AD, 87285, 0x00D205CD, 168.941, -148.51, -11.945, -0.895479, 0, 0, -0.445104, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205CD [168.940994 -148.509995 -11.945000] -0.895479 0.000000 0.000000 -0.445104 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21FA, 87285, 0x00D205E2, 180.116, -135.483, -11.945, 0.999937, 0, 0, -0.011199, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205E2 [180.115997 -135.483002 -11.945000] 0.999937 0.000000 0.000000 -0.011199 */
+VALUES (0x700D22AE, 87285, 0x00D205CA, 168.473, -122.253, -11.945, -0.403445, 0, 0, -0.915004, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205CA [168.473007 -122.252998 -11.945000] -0.403445 0.000000 0.000000 -0.915004 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21FB, 87285, 0x00D205AA, 152.529, -206.404, -11.945, 0.719689, 0, 0, -0.694297, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205AA [152.529007 -206.404007 -11.945000] 0.719689 0.000000 0.000000 -0.694297 */
+VALUES (0x700D22B1, 87285, 0x00D2059F, 150.165, -140.092, -11.945, -0.986717, 0, 0, -0.162447, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2059F [150.164993 -140.091995 -11.945000] -0.986717 0.000000 0.000000 -0.162447 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21FC, 87285, 0x00D204CC, 102, -89.4973, -11.945, 0.997999, 0, 0, 0.063226, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D204CC [102.000000 -89.497299 -11.945000] 0.997999 0.000000 0.000000 0.063226 */
+VALUES (0x700D22B2, 87288, 0x00D2051A, 121.718, -100.959, -11.945, 0.031303, 0, 0, -0.99951, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2051A [121.718002 -100.959000 -11.945000] 0.031303 0.000000 0.000000 -0.999510 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21FD, 87285, 0x00D20518, 116.397, -80.4227, -11.945, -0.005835, 0, 0, -0.999983, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20518 [116.397003 -80.422699 -11.945000] -0.005835 0.000000 0.000000 -0.999983 */
+VALUES (0x700D22B3, 87288, 0x00D204F2, 111.83, -100.797, -11.945, 0.031303, 0, 0, -0.99951, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D204F2 [111.830002 -100.796997 -11.945000] 0.031303 0.000000 0.000000 -0.999510 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21FE, 87285, 0x00D20542, 129.032, -88.1236, -11.945, 0.998375, 0, 0, 0.05698, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20542 [129.031998 -88.123596 -11.945000] 0.998375 0.000000 0.000000 0.056980 */
+VALUES (0x700D22B4, 87285, 0x00D2048A, 79.9326, -138.94, -11.945, 0.732299, 0, 0, -0.680983, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D2048A [79.932602 -138.940002 -11.945000] 0.732299 0.000000 0.000000 -0.680983 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D21FF, 87288, 0x00D2051C, 115.058, -99.9528, -11.945, -0.04986, 0, 0, 0.998756, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2051C [115.057999 -99.952797 -11.945000] -0.049860 0.000000 0.000000 0.998756 */
+VALUES (0x700D22B5, 87285, 0x00D204DE, 100.998, -148.749, -11.945, 0.9751, 0, 0, -0.221766, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D204DE [100.998001 -148.748993 -11.945000] 0.975100 0.000000 0.000000 -0.221766 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2200, 87288, 0x00D205A1, 150.77, -135.439, -11.945, 0.696348, 0, 0, 0.717704, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D205A1 [150.770004 -135.438995 -11.945000] 0.696348 0.000000 0.000000 0.717704 */
+VALUES (0x700D22B6, 87288, 0x00D202D3, 140.42, -139.003, -23.945, -0.931624, 0, 0, 0.363424, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D202D3 [140.419998 -139.003006 -23.945000] -0.931624 0.000000 0.000000 0.363424 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2201, 87288, 0x00D20554, 127.475, -150.405, -11.945, -0.97176, 0, 0, -0.23597, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20554 [127.474998 -150.404999 -11.945000] -0.971760 0.000000 0.000000 -0.235970 */
+VALUES (0x700D22B7, 87288, 0x00D20311, 168.233, -162.712, -23.945, 0.303031, 0, 0, 0.952981, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20311 [168.233002 -162.712006 -23.945000] 0.303031 0.000000 0.000000 0.952981 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2202, 87285, 0x00D2055E, 128.924, -188.005, -11.945, -0.946966, 0, 0, -0.321333, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2055E [128.923996 -188.005005 -11.945000] -0.946966 0.000000 0.000000 -0.321333 */
+VALUES (0x700D22B9, 87288, 0x00D202CA, 125.753, -226.955, -23.945, 0.996138, 0, 0, 0.087802, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D202CA [125.752998 -226.955002 -23.945000] 0.996138 0.000000 0.000000 0.087802 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2203, 87285, 0x00D204E8, 101.336, -188.803, -11.945, -0.949393, 0, 0, 0.314092, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D204E8 [101.335999 -188.802994 -11.945000] -0.949393 0.000000 0.000000 0.314092 */
+VALUES (0x700D22BA, 87288, 0x00D2026D, 104.789, -228.611, -23.945, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2026D [104.789001 -228.610992 -23.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2204, 87288, 0x00D20300, 151.638, -285.236, -23.945, 0.702886, 0, 0, -0.711303, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20300 [151.638000 -285.235992 -23.945000] 0.702886 0.000000 0.000000 -0.711303 */
+VALUES (0x700D22BD, 87288, 0x00D20242, 88.864, -139.202, -23.945, -0.921554, 0, 0, -0.388249, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20242 [88.863998 -139.201996 -23.945000] -0.921554 0.000000 0.000000 -0.388249 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2205, 87288, 0x00D20348, 185.458, -317.973, -23.945, -0.998485, 0, 0, -0.055028, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20348 [185.457993 -317.972992 -23.945000] -0.998485 0.000000 0.000000 -0.055028 */
+VALUES (0x700D22BE, 87288, 0x00D20274, 114.699, -112.242, -23.945, 0, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20274 [114.698997 -112.241997 -23.945000] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2206, 87288, 0x00D20331, 183.393, -241.439, -23.945, 0.008759, 0, 0, 0.999962, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20331 [183.393005 -241.438995 -23.945000] 0.008759 0.000000 0.000000 0.999962 */
+VALUES (0x700D22BF, 87288, 0x00D20360, 215.561, -155.491, -23.945, -0.490731, 0, 0, -0.871311, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20360 [215.561005 -155.490997 -23.945000] -0.490731 0.000000 0.000000 -0.871311 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2207, 87288, 0x00D2030B, 157.522, -246.066, -23.945, -0.932186, 0, 0, -0.361979, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2030B [157.522003 -246.065994 -23.945000] -0.932186 0.000000 0.000000 -0.361979 */
+VALUES (0x700D22C1, 87288, 0x00D201A9, 163.851, -220.844, -29.945, 0.954613, 0, 0, -0.297849, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D201A9 [163.850998 -220.843994 -29.945000] 0.954613 0.000000 0.000000 -0.297849 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2208, 87288, 0x00D2028A, 111.932, -223.355, -23.945, -0.055161, 0, 0, -0.998477, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2028A [111.931999 -223.354996 -23.945000] -0.055161 0.000000 0.000000 -0.998477 */
+VALUES (0x700D22C2, 87288, 0x00D202BF, 129.277, -181.197, -23.945, 0.681745, 0, 0, 0.73159, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D202BF [129.276993 -181.197006 -23.945000] 0.681745 0.000000 0.000000 0.731590 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2209, 87288, 0x00D2020F, 61.6073, -187.243, -23.945, -0.906728, 0, 0, 0.421717, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2020F [61.607300 -187.242996 -23.945000] -0.906728 0.000000 0.000000 0.421717 */
+VALUES (0x700D22C3, 87288, 0x00D20261, 102.31, -180.98, -23.945, 0.729053, 0, 0, -0.684457, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20261 [102.309998 -180.979996 -23.945000] 0.729053 0.000000 0.000000 -0.684457 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D220A, 87288, 0x00D2020C, 60.7057, -160.867, -23.945, -0.241227, 0, 0, 0.970469, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2020C [60.705700 -160.867004 -23.945000] -0.241227 0.000000 0.000000 0.970469 */
+VALUES (0x700D22C4, 87288, 0x00D20286, 109.986, -208.359, -23.945, 1, 0, 0, -0.000006, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20286 [109.986000 -208.358994 -23.945000] 1.000000 0.000000 0.000000 -0.000006 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D220B, 87288, 0x00D20242, 89.138, -138.842, -23.945, 0.867484, 0, 0, 0.497465, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20242 [89.138000 -138.841995 -23.945000] 0.867484 0.000000 0.000000 0.497465 */
+VALUES (0x700D22C5, 87288, 0x00D202A8, 120.149, -206.752, -23.945, 1, 0, 0, -0.000006, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D202A8 [120.149002 -206.751999 -23.945000] 1.000000 0.000000 0.000000 -0.000006 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D220C, 87288, 0x00D20274, 114.287, -110.306, -23.945, 0.034256, 0, 0, -0.999413, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20274 [114.287003 -110.306000 -23.945000] 0.034256 0.000000 0.000000 -0.999413 */
+VALUES (0x700D22C6, 87288, 0x00D20165, 119.921, -163.452, -29.945, 0.0083, 0, 0, -0.999966, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20165 [119.920998 -163.451996 -29.945000] 0.008300 0.000000 0.000000 -0.999966 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D220D, 87288, 0x00D202D3, 140.783, -139.537, -23.945, 0.887753, 0, 0, -0.460321, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D202D3 [140.783005 -139.537003 -23.945000] 0.887753 0.000000 0.000000 -0.460321 */
+VALUES (0x700D22C7, 87288, 0x00D20127, 79.9068, -149.907, -29.945, 0.702552, 0, 0, -0.711633, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20127 [79.906799 -149.906998 -29.945000] 0.702552 0.000000 0.000000 -0.711633 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D220E, 87288, 0x00D20311, 167.893, -164.753, -23.945, -0.480143, 0, 0, -0.87719, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20311 [167.893005 -164.753006 -23.945000] -0.480143 0.000000 0.000000 -0.877190 */
+VALUES (0x700D22C8, 87288, 0x00D2019D, 160.235, -150.266, -29.945, 0.705952, 0, 0, 0.708259, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2019D [160.235001 -150.266006 -29.945000] 0.705952 0.000000 0.000000 0.708259 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D220F, 87288, 0x00D20314, 168.853, -188.555, -23.945, -0.835635, 0, 0, -0.549285, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20314 [168.852997 -188.554993 -23.945000] -0.835635 0.000000 0.000000 -0.549285 */
+VALUES (0x700D22CA, 87285, 0x00D205FA, 204.433, -119.226, -11.945, 0.999687, 0, 0, 0.024998, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205FA [204.432999 -119.225998 -11.945000] 0.999687 0.000000 0.000000 0.024998 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2210, 87288, 0x00D20111, 70.5242, -149.912, -29.945, -0.728227, 0, 0, 0.685336, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20111 [70.524200 -149.912003 -29.945000] -0.728227 0.000000 0.000000 0.685336 */
+VALUES (0x700D22CB, 87285, 0x00D20610, 226.791, -86.4536, -11.945, 0.720448, 0, 0, 0.693509, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20610 [226.791000 -86.453598 -11.945000] 0.720448 0.000000 0.000000 0.693509 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2211, 87288, 0x00D20199, 160.317, -141.232, -29.945, 0.060656, 0, 0, 0.998159, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20199 [160.317001 -141.231995 -29.945000] 0.060656 0.000000 0.000000 0.998159 */
+VALUES (0x700D22CC, 87285, 0x00D205F7, 204.798, -51.6981, -11.945, -0.000355, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205F7 [204.798004 -51.698101 -11.945000] -0.000355 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2212, 87288, 0x00D2017A, 129.944, -160.755, -29.945, 0.392618, 0, 0, 0.919702, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2017A [129.944000 -160.755005 -29.945000] 0.392618 0.000000 0.000000 0.919702 */
+VALUES (0x700D22CD, 87285, 0x00D205C4, 172.967, -82.5532, -11.945, -0.253791, 0, 0, 0.967259, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D205C4 [172.966995 -82.553200 -11.945000] -0.253791 0.000000 0.000000 0.967259 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2213, 87288, 0x00D20153, 107.734, -157.791, -29.945, -0.280686, 0, 0, 0.9598, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20153 [107.734001 -157.791000 -29.945000] -0.280686 0.000000 0.000000 0.959800 */
+VALUES (0x700D22CF, 87285, 0x00D20107, 64.138, -219.96, -29.945, -0.715466, 0, 0, 0.698647, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
+/* @teleloc 0x00D20107 [64.138000 -219.960007 -29.945000] -0.715466 0.000000 0.000000 0.698647 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2214, 87288, 0x00D202A9, 115.367, -211.106, -23.945, 0.999996, 0, 0, -0.002852, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D202A9 [115.366997 -211.106003 -23.945000] 0.999996 0.000000 0.000000 -0.002852 */
+VALUES (0x700D22D1, 87288, 0x00D2034A, 195.285, -174.433, -23.945, -0.895057, 0, 0, 0.445951, False, '2024-06-04 16:52:20'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2034A [195.285004 -174.432999 -23.945000] -0.895057 0.000000 0.000000 0.445951 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2215, 87288, 0x00D20261, 102.083, -176.752, -23.945, 0.830213, 0, 0, -0.557446, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20261 [102.083000 -176.751999 -23.945000] 0.830213 0.000000 0.000000 -0.557446 */
+VALUES (0x700D22D2, 87288, 0x00D2020C, 62.429, -163.266, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 17:23:09'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2020C [62.429001 -163.266006 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2216, 87288, 0x00D202BF, 129.337, -179.077, -23.945, 0.936355, 0, 0, 0.351056, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D202BF [129.337006 -179.076996 -23.945000] 0.936355 0.000000 0.000000 0.351056 */
+VALUES (0x700D22D3, 87288, 0x00D2020F, 62.7458, -187.501, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 17:23:37'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2020F [62.745800 -187.501007 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2217, 87288, 0x00D20251, 88.3512, -241.484, -23.945, 0.425972, 0, 0, 0.904736, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20251 [88.351196 -241.483994 -23.945000] 0.425972 0.000000 0.000000 0.904736 */
+VALUES (0x700D22D4, 87288, 0x00D20314, 168.655, -186.708, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 17:24:59'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20314 [168.654999 -186.707993 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2218, 87288, 0x00D20221, 68.8119, -220.933, -23.945, 0.337584, 0, 0, 0.941295, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20221 [68.811897 -220.932999 -23.945000] 0.337584 0.000000 0.000000 0.941295 */
+VALUES (0x700D22D5, 73190, 0x00D205E2, 179.972, -140.04, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:03:46');
+/* @teleloc 0x00D205E2 [179.972000 -140.039993 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2219, 87288, 0x00D20206, 48.3887, -241.778, -23.945, 0.223273, 0, 0, 0.974756, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20206 [48.388699 -241.778000 -23.945000] 0.223273 0.000000 0.000000 0.974756 */
+VALUES (0x700D22D6, 73190, 0x00D20593, 151.09, -89.1645, -11.945, 0.931298, 0, 0, -0.364258, False, '2024-06-04 18:05:07');
+/* @teleloc 0x00D20593 [151.089996 -89.164497 -11.945000] 0.931298 0.000000 0.000000 -0.364258 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D221A, 87288, 0x00D20240, 79.0263, -287.812, -23.945, 0.73467, 0, 0, 0.678424, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20240 [79.026299 -287.812012 -23.945000] 0.734670 0.000000 0.000000 0.678424 */
+VALUES (0x700D22D7, 73190, 0x00D2047E, 78.936, -89.0569, -11.945, 0.95355, 0, 0, 0.301236, False, '2024-06-04 18:06:03');
+/* @teleloc 0x00D2047E [78.935997 -89.056900 -11.945000] 0.953550 0.000000 0.000000 0.301236 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D221B, 87288, 0x00D2020A, 45.0108, -318.877, -23.945, 0.998723, 0, 0, -0.050524, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2020A [45.010799 -318.877014 -23.945000] 0.998723 0.000000 0.000000 -0.050524 */
+VALUES (0x700D22D8, 73190, 0x00D2043F, 50.205, -135.598, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:06:58');
+/* @teleloc 0x00D2043F [50.205002 -135.598007 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D221C, 87285, 0x00D20451, 61.0602, -121.951, -11.945, 0.505781, 0, 0, -0.862662, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20451 [61.060200 -121.950996 -11.945000] 0.505781 0.000000 0.000000 -0.862662 */
+VALUES (0x700D22D9, 73190, 0x00D2055A, 128.322, -169.075, -11.945, -0.963114, 0, 0, -0.269095, False, '2024-06-04 18:11:34');
+/* @teleloc 0x00D2055A [128.322006 -169.074997 -11.945000] -0.963114 0.000000 0.000000 -0.269095 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D221D, 87285, 0x00D20454, 61.8536, -149.145, -11.945, 0.881641, 0, 0, -0.471921, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D20454 [61.853600 -149.145004 -11.945000] 0.881641 0.000000 0.000000 -0.471921 */
+VALUES (0x700D22DA, 73190, 0x00D20554, 129.204, -149.331, -11.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:12:05');
+/* @teleloc 0x00D20554 [129.203995 -149.330994 -11.945000] 0.923880 0.000000 0.000000 0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D221E, 87285, 0x00D204DE, 100.273, -149.033, -11.945, 0.974225, 0, 0, -0.22558, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D204DE [100.273003 -149.033005 -11.945000] 0.974225 0.000000 0.000000 -0.225580 */
+VALUES (0x700D22DB, 73191, 0x00D20247, 89.1972, -178.786, -23.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:15:01');
+/* @teleloc 0x00D20247 [89.197197 -178.785995 -23.945000] 0.923880 0.000000 0.000000 0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D221F, 87285, 0x00D2048A, 81.2812, -140.882, -11.945, 0.999091, 0, 0, 0.042635, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D2048A [81.281197 -140.882004 -11.945000] 0.999091 0.000000 0.000000 0.042635 */
+VALUES (0x700D22DC, 34830, 0x00D20355, 199.263, -300.965, -24.2098, 1, 0, 0, 0, False, '2024-06-04 18:20:55'); /* Northern Catacombs Exit */
+/* @teleloc 0x00D20355 [199.263000 -300.964996 -24.209801] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2220, 87285, 0x00D205CD, 168.553, -147.191, -11.945, 0.900447, 0, 0, 0.434966, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205CD [168.552994 -147.190994 -11.945000] 0.900447 0.000000 0.000000 0.434966 */
+VALUES (0x700D22DD, 34830, 0x00D201DF, 31.3129, -301.707, -24.2098, 1, 0, 0, 0, False, '2024-06-04 18:21:34'); /* Northern Catacombs Exit */
+/* @teleloc 0x00D201DF [31.312901 -301.707001 -24.209801] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2221, 87285, 0x00D205CA, 167.805, -121.532, -11.945, 0.519505, 0, 0, 0.854468, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D205CA [167.804993 -121.531998 -11.945000] 0.519505 0.000000 0.000000 0.854468 */
+VALUES (0x700D22DE, 87288, 0x00D20206, 45.2879, -243.315, -23.945, 0, 0, 0, 1, False, '2024-06-04 18:22:25'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20206 [45.287899 -243.315002 -23.945000] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2222, 87285, 0x00D201A9, 163.666, -219.783, -29.945, 0.729675, 0, 0, -0.683794, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
-/* @teleloc 0x00D201A9 [163.666000 -219.783005 -29.945000] 0.729675 0.000000 0.000000 -0.683794 */
+VALUES (0x700D22DF, 87288, 0x00D2023F, 77.4848, -284.663, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 18:23:05'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2023F [77.484802 -284.662994 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2223, 87291, 0x00D2015B, 120.184, -124.14, -30.2098, 0, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Humid Guruk Caverns */
-/* @teleloc 0x00D2015B [120.183998 -124.139999 -30.209801] 0.000000 0.000000 0.000000 1.000000 */
+VALUES (0x700D22E0, 87288, 0x00D202FF, 153.524, -284.536, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 18:23:52'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D202FF [153.524002 -284.536011 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2224, 34830, 0x00D201B4, 170.179, -150.141, -30.2098, 0.703238, 0, 0, 0.710954, False, '2021-11-01 00:00:00'); /* Northern Catacombs Exit */
-/* @teleloc 0x00D201B4 [170.179001 -150.141006 -30.209801] 0.703238 0.000000 0.000000 0.710954 */
+VALUES (0x700D22E1, 87288, 0x00D20332, 183.164, -245.538, -23.945, 0.292173, 0, 0, -0.956366, False, '2024-06-04 18:24:56'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20332 [183.164001 -245.537994 -23.945000] 0.292173 0.000000 0.000000 -0.956366 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2225, 34830, 0x00D20111, 69.4372, -149.79, -30.2098, 0.689419, 0, 0, -0.724363, False, '2021-11-01 00:00:00'); /* Northern Catacombs Exit */
-/* @teleloc 0x00D20111 [69.437202 -149.789993 -30.209801] 0.689419 0.000000 0.000000 -0.724363 */
+VALUES (0x700D22E2, 87288, 0x00D2030B, 156.03, -246.767, -23.945, 0.947278, 0, 0, 0.320413, False, '2024-06-04 18:25:50'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2030B [156.029999 -246.766998 -23.945000] 0.947278 0.000000 0.000000 0.320413 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2226, 87288, 0x00D20171, 130.663, -139.288, -29.945, -0.470029, 0, 0, -0.882651, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20171 [130.662994 -139.287994 -29.945000] -0.470029 0.000000 0.000000 -0.882651 */
+VALUES (0x700D22E6, 87288, 0x00D20215, 64.6674, -229.002, -23.945, -0.967405, 0, 0, 0.253233, False, '2024-06-04 18:28:32'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D20215 [64.667397 -229.001999 -23.945000] -0.967405 0.000000 0.000000 0.253233 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2227, 87288, 0x00D2013B, 103.581, -138.91, -29.945, 0.453147, 0, 0, -0.891436, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D2013B [103.581001 -138.910004 -29.945000] 0.453147 0.000000 0.000000 -0.891436 */
+VALUES (0x700D22E9, 87288, 0x00D202E3, 137.336, -254.854, -23.945, -0.544272, 0, 0, 0.838909, False, '2024-06-04 18:31:30'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D202E3 [137.335999 -254.854004 -23.945000] -0.544272 0.000000 0.000000 0.838909 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2228, 87288, 0x00D20138, 87.8147, -159.934, -29.945, -0.998351, 0, 0, -0.05741, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20138 [87.814697 -159.934006 -29.945000] -0.998351 0.000000 0.000000 -0.057410 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D2229, 87288, 0x00D20193, 151.871, -160.662, -29.945, -0.988153, 0, 0, 0.153471, False, '2021-11-01 00:00:00'); /* Northern Catacombs Lower Generator */
-/* @teleloc 0x00D20193 [151.871002 -160.662003 -29.945000] -0.988153 0.000000 0.000000 0.153471 */
+VALUES (0x700D22EA, 87288, 0x00D2023C, 84.1921, -244.822, -23.945, 0.391163, 0, 0, 0.920321, False, '2024-06-04 18:38:43'); /* Northern Catacombs Lower Generator */
+/* @teleloc 0x00D2023C [84.192101 -244.822006 -23.945000] 0.391163 0.000000 0.000000 0.920321 */

--- a/Database/Patches/6 LandBlockExtendedData/00D2.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00D2.sql
@@ -25,10 +25,6 @@ VALUES (0x700D203C, 34830, 0x00D20539, 118.502, -216.499, -12.2098, -0.34202, 0,
 /* @teleloc 0x00D20539 [118.501999 -216.498993 -12.209800] -0.342020 0.000000 0.000000 -0.939693 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D204F, 35801, 0x00D2060F, 228.617, -81.2211, -12.063, -0.925411, 0, 0, 0.378964, False, '2021-11-01 00:00:00'); /* Temple of the Three, Ritual Chambers */
-/* @teleloc 0x00D2060F [228.617004 -81.221100 -12.063000] -0.925411 0.000000 0.000000 0.378964 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D2296, 87285, 0x00D205EC, 182.447, -233.84, -11.945, 0.95201, 0, 0, 0.306068, False, '2021-11-01 00:00:00'); /* Northern Catacombs Upper Generator */
 /* @teleloc 0x00D205EC [182.447006 -233.839996 -11.945000] 0.952010 0.000000 0.000000 0.306068 */
 
@@ -233,31 +229,31 @@ VALUES (0x700D22D4, 87288, 0x00D20314, 168.655, -186.708, -23.945, 0.707107, 0, 
 /* @teleloc 0x00D20314 [168.654999 -186.707993 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22D5, 73190, 0x00D205E2, 179.972, -140.04, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:03:46');
+VALUES (0x700D22D5, 73190, 0x00D205E2, 179.972, -140.04, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:03:46'); /* Northern Catacombs Upper Mixed Gen */
 /* @teleloc 0x00D205E2 [179.972000 -140.039993 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22D6, 73190, 0x00D20593, 151.09, -89.1645, -11.945, 0.931298, 0, 0, -0.364258, False, '2024-06-04 18:05:07');
+VALUES (0x700D22D6, 73190, 0x00D20593, 151.09, -89.1645, -11.945, 0.931298, 0, 0, -0.364258, False, '2024-06-04 18:05:07'); /* Northern Catacombs Upper Mixed Gen */
 /* @teleloc 0x00D20593 [151.089996 -89.164497 -11.945000] 0.931298 0.000000 0.000000 -0.364258 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22D7, 73190, 0x00D2047E, 78.936, -89.0569, -11.945, 0.95355, 0, 0, 0.301236, False, '2024-06-04 18:06:03');
+VALUES (0x700D22D7, 73190, 0x00D2047E, 78.936, -89.0569, -11.945, 0.95355, 0, 0, 0.301236, False, '2024-06-04 18:06:03'); /* Northern Catacombs Upper Mixed Gen */
 /* @teleloc 0x00D2047E [78.935997 -89.056900 -11.945000] 0.953550 0.000000 0.000000 0.301236 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22D8, 73190, 0x00D2043F, 50.205, -135.598, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:06:58');
+VALUES (0x700D22D8, 73190, 0x00D2043F, 50.205, -135.598, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:06:58'); /* Northern Catacombs Upper Mixed Gen */
 /* @teleloc 0x00D2043F [50.205002 -135.598007 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22D9, 73190, 0x00D2055A, 128.322, -169.075, -11.945, -0.963114, 0, 0, -0.269095, False, '2024-06-04 18:11:34');
+VALUES (0x700D22D9, 73190, 0x00D2055A, 128.322, -169.075, -11.945, -0.963114, 0, 0, -0.269095, False, '2024-06-04 18:11:34'); /* Northern Catacombs Upper Mixed Gen */
 /* @teleloc 0x00D2055A [128.322006 -169.074997 -11.945000] -0.963114 0.000000 0.000000 -0.269095 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22DA, 73190, 0x00D20554, 129.204, -149.331, -11.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:12:05');
+VALUES (0x700D22DA, 73190, 0x00D20554, 129.204, -149.331, -11.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:12:05'); /* Northern Catacombs Upper Mixed Gen */
 /* @teleloc 0x00D20554 [129.203995 -149.330994 -11.945000] 0.923880 0.000000 0.000000 0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D22DB, 73191, 0x00D20247, 89.1972, -178.786, -23.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:15:01');
+VALUES (0x700D22DB, 73191, 0x00D20247, 89.1972, -178.786, -23.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:15:01'); /* Northern Catacombs Lower Mixed Gen */
 /* @teleloc 0x00D20247 [89.197197 -178.785995 -23.945000] 0.923880 0.000000 0.000000 0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/00D3.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00D3.sql
@@ -1,6 +1,14 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x00D3;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D3001, 34832, 0x00D30115, 70.4479, -159.911, -30.2098, 0.939373, 0, 0, -0.342898, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Exit */
+/* @teleloc 0x00D30115 [70.447899 -159.910995 -30.209801] 0.939373 0.000000 0.000000 -0.342898 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D3007, 34832, 0x00D301B8, 169.868, -159.664, -30.2098, 0.921061, 0, 0, 0.389418, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Exit */
+/* @teleloc 0x00D301B8 [169.867996 -159.664001 -30.209801] 0.921061 0.000000 0.000000 0.389418 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D3037, 34832, 0x00D30511, 111.579, -216.585, -12.2098, -0.923879, 0, 0, -0.382684, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Exit */
 /* @teleloc 0x00D30511 [111.579002 -216.585007 -12.209800] -0.923879 0.000000 0.000000 -0.382684 */
 
@@ -13,269 +21,281 @@ VALUES (0x700D303C, 34832, 0x00D30539, 118.502, -216.499, -12.2098, -0.34202, 0,
 /* @teleloc 0x00D30539 [118.501999 -216.498993 -12.209800] -0.342020 0.000000 0.000000 -0.939693 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D304D, 35210, 0x00D30448, 51.3391, -221.362, -12.2098, -0.956205, 0, 0, -0.292699, False, '2021-11-01 00:00:00'); /* Swamp Cavern */
-/* @teleloc 0x00D30448 [51.339100 -221.362000 -12.209800] -0.956205 0.000000 0.000000 -0.292699 */
+VALUES (0x700D3296, 87292, 0x00D305EC, 182.447, -233.84, -11.945, 0.95201, 0, 0, 0.306068, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305EC [182.447006 -233.839996 -11.945000] 0.952010 0.000000 0.000000 0.306068 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3119, 87292, 0x00D305ED, 184.908, -238.666, -11.945, 0.999311, 0, 0, -0.037112, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305ED [184.908005 -238.666000 -11.945000] 0.999311 0.000000 0.000000 -0.037112 */
+VALUES (0x700D3297, 87292, 0x00D3060D, 217.43, -203.992, -11.945, -0.701028, 0, 0, -0.713134, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3060D [217.429993 -203.992004 -11.945000] -0.701028 0.000000 0.000000 -0.713134 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D311A, 87292, 0x00D3060D, 218.463, -204.715, -11.945, 0.703988, 0, 0, 0.710212, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3060D [218.462997 -204.714996 -11.945000] 0.703988 0.000000 0.000000 0.710212 */
+VALUES (0x700D3298, 87292, 0x00D305E7, 184.809, -171.444, -11.945, -0.260278, 0, 0, 0.965534, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305E7 [184.809006 -171.444000 -11.945000] -0.260278 0.000000 0.000000 0.965534 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D311B, 87292, 0x00D305F3, 185.296, -171.686, -11.945, -0.287938, 0, 0, 0.957649, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305F3 [185.296005 -171.686005 -11.945000] -0.287938 0.000000 0.000000 0.957649 */
+VALUES (0x700D329A, 87292, 0x00D30495, 77.5686, -206.424, -11.945, 0.856562, 0, 0, 0.516044, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30495 [77.568604 -206.423996 -11.945000] 0.856562 0.000000 0.000000 0.516044 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D311C, 87292, 0x00D305AA, 151.667, -206.626, -11.945, -0.705708, 0, 0, 0.708503, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305AA [151.667007 -206.626007 -11.945000] -0.705708 0.000000 0.000000 0.708503 */
+VALUES (0x700D329B, 87292, 0x00D30435, 42.2548, -238.64, -11.945, 0.944352, 0, 0, -0.328937, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30435 [42.254799 -238.639999 -11.945000] 0.944352 0.000000 0.000000 -0.328937 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D311D, 87292, 0x00D305E2, 180.325, -143.489, -11.945, 1, 0, 0, 0.000374, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305E2 [180.324997 -143.488998 -11.945000] 1.000000 0.000000 0.000000 0.000374 */
+VALUES (0x700D329C, 87292, 0x00D3041A, 11.8089, -205.235, -11.945, 0.707619, 0, 0, -0.706594, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3041A [11.808900 -205.235001 -11.945000] 0.707619 0.000000 0.000000 -0.706594 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D311E, 87292, 0x00D30604, 205.118, -117.649, -11.945, -0.998814, 0, 0, -0.048699, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30604 [205.117996 -117.649002 -11.945000] -0.998814 0.000000 0.000000 -0.048699 */
+VALUES (0x700D329D, 87292, 0x00D30432, 43.615, -172.706, -11.945, 0.010168, 0, 0, -0.999948, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30432 [43.615002 -172.705994 -11.945000] 0.010168 0.000000 0.000000 -0.999948 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D311F, 87292, 0x00D30610, 227.28, -85.1335, -11.945, -0.696242, 0, 0, -0.717807, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30610 [227.279999 -85.133499 -11.945000] -0.696242 0.000000 0.000000 -0.717807 */
+VALUES (0x700D329F, 87292, 0x00D30420, 23.9231, -118.79, -11.945, 0.985956, 0, 0, -0.167007, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30420 [23.923100 -118.790001 -11.945000] 0.985956 0.000000 0.000000 -0.167007 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3120, 87292, 0x00D305F7, 203.445, -52.3864, -11.945, -0.021927, 0, 0, 0.99976, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305F7 [203.445007 -52.386398 -11.945000] -0.021927 0.000000 0.000000 0.999760 */
+VALUES (0x700D32A0, 87292, 0x00D30414, 1.4181, -85.3999, -11.945, 0.703565, 0, 0, -0.710631, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30414 [1.418100 -85.399902 -11.945000] 0.703565 0.000000 0.000000 -0.710631 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3121, 87292, 0x00D305C4, 171.446, -81.2691, -11.945, -0.480107, 0, 0, 0.87721, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305C4 [171.445999 -81.269096 -11.945000] -0.480107 0.000000 0.000000 0.877210 */
+VALUES (0x700D32A1, 87292, 0x00D30425, 25.9497, -52.0979, -11.945, 0.007811, 0, 0, -0.999969, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30425 [25.949699 -52.097900 -11.945000] 0.007811 0.000000 0.000000 -0.999969 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3122, 87292, 0x00D30593, 149.562, -89.1742, -11.945, 0.925477, 0, 0, -0.378803, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30593 [149.561996 -89.174202 -11.945000] 0.925477 0.000000 0.000000 -0.378803 */
+VALUES (0x700D32A2, 87292, 0x00D3044B, 58.0569, -83.0979, -11.945, -0.693751, 0, 0, -0.720215, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3044B [58.056900 -83.097900 -11.945000] -0.693751 0.000000 0.000000 -0.720215 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3123, 87292, 0x00D304EF, 114.951, -67.5337, -11.945, 0.998729, 0, 0, 0.050396, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D304EF [114.950996 -67.533699 -11.945000] 0.998729 0.000000 0.000000 0.050396 */
+VALUES (0x700D32A4, 87292, 0x00D30479, 80.7105, -34.9683, -11.945, -0.700354, 0, 0, 0.713796, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30479 [80.710503 -34.968300 -11.945000] -0.700354 0.000000 0.000000 0.713796 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3124, 87292, 0x00D3058F, 147.837, -35.2189, -11.945, 0.719826, 0, 0, 0.694155, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3058F [147.837006 -35.218899 -11.945000] 0.719826 0.000000 0.000000 0.694155 */
+VALUES (0x700D32A5, 87292, 0x00D304EA, 114.698, -1.02804, -11.945, 0.001506, 0, 0, 0.999999, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D304EA [114.697998 -1.028040 -11.945000] 0.001506 0.000000 0.000000 0.999999 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3125, 87292, 0x00D304EA, 114.501, -1.73729, -11.945, -0.015686, 0, 0, 0.999877, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D304EA [114.500999 -1.737290 -11.945000] -0.015686 0.000000 0.000000 0.999877 */
+VALUES (0x700D32A6, 87292, 0x00D3058F, 148.11, -35.8981, -11.945, 0.721077, 0, 0, 0.692855, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3058F [148.110001 -35.898102 -11.945000] 0.721077 0.000000 0.000000 0.692855 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3126, 87292, 0x00D30479, 81.7618, -33.7637, -11.945, -0.616088, 0, 0, 0.787677, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30479 [81.761803 -33.763699 -11.945000] -0.616088 0.000000 0.000000 0.787677 */
+VALUES (0x700D32A7, 87292, 0x00D30518, 123.425, -80.828, -11.945, -0.022498, 0, 0, 0.999747, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30518 [123.425003 -80.828003 -11.945000] -0.022498 0.000000 0.000000 0.999747 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3127, 87292, 0x00D304CC, 102.307, -88.1805, -11.945, -0.999988, 0, 0, -0.004957, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D304CC [102.306999 -88.180496 -11.945000] -0.999988 0.000000 0.000000 -0.004957 */
+VALUES (0x700D32A8, 87292, 0x00D304F0, 107.799, -82.9879, -11.945, -0.014802, 0, 0, 0.99989, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D304F0 [107.799004 -82.987900 -11.945000] -0.014802 0.000000 0.000000 0.999890 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3128, 87292, 0x00D30518, 115.843, -81.6818, -11.945, -0.057636, 0, 0, -0.998338, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30518 [115.843002 -81.681801 -11.945000] -0.057636 0.000000 0.000000 -0.998338 */
+VALUES (0x700D32A9, 87292, 0x00D30451, 61.992, -122.576, -11.945, -0.567332, 0, 0, 0.823489, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30451 [61.992001 -122.575996 -11.945000] -0.567332 0.000000 0.000000 0.823489 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3129, 87292, 0x00D305CA, 168.337, -122.063, -11.945, -0.302841, 0, 0, -0.953041, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305CA [168.337006 -122.063004 -11.945000] -0.302841 0.000000 0.000000 -0.953041 */
+VALUES (0x700D32AA, 87292, 0x00D30454, 60.9961, -148.639, -11.945, -0.909551, 0, 0, 0.415593, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30454 [60.996101 -148.639008 -11.945000] -0.909551 0.000000 0.000000 0.415593 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D312A, 87292, 0x00D305CD, 168.878, -148.45, -11.945, -0.883666, 0, 0, -0.468117, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D305CD [168.878006 -148.449997 -11.945000] -0.883666 0.000000 0.000000 -0.468117 */
+VALUES (0x700D32AB, 87292, 0x00D304E8, 102.423, -188.321, -11.945, -0.951349, 0, 0, 0.308114, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D304E8 [102.422997 -188.320999 -11.945000] -0.951349 0.000000 0.000000 0.308114 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D312B, 87292, 0x00D3055E, 128.531, -188.608, -11.945, -0.93081, 0, 0, -0.365504, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3055E [128.531006 -188.608002 -11.945000] -0.930810 0.000000 0.000000 -0.365504 */
+VALUES (0x700D32AC, 87292, 0x00D3055E, 126.666, -187.149, -11.945, -0.912322, 0, 0, -0.409473, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3055E [126.666000 -187.149002 -11.945000] -0.912322 0.000000 0.000000 -0.409473 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D312C, 87292, 0x00D304E8, 101.889, -188.633, -11.945, -0.964267, 0, 0, 0.264932, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D304E8 [101.889000 -188.632996 -11.945000] -0.964267 0.000000 0.000000 0.264932 */
+VALUES (0x700D32AD, 87292, 0x00D305CD, 168.941, -148.51, -11.945, -0.895479, 0, 0, -0.445104, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305CD [168.940994 -148.509995 -11.945000] -0.895479 0.000000 0.000000 -0.445104 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D312D, 87292, 0x00D30454, 61.5409, -148.248, -11.945, -0.899667, 0, 0, 0.436577, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30454 [61.540901 -148.248001 -11.945000] -0.899667 0.000000 0.000000 0.436577 */
+VALUES (0x700D32AE, 87292, 0x00D305CA, 168.473, -122.253, -11.945, -0.403445, 0, 0, -0.915004, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305CA [168.473007 -122.252998 -11.945000] -0.403445 0.000000 0.000000 -0.915004 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D312E, 87292, 0x00D30451, 61.3418, -121.896, -11.945, -0.51509, 0, 0, 0.857136, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30451 [61.341801 -121.896004 -11.945000] -0.515090 0.000000 0.000000 0.857136 */
+VALUES (0x700D32B1, 87292, 0x00D3059F, 150.165, -140.092, -11.945, -0.986717, 0, 0, -0.162447, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3059F [150.164993 -140.091995 -11.945000] -0.986717 0.000000 0.000000 -0.162447 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D312F, 87292, 0x00D30557, 130.94, -161.376, -11.945, 0.133007, 0, 0, 0.991115, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30557 [130.940002 -161.376007 -11.945000] 0.133007 0.000000 0.000000 0.991115 */
+VALUES (0x700D32B2, 87295, 0x00D3051A, 121.718, -100.959, -11.945, 0.031303, 0, 0, -0.99951, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3051A [121.718002 -100.959000 -11.945000] 0.031303 0.000000 0.000000 -0.999510 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3130, 87292, 0x00D30554, 129.535, -148.581, -11.945, 0.982398, 0, 0, 0.186799, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30554 [129.535004 -148.580994 -11.945000] 0.982398 0.000000 0.000000 0.186799 */
+VALUES (0x700D32B3, 87295, 0x00D304F2, 111.83, -100.797, -11.945, 0.031303, 0, 0, -0.99951, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D304F2 [111.830002 -100.796997 -11.945000] 0.031303 0.000000 0.000000 -0.999510 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3131, 87292, 0x00D3059F, 150.056, -136.822, -11.945, 0.978722, 0, 0, 0.205192, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3059F [150.056000 -136.822006 -11.945000] 0.978722 0.000000 0.000000 0.205192 */
+VALUES (0x700D32B4, 87292, 0x00D3048A, 79.9326, -138.94, -11.945, 0.732299, 0, 0, -0.680983, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D3048A [79.932602 -138.940002 -11.945000] 0.732299 0.000000 0.000000 -0.680983 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3132, 87295, 0x00D3051A, 123.085, -100.129, -11.945, 0.045383, 0, 0, 0.99897, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3051A [123.084999 -100.128998 -11.945000] 0.045383 0.000000 0.000000 0.998970 */
+VALUES (0x700D32B5, 87292, 0x00D304DE, 100.998, -148.749, -11.945, 0.9751, 0, 0, -0.221766, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D304DE [100.998001 -148.748993 -11.945000] 0.975100 0.000000 0.000000 -0.221766 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3133, 87295, 0x00D304F2, 110.236, -99.9066, -11.945, -0.004602, 0, 0, 0.999989, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D304F2 [110.236000 -99.906601 -11.945000] -0.004602 0.000000 0.000000 0.999989 */
+VALUES (0x700D32B6, 87295, 0x00D302D3, 140.42, -139.003, -23.945, -0.931624, 0, 0, 0.363424, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D302D3 [140.419998 -139.003006 -23.945000] -0.931624 0.000000 0.000000 0.363424 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3134, 87292, 0x00D3048A, 80.6535, -139.836, -11.945, -0.802534, 0, 0, 0.596606, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3048A [80.653503 -139.835999 -11.945000] -0.802534 0.000000 0.000000 0.596606 */
+VALUES (0x700D32B7, 87295, 0x00D30311, 168.233, -162.712, -23.945, 0.303031, 0, 0, 0.952981, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30311 [168.233002 -162.712006 -23.945000] 0.303031 0.000000 0.000000 0.952981 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3135, 87292, 0x00D304DE, 101.371, -149.811, -11.945, -0.995116, 0, 0, 0.098716, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D304DE [101.371002 -149.811005 -11.945000] -0.995116 0.000000 0.000000 0.098716 */
+VALUES (0x700D32B9, 87295, 0x00D302CA, 125.753, -226.955, -23.945, 0.996138, 0, 0, 0.087802, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D302CA [125.752998 -226.955002 -23.945000] 0.996138 0.000000 0.000000 0.087802 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3136, 87295, 0x00D30274, 114.498, -111.122, -23.945, 0.01595, 0, 0, -0.999873, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30274 [114.498001 -111.122002 -23.945000] 0.015950 0.000000 0.000000 -0.999873 */
+VALUES (0x700D32BA, 87295, 0x00D3026D, 104.789, -228.611, -23.945, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3026D [104.789001 -228.610992 -23.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3137, 87295, 0x00D30311, 168.319, -162.751, -23.945, -0.405222, 0, 0, -0.914218, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30311 [168.319000 -162.751007 -23.945000] -0.405222 0.000000 0.000000 -0.914218 */
+VALUES (0x700D32BD, 87295, 0x00D30242, 88.864, -139.202, -23.945, -0.921554, 0, 0, -0.388249, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30242 [88.863998 -139.201996 -23.945000] -0.921554 0.000000 0.000000 -0.388249 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3138, 87295, 0x00D30314, 169.491, -187.983, -23.945, -0.835135, 0, 0, -0.550045, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30314 [169.490997 -187.983002 -23.945000] -0.835135 0.000000 0.000000 -0.550045 */
+VALUES (0x700D32BE, 87295, 0x00D30274, 114.699, -112.242, -23.945, 0, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30274 [114.698997 -112.241997 -23.945000] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3139, 87295, 0x00D302AD, 120.993, -227.982, -23.945, -0.999956, 0, 0, 0.00941, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D302AD [120.992996 -227.981995 -23.945000] -0.999956 0.000000 0.000000 0.009410 */
+VALUES (0x700D32BF, 87295, 0x00D30360, 215.561, -155.491, -23.945, -0.490731, 0, 0, -0.871311, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30360 [215.561005 -155.490997 -23.945000] -0.490731 0.000000 0.000000 -0.871311 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D313A, 87295, 0x00D3028B, 105.318, -227.499, -23.945, -0.999956, 0, 0, 0.00941, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3028B [105.318001 -227.498993 -23.945000] -0.999956 0.000000 0.000000 0.009410 */
+VALUES (0x700D32C1, 87295, 0x00D301A9, 163.851, -220.844, -29.945, 0.954613, 0, 0, -0.297849, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D301A9 [163.850998 -220.843994 -29.945000] 0.954613 0.000000 0.000000 -0.297849 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D313B, 87295, 0x00D3020F, 61.4377, -187.747, -23.945, -0.935934, 0, 0, 0.352175, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3020F [61.437698 -187.746994 -23.945000] -0.935934 0.000000 0.000000 0.352175 */
+VALUES (0x700D32C2, 87295, 0x00D302BF, 129.277, -181.197, -23.945, 0.681745, 0, 0, 0.73159, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D302BF [129.276993 -181.197006 -23.945000] 0.681745 0.000000 0.000000 0.731590 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D313C, 87295, 0x00D3020C, 60.6624, -161.828, -23.945, -0.408671, 0, 0, 0.912682, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3020C [60.662399 -161.828003 -23.945000] -0.408671 0.000000 0.000000 0.912682 */
+VALUES (0x700D32C3, 87295, 0x00D30261, 102.31, -180.98, -23.945, 0.729053, 0, 0, -0.684457, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30261 [102.309998 -180.979996 -23.945000] 0.729053 0.000000 0.000000 -0.684457 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D313D, 87295, 0x00D30242, 89.1855, -138.437, -23.945, 0.480415, 0, 0, 0.877041, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30242 [89.185501 -138.436996 -23.945000] 0.480415 0.000000 0.000000 0.877041 */
+VALUES (0x700D32C4, 87295, 0x00D30286, 109.986, -208.359, -23.945, 1, 0, 0, -0.000006, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30286 [109.986000 -208.358994 -23.945000] 1.000000 0.000000 0.000000 -0.000006 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D313E, 87295, 0x00D302E9, 148.228, -140.369, -23.945, 0.083185, 0, 0, -0.996534, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D302E9 [148.227997 -140.369003 -23.945000] 0.083185 0.000000 0.000000 -0.996534 */
+VALUES (0x700D32C5, 87295, 0x00D302A8, 120.149, -206.752, -23.945, 1, 0, 0, -0.000006, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D302A8 [120.149002 -206.751999 -23.945000] 1.000000 0.000000 0.000000 -0.000006 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D313F, 87295, 0x00D3033D, 194.871, -175.261, -23.945, -0.940593, 0, 0, 0.339537, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3033D [194.871002 -175.261002 -23.945000] -0.940593 0.000000 0.000000 0.339537 */
+VALUES (0x700D32C6, 87295, 0x00D30165, 119.921, -163.452, -29.945, 0.0083, 0, 0, -0.999966, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30165 [119.920998 -163.451996 -29.945000] 0.008300 0.000000 0.000000 -0.999966 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3140, 87295, 0x00D3035F, 217.715, -151.551, -23.945, -0.344623, 0, 0, -0.938741, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3035F [217.714996 -151.550995 -23.945000] -0.344623 0.000000 0.000000 -0.938741 */
+VALUES (0x700D32C7, 87295, 0x00D30127, 79.9068, -149.907, -29.945, 0.702552, 0, 0, -0.711633, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30127 [79.906799 -149.906998 -29.945000] 0.702552 0.000000 0.000000 -0.711633 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3141, 87295, 0x00D301C2, 165.016, -219.561, -29.945, 0.7191, 0, 0, -0.694907, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D301C2 [165.016006 -219.561005 -29.945000] 0.719100 0.000000 0.000000 -0.694907 */
+VALUES (0x700D32C8, 87295, 0x00D3019D, 160.235, -150.266, -29.945, 0.705952, 0, 0, 0.708259, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3019D [160.235001 -150.266006 -29.945000] 0.705952 0.000000 0.000000 0.708259 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3142, 87295, 0x00D30221, 69.352, -224.526, -23.945, -0.229512, 0, 0, -0.973306, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30221 [69.351997 -224.526001 -23.945000] -0.229512 0.000000 0.000000 -0.973306 */
+VALUES (0x700D32CA, 87292, 0x00D305FA, 204.433, -119.226, -11.945, 0.999687, 0, 0, 0.024998, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305FA [204.432999 -119.225998 -11.945000] 0.999687 0.000000 0.000000 0.024998 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3143, 87295, 0x00D30272, 97.4702, -255.408, -23.945, -0.884728, 0, 0, -0.466108, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30272 [97.470200 -255.408005 -23.945000] -0.884728 0.000000 0.000000 -0.466108 */
+VALUES (0x700D32CB, 87292, 0x00D30610, 226.791, -86.4536, -11.945, 0.720448, 0, 0, 0.693509, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30610 [226.791000 -86.453598 -11.945000] 0.720448 0.000000 0.000000 0.693509 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3144, 87295, 0x00D30206, 48.3641, -243.161, -23.945, -0.071454, 0, 0, -0.997444, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30206 [48.364101 -243.160995 -23.945000] -0.071454 0.000000 0.000000 -0.997444 */
+VALUES (0x700D32CC, 87292, 0x00D305F7, 204.798, -51.6981, -11.945, -0.000355, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305F7 [204.798004 -51.698101 -11.945000] -0.000355 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3145, 87295, 0x00D3023F, 78.9238, -284.781, -23.945, -0.715601, 0, 0, -0.698509, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3023F [78.923798 -284.781006 -23.945000] -0.715601 0.000000 0.000000 -0.698509 */
+VALUES (0x700D32CD, 87292, 0x00D305C4, 172.967, -82.5532, -11.945, -0.253791, 0, 0, 0.967259, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D305C4 [172.966995 -82.553200 -11.945000] -0.253791 0.000000 0.000000 0.967259 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3146, 87295, 0x00D3020A, 45.2551, -318.736, -23.945, -0.999976, 0, 0, -0.006973, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3020A [45.255100 -318.735992 -23.945000] -0.999976 0.000000 0.000000 -0.006973 */
+VALUES (0x700D32CF, 87292, 0x00D30107, 64.138, -219.96, -29.945, -0.715466, 0, 0, 0.698647, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
+/* @teleloc 0x00D30107 [64.138000 -219.960007 -29.945000] -0.715466 0.000000 0.000000 0.698647 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3147, 87295, 0x00D301DF, 31.4456, -302.498, -23.945, 0.487097, 0, 0, -0.873348, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D301DF [31.445601 -302.497986 -23.945000] 0.487097 0.000000 0.000000 -0.873348 */
+VALUES (0x700D32D1, 87295, 0x00D3034A, 195.285, -174.433, -23.945, -0.895057, 0, 0, 0.445951, False, '2024-06-04 16:52:20'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3034A [195.285004 -174.432999 -23.945000] -0.895057 0.000000 0.000000 0.445951 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3148, 87295, 0x00D30286, 107.408, -210.024, -23.945, -0.994285, 0, 0, 0.106758, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30286 [107.407997 -210.024002 -23.945000] -0.994285 0.000000 0.000000 0.106758 */
+VALUES (0x700D32D2, 87295, 0x00D3020C, 62.429, -163.266, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 17:23:09'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3020C [62.429001 -163.266006 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3149, 87295, 0x00D302A8, 121.944, -209.161, -23.945, -0.998563, 0, 0, -0.053593, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D302A8 [121.944000 -209.160995 -23.945000] -0.998563 0.000000 0.000000 -0.053593 */
+VALUES (0x700D32D3, 87295, 0x00D3020F, 62.7458, -187.501, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 17:23:37'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3020F [62.745800 -187.501007 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D314A, 87295, 0x00D30260, 102.742, -173.562, -23.945, -0.531983, 0, 0, 0.846755, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30260 [102.741997 -173.561996 -23.945000] -0.531983 0.000000 0.000000 0.846755 */
+VALUES (0x700D32D4, 87295, 0x00D30314, 168.655, -186.708, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 17:24:59'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30314 [168.654999 -186.707993 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D314B, 87295, 0x00D302BE, 128.285, -172.58, -23.945, -0.405204, 0, 0, -0.914226, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D302BE [128.285004 -172.580002 -23.945000] -0.405204 0.000000 0.000000 -0.914226 */
+VALUES (0x700D32D5, 73192, 0x00D305E2, 179.972, -140.04, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:03:46'); /* Eastern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D305E2 [179.972000 -140.039993 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D314C, 87295, 0x00D3019D, 160.729, -151.36, -29.945, 0.518672, 0, 0, 0.854973, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D3019D [160.729004 -151.360001 -29.945000] 0.518672 0.000000 0.000000 0.854973 */
+VALUES (0x700D32D6, 73192, 0x00D30593, 151.09, -89.1645, -11.945, 0.931298, 0, 0, -0.364258, False, '2024-06-04 18:05:07'); /* Eastern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D30593 [151.089996 -89.164497 -11.945000] 0.931298 0.000000 0.000000 -0.364258 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D314D, 87295, 0x00D30127, 80.9431, -149.6, -29.945, -0.699288, 0, 0, 0.71484, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Lower Generator */
-/* @teleloc 0x00D30127 [80.943100 -149.600006 -29.945000] -0.699288 0.000000 0.000000 0.714840 */
+VALUES (0x700D32D7, 73192, 0x00D3047E, 78.936, -89.0569, -11.945, 0.95355, 0, 0, 0.301236, False, '2024-06-04 18:06:03'); /* Eastern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D3047E [78.935997 -89.056900 -11.945000] 0.953550 0.000000 0.000000 0.301236 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D314E, 87298, 0x00D3015B, 119.861, -124.308, -30.2098, -0.011896, 0, 0, 0.999929, False, '2021-11-01 00:00:00'); /* Steamy Guruk Caverns */
-/* @teleloc 0x00D3015B [119.861000 -124.307999 -30.209801] -0.011896 0.000000 0.000000 0.999929 */
+VALUES (0x700D32D8, 73192, 0x00D3043F, 50.205, -135.598, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:06:58'); /* Eastern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D3043F [50.205002 -135.598007 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D314F, 34832, 0x00D30111, 70.754, -150.086, -30.2098, -0.723616, 0, 0, 0.690203, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Exit */
-/* @teleloc 0x00D30111 [70.753998 -150.085999 -30.209801] -0.723616 0.000000 0.000000 0.690203 */
+VALUES (0x700D32D9, 73192, 0x00D3055A, 128.322, -169.075, -11.945, -0.963114, 0, 0, -0.269095, False, '2024-06-04 18:11:34'); /* Eastern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D3055A [128.322006 -169.074997 -11.945000] -0.963114 0.000000 0.000000 -0.269095 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3150, 34832, 0x00D301B4, 168.221, -150.049, -30.2098, 0.71609, 0, 0, 0.698008, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Exit */
-/* @teleloc 0x00D301B4 [168.220993 -150.048996 -30.209801] 0.716090 0.000000 0.000000 0.698008 */
+VALUES (0x700D32DA, 73192, 0x00D30554, 129.204, -149.331, -11.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:12:05'); /* Eastern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D30554 [129.203995 -149.330994 -11.945000] 0.923880 0.000000 0.000000 0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3151, 87292, 0x00D3047E, 78.9683, -89.1326, -11.945, 0.939372, 0, 0, 0.342898, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3047E [78.968300 -89.132599 -11.945000] 0.939372 0.000000 0.000000 0.342898 */
+VALUES (0x700D32DB, 73193, 0x00D30247, 89.1972, -178.786, -23.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:15:01'); /* Eastern Catacombs Lower Mixed Gen */
+/* @teleloc 0x00D30247 [89.197197 -178.785995 -23.945000] 0.923880 0.000000 0.000000 0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3152, 87292, 0x00D3044B, 59.6063, -82.4081, -11.945, 0.678193, 0, 0, 0.734884, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3044B [59.606300 -82.408096 -11.945000] 0.678193 0.000000 0.000000 0.734884 */
+VALUES (0x700D32DC, 34832, 0x00D30355, 199.263, -300.965, -24.2098, 1, 0, 0, 0, False, '2024-06-04 18:20:55'); /* Eastern Catacombs Exit */
+/* @teleloc 0x00D30355 [199.263000 -300.964996 -24.209801] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3153, 87292, 0x00D30420, 23.587, -117.7, -11.945, 0.999298, 0, 0, -0.037471, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30420 [23.587000 -117.699997 -11.945000] 0.999298 0.000000 0.000000 -0.037471 */
+VALUES (0x700D32DD, 34832, 0x00D301DF, 31.3129, -301.707, -24.2098, 1, 0, 0, 0, False, '2024-06-04 18:21:34'); /* Eastern Catacombs Exit */
+/* @teleloc 0x00D301DF [31.312901 -301.707001 -24.209801] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3154, 87292, 0x00D30414, 1.60634, -85.9892, -11.945, 0.701873, 0, 0, -0.712302, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30414 [1.606340 -85.989197 -11.945000] 0.701873 0.000000 0.000000 -0.712302 */
+VALUES (0x700D32DE, 87295, 0x00D30206, 45.2879, -243.315, -23.945, 0, 0, 0, 1, False, '2024-06-04 18:22:25'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30206 [45.287899 -243.315002 -23.945000] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3155, 87292, 0x00D3041B, 24.9099, -50.9453, -11.945, 0.016478, 0, 0, -0.999864, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3041B [24.909901 -50.945301 -11.945000] 0.016478 0.000000 0.000000 -0.999864 */
+VALUES (0x700D32DF, 87295, 0x00D3023F, 77.4848, -284.663, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 18:23:05'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3023F [77.484802 -284.662994 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3156, 87292, 0x00D3043F, 50.1349, -139.099, -11.945, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D3043F [50.134899 -139.098999 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x700D32E0, 87295, 0x00D302FF, 153.524, -284.536, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 18:23:52'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D302FF [153.524002 -284.536011 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3157, 87292, 0x00D30444, 47.8371, -171.838, -11.945, 0.304912, 0, 0, 0.95238, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30444 [47.837101 -171.837997 -11.945000] 0.304912 0.000000 0.000000 0.952380 */
+VALUES (0x700D32E1, 87295, 0x00D30332, 183.164, -245.538, -23.945, 0.292173, 0, 0, -0.956366, False, '2024-06-04 18:24:56'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30332 [183.164001 -245.537994 -23.945000] 0.292173 0.000000 0.000000 -0.956366 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3158, 87292, 0x00D30495, 79.003, -208.411, -11.945, 0.845924, 0, 0, 0.533303, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30495 [79.002998 -208.410995 -11.945000] 0.845924 0.000000 0.000000 0.533303 */
+VALUES (0x700D32E2, 87295, 0x00D3030B, 156.03, -246.767, -23.945, 0.947278, 0, 0, 0.320413, False, '2024-06-04 18:25:50'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3030B [156.029999 -246.766998 -23.945000] 0.947278 0.000000 0.000000 0.320413 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D3159, 87292, 0x00D30419, 10.7474, -204.838, -11.945, 0.676829, 0, 0, -0.73614, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30419 [10.747400 -204.837997 -11.945000] 0.676829 0.000000 0.000000 -0.736140 */
+VALUES (0x700D32E6, 87295, 0x00D30215, 64.6674, -229.002, -23.945, -0.967405, 0, 0, 0.253233, False, '2024-06-04 18:28:32'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D30215 [64.667397 -229.001999 -23.945000] -0.967405 0.000000 0.000000 0.253233 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D315A, 87292, 0x00D30435, 44.9871, -239.436, -11.945, 0.999687, 0, 0, -0.024998, False, '2021-11-01 00:00:00'); /* Eastern Catacombs Upper Generator */
-/* @teleloc 0x00D30435 [44.987099 -239.436005 -11.945000] 0.999687 0.000000 0.000000 -0.024998 */
+VALUES (0x700D32E9, 87295, 0x00D302E3, 137.336, -254.854, -23.945, -0.544272, 0, 0, 0.838909, False, '2024-06-04 18:31:30'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D302E3 [137.335999 -254.854004 -23.945000] -0.544272 0.000000 0.000000 0.838909 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D32EA, 87295, 0x00D3023C, 84.1921, -244.822, -23.945, 0.391163, 0, 0, 0.920321, False, '2024-06-04 18:38:43'); /* Eastern Catacombs Lower Generator */
+/* @teleloc 0x00D3023C [84.192101 -244.822006 -23.945000] 0.391163 0.000000 0.000000 0.920321 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D32EB, 35210, 0x00D30448, 51.3391, -221.363, -12.2098, 1, 0, 0, 0, False, '2024-06-05 15:28:22'); /* Swamp Cavern */
+/* @teleloc 0x00D30448 [51.339100 -221.363007 -12.209800] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D32EC, 87298, 0x00D3015B, 120, -124.7344, -30.20983, 1, 0, 0, 0, False, '2024-06-05 15:29:16'); /* Steamy Guruk Caverns */
+/* @teleloc 0x00D3015B [120.000000 -124.734398 -30.209829] 1.000000 0.000000 0.000000 0.000000 */

--- a/Database/Patches/6 LandBlockExtendedData/00D4.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00D4.sql
@@ -52,10 +52,6 @@ VALUES (0x700D4298, 87300, 0x00D405E7, 184.809, -171.444, -11.945, -0.260278, 0,
 /* @teleloc 0x00D405E7 [184.809006 -171.444000 -11.945000] -0.260278 0.000000 0.000000 0.965534 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D4299, 87300, 0x00D405AA, 152.822, -205.905, -11.945, -0.715243, 0, 0, 0.698876, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D405AA [152.822006 -205.904999 -11.945000] -0.715243 0.000000 0.000000 0.698876 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D429A, 87300, 0x00D40495, 77.5686, -206.424, -11.945, 0.856562, 0, 0, 0.516044, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
 /* @teleloc 0x00D40495 [77.568604 -206.423996 -11.945000] 0.856562 0.000000 0.000000 0.516044 */
 
@@ -176,40 +172,24 @@ VALUES (0x700D42B7, 87303, 0x00D40311, 168.233, -162.712, -23.945, 0.303031, 0, 
 /* @teleloc 0x00D40311 [168.233002 -162.712006 -23.945000] 0.303031 0.000000 0.000000 0.952981 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42B8, 87303, 0x00D40314, 169.209, -188.383, -23.945, 0.875994, 0, 0, 0.482322, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D40314 [169.209000 -188.382996 -23.945000] 0.875994 0.000000 0.000000 0.482322 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42B9, 87303, 0x00D402CA, 125.753, -226.955, -23.945, 0.996138, 0, 0, 0.087802, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
 /* @teleloc 0x00D402CA [125.752998 -226.955002 -23.945000] 0.996138 0.000000 0.000000 0.087802 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42BA, 87303, 0x00D4026D, 104.789, -228.611, -23.945, -0.997129, 0, 0, 0.075726, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D4026D [104.789001 -228.610992 -23.945000] -0.997129 0.000000 0.000000 0.075726 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42BB, 87303, 0x00D4020F, 60.8399, -188.488, -23.945, -0.885155, 0, 0, 0.465297, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D4020F [60.839901 -188.488007 -23.945000] -0.885155 0.000000 0.000000 0.465297 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42BC, 87303, 0x00D4020C, 60.6886, -161.285, -23.945, -0.518006, 0, 0, 0.855377, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D4020C [60.688599 -161.285004 -23.945000] -0.518006 0.000000 0.000000 0.855377 */
+VALUES (0x700D42BA, 87303, 0x00D4026D, 104.789, -228.611, -23.945, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4026D [104.789001 -228.610992 -23.945000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42BD, 87303, 0x00D40242, 88.864, -139.202, -23.945, -0.921554, 0, 0, -0.388249, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
 /* @teleloc 0x00D40242 [88.863998 -139.201996 -23.945000] -0.921554 0.000000 0.000000 -0.388249 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42BE, 87303, 0x00D40274, 114.699, -112.242, -23.945, -0.026732, 0, 0, 0.999643, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D40274 [114.698997 -112.241997 -23.945000] -0.026732 0.000000 0.000000 0.999643 */
+VALUES (0x700D42BE, 87303, 0x00D40274, 114.699, -112.242, -23.945, 0, 0, 0, 1, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D40274 [114.698997 -112.241997 -23.945000] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42BF, 87303, 0x00D40360, 215.561, -155.491, -23.945, -0.490731, 0, 0, -0.871311, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
 /* @teleloc 0x00D40360 [215.561005 -155.490997 -23.945000] -0.490731 0.000000 0.000000 -0.871311 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42C0, 87303, 0x00D4033D, 191.62, -177.656, -23.945, -0.92719, 0, 0, 0.374591, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D4033D [191.619995 -177.656006 -23.945000] -0.927190 0.000000 0.000000 0.374591 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42C1, 87303, 0x00D401A9, 163.851, -220.844, -29.945, 0.954613, 0, 0, -0.297849, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
@@ -274,3 +254,19 @@ VALUES (0x700D42CF, 87300, 0x00D40107, 64.138, -219.96, -29.945, -0.715466, 0, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42D0, 87303, 0x00D40247, 89.4298, -179.499, -23.945, 0.889293, 0, 0, 0.457338, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
 /* @teleloc 0x00D40247 [89.429802 -179.498993 -23.945000] 0.889293 0.000000 0.000000 0.457338 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D1, 87303, 0x00D4034A, 195.285, -174.433, -23.945, -0.895057, 0, 0, 0.445951, False, '2024-06-04 16:52:20'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4034A [195.285004 -174.432999 -23.945000] -0.895057 0.000000 0.000000 0.445951 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D2, 87303, 0x00D4020C, 62.429, -163.266, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 17:23:09'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4020C [62.429001 -163.266006 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D3, 87303, 0x00D4020F, 62.7458, -187.501, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 17:23:37'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4020F [62.745800 -187.501007 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D4, 87303, 0x00D40314, 168.655, -186.708, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 17:24:59'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D40314 [168.654999 -186.707993 -23.945000] 0.707107 0.000000 0.000000 0.707107 */

--- a/Database/Patches/6 LandBlockExtendedData/00D4.sql
+++ b/Database/Patches/6 LandBlockExtendedData/00D4.sql
@@ -68,10 +68,6 @@ VALUES (0x700D429D, 87300, 0x00D40432, 43.615, -172.706, -11.945, 0.010168, 0, 0
 /* @teleloc 0x00D40432 [43.615002 -172.705994 -11.945000] 0.010168 0.000000 0.000000 -0.999948 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D429E, 87300, 0x00D4043F, 50.0652, -135.389, -11.945, 0.99985, 0, 0, 0.017311, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D4043F [50.065201 -135.389008 -11.945000] 0.999850 0.000000 0.000000 0.017311 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D429F, 87300, 0x00D40420, 23.9231, -118.79, -11.945, 0.985956, 0, 0, -0.167007, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
 /* @teleloc 0x00D40420 [23.923100 -118.790001 -11.945000] 0.985956 0.000000 0.000000 -0.167007 */
 
@@ -86,10 +82,6 @@ VALUES (0x700D42A1, 87300, 0x00D40425, 25.9497, -52.0979, -11.945, 0.007811, 0, 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42A2, 87300, 0x00D4044B, 58.0569, -83.0979, -11.945, -0.693751, 0, 0, -0.720215, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
 /* @teleloc 0x00D4044B [58.056900 -83.097900 -11.945000] -0.693751 0.000000 0.000000 -0.720215 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42A3, 87300, 0x00D4047E, 79.2696, -89.6971, -11.945, -0.962736, 0, 0, -0.270444, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D4047E [79.269600 -89.697098 -11.945000] -0.962736 0.000000 0.000000 -0.270444 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42A4, 87300, 0x00D40479, 80.7105, -34.9683, -11.945, -0.700354, 0, 0, 0.713796, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
@@ -134,14 +126,6 @@ VALUES (0x700D42AD, 87300, 0x00D405CD, 168.941, -148.51, -11.945, -0.895479, 0, 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42AE, 87300, 0x00D405CA, 168.473, -122.253, -11.945, -0.403445, 0, 0, -0.915004, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
 /* @teleloc 0x00D405CA [168.473007 -122.252998 -11.945000] -0.403445 0.000000 0.000000 -0.915004 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42AF, 87300, 0x00D4055A, 129.837, -170.256, -11.945, -0.95151, 0, 0, -0.307619, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D4055A [129.837006 -170.255997 -11.945000] -0.951510 0.000000 0.000000 -0.307619 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42B0, 87300, 0x00D40554, 129.197, -149.381, -11.945, -0.933572, 0, 0, -0.358391, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D40554 [129.197006 -149.380997 -11.945000] -0.933572 0.000000 0.000000 -0.358391 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42B1, 87300, 0x00D4059F, 150.165, -140.092, -11.945, -0.986717, 0, 0, -0.162447, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
@@ -224,10 +208,6 @@ VALUES (0x700D42C8, 87303, 0x00D4019D, 160.235, -150.266, -29.945, 0.705952, 0, 
 /* @teleloc 0x00D4019D [160.235001 -150.266006 -29.945000] 0.705952 0.000000 0.000000 0.708259 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42C9, 87300, 0x00D405E2, 180.118, -140, -11.945, 1, 0, 0, 0, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D405E2 [180.117996 -140.000000 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42CA, 87300, 0x00D405FA, 204.433, -119.226, -11.945, 0.999687, 0, 0, 0.024998, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
 /* @teleloc 0x00D405FA [204.432999 -119.225998 -11.945000] 0.999687 0.000000 0.000000 0.024998 */
 
@@ -244,16 +224,8 @@ VALUES (0x700D42CD, 87300, 0x00D405C4, 172.967, -82.5532, -11.945, -0.253791, 0,
 /* @teleloc 0x00D405C4 [172.966995 -82.553200 -11.945000] -0.253791 0.000000 0.000000 0.967259 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42CE, 87300, 0x00D40593, 150.806, -89.2616, -11.945, 0.948724, 0, 0, -0.316106, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
-/* @teleloc 0x00D40593 [150.806000 -89.261597 -11.945000] 0.948724 0.000000 0.000000 -0.316106 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42CF, 87300, 0x00D40107, 64.138, -219.96, -29.945, -0.715466, 0, 0, 0.698647, False, '2021-11-01 00:00:00'); /* Southern Catacombs Upper Generator */
 /* @teleloc 0x00D40107 [64.138000 -219.960007 -29.945000] -0.715466 0.000000 0.000000 0.698647 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x700D42D0, 87303, 0x00D40247, 89.4298, -179.499, -23.945, 0.889293, 0, 0, 0.457338, False, '2021-11-01 00:00:00'); /* Southern Catacombs Lower Generator */
-/* @teleloc 0x00D40247 [89.429802 -179.498993 -23.945000] 0.889293 0.000000 0.000000 0.457338 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42D1, 87303, 0x00D4034A, 195.285, -174.433, -23.945, -0.895057, 0, 0, 0.445951, False, '2024-06-04 16:52:20'); /* Southern Catacombs Lower Generator */
@@ -270,3 +242,71 @@ VALUES (0x700D42D3, 87303, 0x00D4020F, 62.7458, -187.501, -23.945, 0.707107, 0, 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x700D42D4, 87303, 0x00D40314, 168.655, -186.708, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 17:24:59'); /* Southern Catacombs Lower Generator */
 /* @teleloc 0x00D40314 [168.654999 -186.707993 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D5, 73188, 0x00D405E2, 179.972, -140.04, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:03:46'); /* Southern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D405E2 [179.972000 -140.039993 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D6, 73188, 0x00D40593, 151.09, -89.1645, -11.945, 0.931298, 0, 0, -0.364258, False, '2024-06-04 18:05:07'); /* Southern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D40593 [151.089996 -89.164497 -11.945000] 0.931298 0.000000 0.000000 -0.364258 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D7, 73188, 0x00D4047E, 78.936, -89.0569, -11.945, 0.95355, 0, 0, 0.301236, False, '2024-06-04 18:06:03'); /* Southern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D4047E [78.935997 -89.056900 -11.945000] 0.953550 0.000000 0.000000 0.301236 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D8, 73188, 0x00D4043F, 50.205, -135.598, -11.945, 1, 0, 0, 0, False, '2024-06-04 18:06:58'); /* Southern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D4043F [50.205002 -135.598007 -11.945000] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42D9, 73188, 0x00D4055A, 128.322, -169.075, -11.945, -0.963114, 0, 0, -0.269095, False, '2024-06-04 18:11:34'); /* Southern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D4055A [128.322006 -169.074997 -11.945000] -0.963114 0.000000 0.000000 -0.269095 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42DA, 73188, 0x00D40554, 129.204, -149.331, -11.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:12:05'); /* Southern Catacombs Upper Mixed Gen */
+/* @teleloc 0x00D40554 [129.203995 -149.330994 -11.945000] 0.923880 0.000000 0.000000 0.382684 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42DB, 73189, 0x00D40247, 89.1972, -178.786, -23.945, 0.92388, 0, 0, 0.382684, False, '2024-06-04 18:15:01'); /* Southern Catacombs Lower Mixed Gen */
+/* @teleloc 0x00D40247 [89.197197 -178.785995 -23.945000] 0.923880 0.000000 0.000000 0.382684 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42DC, 34828, 0x00D40355, 199.263, -300.965, -24.2098, 1, 0, 0, 0, False, '2024-06-04 18:20:55'); /* Southern Catacombs Exit */
+/* @teleloc 0x00D40355 [199.263000 -300.964996 -24.209801] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42DD, 34828, 0x00D401DF, 31.3129, -301.707, -24.2098, 1, 0, 0, 0, False, '2024-06-04 18:21:34'); /* Southern Catacombs Exit */
+/* @teleloc 0x00D401DF [31.312901 -301.707001 -24.209801] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42DE, 87303, 0x00D40206, 45.2879, -243.315, -23.945, 0, 0, 0, 1, False, '2024-06-04 18:22:25'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D40206 [45.287899 -243.315002 -23.945000] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42DF, 87303, 0x00D4023F, 77.4848, -284.663, -23.945, 0.707107, 0, 0, 0.707107, False, '2024-06-04 18:23:05'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4023F [77.484802 -284.662994 -23.945000] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42E0, 87303, 0x00D402FF, 153.524, -284.536, -23.945, 0.707107, 0, 0, -0.707107, False, '2024-06-04 18:23:52'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D402FF [153.524002 -284.536011 -23.945000] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42E1, 87303, 0x00D40332, 183.164, -245.538, -23.945, 0.292173, 0, 0, -0.956366, False, '2024-06-04 18:24:56'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D40332 [183.164001 -245.537994 -23.945000] 0.292173 0.000000 0.000000 -0.956366 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42E2, 87303, 0x00D4030B, 156.03, -246.767, -23.945, 0.947278, 0, 0, 0.320413, False, '2024-06-04 18:25:50'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4030B [156.029999 -246.766998 -23.945000] 0.947278 0.000000 0.000000 0.320413 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42E6, 87303, 0x00D40215, 64.6674, -229.002, -23.945, -0.967405, 0, 0, 0.253233, False, '2024-06-04 18:28:32'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D40215 [64.667397 -229.001999 -23.945000] -0.967405 0.000000 0.000000 0.253233 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42E9, 87303, 0x00D402E3, 137.336, -254.854, -23.945, -0.544272, 0, 0, 0.838909, False, '2024-06-04 18:31:30'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D402E3 [137.335999 -254.854004 -23.945000] -0.544272 0.000000 0.000000 0.838909 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x700D42EA, 87303, 0x00D4023C, 84.19212, -244.822, -23.945, 0.391163, 0, 0, 0.920321, False, '2024-06-04 18:38:43'); /* Southern Catacombs Lower Generator */
+/* @teleloc 0x00D4023C [84.192123 -244.822006 -23.945000] 0.391163 0.000000 0.000000 0.920321 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Thrungus/34868 Baby Thrungus.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Thrungus/34868 Baby Thrungus.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 34868;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (34868, 'ace34868-babythrungus', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (34868, 'ace34868-babythrungus', 10, '2024-06-04 01:55:14') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (34868,   1,         16) /* ItemType - Creature */
@@ -92,19 +92,19 @@ VALUES (34868,  6, 0, 3, 0,  20, 0, 0) /* MeleeDefense        Specialized */
      , (34868, 45, 0, 3, 0,  50, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (34868,  0, 32, 12,  0.3,   60,   54,   60,   66,   48,   48,   60,   48,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (34868,  1,  4,  0,    0,   60,   54,   60,   66,   48,   48,   60,   48,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (34868,  2,  4,  0,    0,   60,   54,   60,   66,   48,   48,   60,   48,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (34868,  3,  1,  0,    0,   60,   54,   60,   66,   48,   48,   60,   48,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (34868,  4,  1,  0,    0,   60,   54,   60,   66,   48,   48,   60,   48,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (34868,  5,  1, 12,  0.4,   60,   54,   60,   66,   48,   48,   60,   48,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (34868,  6,  4,  0,    0,   60,   54,   60,   66,   48,   48,   60,   48,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (34868,  7,  4,  0,    0,   60,   54,   60,   66,   48,   48,   60,   48,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (34868,  8, 32, 12,  0.4,   60,   54,   60,   66,   48,   48,   60,   48,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */
-     , (34868, 22, 32, 10,  0.3,   60,   54,   60,   66,   48,   48,   60,   48,    0, 0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Breath */;
+VALUES (34868,  0, 32, 12,  0.3,   60,   30,   30,   30,   30,   30,   30,   30,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (34868,  1,  4,  0,    0,   60,   30,   30,   30,   30,   30,   30,   30,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (34868,  2,  4,  0,    0,   60,   30,   30,   30,   30,   30,   30,   30,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (34868,  3,  1,  0,    0,   60,   30,   30,   30,   30,   30,   30,   30,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (34868,  4,  1,  0,    0,   60,   30,   30,   30,   30,   30,   30,   30,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (34868,  5,  1, 12,  0.4,   60,   30,   30,   30,   30,   30,   30,   30,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (34868,  6,  4,  0,    0,   60,   30,   30,   30,   30,   30,   30,   30,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (34868,  7,  4,  0,    0,   60,   30,   30,   30,   30,   30,   30,   30,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (34868,  8, 32, 12,  0.4,   60,   30,   30,   30,   30,   30,   30,   30,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */
+     , (34868, 22, 32, 10,  0.3,   60,   30,   30,   30,   30,   30,   30,   30,    0, 0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (34868,  5 /* HeartBeat */,  0.085, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (34868,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -112,7 +112,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (34868,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (34868,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -120,9 +120,65 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (34868,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (34868,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,   0.05, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,  0.075, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,  0.172, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 6, 6, 0, 1, 0, 0, 0);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,  0.272, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 12, 0, 1, 0, 0, 0);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,  0.372, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, -6, 6, 0, 1, 0, 0, 0);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (34868,  5 /* HeartBeat */,  0.472, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   6 /* Move */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0, 0, 1, 0, 0, 0);

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73188 Southern Catacombs Upper Mixed Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73188 Southern Catacombs Upper Mixed Gen.sql
@@ -1,0 +1,41 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73188;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73188, 'ace73188-southerncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73188,  81,          2) /* MaxGeneratedObjects */
+     , (73188,  82,          2) /* InitGeneratedObjects */
+     , (73188,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73188,   1, True ) /* Stuck */
+     , (73188,  11, True ) /* IgnoreCollisions */
+     , (73188,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73188,  41,     300) /* RegenerationInterval */
+     , (73188,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73188,   1, 'Southern Catacombs Upper Mixed Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73188,   1, 0x0200026B) /* Setup */
+     , (73188,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73188, 0.07, 34779, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Beast (34779) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.14, 34780, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.21, 34782, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.28, 34783, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.35, 34785, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Destroyer (34785) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.42, 34790, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hulk (34790) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.49, 34797, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (34797) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.56, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.63, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.7, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.77, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.84, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 0.93, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73188, 1, 34837, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Burning Mushroom (34837) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73189 Southern Catacombs Lower Mixed Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73189 Southern Catacombs Lower Mixed Gen.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73189;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73189, 'ace73189-southerncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73189,  81,          2) /* MaxGeneratedObjects */
+     , (73189,  82,          2) /* InitGeneratedObjects */
+     , (73189,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73189,   1, True ) /* Stuck */
+     , (73189,  11, True ) /* IgnoreCollisions */
+     , (73189,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73189,  41,     300) /* RegenerationInterval */
+     , (73189,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73189,   1, 'Southern Catacombs Lower Mixed Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73189,   1, 0x0200026B) /* Setup */
+     , (73189,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73189, 0.08, 34780, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.16, 34783, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.24, 34787, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Gorefiend (34787) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.32, 34786, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Fiend (34786) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.4, 34793, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Monstrosity (34793) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.48, 34801, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Titan (34801) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.56, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.62, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.7, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.78, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.86, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 0.93, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73189, 1, 87299, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Burning Mushroom (87299) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73190 Northern Catacombs Upper Mixed Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73190 Northern Catacombs Upper Mixed Gen.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73190;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73190, 'ace73190-southerncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73190,  81,          2) /* MaxGeneratedObjects */
+     , (73190,  82,          2) /* InitGeneratedObjects */
+     , (73190,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73190,   1, True ) /* Stuck */
+     , (73190,  11, True ) /* IgnoreCollisions */
+     , (73190,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73190,  41,     300) /* RegenerationInterval */
+     , (73190,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73190,   1, 'Northern Catacombs Upper Mixed Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73190,   1, 0x0200026B) /* Setup */
+     , (73190,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73190, 0.085, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.17, 34795, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Pug (34795) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.25, 34788, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hatchling (34788) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.34, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.42, 34795, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Pug (34795) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.51, 34788, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hatchling (34788) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.59, 28678, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Beefsteak Thrungus (28678) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.68, 29296, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Porcini Thrungus (29296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.76, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.85, 28673, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Deathcap Thrungus (28673) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 0.93, 28675, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Portobello Thrungus (28675) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73190, 1, 34833, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Glow Mushroom (34833) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73191 Northern Catacombs Lower Mixed Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73191 Northern Catacombs Lower Mixed Gen.sql
@@ -1,0 +1,36 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73191;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73191, 'ace73191-southerncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73191,  81,          2) /* MaxGeneratedObjects */
+     , (73191,  82,          2) /* InitGeneratedObjects */
+     , (73191,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73191,   1, True ) /* Stuck */
+     , (73191,  11, True ) /* IgnoreCollisions */
+     , (73191,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73191,  41,     300) /* RegenerationInterval */
+     , (73191,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73191,   1, 'Northern Catacombs Lower Mixed Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73191,   1, 0x0200026B) /* Setup */
+     , (73191,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73191, 0.12, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.24, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.36, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.48, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.6, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.72, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.84, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 0.93, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73191, 1, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73192 Eastern Catacombs Upper Mixed Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73192 Eastern Catacombs Upper Mixed Gen.sql
@@ -1,0 +1,39 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73192;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73192, 'ace73192-easterncatacombsuppermixedgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73192,  81,          2) /* MaxGeneratedObjects */
+     , (73192,  82,          2) /* InitGeneratedObjects */
+     , (73192,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73192,   1, True ) /* Stuck */
+     , (73192,  11, True ) /* IgnoreCollisions */
+     , (73192,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73192,  41,     300) /* RegenerationInterval */
+     , (73192,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73192,   1, 'Eastern Catacombs Upper Mixed Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73192,   1, 0x0200026B) /* Setup */
+     , (73192,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73192, 0.085, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.17, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.25, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.34, 27988, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.42, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.51, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.59, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.68, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.76, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.85, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 0.93, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73192, 1, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73193 Eastern Catacombs Lower Mixed Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73193 Eastern Catacombs Lower Mixed Gen.sql
@@ -1,0 +1,40 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73193;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73193, 'ace73193-easterncatacombsuppermixedgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73193,  81,          2) /* MaxGeneratedObjects */
+     , (73193,  82,          2) /* InitGeneratedObjects */
+     , (73193,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73193,   1, True ) /* Stuck */
+     , (73193,  11, True ) /* IgnoreCollisions */
+     , (73193,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73193,  41,     300) /* RegenerationInterval */
+     , (73193,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73193,   1, 'Eastern Catacombs Lower Mixed Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73193,   1, 0x0200026B) /* Setup */
+     , (73193,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73193, 0.08, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.16, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.24, 34782, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.32, 27984, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Crusher (27984) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.4, 27987, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Heavy (27987) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.48, 27988, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.56, 27989, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (27989) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.62, 28674, 180, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.7, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.78, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.86, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 0.93, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73193, 1, 34836, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Glow Mushroom (34836) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87285 Northern Catacombs Upper Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87285 Northern Catacombs Upper Generator.sql
@@ -25,5 +25,6 @@ VALUES (87285,   1, 0x0200026B) /* Setup */
      , (87285,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87285, 0.45, 87287, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Upper Guruk Generator (87287) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87285, 0.85, 87286, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Upper Thrungus Generator (87286) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87285, 0.5, 73190, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Upper Mixed Generator (73190) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87285, 0.75, 87287, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Upper Guruk Generator (87287) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87285, 1, 87286, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Upper Thrungus Generator (87286) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87286 Northern Catacombs Upper Thrungus Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87286 Northern Catacombs Upper Thrungus Generator.sql
@@ -25,9 +25,11 @@ VALUES (87286,   1, 0x0200026B) /* Setup */
      , (87286,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87286, 0.16, 28678, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Beefsteak Thrungus (28678) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87286, 0.32, 29296, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Porcini Thrungus (29296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87286, 0.48, 29297, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87286, 0.64, 28673, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Deathcap Thrungus (28673) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87286, 0.8, 28675, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Portobello Thrungus (28675) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87286, 0.99, 34833, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Glow Mushroom (34833) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87286, 0.18, 28678, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Beefsteak Thrungus (28678) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 0.36, 29296, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Porcini Thrungus (29296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 0.54, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 0.72, 28673, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Deathcap Thrungus (28673) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 0.91, 28675, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Portobello Thrungus (28675) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 0.94, 34833, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Glow Mushroom (34833) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 0.97, 34833, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Glow Mushroom (34833) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87286, 1, 34833, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Glow Mushroom (34833) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87287 Northern Catacombs Upper Guruk Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87287 Northern Catacombs Upper Guruk Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (87287, 'ace87287-northerncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87287,  81,          2) /* MaxGeneratedObjects */
-     , (87287,  82,          2) /* InitGeneratedObjects */
+VALUES (87287,  81,          5) /* MaxGeneratedObjects */
+     , (87287,  82,          5) /* InitGeneratedObjects */
      , (87287,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -25,6 +25,9 @@ VALUES (87287,   1, 0x0200026B) /* Setup */
      , (87287,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87287, 0.25, 34833, 900, 1, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Glow Mushroom (34833) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87287, 0.99, 34791, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87287, 0.99, 34788, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hatchling (34788) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87287, 0.16, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87287, 0.32, 34795, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Pug (34795) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87287, 0.48, 34788, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hatchling (34788) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87287, 0.64, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87287, 0.82, 34795, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Pug (34795) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87287, 1, 34788, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hatchling (34788) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87288 Northern Catacombs Lower Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87288 Northern Catacombs Lower Generator.sql
@@ -25,5 +25,6 @@ VALUES (87288,   1, 0x0200026B) /* Setup */
      , (87288,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87288, 0.45, 87290, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Lower Guruk Generator (87290) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87288, 0.85, 87289, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Lower Thrungus Generator (87289) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87288, 0.5, 73191, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Lower Mixed Generator (73191) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87288, 0.75, 87290, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Lower Guruk Generator (87290) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87288, 1, 87289, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Northern Catacombs Lower Thrungus Generator (87289) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87289 Northern Catacombs Lower Thrungus Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87289 Northern Catacombs Lower Thrungus Generator.sql
@@ -25,10 +25,11 @@ VALUES (87289,   1, 0x0200026B) /* Setup */
      , (87289,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87289, 0.16, 28678, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Beefsteak Thrungus (28678) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87289, 0.32, 29296, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Porcini Thrungus (29296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87289, 0.44, 28675, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Portobello Thrungus (28675) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87289, 0.48, 29297, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87289, 0.64, 28673, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Deathcap Thrungus (28673) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87289, 0.8, 28674, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87289, 0.99, 34835, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87289, 0.18, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 0.36, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 0.54, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 0.72, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 0.91, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 0.94, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 0.97, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87289, 1, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87290 Northern Catacombs Lower Guruk Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87290 Northern Catacombs Lower Guruk Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (87290, 'ace87290-northerncatacombslowergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87290,  81,          2) /* MaxGeneratedObjects */
-     , (87290,  82,          2) /* InitGeneratedObjects */
+VALUES (87290,  81,          5) /* MaxGeneratedObjects */
+     , (87290,  82,          5) /* InitGeneratedObjects */
      , (87290,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -25,8 +25,11 @@ VALUES (87290,   1, 0x0200026B) /* Setup */
      , (87290,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87290, 0.25, 34835, 900, 1, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87290, 0.45, 34794, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87290, 0.55, 34781, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87290, 0.65, 34791, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87290, 0.99, 34778, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87290, 0.125, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 0.25, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 0.375, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 0.5, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 0.625, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 0.75, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 0.875, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87290, 1, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87292 Eastern Catacombs Upper Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87292 Eastern Catacombs Upper Generator.sql
@@ -25,5 +25,6 @@ VALUES (87292,   1, 0x0200026B) /* Setup */
      , (87292,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87292, 0.45, 87294, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Upper Guruk Generator (87294) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87292, 0.99, 87293, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Upper Thrungus Generator (87293) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87292, 0.5, 73192, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Upper Mixed Generator (73192) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87292, 0.75, 87294, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Upper Guruk Generator (87294) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87292, 1, 87293, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Upper Thrungus Generator (87293) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87293 Eastern Catacombs Upper Thrungus Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87293 Eastern Catacombs Upper Thrungus Generator.sql
@@ -25,6 +25,11 @@ VALUES (87293,   1, 0x0200026B) /* Setup */
      , (87293,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87293, 0.33, 28674, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87293, 0.48, 29297, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87293, 0.99, 34835, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87293, 0.18, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 0.36, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 0.54, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 0.72, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 0.91, 29297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 0.94, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 0.97, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87293, 1, 34835, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87294 Eastern Catacombs Upper Guruk Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87294 Eastern Catacombs Upper Guruk Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (87294, 'ace87294-easterncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87294,  81,          2) /* MaxGeneratedObjects */
-     , (87294,  82,          2) /* InitGeneratedObjects */
+VALUES (87294,  81,          5) /* MaxGeneratedObjects */
+     , (87294,  82,          5) /* InitGeneratedObjects */
      , (87294,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -25,9 +25,13 @@ VALUES (87294,   1, 0x0200026B) /* Setup */
      , (87294,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87294, 0.25, 34835, 900, 1, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Green Glow Mushroom (34835) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87294, 0.33, 34794, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87294, 0.44, 34778, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87294, 0.55, 34781, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87294, 0.77, 27988, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87294, 0.99, 34791, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87294, 0.1, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.2, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.3, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.4, 27988, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.5, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.6, 34794, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Plunderer (34794) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.7, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.8, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 0.9, 27988, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87294, 1, 34791, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Marauder (34791) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87295 Eastern Catacombs Lower Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87295 Eastern Catacombs Lower Generator.sql
@@ -25,5 +25,6 @@ VALUES (87295,   1, 0x0200026B) /* Setup */
      , (87295,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87295, 0.45, 87297, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Lower Guruk Generator (87297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87295, 0.85, 87296, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Lower Thrungus Generator (87296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87295, 0.5, 73193, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Lower Mixed Generator (73193) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87295, 0.75, 87297, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Lower Guruk Generator (87297) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87295, 1, 87296, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eastern Catacombs Lower Thrungus Generator (87296) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87296 Eastern Catacombs Lower Thrungus Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87296 Eastern Catacombs Lower Thrungus Generator.sql
@@ -25,6 +25,11 @@ VALUES (87296,   1, 0x0200026B) /* Setup */
      , (87296,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87296, 0.48, 29297, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Truffle Thrungus (29297) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87296, 0.8, 28674, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87296, 0.99, 34836, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Glow Mushroom (34836) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87296, 0.18, 28674, 180, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 0.36, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 0.54, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 0.72, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 0.91, 28674, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Enoki Thrungus (28674) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 0.94, 34836, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Glow Mushroom (34836) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 0.97, 34836, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Glow Mushroom (34836) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87296, 1, 34836, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Glow Mushroom (34836) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87297 Eastern Catacombs Lower Guruk Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87297 Eastern Catacombs Lower Guruk Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (87297, 'ace87297-easterncatacombslowergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87297,  81,          2) /* MaxGeneratedObjects */
-     , (87297,  82,          2) /* InitGeneratedObjects */
+VALUES (87297,  81,          5) /* MaxGeneratedObjects */
+     , (87297,  82,          5) /* InitGeneratedObjects */
      , (87297,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -25,7 +25,17 @@ VALUES (87297,   1, 0x0200026B) /* Setup */
      , (87297,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87297, 0.25, 34836, 900, 1, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Glow Mushroom (34836) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87297, 0.45, 27984, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Crusher (27984) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87297, 0.55, 27987, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Heavy (27987) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87297, 0.65, 27989, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (27989) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87297, 0.07, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.14, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.21, 34782, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.28, 27984, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Crusher (27984) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.35, 27987, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Heavy (27987) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.42, 27988, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.49, 27989, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (27989) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.56, 34778, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Basher (34778) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.63, 34781, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Boor (34781) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.7, 34782, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.77, 27984, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Crusher (27984) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.84, 27987, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Heavy (27987) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 0.92, 27988, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Miscreant (27988) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87297, 1, 27989, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (27989) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87300 Southern Catacombs Upper Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87300 Southern Catacombs Upper Generator.sql
@@ -25,5 +25,6 @@ VALUES (87300,   1, 0x0200026B) /* Setup */
      , (87300,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87300, 0.45, 87302, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Upper Guruk Generator (87302) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87300, 0.99, 87301, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Upper Thrungus Generator (87301) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87300, 0.5, 73188, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Upper Mixed Generator (73188) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87300, 0.75, 87302, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Upper Guruk Generator (87302) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87300, 1, 87301, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Upper Thrungus Generator (87301) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87301 Southern Catacombs Upper Thrungus Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87301 Southern Catacombs Upper Thrungus Generator.sql
@@ -25,7 +25,11 @@ VALUES (87301,   1, 0x0200026B) /* Setup */
      , (87301,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87301, 0.33, 32593, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87301, 0.44, 32593, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87301, 0.66, 32593, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87301, 0.99, 34837, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Burning Mushroom (34837) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87301, 0.18, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 0.36, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 0.54, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 0.72, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 0.91, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 0.94, 34837, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Burning Mushroom (34837) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 0.97, 34837, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Burning Mushroom (34837) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87301, 1, 34837, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Burning Mushroom (34837) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87302 Southern Catacombs Upper Guruk Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87302 Southern Catacombs Upper Guruk Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (87302, 'ace87302-southerncatacombsuppergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87302,  81,          2) /* MaxGeneratedObjects */
-     , (87302,  82,          2) /* InitGeneratedObjects */
+VALUES (87302,  81,          5) /* MaxGeneratedObjects */
+     , (87302,  82,          5) /* InitGeneratedObjects */
      , (87302,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -25,9 +25,17 @@ VALUES (87302,   1, 0x0200026B) /* Setup */
      , (87302,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87302, 0.25, 34837, 900, 1, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Blue Burning Mushroom (34837) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87302, 0.33, 34779, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Beast (34779) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87302, 0.44, 34780, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87302, 0.55, 34782, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87302, 0.77, 34790, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hulk (34790) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87302, 0.99, 34797, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (34797) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87302, 0.07, 34779, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Beast (34779) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.14, 34780, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.21, 34782, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.28, 34783, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.35, 34785, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Destroyer (34785) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.42, 34790, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hulk (34790) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.49, 34797, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (34797) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.56, 34779, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Beast (34779) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.63, 34780, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.7, 34782, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Brute (34782) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.77, 34783, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.84, 34785, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Destroyer (34785) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 0.92, 34790, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Hulk (34790) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87302, 1, 34797, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Smasher (34797) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87303 Southern Catacombs Lower Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87303 Southern Catacombs Lower Generator.sql
@@ -25,5 +25,6 @@ VALUES (87303,   1, 0x0200026B) /* Setup */
      , (87303,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87303, 0.45, 87305, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Lower Guruk Generator (87305) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87303, 0.85, 87304, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Lower Thrungus Generator (87304) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87303, 0.5, 73189, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Lower Mixed Generator (73189) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87303, 0.75, 87305, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Lower Guruk Generator (87305) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87303, 1, 87304, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Southern Catacombs Lower Thrungus Generator (87304) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87304 Southern Catacombs Lower Thrungus Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87304 Southern Catacombs Lower Thrungus Generator.sql
@@ -25,8 +25,11 @@ VALUES (87304,   1, 0x0200026B) /* Setup */
      , (87304,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87304, 0.48, 32593, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87304, 0.55, 31024, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87304, 0.77, 31024, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87304, 0.88, 31024, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87304, 0.99, 87299, 900, 1, 3, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Burning Mushroom (87299) (x1 up to max of 3) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87304, 0.18, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 0.36, 32593, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate False Morel Thrungus (32593) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 0.54, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 0.72, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 0.91, 31024, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Mudwort Thrungus (31024) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 0.94, 87299, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Burning Mushroom (87299) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 0.97, 87299, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Burning Mushroom (87299) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87304, 1, 87299, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Burning Mushroom (87299) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87305 Southern Catacombs Lower Guruk Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87305 Southern Catacombs Lower Guruk Generator.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (87305, 'ace87305-southerncatacombslowergurukgenerator', 1, '2021-11-01 00:00:00') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87305,  81,          2) /* MaxGeneratedObjects */
-     , (87305,  82,          2) /* InitGeneratedObjects */
+VALUES (87305,  81,          5) /* MaxGeneratedObjects */
+     , (87305,  82,          5) /* InitGeneratedObjects */
      , (87305,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
@@ -25,9 +25,15 @@ VALUES (87305,   1, 0x0200026B) /* Setup */
      , (87305,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87305, 0.25, 87299, 900, 1, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Red Burning Mushroom (87299) (x1 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87305, 0.45, 34783, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87305, 0.55, 34785, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Destroyer (34785) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87305, 0.65, 34786, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Fiend (34786) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87305, 0.75, 34793, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Monstrosity (34793) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87305, 0.85, 34801, 900, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Titan (34801) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87305, 0.08, 34780, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.16, 34783, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.24, 34787, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Gorefiend (34787) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.32, 34786, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Fiend (34786) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.4, 34793, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Monstrosity (34793) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.48, 34801, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Titan (34801) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.56, 34780, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Behemoth (34780) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.64, 34783, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Colossus (34783) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.72, 34787, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Gorefiend (34787) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.82, 34786, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Fiend (34786) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 0.9, 34793, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Monstrosity (34793) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87305, 1, 34801, 180, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Guruk Titan (34801) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Useless/34576 Decorative Stone Axe.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Useless/34576 Decorative Stone Axe.sql
@@ -18,7 +18,8 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (34576,  39,    0.75) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (34576,   1, 'Decorative Stone Axe') /* Name */;
+VALUES (34576,   1, 'Decorative Stone Axe') /* Name */
+     , (34576,  16, 'A Stone Axe, taken from the Guruk on Bur and fitted with points to hook it to a wall. It is far too heavy to be weilded as a weapon.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (34576,   1, 0x02001673) /* Setup */

--- a/Database/Patches/9 WeenieDefaults/Generic/Useless/34577 Decorative Tree Trunk Club.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Useless/34577 Decorative Tree Trunk Club.sql
@@ -18,7 +18,8 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (34577,  39,     0.8) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (34577,   1, 'Decorative Tree Trunk Club') /* Name */;
+VALUES (34577,   1, 'Decorative Tree Trunk Club') /* Name */
+     , (34577,  16, 'A Tree Trunk Club, taken from the Guruk on Bur and fitted with points to hook it to a wall. It is far too heavy to be wielded as a weapon.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (34577,   1, 0x02001674) /* Setup */

--- a/Database/Patches/9 WeenieDefaults/Generic/Useless/34578 Decorative Repugnant Staff.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Useless/34578 Decorative Repugnant Staff.sql
@@ -18,7 +18,8 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (34578,  39,     0.8) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (34578,   1, 'Decorative Repugnant Staff') /* Name */;
+VALUES (34578,   1, 'Decorative Repugnant Staff') /* Name */
+     , (34578,  16, 'A Staff, carved to the likeness of those carried by the Buruun Kukuur on Bur and fitted with points to hook it to a wall. It is far too heavy to be wielded as a weapon.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (34578,   1, 0x02001675) /* Setup */

--- a/Database/Patches/9 WeenieDefaults/Generic/Useless/34579 Decorative Bone Sword.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Useless/34579 Decorative Bone Sword.sql
@@ -18,7 +18,8 @@ INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (34579,  39,     0.8) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (34579,   1, 'Decorative Bone Sword') /* Name */;
+VALUES (34579,   1, 'Decorative Bone Sword') /* Name */
+     , (34579,  16, 'A Bone Sword, taken from the Guruk on Bur and fitted with points to hook it to a wall. It is far too heavy to be wielded as a weapon.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (34579,   1, 0x02001676) /* Setup */


### PR DESCRIPTION
Revises S, E and N Catacombs spawns for a closer match to retail (as seen in Berek retail video). Also reduces mushroom spawn rate which was excessive. In the pcap, mushrooms make up 6-7% of the spawns. Currently, more than half of spawns appear to be mushrooms.
Cleans up duplicate Baby Thrungus in Kor Gursha and adds emote so they roam around (as seen in Tzepesh retail video).
Adds missing descriptions to some decorative house items sold on Bur.