### PR TITLE
2DAF BB9D Fix Life Stone Placement.

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/2DAF.sql
+++ b/Database/Patches/6 LandBlockExtendedData/2DAF.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x2DAF;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x72DAF007,   509, 0x2DAF000E, 45.7621, 141.364, 48, 0.770446, 0, 0, -0.637505, False, '2021-11-01 00:00:00'); /* Life Stone */
-/* @teleloc 0x2DAF000E [45.762100 141.363998 48.000000] 0.770446 0.000000 0.000000 -0.637505 */
+VALUES (0x72DAF007, 509, 0x2DAF000E, 45.761719, 141.363281, 0, 1, 0, 0, 0, False, '2024-06-13 12:00:00'); /* Life Stone */
+/* @teleloc 0x2DAF000E [45.761719 141.363281 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x72DAF008, 24129, 0x2DAF0018, 51.3585, 190.145, -0.438, 0.726705, 0, 0, -0.68695, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 2 Min.) */

--- a/Database/Patches/6 LandBlockExtendedData/BB9D.sql
+++ b/Database/Patches/6 LandBlockExtendedData/BB9D.sql
@@ -1,8 +1,8 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0xBB9D;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7BB9D000,   509, 0xBB9D0000, 155.176, 189.496, 36.6771, 0.90658, 0, 0, 0.422034, False, '2021-11-01 00:00:00'); /* Life Stone */
-/* @teleloc 0xBB9D0000 [155.175995 189.496002 36.677101] 0.906580 0.000000 0.000000 0.422034 */
+VALUES (0x7BB9D000, 509, 0xBB9D0038, 155.175781, 189.496094, 0.000000, 1, 0, 0, 0, False, '2024-06-13 12:00:00'); /* Life Stone */
+/* @teleloc 0xBB9D0038 [155.175781 189.496094 0.000000] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7BB9D043, 43249, 0xBB9D0038, 157.828, 184.569, 35.6142, -0.950534, 0, 0, 0.31062, False, '2021-11-01 00:00:00'); /* Emissary of Asheron */


### PR DESCRIPTION
Align positioning to match vloc data for 'Flame Guardian' and 'Cragstone Advocate' Life Stones

'Flame Guardian' Life Stone was not on top of hill as expected, but down at bottom of cliff
 'Cragstone Advocate' Life Stone was failing to spawn

Now aligned with vloc data, the Life Stones spawn in the correct places.