### PR TITLE
Add Prismatic Amuli and Celdon Recipes

### DIFF
--- a/Database/Patches/4 CraftTable/09225 Prismatic Amuli Coat.sql
+++ b/Database/Patches/4 CraftTable/09225 Prismatic Amuli Coat.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9225;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9225, 0, 0, 0, 0, 32756 /* Prismatic Amuli Coat */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (9225, 0, 0, 0, 0, 32756 /* Prismatic Amuli Coat */, 1, 'You''ve altered your armor!', 0, 0, '', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9225;
 

--- a/Database/Patches/4 CraftTable/09225 Prismatic Amuli Coat.sql
+++ b/Database/Patches/4 CraftTable/09225 Prismatic Amuli Coat.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9225;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9225, 0, 0, 0, 0, 32756 /* Prismatic Amuli Coat */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9225;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9225, 32945 /* Prismatic Glyph */, 14831 /* Greater Amuli Shadow Coat */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09226 Prismatic Amuli Leggings.sql
+++ b/Database/Patches/4 CraftTable/09226 Prismatic Amuli Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9226;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9226, 0, 0, 0, 0, 32757 /* Prismatic Amuli Leggings */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (9226, 0, 0, 0, 0, 32757 /* Prismatic Amuli Leggings */, 1, 'You''ve altered your armor!', 0, 0, '', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9226;
 

--- a/Database/Patches/4 CraftTable/09226 Prismatic Amuli Leggings.sql
+++ b/Database/Patches/4 CraftTable/09226 Prismatic Amuli Leggings.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9226;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9226, 0, 0, 0, 0, 32757 /* Prismatic Amuli Leggings */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9226;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9226, 32945 /* Prismatic Glyph */, 14839 /* Greater Amuli Shadow Leggings */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09227 Prismatic Celdon Breastplate.sql
+++ b/Database/Patches/4 CraftTable/09227 Prismatic Celdon Breastplate.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9227;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9227, 0, 0, 0, 0, 32759 /* Prismatic Celdon Breastplate */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9227;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9227, 32945 /* Prismatic Glyph */, 14823 /* Greater Celdon Shadow Breastplate */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09227 Prismatic Celdon Breastplate.sql
+++ b/Database/Patches/4 CraftTable/09227 Prismatic Celdon Breastplate.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9227;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9227, 0, 0, 0, 0, 32759 /* Prismatic Celdon Breastplate */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (9227, 0, 0, 0, 0, 32759 /* Prismatic Celdon Breastplate */, 1, 'You''ve altered your armor!', 0, 0, '', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9227;
 

--- a/Database/Patches/4 CraftTable/09228 Prismatic Celdon Girth.sql
+++ b/Database/Patches/4 CraftTable/09228 Prismatic Celdon Girth.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9228;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9228, 0, 0, 0, 0, 32761 /* Prismatic Celdon Girth */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (9228, 0, 0, 0, 0, 32761 /* Prismatic Celdon Girth */, 1, 'You''ve altered your armor!', 0, 0, '', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9228;
 

--- a/Database/Patches/4 CraftTable/09228 Prismatic Celdon Girth.sql
+++ b/Database/Patches/4 CraftTable/09228 Prismatic Celdon Girth.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9228;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9228, 0, 0, 0, 0, 32761 /* Prismatic Celdon Girth */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9228;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9228, 32945 /* Prismatic Glyph */, 14835 /* Greater Celdon Shadow Girth */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09229 Prismatic Celdon Leggings.sql
+++ b/Database/Patches/4 CraftTable/09229 Prismatic Celdon Leggings.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9229;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9229, 0, 0, 0, 0, 32762 /* Prismatic Celdon Leggings */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9229;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9229, 32945 /* Prismatic Glyph */, 14843 /* Greater Celdon Shadow Leggings */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09229 Prismatic Celdon Leggings.sql
+++ b/Database/Patches/4 CraftTable/09229 Prismatic Celdon Leggings.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9229;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9229, 0, 0, 0, 0, 32762 /* Prismatic Celdon Leggings */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (9229, 0, 0, 0, 0, 32762 /* Prismatic Celdon Leggings */, 1, 'You''ve altered your armor!', 0, 0, '', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9229;
 

--- a/Database/Patches/4 CraftTable/09230 Prismatic Celdon Sleeves.sql
+++ b/Database/Patches/4 CraftTable/09230 Prismatic Celdon Sleeves.sql
@@ -1,0 +1,9 @@
+DELETE FROM `recipe` WHERE `id` = 9230;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9230, 0, 0, 0, 0, 32765 /* Prismatic Celdon Sleeves */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9230;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9230, 32945 /* Prismatic Glyph */, 14851 /* Greater Celdon Shadow Sleeves */, '2021-11-01 00:00:00');

--- a/Database/Patches/4 CraftTable/09230 Prismatic Celdon Sleeves.sql
+++ b/Database/Patches/4 CraftTable/09230 Prismatic Celdon Sleeves.sql
@@ -1,7 +1,7 @@
 DELETE FROM `recipe` WHERE `id` = 9230;
 
 INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (9230, 0, 0, 0, 0, 32765 /* Prismatic Celdon Sleeves */, 1, 'You''ve altered your armor!', 0, 0, '', 1, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
+VALUES (9230, 0, 0, 0, 0, 32765 /* Prismatic Celdon Sleeves */, 1, 'You''ve altered your armor!', 0, 0, '', 0, 0, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, '2021-11-01 00:00:00');
 
 DELETE FROM `cook_book` WHERE `recipe_Id` = 9230;
 


### PR DESCRIPTION
Adds recipes to create these Shadow Armor pieces. Although retired, they could still be made at the end of retail if a person had left over armor pieces, and could be useful for server operators who wish to make this armor available again.