### PR TITLE
Update Paradox Olthoi

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35731 Paradox-touched Olthoi Eviscerator Grub.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35731 Paradox-touched Olthoi Eviscerator Grub.sql
@@ -30,24 +30,24 @@ VALUES (35731,   1,       5) /* HeartbeatInterval */
      , (35731,   4,       4) /* StaminaRate */
      , (35731,   5,       2) /* ManaRate */
      , (35731,  12,     0.8) /* Shade */
-     , (35731,  13,    2.25) /* ArmorModVsSlash */
-     , (35731,  14,    1.75) /* ArmorModVsPierce */
-     , (35731,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35731,  16,     3.5) /* ArmorModVsCold */
-     , (35731,  17,     3.5) /* ArmorModVsFire */
-     , (35731,  18,       4) /* ArmorModVsAcid */
-     , (35731,  19,     3.5) /* ArmorModVsElectric */
+     , (35731,  13,       1) /* ArmorModVsSlash */
+     , (35731,  14,       1) /* ArmorModVsPierce */
+     , (35731,  15,       1) /* ArmorModVsBludgeon */
+     , (35731,  16,       1) /* ArmorModVsCold */
+     , (35731,  17,       1) /* ArmorModVsFire */
+     , (35731,  18,    1.25) /* ArmorModVsAcid */
+     , (35731,  19,    1.05) /* ArmorModVsElectric */
      , (35731,  31,      10) /* VisualAwarenessRange */
      , (35731,  34,     1.2) /* PowerupTime */
      , (35731,  36,       1) /* ChargeSpeed */
      , (35731,  39,     1.1) /* DefaultScale */
-     , (35731,  64,       1) /* ResistSlash */
-     , (35731,  65,    0.95) /* ResistPierce */
-     , (35731,  66,       1) /* ResistBludgeon */
-     , (35731,  67,    0.75) /* ResistFire */
-     , (35731,  68,     0.5) /* ResistCold */
-     , (35731,  69,     0.5) /* ResistAcid */
-     , (35731,  70,    0.75) /* ResistElectric */
+     , (35731,  64,    0.65) /* ResistSlash */
+     , (35731,  65,     0.7) /* ResistPierce */
+     , (35731,  66,    0.75) /* ResistBludgeon */
+     , (35731,  67,    0.55) /* ResistFire */
+     , (35731,  68,     0.6) /* ResistCold */
+     , (35731,  69,    0.25) /* ResistAcid */
+     , (35731,  70,    0.45) /* ResistElectric */
      , (35731,  71,       1) /* ResistHealthBoost */
      , (35731,  72,       1) /* ResistStaminaDrain */
      , (35731,  73,       1) /* ResistStaminaBoost */
@@ -88,21 +88,21 @@ VALUES (35731,   1,   165, 0, 0, 260) /* MaxHealth */
      , (35731,   5,     0, 0, 0, 90) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35731,  6, 0, 3, 0, 220, 0, 0) /* MeleeDefense        Specialized */
-     , (35731,  7, 0, 3, 0, 312, 0, 0) /* MissileDefense      Specialized */
-     , (35731, 15, 0, 3, 0, 244, 0, 0) /* MagicDefense        Specialized */
+VALUES (35731,  6, 0, 3, 0, 250, 0, 0) /* MeleeDefense        Specialized */
+     , (35731,  7, 0, 3, 0, 315, 0, 0) /* MissileDefense      Specialized */
+     , (35731, 15, 0, 3, 0, 220, 0, 0) /* MagicDefense        Specialized */
      , (35731, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
      , (35731, 22, 0, 3, 0,  50, 0, 0) /* Jump                Specialized */
      , (35731, 24, 0, 3, 0, 200, 0, 0) /* Run                 Specialized */
-     , (35731, 45, 0, 3, 0, 205, 0, 0) /* LightWeapons        Specialized */;
+     , (35731, 45, 0, 3, 0, 245, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35731,  0,  4, 55, 0.75,  275,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35731, 16,  4,  0,    0,  225,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35731, 18,  4, 55, 0.75,  225,  506,  394,  252,  788,  788,  900,  788,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35731, 19,  4, 55,    0,  225,  506,  394,  252,  788,  788,  900,  788,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35731, 20,  4, 55, 0.75,  225,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35731, 22, 32,  0,  0.5,  275,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35731,  0,  4, 55, 0.75,  170,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35731, 16,  4,  0,    0,  170,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35731, 18,  4, 55, 0.75,  170,  506,  394,  252,  788,  788,  900,  788,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35731, 19,  4, 55,    0,  170,  506,  394,  252,  788,  788,  900,  788,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35731, 20,  4, 55, 0.75,  170,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35731, 22, 32,  0,  0.5,  170,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35731,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35732 Paradox-touched Olthoi Noble Grub.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35732 Paradox-touched Olthoi Noble Grub.sql
@@ -29,24 +29,24 @@ VALUES (35732,   1,       5) /* HeartbeatInterval */
      , (35732,   3,    0.25) /* HealthRate */
      , (35732,   4,       4) /* StaminaRate */
      , (35732,   5,       2) /* ManaRate */
-     , (35732,  13,    2.25) /* ArmorModVsSlash */
-     , (35732,  14,    1.75) /* ArmorModVsPierce */
-     , (35732,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35732,  16,     3.5) /* ArmorModVsCold */
-     , (35732,  17,     3.5) /* ArmorModVsFire */
-     , (35732,  18,       4) /* ArmorModVsAcid */
-     , (35732,  19,     3.5) /* ArmorModVsElectric */
+     , (35732,  13,       1) /* ArmorModVsSlash */
+     , (35732,  14,       1) /* ArmorModVsPierce */
+     , (35732,  15,       1) /* ArmorModVsBludgeon */
+     , (35732,  16,       1) /* ArmorModVsCold */
+     , (35732,  17,       1) /* ArmorModVsFire */
+     , (35732,  18,    1.25) /* ArmorModVsAcid */
+     , (35732,  19,    1.05) /* ArmorModVsElectric */
      , (35732,  31,      10) /* VisualAwarenessRange */
      , (35732,  34,     1.2) /* PowerupTime */
      , (35732,  36,       1) /* ChargeSpeed */
      , (35732,  39,     1.2) /* DefaultScale */
-     , (35732,  64,       1) /* ResistSlash */
-     , (35732,  65,    0.95) /* ResistPierce */
-     , (35732,  66,       1) /* ResistBludgeon */
-     , (35732,  67,    0.75) /* ResistFire */
-     , (35732,  68,     0.5) /* ResistCold */
-     , (35732,  69,     0.5) /* ResistAcid */
-     , (35732,  70,    0.75) /* ResistElectric */
+     , (35732,  64,    0.65) /* ResistSlash */
+     , (35732,  65,     0.7) /* ResistPierce */
+     , (35732,  66,    0.75) /* ResistBludgeon */
+     , (35732,  67,    0.55) /* ResistFire */
+     , (35732,  68,     0.6) /* ResistCold */
+     , (35732,  69,    0.25) /* ResistAcid */
+     , (35732,  70,    0.45) /* ResistElectric */
      , (35732,  71,       1) /* ResistHealthBoost */
      , (35732,  72,       1) /* ResistStaminaDrain */
      , (35732,  73,       1) /* ResistStaminaBoost */
@@ -87,21 +87,21 @@ VALUES (35732,   1,   165, 0, 0, 260) /* MaxHealth */
      , (35732,   5,     0, 0, 0, 90) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35732,  6, 0, 3, 0, 229, 0, 0) /* MeleeDefense        Specialized */
-     , (35732,  7, 0, 3, 0, 314, 0, 0) /* MissileDefense      Specialized */
-     , (35732, 15, 0, 3, 0, 244, 0, 0) /* MagicDefense        Specialized */
+VALUES (35732,  6, 0, 3, 0, 250, 0, 0) /* MeleeDefense        Specialized */
+     , (35732,  7, 0, 3, 0, 315, 0, 0) /* MissileDefense      Specialized */
+     , (35732, 15, 0, 3, 0, 220, 0, 0) /* MagicDefense        Specialized */
      , (35732, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
      , (35732, 22, 0, 3, 0,  50, 0, 0) /* Jump                Specialized */
      , (35732, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (35732, 45, 0, 3, 0, 209, 0, 0) /* LightWeapons        Specialized */;
+     , (35732, 45, 0, 3, 0, 245, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35732,  0,  4, 55, 0.75,  275,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35732, 16,  4,  0,    0,  225,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35732, 18,  4, 55, 0.75,  225,  506,  394,  252,  788,  788,  900,  788,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35732, 19,  4, 55,    0,  225,  506,  394,  252,  788,  788,  900,  788,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35732, 20,  4, 55, 0.75,  225,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35732, 22, 32,  0,  0.5,  275,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35732,  0,  4, 55, 0.75,  170,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35732, 16,  4,  0,    0,  170,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35732, 18,  4, 55, 0.75,  170,  506,  394,  252,  788,  788,  900,  788,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35732, 19,  4, 55,    0,  170,  506,  394,  252,  788,  788,  900,  788,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35732, 20,  4, 55, 0.75,  170,  506,  394,  252,  788,  788,  900,  788,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35732, 22, 32,  0,  0.5,  170,  619,  481,  308,  963,  963, 1100,  963,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35732,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35733 Paradox-touched Olthoi Eviscerator Nymph.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35733 Paradox-touched Olthoi Eviscerator Nymph.sql
@@ -29,24 +29,24 @@ VALUES (35733,   1,       5) /* HeartbeatInterval */
      , (35733,   3,       5) /* HealthRate */
      , (35733,   4,       4) /* StaminaRate */
      , (35733,   5,       2) /* ManaRate */
-     , (35733,  13,    2.25) /* ArmorModVsSlash */
-     , (35733,  14,    1.75) /* ArmorModVsPierce */
-     , (35733,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35733,  16,     3.5) /* ArmorModVsCold */
-     , (35733,  17,     3.5) /* ArmorModVsFire */
-     , (35733,  18,       4) /* ArmorModVsAcid */
-     , (35733,  19,     3.5) /* ArmorModVsElectric */
+     , (35733,  13,     1.1) /* ArmorModVsSlash */
+     , (35733,  14,     0.8) /* ArmorModVsPierce */
+     , (35733,  15,     0.8) /* ArmorModVsBludgeon */
+     , (35733,  16,       1) /* ArmorModVsCold */
+     , (35733,  17,     1.1) /* ArmorModVsFire */
+     , (35733,  18,     1.1) /* ArmorModVsAcid */
+     , (35733,  19,       1) /* ArmorModVsElectric */
      , (35733,  31,      24) /* VisualAwarenessRange */
      , (35733,  34,       1) /* PowerupTime */
      , (35733,  36,       1) /* ChargeSpeed */
      , (35733,  39,     0.8) /* DefaultScale */
-     , (35733,  64,       1) /* ResistSlash */
-     , (35733,  65,    0.95) /* ResistPierce */
+     , (35733,  64,    0.75) /* ResistSlash */
+     , (35733,  65,     0.7) /* ResistPierce */
      , (35733,  66,       1) /* ResistBludgeon */
      , (35733,  67,    0.75) /* ResistFire */
-     , (35733,  68,     0.5) /* ResistCold */
-     , (35733,  69,     0.5) /* ResistAcid */
-     , (35733,  70,    0.75) /* ResistElectric */
+     , (35733,  68,    0.75) /* ResistCold */
+     , (35733,  69,    0.25) /* ResistAcid */
+     , (35733,  70,     0.4) /* ResistElectric */
      , (35733,  71,       1) /* ResistHealthBoost */
      , (35733,  72,       1) /* ResistStaminaDrain */
      , (35733,  73,       1) /* ResistStaminaBoost */
@@ -87,18 +87,34 @@ VALUES (35733,   1,   775, 0, 0, 940) /* MaxHealth */
      , (35733,   5,     0, 0, 0, 60) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35733,  6, 0, 3, 0, 308, 0, 0) /* MeleeDefense        Specialized */
-     , (35733,  7, 0, 3, 0, 351, 0, 0) /* MissileDefense      Specialized */
-     , (35733, 15, 0, 3, 0, 308, 0, 0) /* MagicDefense        Specialized */
+VALUES (35733,  6, 0, 3, 0, 360, 0, 0) /* MeleeDefense        Specialized */
+     , (35733,  7, 0, 3, 0, 380, 0, 0) /* MissileDefense      Specialized */
+     , (35733, 15, 0, 3, 0, 305, 0, 0) /* MagicDefense        Specialized */
      , (35733, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
      , (35733, 22, 0, 2, 0, 200, 0, 0) /* Jump                Trained */
      , (35733, 24, 0, 2, 0,  50, 0, 0) /* Run                 Trained */
-     , (35733, 45, 0, 3, 0, 266, 0, 0) /* LightWeapons        Specialized */;
+     , (35733, 45, 0, 3, 0, 320, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35733,  0,  4,  0,    0,  150,  338,  263,  168,  525,  525,  600,  525,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35733, 16,  4,  0,    0,  150,  338,  263,  168,  525,  525,  600,  525,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35733, 18,  4, 40,  0.5,  150,  338,  263,  168,  525,  525,  600,  525,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35733, 19,  4,  0,    0,  150,  338,  263,  168,  525,  525,  600,  525,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35733, 20,  2, 40, 0.12,  150,  338,  263,  168,  525,  525,  600,  525,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35733, 22, 16,  0,  0.5,  150,  338,  263,  168,  525,  525,  600,  525,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35733,  0,  4,  0,    0,  235,  338,  263,  168,  525,  525,  600,  525,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35733, 16,  4,  0,    0,  235,  338,  263,  168,  525,  525,  600,  525,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35733, 18,  4, 40,  0.5,  235,  338,  263,  168,  525,  525,  600,  525,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35733, 19,  4,  0,    0,  235,  338,  263,  168,  525,  525,  600,  525,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35733, 20,  2, 40, 0.12,  235,  338,  263,  168,  525,  525,  600,  525,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35733, 22, 16,  0,  0.5,  235,  338,  263,  168,  525,  525,  600,  525,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35733,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35733,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35734 Paradox-touched Olthoi Flyer Nymph.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35734 Paradox-touched Olthoi Flyer Nymph.sql
@@ -30,24 +30,24 @@ VALUES (35734,   1,       5) /* HeartbeatInterval */
      , (35734,   4,       4) /* StaminaRate */
      , (35734,   5,       2) /* ManaRate */
      , (35734,  12,     0.5) /* Shade */
-     , (35734,  13,    2.25) /* ArmorModVsSlash */
-     , (35734,  14,    1.75) /* ArmorModVsPierce */
-     , (35734,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35734,  16,     3.5) /* ArmorModVsCold */
-     , (35734,  17,     3.5) /* ArmorModVsFire */
-     , (35734,  18,       4) /* ArmorModVsAcid */
-     , (35734,  19,     3.5) /* ArmorModVsElectric */
+     , (35734,  13,       1) /* ArmorModVsSlash */
+     , (35734,  14,       1) /* ArmorModVsPierce */
+     , (35734,  15,     1.1) /* ArmorModVsBludgeon */
+     , (35734,  16,       1) /* ArmorModVsCold */
+     , (35734,  17,     1.1) /* ArmorModVsFire */
+     , (35734,  18,     1.5) /* ArmorModVsAcid */
+     , (35734,  19,    1.25) /* ArmorModVsElectric */
      , (35734,  31,      28) /* VisualAwarenessRange */
      , (35734,  34,       1) /* PowerupTime */
      , (35734,  36,       1) /* ChargeSpeed */
      , (35734,  39,     0.6) /* DefaultScale */
-     , (35734,  64,       1) /* ResistSlash */
-     , (35734,  65,    0.95) /* ResistPierce */
-     , (35734,  66,       1) /* ResistBludgeon */
-     , (35734,  67,    0.75) /* ResistFire */
-     , (35734,  68,     0.5) /* ResistCold */
-     , (35734,  69,     0.5) /* ResistAcid */
-     , (35734,  70,    0.75) /* ResistElectric */
+     , (35734,  64,     0.7) /* ResistSlash */
+     , (35734,  65,       1) /* ResistPierce */
+     , (35734,  66,    0.75) /* ResistBludgeon */
+     , (35734,  67,    0.55) /* ResistFire */
+     , (35734,  68,     0.6) /* ResistCold */
+     , (35734,  69,    0.25) /* ResistAcid */
+     , (35734,  70,    0.45) /* ResistElectric */
      , (35734,  71,       1) /* ResistHealthBoost */
      , (35734,  72,       1) /* ResistStaminaDrain */
      , (35734,  73,       1) /* ResistStaminaBoost */
@@ -88,25 +88,19 @@ VALUES (35734,   1,   655, 0, 0, 815) /* MaxHealth */
      , (35734,   5,     0, 0, 0, 60) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35734,  6, 0, 2, 0, 290, 0, 0) /* MeleeDefense        Trained */
-     , (35734,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (35734, 15, 0, 2, 0, 280, 0, 0) /* MagicDefense        Trained */
-     , (35734, 16, 0, 2, 0, 175, 0, 0) /* ManaConversion      Trained */
-     , (35734, 31, 0, 2, 0, 400, 0, 0) /* CreatureEnchantment Trained */
-     , (35734, 33, 0, 2, 0, 400, 0, 0) /* LifeMagic           Trained */
-     , (35734, 41, 0, 2, 0, 300, 0, 0) /* TwoHandedCombat     Trained */
-     , (35734, 44, 0, 2, 0, 300, 0, 0) /* HeavyWeapons        Trained */
-     , (35734, 45, 0, 2, 0, 300, 0, 0) /* LightWeapons        Trained */
-     , (35734, 46, 0, 2, 0, 300, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35734,  6, 0, 2, 0, 340, 0, 0) /* MeleeDefense        Trained */
+     , (35734,  7, 0, 2, 0, 400, 0, 0) /* MissileDefense      Trained */
+     , (35734, 15, 0, 2, 0, 240, 0, 0) /* MagicDefense        Trained */
+     , (35734, 45, 0, 2, 0, 320, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35734,  0,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35734, 10,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
-     , (35734, 13,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
-     , (35734, 16,  2,  0,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35734, 17,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
-     , (35734, 19,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
-     , (35734, 22, 32, 85,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35734,  0,  2, 75,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35734, 10,  2, 75,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
+     , (35734, 13,  2, 75,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
+     , (35734, 16,  2,  0,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35734, 17,  2, 75,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
+     , (35734, 19,  2, 75,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
+     , (35734, 22, 32, 38,  0.5,  235,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35734,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35735 Paradox-touched Olthoi Warrior Nymph.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35735 Paradox-touched Olthoi Warrior Nymph.sql
@@ -29,24 +29,23 @@ VALUES (35735,   1,       5) /* HeartbeatInterval */
      , (35735,   3,    0.16) /* HealthRate */
      , (35735,   4,       4) /* StaminaRate */
      , (35735,   5,       2) /* ManaRate */
-     , (35735,  13,    2.25) /* ArmorModVsSlash */
-     , (35735,  14,    1.75) /* ArmorModVsPierce */
-     , (35735,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35735,  16,     3.5) /* ArmorModVsCold */
-     , (35735,  17,     3.5) /* ArmorModVsFire */
-     , (35735,  18,       4) /* ArmorModVsAcid */
-     , (35735,  19,     3.5) /* ArmorModVsElectric */
+     , (35735,  13,       1) /* ArmorModVsSlash */
+     , (35735,  14,     0.8) /* ArmorModVsPierce */
+     , (35735,  15,     0.6) /* ArmorModVsBludgeon */
+     , (35735,  16,       1) /* ArmorModVsCold */
+     , (35735,  17,       1) /* ArmorModVsFire */
+     , (35735,  18,       1) /* ArmorModVsAcid */
+     , (35735,  19,       2) /* ArmorModVsElectric */
      , (35735,  31,      30) /* VisualAwarenessRange */
      , (35735,  34,       1) /* PowerupTime */
      , (35735,  36,       1) /* ChargeSpeed */
-     , (35735,  39,     1.3) /* DefaultScale */
-     , (35735,  64,       1) /* ResistSlash */
-     , (35735,  65,    0.95) /* ResistPierce */
+     , (35735,  64,    0.75) /* ResistSlash */
+     , (35735,  65,       1) /* ResistPierce */
      , (35735,  66,       1) /* ResistBludgeon */
      , (35735,  67,    0.75) /* ResistFire */
-     , (35735,  68,     0.5) /* ResistCold */
-     , (35735,  69,     0.5) /* ResistAcid */
-     , (35735,  70,    0.75) /* ResistElectric */
+     , (35735,  68,    0.75) /* ResistCold */
+     , (35735,  69,    0.42) /* ResistAcid */
+     , (35735,  70,    0.25) /* ResistElectric */
      , (35735,  71,       1) /* ResistHealthBoost */
      , (35735,  72,       1) /* ResistStaminaDrain */
      , (35735,  73,       1) /* ResistStaminaBoost */
@@ -87,21 +86,21 @@ VALUES (35735,   1,   775, 0, 0, 940) /* MaxHealth */
      , (35735,   5,     0, 0, 0, 60) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35735,  6, 0, 3, 0, 315, 0, 0) /* MeleeDefense        Specialized */
+VALUES (35735,  6, 0, 3, 0, 350, 0, 0) /* MeleeDefense        Specialized */
      , (35735,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
      , (35735, 15, 0, 3, 0, 315, 0, 0) /* MagicDefense        Specialized */
      , (35735, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
      , (35735, 22, 0, 3, 0, 200, 0, 0) /* Jump                Specialized */
      , (35735, 24, 0, 3, 0,  80, 0, 0) /* Run                 Specialized */
-     , (35735, 45, 0, 3, 0, 295, 0, 0) /* LightWeapons        Specialized */;
+     , (35735, 45, 0, 3, 0, 320, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35735,  0,  4,  5,    0,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35735, 16,  4,  5,    0,  280,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35735, 18,  4, 100,  0.5,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35735, 19,  4, 10,    0,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35735, 20,  2, 100, 0.75,  280,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35735, 22, 32, 40,  0.5,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35735,  0,  4,  5,    0,  220,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35735, 16,  4,  5,    0,  220,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35735, 18,  4, 80,  0.5,  220,  585,  455,  291,  910,  910, 1040,  910,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35735, 19,  4, 10,    0,  220,  585,  455,  291,  910,  910, 1040,  910,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35735, 20,  2, 80, 0.75,  220,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35735, 22, 32, 40,  0.5,  220,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35735,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35812 Paradox-touched Olthoi Ward Guardian.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35812 Paradox-touched Olthoi Ward Guardian.sql
@@ -23,27 +23,27 @@ VALUES (35812,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35812,   1,       5) /* HeartbeatInterval */
      , (35812,   2,       0) /* HeartbeatTimestamp */
-     , (35812,   3,    0.65) /* HealthRate */
-     , (35812,   4,       4) /* StaminaRate */
-     , (35812,   5,       2) /* ManaRate */
-     , (35812,  13,    2.25) /* ArmorModVsSlash */
-     , (35812,  14,    1.75) /* ArmorModVsPierce */
-     , (35812,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35812,  16,     3.5) /* ArmorModVsCold */
-     , (35812,  17,     3.5) /* ArmorModVsFire */
-     , (35812,  18,       4) /* ArmorModVsAcid */
-     , (35812,  19,     3.5) /* ArmorModVsElectric */
+     , (35812,   3,      50) /* HealthRate */
+     , (35812,   4,      24) /* StaminaRate */
+     , (35812,   5,      12) /* ManaRate */
+     , (35812,  13,     1.2) /* ArmorModVsSlash */
+     , (35812,  14,     1.2) /* ArmorModVsPierce */
+     , (35812,  15,     1.2) /* ArmorModVsBludgeon */
+     , (35812,  16,       1) /* ArmorModVsCold */
+     , (35812,  17,       1) /* ArmorModVsFire */
+     , (35812,  18,       1) /* ArmorModVsAcid */
+     , (35812,  19,       1) /* ArmorModVsElectric */
      , (35812,  31,      24) /* VisualAwarenessRange */
      , (35812,  34,       1) /* PowerupTime */
      , (35812,  36,       1) /* ChargeSpeed */
      , (35812,  39,     1.1) /* DefaultScale */
-     , (35812,  64,       1) /* ResistSlash */
-     , (35812,  65,     1.2) /* ResistPierce */
-     , (35812,  66,     1.3) /* ResistBludgeon */
-     , (35812,  67,    0.75) /* ResistFire */
-     , (35812,  68,     0.5) /* ResistCold */
-     , (35812,  69,     0.5) /* ResistAcid */
-     , (35812,  70,    0.75) /* ResistElectric */
+     , (35812,  64,     0.6) /* ResistSlash */
+     , (35812,  65,    0.65) /* ResistPierce */
+     , (35812,  66,     0.7) /* ResistBludgeon */
+     , (35812,  67,    0.35) /* ResistFire */
+     , (35812,  68,    0.35) /* ResistCold */
+     , (35812,  69,    0.35) /* ResistAcid */
+     , (35812,  70,    0.35) /* ResistElectric */
      , (35812,  77,       1) /* PhysicsScriptIntensity */
      , (35812, 104,      10) /* ObviousRadarRange */
      , (35812, 125,       1) /* ResistHealthDrain */
@@ -81,19 +81,16 @@ VALUES (35812,   1, 30000, 0, 0, 30250) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (35812,  6, 0, 2, 0, 460, 0, 0) /* MeleeDefense        Trained */
      , (35812,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (35812, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
-     , (35812, 41, 0, 2, 0, 519, 0, 0) /* TwoHandedCombat     Trained */
-     , (35812, 44, 0, 2, 0, 519, 0, 0) /* HeavyWeapons        Trained */
-     , (35812, 45, 0, 2, 0, 519, 0, 0) /* LightWeapons        Trained */
-     , (35812, 46, 0, 2, 0, 519, 0, 0) /* FinesseWeapons      Trained */;
+     , (35812, 15, 0, 2, 0, 380, 0, 0) /* MagicDefense        Trained */
+     , (35812, 45, 0, 2, 0, 445, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35812,  0,  2, 450, 0.75,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35812, 16,  4,  0,    0,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35812, 18,  1, 350,  0.5,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35812, 19,  1,  0,    0,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35812, 20,  1, 500, 0.75,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35812, 22, 32, 475,  0.5,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Breath */;
+VALUES (35812,  0,  2, 450,    0,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35812, 16,  4, 450,    0,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35812, 18,  2, 450,  0.5,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35812, 19,  2, 450, 0.75,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35812, 20,  1, 450, 0.75,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35812, 22, 32, 400,  0.5,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35812,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35875 Paradox-touched Olthoi Sentinel.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35875 Paradox-touched Olthoi Sentinel.sql
@@ -23,26 +23,26 @@ VALUES (35875,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35875,   1,       5) /* HeartbeatInterval */
      , (35875,   2,       0) /* HeartbeatTimestamp */
-     , (35875,   3,     100) /* HealthRate */
-     , (35875,   4,       4) /* StaminaRate */
-     , (35875,   5,       2) /* ManaRate */
-     , (35875,  13,    2.25) /* ArmorModVsSlash */
-     , (35875,  14,    1.75) /* ArmorModVsPierce */
-     , (35875,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35875,  16,     3.5) /* ArmorModVsCold */
-     , (35875,  17,     3.5) /* ArmorModVsFire */
-     , (35875,  18,       4) /* ArmorModVsAcid */
-     , (35875,  19,     3.5) /* ArmorModVsElectric */
+     , (35875,   3,      50) /* HealthRate */
+     , (35875,   4,      24) /* StaminaRate */
+     , (35875,   5,      12) /* ManaRate */
+     , (35875,  13,     1.2) /* ArmorModVsSlash */
+     , (35875,  14,     1.2) /* ArmorModVsPierce */
+     , (35875,  15,     1.2) /* ArmorModVsBludgeon */
+     , (35875,  16,       1) /* ArmorModVsCold */
+     , (35875,  17,       1) /* ArmorModVsFire */
+     , (35875,  18,       1) /* ArmorModVsAcid */
+     , (35875,  19,       1) /* ArmorModVsElectric */
      , (35875,  31,      24) /* VisualAwarenessRange */
      , (35875,  34,       1) /* PowerupTime */
      , (35875,  36,       1) /* ChargeSpeed */
-     , (35875,  64,       1) /* ResistSlash */
-     , (35875,  65,    0.95) /* ResistPierce */
-     , (35875,  66,       1) /* ResistBludgeon */
-     , (35875,  67,    0.75) /* ResistFire */
-     , (35875,  68,     0.5) /* ResistCold */
-     , (35875,  69,     0.5) /* ResistAcid */
-     , (35875,  70,    0.75) /* ResistElectric */
+     , (35875,  64,     0.6) /* ResistSlash */
+     , (35875,  65,    0.65) /* ResistPierce */
+     , (35875,  66,     0.7) /* ResistBludgeon */
+     , (35875,  67,    0.35) /* ResistFire */
+     , (35875,  68,    0.35) /* ResistCold */
+     , (35875,  69,    0.35) /* ResistAcid */
+     , (35875,  70,    0.35) /* ResistElectric */
      , (35875,  77,       1) /* PhysicsScriptIntensity */
      , (35875, 104,      10) /* ObviousRadarRange */
      , (35875, 125,       1) /* ResistHealthDrain */
@@ -80,19 +80,16 @@ VALUES (35875,   1, 20000, 0, 0, 20250) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (35875,  6, 0, 2, 0, 460, 0, 0) /* MeleeDefense        Trained */
      , (35875,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (35875, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
-     , (35875, 41, 0, 2, 0, 519, 0, 0) /* TwoHandedCombat     Trained */
-     , (35875, 44, 0, 2, 0, 519, 0, 0) /* HeavyWeapons        Trained */
-     , (35875, 45, 0, 2, 0, 519, 0, 0) /* LightWeapons        Trained */
-     , (35875, 46, 0, 2, 0, 519, 0, 0) /* FinesseWeapons      Trained */;
+     , (35875, 15, 0, 2, 0, 380, 0, 0) /* MagicDefense        Trained */
+     , (35875, 45, 0, 2, 0, 445, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35875,  0,  2, 450, 0.75,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35875, 16,  4,  0,    0,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35875, 18,  1, 350,  0.5,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35875, 19,  1,  0,    0,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35875, 20,  1, 500, 0.75,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35875, 22, 32, 475,  0.5,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Breath */;
+VALUES (35875,  0,  2, 450,    0,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35875, 16,  4, 450,    0,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35875, 18,  2, 450,  0.5,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35875, 19,  2, 450, 0.75,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35875, 20,  1, 450, 0.75,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35875, 22, 32, 400,  0.5,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35875,  5 /* HeartBeat */,   0.25, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35877 Paradox-touched Olthoi Sentinel.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35877 Paradox-touched Olthoi Sentinel.sql
@@ -23,26 +23,26 @@ VALUES (35877,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35877,   1,       5) /* HeartbeatInterval */
      , (35877,   2,       0) /* HeartbeatTimestamp */
-     , (35877,   3,     100) /* HealthRate */
-     , (35877,   4,       4) /* StaminaRate */
-     , (35877,   5,       2) /* ManaRate */
-     , (35877,  13,    2.25) /* ArmorModVsSlash */
-     , (35877,  14,    1.75) /* ArmorModVsPierce */
-     , (35877,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35877,  16,     3.5) /* ArmorModVsCold */
-     , (35877,  17,     3.5) /* ArmorModVsFire */
-     , (35877,  18,       4) /* ArmorModVsAcid */
-     , (35877,  19,     3.5) /* ArmorModVsElectric */
+     , (35877,   3,      50) /* HealthRate */
+     , (35877,   4,      24) /* StaminaRate */
+     , (35877,   5,      12) /* ManaRate */
+     , (35877,  13,     1.2) /* ArmorModVsSlash */
+     , (35877,  14,     1.2) /* ArmorModVsPierce */
+     , (35877,  15,     1.2) /* ArmorModVsBludgeon */
+     , (35877,  16,       1) /* ArmorModVsCold */
+     , (35877,  17,       1) /* ArmorModVsFire */
+     , (35877,  18,       1) /* ArmorModVsAcid */
+     , (35877,  19,       1) /* ArmorModVsElectric */
      , (35877,  31,      24) /* VisualAwarenessRange */
      , (35877,  34,       1) /* PowerupTime */
      , (35877,  36,       1) /* ChargeSpeed */
-     , (35877,  64,       1) /* ResistSlash */
-     , (35877,  65,    0.95) /* ResistPierce */
-     , (35877,  66,       1) /* ResistBludgeon */
-     , (35877,  67,    0.75) /* ResistFire */
-     , (35877,  68,     0.5) /* ResistCold */
-     , (35877,  69,     0.5) /* ResistAcid */
-     , (35877,  70,    0.75) /* ResistElectric */
+     , (35877,  64,     0.6) /* ResistSlash */
+     , (35877,  65,    0.65) /* ResistPierce */
+     , (35877,  66,     0.7) /* ResistBludgeon */
+     , (35877,  67,    0.35) /* ResistFire */
+     , (35877,  68,    0.35) /* ResistCold */
+     , (35877,  69,    0.35) /* ResistAcid */
+     , (35877,  70,    0.35) /* ResistElectric */
      , (35877,  77,       1) /* PhysicsScriptIntensity */
      , (35877, 104,      10) /* ObviousRadarRange */
      , (35877, 125,       1) /* ResistHealthDrain */
@@ -80,19 +80,16 @@ VALUES (35877,   1, 20000, 0, 0, 20250) /* MaxHealth */
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (35877,  6, 0, 2, 0, 460, 0, 0) /* MeleeDefense        Trained */
      , (35877,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
-     , (35877, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
-     , (35877, 41, 0, 2, 0, 519, 0, 0) /* TwoHandedCombat     Trained */
-     , (35877, 44, 0, 2, 0, 919, 0, 0) /* HeavyWeapons        Trained */
-     , (35877, 45, 0, 2, 0, 519, 0, 0) /* LightWeapons        Trained */
-     , (35877, 46, 0, 2, 0, 519, 0, 0) /* FinesseWeapons      Trained */;
+     , (35877, 15, 0, 2, 0, 380, 0, 0) /* MagicDefense        Trained */
+     , (35877, 45, 0, 2, 0, 445, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35877,  0,  2, 450, 0.75,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35877, 16,  4,  0,    0,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35877, 18,  1, 350,  0.5,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35877, 19,  1,  0,    0,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35877, 20,  1, 500, 0.75,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35877, 22, 32, 475,  0.5,  700, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Breath */;
+VALUES (35877,  0,  2, 450,    0,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35877, 16,  4, 450,    0,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35877, 18,  2, 450,  0.5,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35877, 19,  2, 450, 0.75,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35877, 20,  1, 450, 0.75,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35877, 22, 32, 400,  0.5,  450, 1575, 1225,  784, 2450, 2450, 2800, 2450,    0, 0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (35877,  5 /* HeartBeat */,   0.25, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35878 Paradox-touched Olthoi Lacerator.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35878 Paradox-touched Olthoi Lacerator.sql
@@ -23,26 +23,26 @@ VALUES (35878,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35878,   1,       5) /* HeartbeatInterval */
      , (35878,   2,       0) /* HeartbeatTimestamp */
-     , (35878,   3,    0.65) /* HealthRate */
-     , (35878,   4,       4) /* StaminaRate */
-     , (35878,   5,       2) /* ManaRate */
-     , (35878,  13,    2.25) /* ArmorModVsSlash */
-     , (35878,  14,    1.75) /* ArmorModVsPierce */
-     , (35878,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35878,  16,     3.5) /* ArmorModVsCold */
-     , (35878,  17,     3.5) /* ArmorModVsFire */
-     , (35878,  18,       4) /* ArmorModVsAcid */
-     , (35878,  19,     3.5) /* ArmorModVsElectric */
-     , (35878,  31,      24) /* VisualAwarenessRange */
+     , (35878,   3,      20) /* HealthRate */
+     , (35878,   4,      12) /* StaminaRate */
+     , (35878,   5,       6) /* ManaRate */
+     , (35878,  13,       1) /* ArmorModVsSlash */
+     , (35878,  14,       1) /* ArmorModVsPierce */
+     , (35878,  15,     1.1) /* ArmorModVsBludgeon */
+     , (35878,  16,       1) /* ArmorModVsCold */
+     , (35878,  17,     1.1) /* ArmorModVsFire */
+     , (35878,  18,     1.5) /* ArmorModVsAcid */
+     , (35878,  19,    1.25) /* ArmorModVsElectric */
+     , (35878,  31,      28) /* VisualAwarenessRange */
      , (35878,  34,       1) /* PowerupTime */
      , (35878,  36,       1) /* ChargeSpeed */
-     , (35878,  64,       1) /* ResistSlash */
-     , (35878,  65,    0.95) /* ResistPierce */
-     , (35878,  66,       1) /* ResistBludgeon */
-     , (35878,  67,    0.75) /* ResistFire */
-     , (35878,  68,     0.5) /* ResistCold */
-     , (35878,  69,     0.5) /* ResistAcid */
-     , (35878,  70,    0.75) /* ResistElectric */
+     , (35878,  64,     0.7) /* ResistSlash */
+     , (35878,  65,       1) /* ResistPierce */
+     , (35878,  66,    0.75) /* ResistBludgeon */
+     , (35878,  67,    0.55) /* ResistFire */
+     , (35878,  68,     0.6) /* ResistCold */
+     , (35878,  69,    0.25) /* ResistAcid */
+     , (35878,  70,    0.45) /* ResistElectric */
      , (35878,  77,       1) /* PhysicsScriptIntensity */
      , (35878, 104,      10) /* ObviousRadarRange */
      , (35878, 125,       1) /* ResistHealthDrain */;
@@ -77,28 +77,23 @@ VALUES (35878,   1,  1590, 0, 0, 1780) /* MaxHealth */
      , (35878,   5,   840, 0, 0, 1000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35878,  6, 0, 2, 0, 461, 0, 0) /* MeleeDefense        Trained */
-     , (35878,  7, 0, 2, 0, 408, 0, 0) /* MissileDefense      Trained */
-     , (35878, 15, 0, 2, 0, 445, 0, 0) /* MagicDefense        Trained */
-     , (35878, 16, 0, 2, 0, 175, 0, 0) /* ManaConversion      Trained */
-     , (35878, 31, 0, 2, 0, 405, 0, 0) /* CreatureEnchantment Trained */
-     , (35878, 33, 0, 2, 0, 400, 0, 0) /* LifeMagic           Trained */
-     , (35878, 41, 0, 2, 0, 386, 0, 0) /* TwoHandedCombat     Trained */
-     , (35878, 44, 0, 2, 0, 386, 0, 0) /* HeavyWeapons        Trained */
-     , (35878, 45, 0, 2, 0, 386, 0, 0) /* LightWeapons        Trained */
-     , (35878, 46, 0, 2, 0, 386, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35878,  6, 0, 2, 0, 480, 0, 0) /* MeleeDefense        Trained */
+     , (35878,  7, 0, 2, 0, 580, 0, 0) /* MissileDefense      Trained */
+     , (35878, 15, 0, 2, 0, 400, 0, 0) /* MagicDefense        Trained */
+     , (35878, 33, 0, 2, 0, 360, 0, 0) /* LifeMagic           Trained */
+     , (35878, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35878,  0,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35878, 10,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
-     , (35878, 13,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
+VALUES (35878,  0,  2, 150,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35878, 10,  2, 150,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
+     , (35878, 13,  2, 150,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
      , (35878, 16,  2,  0,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35878, 17,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
-     , (35878, 19,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
-     , (35878, 22, 32, 85,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+     , (35878, 17,  2, 150,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
+     , (35878, 19,  2, 150,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
+     , (35878, 22, 32, 105,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35878,  2978,   2.03)  /* Nullify All Magic Other */;
+VALUES (35878,  4334,   2.15)  /* Incantation of Nullify All Magic Other */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35878, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35879 Paradox-touched Olthoi Ripper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35879 Paradox-touched Olthoi Ripper.sql
@@ -24,27 +24,27 @@ VALUES (35879,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35879,   1,       5) /* HeartbeatInterval */
      , (35879,   2,       0) /* HeartbeatTimestamp */
-     , (35879,   3,    0.65) /* HealthRate */
-     , (35879,   4,       4) /* StaminaRate */
-     , (35879,   5,       2) /* ManaRate */
-     , (35879,  13,    2.25) /* ArmorModVsSlash */
-     , (35879,  14,    1.75) /* ArmorModVsPierce */
-     , (35879,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35879,  16,     3.5) /* ArmorModVsCold */
-     , (35879,  17,     3.5) /* ArmorModVsFire */
-     , (35879,  18,       4) /* ArmorModVsAcid */
-     , (35879,  19,     3.5) /* ArmorModVsElectric */
+     , (35879,   3,      30) /* HealthRate */
+     , (35879,   4,      24) /* StaminaRate */
+     , (35879,   5,      12) /* ManaRate */
+     , (35879,  13,     1.1) /* ArmorModVsSlash */
+     , (35879,  14,     0.8) /* ArmorModVsPierce */
+     , (35879,  15,     0.8) /* ArmorModVsBludgeon */
+     , (35879,  16,       1) /* ArmorModVsCold */
+     , (35879,  17,     1.1) /* ArmorModVsFire */
+     , (35879,  18,     1.1) /* ArmorModVsAcid */
+     , (35879,  19,       1) /* ArmorModVsElectric */
      , (35879,  31,      24) /* VisualAwarenessRange */
      , (35879,  34,       1) /* PowerupTime */
      , (35879,  36,       1) /* ChargeSpeed */
      , (35879,  39,     0.8) /* DefaultScale */
-     , (35879,  64,       1) /* ResistSlash */
-     , (35879,  65,    0.95) /* ResistPierce */
+     , (35879,  64,    0.75) /* ResistSlash */
+     , (35879,  65,     0.7) /* ResistPierce */
      , (35879,  66,       1) /* ResistBludgeon */
      , (35879,  67,    0.75) /* ResistFire */
-     , (35879,  68,     0.5) /* ResistCold */
-     , (35879,  69,     0.5) /* ResistAcid */
-     , (35879,  70,    0.75) /* ResistElectric */
+     , (35879,  68,    0.75) /* ResistCold */
+     , (35879,  69,    0.25) /* ResistAcid */
+     , (35879,  70,     0.4) /* ResistElectric */
      , (35879,  77,       1) /* PhysicsScriptIntensity */
      , (35879, 104,      10) /* ObviousRadarRange */
      , (35879, 125,       1) /* ResistHealthDrain */
@@ -80,22 +80,34 @@ VALUES (35879,   1,  1895, 0, 0, 2090) /* MaxHealth */
      , (35879,   5,     0, 0, 0, 120) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35879,  6, 0, 2, 0, 480, 0, 0) /* MeleeDefense        Trained */
-     , (35879,  7, 0, 2, 0, 410, 0, 0) /* MissileDefense      Trained */
-     , (35879, 15, 0, 2, 0, 430, 0, 0) /* MagicDefense        Trained */
-     , (35879, 16, 0, 2, 0, 175, 0, 0) /* ManaConversion      Trained */
-     , (35879, 41, 0, 2, 0, 415, 0, 0) /* TwoHandedCombat     Trained */
-     , (35879, 44, 0, 2, 0, 415, 0, 0) /* HeavyWeapons        Trained */
-     , (35879, 45, 0, 2, 0, 415, 0, 0) /* LightWeapons        Trained */
-     , (35879, 46, 0, 2, 0, 415, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35879,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
+     , (35879,  7, 0, 2, 0, 620, 0, 0) /* MissileDefense      Trained */
+     , (35879, 15, 0, 2, 0, 420, 0, 0) /* MagicDefense        Trained */
+     , (35879, 45, 0, 2, 0, 495, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35879,  0,  4,  5,    0,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35879, 16,  4,  5,    0,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35879, 18,  2, 140,  0.5,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35879, 19,  2, 140, 0.75,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35879, 20,  1, 140, 0.75,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35879, 22, 32, 140,  0.5,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35879,  0,  4,  5,    0,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35879, 16,  4,  5,    0,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35879, 18,  2, 140,  0.5,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35879, 19,  2, 140,    0,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35879, 20,  1, 140, 0.75,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35879, 22, 32, 140,  0.5,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35879,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35879,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35879, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35880 Paradox-touched Olthoi Slasher.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35880 Paradox-touched Olthoi Slasher.sql
@@ -24,27 +24,27 @@ VALUES (35880,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35880,   1,       5) /* HeartbeatInterval */
      , (35880,   2,       0) /* HeartbeatTimestamp */
-     , (35880,   3,    0.65) /* HealthRate */
-     , (35880,   4,       4) /* StaminaRate */
-     , (35880,   5,       2) /* ManaRate */
-     , (35880,  13,    2.25) /* ArmorModVsSlash */
-     , (35880,  14,    1.75) /* ArmorModVsPierce */
-     , (35880,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35880,  16,     3.5) /* ArmorModVsCold */
-     , (35880,  17,     3.5) /* ArmorModVsFire */
-     , (35880,  18,       4) /* ArmorModVsAcid */
-     , (35880,  19,     3.5) /* ArmorModVsElectric */
+     , (35880,   3,      15) /* HealthRate */
+     , (35880,   4,      12) /* StaminaRate */
+     , (35880,   5,       6) /* ManaRate */
+     , (35880,  13,       1) /* ArmorModVsSlash */
+     , (35880,  14,     0.8) /* ArmorModVsPierce */
+     , (35880,  15,     0.6) /* ArmorModVsBludgeon */
+     , (35880,  16,       1) /* ArmorModVsCold */
+     , (35880,  17,       1) /* ArmorModVsFire */
+     , (35880,  18,       1) /* ArmorModVsAcid */
+     , (35880,  19,       2) /* ArmorModVsElectric */
      , (35880,  31,      24) /* VisualAwarenessRange */
      , (35880,  34,       1) /* PowerupTime */
      , (35880,  36,       1) /* ChargeSpeed */
      , (35880,  39,     1.1) /* DefaultScale */
-     , (35880,  64,       1) /* ResistSlash */
-     , (35880,  65,    0.95) /* ResistPierce */
+     , (35880,  64,    0.75) /* ResistSlash */
+     , (35880,  65,       1) /* ResistPierce */
      , (35880,  66,       1) /* ResistBludgeon */
      , (35880,  67,    0.75) /* ResistFire */
-     , (35880,  68,     0.5) /* ResistCold */
-     , (35880,  69,     0.5) /* ResistAcid */
-     , (35880,  70,    0.75) /* ResistElectric */
+     , (35880,  68,    0.75) /* ResistCold */
+     , (35880,  69,    0.42) /* ResistAcid */
+     , (35880,  70,    0.25) /* ResistElectric */
      , (35880,  77,       1) /* PhysicsScriptIntensity */
      , (35880, 104,      10) /* ObviousRadarRange */
      , (35880, 125,       1) /* ResistHealthDrain */
@@ -80,21 +80,34 @@ VALUES (35880,   1,  1645, 0, 0, 1830) /* MaxHealth */
      , (35880,   5,     0, 0, 0, 120) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35880,  6, 0, 2, 0, 440, 0, 0) /* MeleeDefense        Trained */
-     , (35880,  7, 0, 2, 0, 405, 0, 0) /* MissileDefense      Trained */
+VALUES (35880,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
+     , (35880,  7, 0, 2, 0, 620, 0, 0) /* MissileDefense      Trained */
      , (35880, 15, 0, 2, 0, 420, 0, 0) /* MagicDefense        Trained */
-     , (35880, 41, 0, 2, 0, 385, 0, 0) /* TwoHandedCombat     Trained */
-     , (35880, 44, 0, 2, 0, 385, 0, 0) /* HeavyWeapons        Trained */
-     , (35880, 45, 0, 2, 0, 385, 0, 0) /* LightWeapons        Trained */
-     , (35880, 46, 0, 2, 0, 385, 0, 0) /* FinesseWeapons      Trained */;
+     , (35880, 45, 0, 2, 0, 450, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35880,  0,  4,  0,    0,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35880, 16,  4,  0,    0,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35880, 18,  1, 75,  0.5,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35880, 19,  4, 15,    0,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35880, 20,  2, 200,  0.5,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35880, 22, 32, 150,  0.5,  350,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35880,  0,  4,  0,    0,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35880, 16,  4,  0,    0,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35880, 18,  1, 75,  0.5,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35880, 19,  4, 15,    0,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35880, 20,  2, 200,  0.5,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35880, 22, 32, 150,  0.5,  405,  788,  613,  392, 1225, 1225, 1400, 1225,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35880,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35880,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35880, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35881 Paradox-touched Olthoi Swarm Eviscerator.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35881 Paradox-touched Olthoi Swarm Eviscerator.sql
@@ -23,27 +23,27 @@ VALUES (35881,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35881,   1,       5) /* HeartbeatInterval */
      , (35881,   2,       0) /* HeartbeatTimestamp */
-     , (35881,   3,    0.65) /* HealthRate */
-     , (35881,   4,       4) /* StaminaRate */
-     , (35881,   5,       2) /* ManaRate */
-     , (35881,  13,    2.25) /* ArmorModVsSlash */
-     , (35881,  14,    1.75) /* ArmorModVsPierce */
-     , (35881,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35881,  16,     3.5) /* ArmorModVsCold */
-     , (35881,  17,     3.5) /* ArmorModVsFire */
-     , (35881,  18,       4) /* ArmorModVsAcid */
-     , (35881,  19,     3.5) /* ArmorModVsElectric */
+     , (35881,   3,      20) /* HealthRate */
+     , (35881,   4,      16) /* StaminaRate */
+     , (35881,   5,       8) /* ManaRate */
+     , (35881,  13,     1.1) /* ArmorModVsSlash */
+     , (35881,  14,     0.8) /* ArmorModVsPierce */
+     , (35881,  15,     0.8) /* ArmorModVsBludgeon */
+     , (35881,  16,       1) /* ArmorModVsCold */
+     , (35881,  17,     1.1) /* ArmorModVsFire */
+     , (35881,  18,     1.1) /* ArmorModVsAcid */
+     , (35881,  19,       1) /* ArmorModVsElectric */
      , (35881,  31,      24) /* VisualAwarenessRange */
      , (35881,  34,       1) /* PowerupTime */
      , (35881,  36,       1) /* ChargeSpeed */
      , (35881,  39,     0.8) /* DefaultScale */
-     , (35881,  64,       1) /* ResistSlash */
-     , (35881,  65,    0.95) /* ResistPierce */
+     , (35881,  64,    0.75) /* ResistSlash */
+     , (35881,  65,       1) /* ResistPierce */
      , (35881,  66,       1) /* ResistBludgeon */
      , (35881,  67,    0.75) /* ResistFire */
-     , (35881,  68,     0.5) /* ResistCold */
-     , (35881,  69,     0.5) /* ResistAcid */
-     , (35881,  70,    0.75) /* ResistElectric */
+     , (35881,  68,    0.75) /* ResistCold */
+     , (35881,  69,    0.25) /* ResistAcid */
+     , (35881,  70,     0.4) /* ResistElectric */
      , (35881,  77,       1) /* PhysicsScriptIntensity */
      , (35881, 104,      10) /* ObviousRadarRange */
      , (35881, 125,       1) /* ResistHealthDrain */;
@@ -78,22 +78,34 @@ VALUES (35881,   1,  1895, 0, 0, 2090) /* MaxHealth */
      , (35881,   5,     0, 0, 0, 120) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35881,  6, 0, 2, 0, 460, 0, 0) /* MeleeDefense        Trained */
-     , (35881,  7, 0, 2, 0, 416, 0, 0) /* MissileDefense      Trained */
-     , (35881, 15, 0, 2, 0, 430, 0, 0) /* MagicDefense        Trained */
-     , (35881, 16, 0, 2, 0, 175, 0, 0) /* ManaConversion      Trained */
-     , (35881, 41, 0, 2, 0, 411, 0, 0) /* TwoHandedCombat     Trained */
-     , (35881, 44, 0, 2, 0, 411, 0, 0) /* HeavyWeapons        Trained */
-     , (35881, 45, 0, 2, 0, 411, 0, 0) /* LightWeapons        Trained */
-     , (35881, 46, 0, 2, 0, 411, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35881,  6, 0, 2, 0, 520, 0, 0) /* MeleeDefense        Trained */
+     , (35881,  7, 0, 2, 0, 620, 0, 0) /* MissileDefense      Trained */
+     , (35881, 15, 0, 2, 0, 420, 0, 0) /* MagicDefense        Trained */
+     , (35881, 45, 0, 2, 0, 495, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35881,  0,  4,  5,    0,  240,  540,  420,  269,  840,  840,  960,  840,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35881, 16,  4,  5,    0,  240,  540,  420,  269,  840,  840,  960,  840,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35881, 18,  4, 65,  0.5,  240,  540,  420,  269,  840,  840,  960,  840,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35881, 19,  4, 65,    0,  240,  540,  420,  269,  840,  840,  960,  840,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35881, 20,  2, 65, 0.75,  240,  540,  420,  269,  840,  840,  960,  840,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35881, 22, 16, 60,  0.5,  240,  540,  420,  269,  840,  840,  960,  840,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35881,  0,  4,  5,    0,  405,  540,  420,  269,  840,  840,  960,  840,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35881, 16,  4,  5,    0,  405,  540,  420,  269,  840,  840,  960,  840,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35881, 18,  4, 140,  0.5,  405,  540,  420,  269,  840,  840,  960,  840,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35881, 19,  4, 140,    0,  405,  540,  420,  269,  840,  840,  960,  840,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35881, 20,  2, 140, 0.75,  405,  540,  420,  269,  840,  840,  960,  840,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35881, 22, 16, 140,  0.5,  405,  540,  420,  269,  840,  840,  960,  840,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35881,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35881,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35881, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35882 Paradox-touched Olthoi Eviscerator.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35882 Paradox-touched Olthoi Eviscerator.sql
@@ -78,21 +78,34 @@ VALUES (35882,   1,  1390, 0, 0, 1570) /* MaxHealth */
      , (35882,   5,     0, 0, 0, 90) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35882,  6, 0, 2, 0, 408, 0, 0) /* MeleeDefense        Trained */
-     , (35882,  7, 0, 2, 0, 393, 0, 0) /* MissileDefense      Trained */
-     , (35882, 15, 0, 2, 0, 398, 0, 0) /* MagicDefense        Trained */
-     , (35882, 41, 0, 2, 0, 349, 0, 0) /* TwoHandedCombat     Trained */
-     , (35882, 44, 0, 2, 0, 349, 0, 0) /* HeavyWeapons        Trained */
-     , (35882, 45, 0, 2, 0, 349, 0, 0) /* LightWeapons        Trained */
-     , (35882, 46, 0, 2, 0, 349, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35882,  6, 0, 2, 0, 410, 0, 0) /* MeleeDefense        Trained */
+     , (35882,  7, 0, 2, 0, 500, 0, 0) /* MissileDefense      Trained */
+     , (35882, 15, 0, 2, 0, 360, 0, 0) /* MagicDefense        Trained */
+     , (35882, 45, 0, 2, 0, 370, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35882,  0,  4,  0,    0,  200,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35882, 16,  4,  0,    0,  200,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35882, 18,  2, 80,  0.5,  200,  450,  350,  224,  700,  700,  800,  700,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35882, 19,  2,  0, 0.75,  200,  450,  350,  224,  700,  700,  800,  700,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35882, 20,  1, 80, 0.75,  200,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35882, 22, 16, 50,  0.5,  200,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35882,  0,  4,  0,    0,  375,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35882, 16,  4,  0,    0,  375,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35882, 18,  2, 80,  0.5,  375,  450,  350,  224,  700,  700,  800,  700,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35882, 19,  2,  0, 0.75,  375,  450,  350,  224,  700,  700,  800,  700,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35882, 20,  1, 80, 0.75,  375,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35882, 22, 16, 50,  0.5,  375,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35882,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (35882,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35882, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35883 Paradox-touched Olthoi Lancer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35883 Paradox-touched Olthoi Lancer.sql
@@ -23,27 +23,27 @@ VALUES (35883,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35883,   1,       5) /* HeartbeatInterval */
      , (35883,   2,       0) /* HeartbeatTimestamp */
-     , (35883,   3,    0.65) /* HealthRate */
-     , (35883,   4,       4) /* StaminaRate */
-     , (35883,   5,       2) /* ManaRate */
-     , (35883,  13,    2.25) /* ArmorModVsSlash */
-     , (35883,  14,    1.75) /* ArmorModVsPierce */
-     , (35883,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35883,  16,     3.5) /* ArmorModVsCold */
-     , (35883,  17,     3.5) /* ArmorModVsFire */
-     , (35883,  18,       4) /* ArmorModVsAcid */
-     , (35883,  19,     3.5) /* ArmorModVsElectric */
-     , (35883,  31,      24) /* VisualAwarenessRange */
+     , (35883,   3,      20) /* HealthRate */
+     , (35883,   4,      12) /* StaminaRate */
+     , (35883,   5,       6) /* ManaRate */
+     , (35883,  13,       1) /* ArmorModVsSlash */
+     , (35883,  14,       1) /* ArmorModVsPierce */
+     , (35883,  15,     1.1) /* ArmorModVsBludgeon */
+     , (35883,  16,       1) /* ArmorModVsCold */
+     , (35883,  17,     1.1) /* ArmorModVsFire */
+     , (35883,  18,     1.5) /* ArmorModVsAcid */
+     , (35883,  19,    1.25) /* ArmorModVsElectric */
+     , (35883,  31,      28) /* VisualAwarenessRange */
      , (35883,  34,       1) /* PowerupTime */
      , (35883,  36,       1) /* ChargeSpeed */
      , (35883,  39,    0.75) /* DefaultScale */
-     , (35883,  64,       1) /* ResistSlash */
-     , (35883,  65,    0.95) /* ResistPierce */
-     , (35883,  66,       1) /* ResistBludgeon */
-     , (35883,  67,    0.75) /* ResistFire */
-     , (35883,  68,     0.5) /* ResistCold */
-     , (35883,  69,     0.5) /* ResistAcid */
-     , (35883,  70,    0.75) /* ResistElectric */
+     , (35883,  64,     0.7) /* ResistSlash */
+     , (35883,  65,       1) /* ResistPierce */
+     , (35883,  66,    0.75) /* ResistBludgeon */
+     , (35883,  67,    0.55) /* ResistFire */
+     , (35883,  68,     0.6) /* ResistCold */
+     , (35883,  69,    0.25) /* ResistAcid */
+     , (35883,  70,    0.45) /* ResistElectric */
      , (35883,  77,       1) /* PhysicsScriptIntensity */
      , (35883, 104,      10) /* ObviousRadarRange */
      , (35883, 125,       1) /* ResistHealthDrain */;
@@ -78,28 +78,19 @@ VALUES (35883,   1,  1390, 0, 0, 1570) /* MaxHealth */
      , (35883,   5,     0, 0, 0, 90) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35883,  6, 0, 2, 0, 408, 0, 0) /* MeleeDefense        Trained */
-     , (35883,  7, 0, 2, 0, 386, 0, 0) /* MissileDefense      Trained */
-     , (35883, 15, 0, 2, 0, 395, 0, 0) /* MagicDefense        Trained */
-     , (35883, 16, 0, 2, 0, 175, 0, 0) /* ManaConversion      Trained */
-     , (35883, 31, 0, 2, 0, 400, 0, 0) /* CreatureEnchantment Trained */
-     , (35883, 33, 0, 2, 0, 400, 0, 0) /* LifeMagic           Trained */
-     , (35883, 41, 0, 2, 0, 345, 0, 0) /* TwoHandedCombat     Trained */
-     , (35883, 44, 0, 2, 0, 345, 0, 0) /* HeavyWeapons        Trained */
-     , (35883, 45, 0, 2, 0, 345, 0, 0) /* LightWeapons        Trained */
-     , (35883, 46, 0, 2, 0, 345, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35883,  6, 0, 2, 0, 370, 0, 0) /* MeleeDefense        Trained */
+     , (35883,  7, 0, 2, 0, 520, 0, 0) /* MissileDefense      Trained */
+     , (35883, 15, 0, 2, 0, 340, 0, 0) /* MagicDefense        Trained */
+     , (35883, 45, 0, 2, 0, 345, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35883,  0,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35883, 10,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
-     , (35883, 13,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
-     , (35883, 16,  2,  0,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35883, 17,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
-     , (35883, 19,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
-     , (35883, 22, 32, 85,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
-
-INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (35883,  4334,   2.15)  /* Incantation of Nullify All Magic Other */;
+VALUES (35883,  0,  2, 125,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35883, 10,  2, 125,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
+     , (35883, 13,  2, 125,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
+     , (35883, 16,  2,  0,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35883, 17,  2, 125,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
+     , (35883, 19,  2, 125,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
+     , (35883, 22, 32, 85,  0.5,  260,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35883, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35884 Paradox-touched Olthoi Noble.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35884 Paradox-touched Olthoi Noble.sql
@@ -23,27 +23,27 @@ VALUES (35884,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35884,   1,       5) /* HeartbeatInterval */
      , (35884,   2,       0) /* HeartbeatTimestamp */
-     , (35884,   3,    0.65) /* HealthRate */
-     , (35884,   4,       4) /* StaminaRate */
-     , (35884,   5,       2) /* ManaRate */
-     , (35884,  13,    2.25) /* ArmorModVsSlash */
-     , (35884,  14,    1.75) /* ArmorModVsPierce */
-     , (35884,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35884,  16,     3.5) /* ArmorModVsCold */
-     , (35884,  17,     3.5) /* ArmorModVsFire */
-     , (35884,  18,       4) /* ArmorModVsAcid */
-     , (35884,  19,     3.5) /* ArmorModVsElectric */
+     , (35884,   3,      15) /* HealthRate */
+     , (35884,   4,      12) /* StaminaRate */
+     , (35884,   5,       6) /* ManaRate */
+     , (35884,  13,    0.69) /* ArmorModVsSlash */
+     , (35884,  14,     0.8) /* ArmorModVsPierce */
+     , (35884,  15,     0.6) /* ArmorModVsBludgeon */
+     , (35884,  16,       1) /* ArmorModVsCold */
+     , (35884,  17,       1) /* ArmorModVsFire */
+     , (35884,  18,     1.1) /* ArmorModVsAcid */
+     , (35884,  19,       1) /* ArmorModVsElectric */
      , (35884,  31,      24) /* VisualAwarenessRange */
      , (35884,  34,       1) /* PowerupTime */
      , (35884,  36,       1) /* ChargeSpeed */
      , (35884,  39,     0.8) /* DefaultScale */
-     , (35884,  64,       1) /* ResistSlash */
-     , (35884,  65,    0.95) /* ResistPierce */
+     , (35884,  64,    0.75) /* ResistSlash */
+     , (35884,  65,       1) /* ResistPierce */
      , (35884,  66,       1) /* ResistBludgeon */
      , (35884,  67,    0.75) /* ResistFire */
-     , (35884,  68,     0.5) /* ResistCold */
-     , (35884,  69,     0.5) /* ResistAcid */
-     , (35884,  70,    0.75) /* ResistElectric */
+     , (35884,  68,    0.75) /* ResistCold */
+     , (35884,  69,    0.42) /* ResistAcid */
+     , (35884,  70,    0.25) /* ResistElectric */
      , (35884,  77,       1) /* PhysicsScriptIntensity */
      , (35884, 104,      10) /* ObviousRadarRange */
      , (35884, 125,       1) /* ResistHealthDrain */;
@@ -78,22 +78,19 @@ VALUES (35884,   1,  1390, 0, 0, 1570) /* MaxHealth */
      , (35884,   5,     0, 0, 0, 90) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35884,  6, 0, 2, 0, 411, 0, 0) /* MeleeDefense        Trained */
-     , (35884,  7, 0, 2, 0, 390, 0, 0) /* MissileDefense      Trained */
-     , (35884, 15, 0, 2, 0, 398, 0, 0) /* MagicDefense        Trained */
-     , (35884, 41, 0, 2, 0, 347, 0, 0) /* TwoHandedCombat     Trained */
-     , (35884, 44, 0, 2, 0, 347, 0, 0) /* HeavyWeapons        Trained */
-     , (35884, 45, 0, 2, 0, 347, 0, 0) /* LightWeapons        Trained */
-     , (35884, 46, 0, 2, 0, 347, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35884,  6, 0, 2, 0, 410, 0, 0) /* MeleeDefense        Trained */
+     , (35884,  7, 0, 2, 0, 500, 0, 0) /* MissileDefense      Trained */
+     , (35884, 15, 0, 2, 0, 360, 0, 0) /* MagicDefense        Trained */
+     , (35884, 45, 0, 2, 0, 370, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35884,  0,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35884, 10,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
-     , (35884, 13,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
-     , (35884, 16,  2,  0,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35884, 17,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
-     , (35884, 19,  2, 125,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
-     , (35884, 22, 32, 85,  0.5,  325,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35884,  0,  4, 125,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35884, 10,  4, 125,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* FrontLeg */
+     , (35884, 13,  4, 125,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* RearLeg */
+     , (35884, 16,  4,  0,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35884, 17,  4, 125,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 3,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0) /* Tail */
+     , (35884, 19,  2, 125,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Leg */
+     , (35884, 22, 32, 85,  0.5,  350,  731,  569,  364, 1138, 1138, 1300, 1138,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35884, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35885 Paradox-touched Olthoi Warrior.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/35885 Paradox-touched Olthoi Warrior.sql
@@ -23,27 +23,27 @@ VALUES (35885,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (35885,   1,       5) /* HeartbeatInterval */
      , (35885,   2,       0) /* HeartbeatTimestamp */
-     , (35885,   3,    0.65) /* HealthRate */
-     , (35885,   4,       4) /* StaminaRate */
-     , (35885,   5,       2) /* ManaRate */
-     , (35885,  13,    2.25) /* ArmorModVsSlash */
-     , (35885,  14,    1.75) /* ArmorModVsPierce */
-     , (35885,  15,    1.12) /* ArmorModVsBludgeon */
-     , (35885,  16,     3.5) /* ArmorModVsCold */
-     , (35885,  17,     3.5) /* ArmorModVsFire */
-     , (35885,  18,       4) /* ArmorModVsAcid */
-     , (35885,  19,     3.5) /* ArmorModVsElectric */
-     , (35885,  31,      24) /* VisualAwarenessRange */
+     , (35885,   3,      15) /* HealthRate */
+     , (35885,   4,      12) /* StaminaRate */
+     , (35885,   5,       6) /* ManaRate */
+     , (35885,  13,       1) /* ArmorModVsSlash */
+     , (35885,  14,     0.8) /* ArmorModVsPierce */
+     , (35885,  15,     0.6) /* ArmorModVsBludgeon */
+     , (35885,  16,       1) /* ArmorModVsCold */
+     , (35885,  17,       1) /* ArmorModVsFire */
+     , (35885,  18,       1) /* ArmorModVsAcid */
+     , (35885,  19,       2) /* ArmorModVsElectric */
+     , (35885,  31,      30) /* VisualAwarenessRange */
      , (35885,  34,       1) /* PowerupTime */
      , (35885,  36,       1) /* ChargeSpeed */
      , (35885,  39,     1.3) /* DefaultScale */
-     , (35885,  64,       1) /* ResistSlash */
-     , (35885,  65,    0.95) /* ResistPierce */
+     , (35885,  64,    0.75) /* ResistSlash */
+     , (35885,  65,       1) /* ResistPierce */
      , (35885,  66,       1) /* ResistBludgeon */
      , (35885,  67,    0.75) /* ResistFire */
-     , (35885,  68,     0.5) /* ResistCold */
-     , (35885,  69,     0.5) /* ResistAcid */
-     , (35885,  70,    0.75) /* ResistElectric */
+     , (35885,  68,    0.75) /* ResistCold */
+     , (35885,  69,    0.42) /* ResistAcid */
+     , (35885,  70,    0.25) /* ResistElectric */
      , (35885,  77,       1) /* PhysicsScriptIntensity */
      , (35885, 104,      10) /* ObviousRadarRange */
      , (35885, 125,       1) /* ResistHealthDrain */;
@@ -78,25 +78,21 @@ VALUES (35885,   1,  1390, 0, 0, 1570) /* MaxHealth */
      , (35885,   5,     0, 0, 0, 90) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35885,  6, 0, 2, 0, 404, 0, 0) /* MeleeDefense        Trained */
-     , (35885,  7, 0, 2, 0, 388, 0, 0) /* MissileDefense      Trained */
-     , (35885, 15, 0, 2, 0, 397, 0, 0) /* MagicDefense        Trained */
-     , (35885, 16, 0, 2, 0, 175, 0, 0) /* ManaConversion      Trained */
-     , (35885, 41, 0, 2, 0, 344, 0, 0) /* TwoHandedCombat     Trained */
-     , (35885, 44, 0, 2, 0, 344, 0, 0) /* HeavyWeapons        Trained */
-     , (35885, 45, 0, 2, 0, 344, 0, 0) /* LightWeapons        Trained */
-     , (35885, 46, 0, 2, 0, 344, 0, 0) /* FinesseWeapons      Trained */;
+VALUES (35885,  6, 0, 2, 0, 410, 0, 0) /* MeleeDefense        Trained */
+     , (35885,  7, 0, 2, 0, 500, 0, 0) /* MissileDefense      Trained */
+     , (35885, 15, 0, 2, 0, 360, 0, 0) /* MagicDefense        Trained */
+     , (35885, 45, 0, 2, 0, 370, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35885,  0,  4,  5,    0,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (35885, 16,  4,  5,    0,  280,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (35885, 18,  4, 100,  0.5,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (35885, 19,  4, 10,    0,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (35885, 20,  2, 100, 0.75,  280,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (35885, 22, 32, 40,  0.5,  260,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (35885,  0,  4,  5,    0,  350,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (35885, 16,  4,  5,    0,  350,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (35885, 18,  4, 100,  0.5,  350,  585,  455,  291,  910,  910, 1040,  910,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (35885, 19,  4, 10,    0,  350,  585,  455,  291,  910,  910, 1040,  910,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (35885, 20,  2, 100, 0.75,  350,  630,  490,  314,  980,  980, 1120,  980,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (35885, 22, 32, 40,  0.5,  350,  585,  455,  291,  910,  910, 1040,  910,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (35885, 9, 35876,  1, 0, 0.1, False) /* Create Coruscating Olthoi Scent Gland (35876) for ContainTreasure */
      , (35885, 9,     0,  1, 0, 0.9, False) /* Create nothing for ContainTreasure */
-     , (35885, 9, 36376,  1, 0, 0.02, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
-     , (35885, 9,     0,  1, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (35885, 9, 36376,  1, 0, 0.03, False) /* Create Small Olthoi Venom Sac (36376) for ContainTreasure */
+     , (35885, 9,     0,  1, 0, 0.97, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/36961 Olthoi Protector.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ParadoxOlthoi/36961 Olthoi Protector.sql
@@ -28,24 +28,23 @@ VALUES (36961,   1,       5) /* HeartbeatInterval */
      , (36961,   3,    0.65) /* HealthRate */
      , (36961,   4,       4) /* StaminaRate */
      , (36961,   5,       2) /* ManaRate */
-     , (36961,  13,    2.25) /* ArmorModVsSlash */
-     , (36961,  14,    1.75) /* ArmorModVsPierce */
-     , (36961,  15,    1.12) /* ArmorModVsBludgeon */
-     , (36961,  16,     3.5) /* ArmorModVsCold */
-     , (36961,  17,     3.5) /* ArmorModVsFire */
-     , (36961,  18,       4) /* ArmorModVsAcid */
-     , (36961,  19,     3.5) /* ArmorModVsElectric */
+     , (36961,  13,     1.2) /* ArmorModVsSlash */
+     , (36961,  14,     1.2) /* ArmorModVsPierce */
+     , (36961,  15,     1.2) /* ArmorModVsBludgeon */
+     , (36961,  16,       1) /* ArmorModVsCold */
+     , (36961,  17,       1) /* ArmorModVsFire */
+     , (36961,  18,       1) /* ArmorModVsAcid */
+     , (36961,  19,       1) /* ArmorModVsElectric */
      , (36961,  31,      24) /* VisualAwarenessRange */
      , (36961,  34,       1) /* PowerupTime */
      , (36961,  36,       1) /* ChargeSpeed */
-     , (36961,  39,     0.8) /* DefaultScale */
-     , (36961,  64,       1) /* ResistSlash */
-     , (36961,  65,    0.95) /* ResistPierce */
-     , (36961,  66,       1) /* ResistBludgeon */
-     , (36961,  67,    0.75) /* ResistFire */
-     , (36961,  68,     0.5) /* ResistCold */
-     , (36961,  69,     0.5) /* ResistAcid */
-     , (36961,  70,    0.75) /* ResistElectric */
+     , (36961,  64,     0.6) /* ResistSlash */
+     , (36961,  65,    0.65) /* ResistPierce */
+     , (36961,  66,     0.7) /* ResistBludgeon */
+     , (36961,  67,    0.35) /* ResistFire */
+     , (36961,  68,    0.35) /* ResistCold */
+     , (36961,  69,    0.35) /* ResistAcid */
+     , (36961,  70,    0.35) /* ResistElectric */
      , (36961,  77,       1) /* PhysicsScriptIntensity */
      , (36961, 104,      10) /* ObviousRadarRange */
      , (36961, 125,       1) /* ResistHealthDrain */;
@@ -79,18 +78,31 @@ VALUES (36961,   1,  9850, 0, 0, 10000) /* MaxHealth */
      , (36961,   5,   700, 0, 0, 1000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36961,  6, 0, 2, 0, 300, 0, 0) /* MeleeDefense        Trained */
+VALUES (36961,  6, 0, 2, 0, 130, 0, 0) /* MeleeDefense        Trained */
      , (36961,  7, 0, 2, 0, 220, 0, 0) /* MissileDefense      Trained */
-     , (36961, 15, 0, 2, 0, 186, 0, 0) /* MagicDefense        Trained */
-     , (36961, 41, 0, 2, 0, 300, 0, 0) /* TwoHandedCombat     Trained */
-     , (36961, 44, 0, 2, 0, 300, 0, 0) /* HeavyWeapons        Trained */
-     , (36961, 45, 0, 2, 0, 300, 0, 0) /* LightWeapons        Trained */
-     , (36961, 46, 0, 2, 0, 349, 0, 0) /* FinesseWeapons      Trained */;
+     , (36961, 15, 0, 2, 0, 180, 0, 0) /* MagicDefense        Trained */
+     , (36961, 45, 0, 2, 0, 280, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (36961,  0,  4,  0,    0,  200,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
-     , (36961, 16,  4,  0,    0,  200,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
-     , (36961, 18,  2, 80,  0.5,  200,  450,  350,  224,  700,  700,  800,  700,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
-     , (36961, 19,  2,  0, 0.75,  200,  450,  350,  224,  700,  700,  800,  700,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
-     , (36961, 20,  1, 80, 0.75,  200,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
-     , (36961, 22, 16, 50,  0.5,  200,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+VALUES (36961,  0,  2, 150,    0,  400,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Head */
+     , (36961, 16,  4, 150,    0,  400,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45, 0.45,  0.4, 0.45) /* Torso */
+     , (36961, 18,  2, 150,  0.5,  400,  450,  350,  224,  700,  700,  800,  700,    0, 2,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1,    0,  0.2,  0.1) /* Arm */
+     , (36961, 19,  2, 150, 0.75,  400,  450,  350,  224,  700,  700,  800,  700,    0, 3,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45,    0,  0.2, 0.45) /* Leg */
+     , (36961, 20,  1, 150, 0.75,  400,  450,  350,  224,  700,  700,  800,  700,    0, 2, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0, 0.45,  0.2,    0) /* Claw */
+     , (36961, 22, 32, 100,  0.5,  400,  450,  350,  224,  700,  700,  800,  700,    0, 1,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0,  0.1,    0,    0) /* Breath */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (36961,  5 /* HeartBeat */,   0.15, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (36961,  5 /* HeartBeat */,   0.15, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Sets skills and armor values from the pcap, and revises resistance mods to match existing olthoi. 
Corrects scale of Ward Guardian, and a few other olthoi. 
Corrects body table of Sentinel type olthoi, which were previously doing 0 damage with one of their body part. 
Adds missing idle emote to some olthoi.
Adjusts damage on some olthoi. For example, Olthoi Swarm Eviscerators were doing too little damage while some low level olthoi were doing too much damage - the same as their higher level counterpart.