### PR TITLE
Misc Updates July

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/0046.sql
+++ b/Database/Patches/6 LandBlockExtendedData/0046.sql
@@ -33,7 +33,7 @@ VALUES (0x70046033,  5627, 0x00460398, 533, -90, 36, -0.707107, 0, 0, -0.707107,
 /* @teleloc 0x00460398 [533.000000 -90.000000 36.000000] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x70046034,  1154, 0x00460125, 41.8391, -318.421, 0, 0.859443, 0, 0, -0.511232, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x70046034,  7924, 0x00460125, 41.8391, -318.421, 0, 0.859443, 0, 0, -0.511232, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x00460125 [41.839100 -318.420990 0.000000] 0.859443 0.000000 0.000000 -0.511232 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/40D8.sql
+++ b/Database/Patches/6 LandBlockExtendedData/40D8.sql
@@ -49,10 +49,7 @@ VALUES (0x740D8006, 0x740D800B, '2021-11-01 00:00:00') /* Bane Grievver (7983) *
      , (0x740D8006, 0x740D802E, '2021-11-01 00:00:00') /* Ripper Grievver (30756) */
      , (0x740D8006, 0x740D802F, '2021-11-01 00:00:00') /* Ripper Grievver (30756) */
      , (0x740D8006, 0x740D8030, '2021-11-01 00:00:00') /* Ripper Grievver (30756) */
-     , (0x740D8006, 0x740D8031, '2021-11-01 00:00:00') /* Flare (5710) */
      , (0x740D8006, 0x740D8032, '2021-11-01 00:00:00') /* Inferno (5712) */
-     , (0x740D8006, 0x740D8033, '2021-11-01 00:00:00') /* Flamma (5711) */
-     , (0x740D8006, 0x740D8034, '2021-11-01 00:00:00') /* Flare (5710) */
      , (0x740D8006, 0x740D8035, '2021-11-01 00:00:00') /* Ripper Grievver (30756) */
      , (0x740D8006, 0x740D8036, '2021-11-01 00:00:00') /* Ripper Grievver (30756) */
      , (0x740D8006, 0x740D8037, '2021-11-01 00:00:00') /* Escaped Thief (32833) */
@@ -62,11 +59,7 @@ VALUES (0x740D8006, 0x740D800B, '2021-11-01 00:00:00') /* Bane Grievver (7983) *
      , (0x740D8006, 0x740D803B, '2021-11-01 00:00:00') /* Abhorrent Eater (28641) */
      , (0x740D8006, 0x740D8041, '2021-11-01 00:00:00') /* Bane Grievver (7983) */
      , (0x740D8006, 0x740D8042, '2021-11-01 00:00:00') /* Bane Grievver (7983) */
-     , (0x740D8006, 0x740D8043, '2021-11-01 00:00:00') /* Flamma (5711) */
-     , (0x740D8006, 0x740D8044, '2021-11-01 00:00:00') /* Flare (5710) */
      , (0x740D8006, 0x740D8045, '2021-11-01 00:00:00') /* Inferno (5712) */
-     , (0x740D8006, 0x740D8046, '2021-11-01 00:00:00') /* Flamma (5711) */
-     , (0x740D8006, 0x740D8047, '2021-11-01 00:00:00') /* Flare (5710) */
      , (0x740D8006, 0x740D8048, '2021-11-01 00:00:00') /* Ripper Grievver (30756) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
@@ -182,20 +175,8 @@ VALUES (0x740D8030, 30756, 0x40D8012C, 92, 43, -43.6022, 1, 0, 0, 0,  True, '202
 /* @teleloc 0x40D8012C [92.000000 43.000000 -43.602200] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8031,  5710, 0x40D80104, 68.1331, 87.52, -61.595, -0.398228, 0, 0, -0.917287,  True, '2021-11-01 00:00:00'); /* Flare */
-/* @teleloc 0x40D80104 [68.133102 87.519997 -61.595001] -0.398228 0.000000 0.000000 -0.917287 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x740D8032,  5712, 0x40D80105, 73.0032, 73.5359, -61.5915, 0.915959, 0, 0, -0.401273,  True, '2021-11-01 00:00:00'); /* Inferno */
 /* @teleloc 0x40D80105 [73.003197 73.535896 -61.591499] 0.915959 0.000000 0.000000 -0.401273 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8033,  5711, 0x40D80105, 70.0751, 68.624, -61.5935, 0.915959, 0, 0, -0.401273,  True, '2021-11-01 00:00:00'); /* Flamma */
-/* @teleloc 0x40D80105 [70.075104 68.624001 -61.593498] 0.915959 0.000000 0.000000 -0.401273 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8034,  5710, 0x40D80105, 67.48, 69.6209, -61.595, 0.915959, 0, 0, -0.401273,  True, '2021-11-01 00:00:00'); /* Flare */
-/* @teleloc 0x40D80105 [67.480003 69.620903 -61.595001] 0.915959 0.000000 0.000000 -0.401273 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x740D8035, 30756, 0x40D8011F, 82, 13, -43.6022, 1, 0, 0, 0,  True, '2021-11-01 00:00:00'); /* Ripper Grievver */
@@ -234,24 +215,8 @@ VALUES (0x740D8042,  7983, 0x40D801E8, 62, 33, -19.6022, 0.731689, 0, 0, -0.6816
 /* @teleloc 0x40D801E8 [62.000000 33.000000 -19.602200] 0.731689 0.000000 0.000000 -0.681639 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8043,  5711, 0x40D80104, 68.9884, 85.7153, -61.5935, -0.398228, 0, 0, -0.917287,  True, '2021-11-01 00:00:00'); /* Flamma */
-/* @teleloc 0x40D80104 [68.988403 85.715302 -61.593498] -0.398228 0.000000 0.000000 -0.917287 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8044,  5710, 0x40D80107, 81.4853, 69.0319, -61.595, 0.915959, 0, 0, -0.401273,  True, '2021-11-01 00:00:00'); /* Flare */
-/* @teleloc 0x40D80107 [81.485298 69.031898 -61.595001] 0.915959 0.000000 0.000000 -0.401273 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x740D8045,  5712, 0x40D80106, 81.3355, 82.0503, -61.5915, -0.398228, 0, 0, -0.917287,  True, '2021-11-01 00:00:00'); /* Inferno */
 /* @teleloc 0x40D80106 [81.335503 82.050301 -61.591499] -0.398228 0.000000 0.000000 -0.917287 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8046,  5711, 0x40D80106, 79.3558, 80.7141, -61.5935, 0.915959, 0, 0, -0.401273,  True, '2021-11-01 00:00:00'); /* Flamma */
-/* @teleloc 0x40D80106 [79.355797 80.714104 -61.593498] 0.915959 0.000000 0.000000 -0.401273 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x740D8047,  5710, 0x40D80106, 80.2736, 83.8487, -61.595, -0.398228, 0, 0, -0.917287,  True, '2021-11-01 00:00:00'); /* Flare */
-/* @teleloc 0x40D80106 [80.273598 83.848701 -61.595001] -0.398228 0.000000 0.000000 -0.917287 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x740D8048, 30756, 0x40D801A7, 81.4006, 38.619, -25.6022, 0.231985, 0, 0, -0.972719,  True, '2021-11-01 00:00:00'); /* Ripper Grievver */

--- a/Database/Patches/9 WeenieDefaults/Book/Writable/32515 Underminer Notes.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Writable/32515 Underminer Notes.sql
@@ -7,7 +7,10 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32515,   1,       8192) /* ItemType - Writable */
      , (32515,   5,          5) /* EncumbranceVal */
      , (32515,  16,          8) /* ItemUseable - Contained */
-     , (32515,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+     , (32515,  19,          0) /* Value */
+     , (32515,  33,          1) /* Bonded - Bonded */
+     , (32515,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (32515, 114,          1) /* Attuned - Attuned */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32515,  11, True ) /* IgnoreCollisions */
@@ -20,6 +23,7 @@ VALUES (32515,  54,       1) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (32515,   1, 'Underminer Notes') /* Name */
+     , (32515,  16, 'A letter belonging to the leader of the Underminers at the quarry near Yanshi.') /* LongDesc */
      , (32515,  33, 'underminernotestimer') /* Quest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Creature/AunTumerok/52015 Aun Ol'tra.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/AunTumerok/52015 Aun Ol'tra.sql
@@ -1,11 +1,12 @@
 DELETE FROM `weenie` WHERE `class_Id` = 52015;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (52015, 'ace52015-aunoltra', 10, '2022-08-22 03:09:27') /* Creature */;
+VALUES (52015, 'ace52015-aunoltra', 10, '2024-07-06 11:30:13') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (52015,   1,         16) /* ItemType - Creature */
      , (52015,   2,         57) /* CreatureType - AunTumerok */
+     , (52015,   3,          8) /* PaletteTemplate - Green */
      , (52015,   6,         -1) /* ItemsCapacity */
      , (52015,   7,         -1) /* ContainersCapacity */
      , (52015,  16,         32) /* ItemUseable - Remote */
@@ -31,12 +32,21 @@ VALUES (52015,   1, 0x02000AB7) /* Setup */
      , (52015,   2, 0x090000C0) /* MotionTable */
      , (52015,   3, 0x20000013) /* SoundTable */
      , (52015,   6, 0x04001140) /* PaletteBase */
+     , (52015,   7, 0x100002E1) /* ClothingBase */
      , (52015,   8, 0x0600210C) /* Icon */;
 
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (52015,   1, 300, 0, 0) /* Strength */
+     , (52015,   2, 330, 0, 0) /* Endurance */
+     , (52015,   3, 330, 0, 0) /* Quickness */
+     , (52015,   4, 300, 0, 0) /* Coordination */
+     , (52015,   5, 324, 0, 0) /* Focus */
+     , (52015,   6, 360, 0, 0) /* Self */;
+
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (52015,   1,   196, 0, 0, 296) /* MaxHealth */
-     , (52015,   3,   196, 0, 0, 396) /* MaxStamina */
-     , (52015,   5,   196, 0, 0, 396) /* MaxMana */;
+VALUES (52015,   1,   131, 0, 0, 296) /* MaxHealth */
+     , (52015,   3,    66, 0, 0, 396) /* MaxStamina */
+     , (52015,   5,    36, 0, 0, 396) /* MaxMana */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (52015,  1 /* Refuse */,      1, 72025 /* Crimson Scarab */, NULL, NULL, NULL, NULL, NULL, NULL);
@@ -45,17 +55,17 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 72025 /* Crimson Scarab */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  74 /* TakeItems */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 72025 /* Crimson Scarab */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  2,  22 /* StampQuest */, 0, 1, NULL, 'EODCompleted_1013', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  3,  31 /* EraseQuest */, 0, 1, NULL, 'EODStarted_1013', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  4,  10 /* Tell */, 0, 1, NULL, 'This trinket contains great power, and great evil. The potency within must be cleansed from this land.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  5,  18 /* DirectBroadcast */, 0, 1, NULL, 'Aun Ol''tra places the Crimson Scarab within a small pouch and shakes it violently.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  6,  10 /* Tell */, 0, 1, NULL, 'The corruption has been removed. Never again will this trinket hold influence for the Rynthid.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  7,  10 /* Tell */, 0, 1, NULL, 'Take these, you have attained great respect from our tribe by your deeds.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  8,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 52036 /* Purified Crimson Scarab */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  9,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 300000000, 0, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  8,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52036 /* Purified Crimson Scarab */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  9,  62 /* AwardNoShareXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 300000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 10, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 15000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id, 11,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 20630 /* Trade Note (250,000) */, 8, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id, 11,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 20630 /* Trade Note (250,000) */, 8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id, 12, 102 /* InqQuestBitsOn */, 0, 1, NULL, 'LegendaryQuestsA@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
@@ -65,7 +75,7 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  12 /* TurnToTarget */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  36 /* InqIntStat */, 0, 1, NULL, 'Level_180-999_3', NULL, 180, 999, NULL, NULL, NULL, NULL, 25 /* PropertyInt.Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+     , (@parent_id,  1,  36 /* InqIntStat */, 0, 1, NULL, 'Level_180-999', NULL, 180, 999, NULL, NULL, NULL, NULL, 25 /* PropertyInt.Level */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (52015, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'EODCompleted_1013@2', NULL, NULL, NULL);
@@ -83,6 +93,15 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You return so soon?', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (52015, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'LegendaryQuestsA@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0, 106 /* SetQuestBitsOn */, 0, 1, NULL, 'LegendaryQuestsA', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  22 /* StampQuest */, 0, 1, NULL, 'LegendaryQuestCounter_0913', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (52015, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'EODCompleted_1013@2', NULL, NULL, NULL);
@@ -107,16 +126,7 @@ VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Greetings. We are in grave 
      , (@parent_id,  6,  22 /* StampQuest */, 0, 1, NULL, 'EODStarted_1013', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (52015, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'LegendaryQuestsA@2', NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0, 106 /* SetQuestBitsOn */, 0, 1, NULL, 'LegendaryQuestsA', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 8, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  22 /* StampQuest */, 0, 1, NULL, 'LegendaryQuestCounter_0913', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (52015, 22 /* TestSuccess */,      1, NULL, NULL, NULL, 'Level_180-999_3', NULL, NULL, NULL);
+VALUES (52015, 22 /* TestSuccess */,      1, NULL, NULL, NULL, 'Level_180-999', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
@@ -124,7 +134,7 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,  21 /* InqQuest */, 0, 1, NULL, 'EODCompleted_1013@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (52015, 23 /* TestFailure */,      1, NULL, NULL, NULL, 'Level_180-999_3', NULL, NULL, NULL);
+VALUES (52015, 23 /* TestFailure */,      1, NULL, NULL, NULL, 'Level_180-999', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 

--- a/Database/Patches/9 WeenieDefaults/Creature/GearKnight/70712 Iron Blade Warmaster.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/GearKnight/70712 Iron Blade Warmaster.sql
@@ -49,7 +49,7 @@ INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70712,   1, 'Iron Blade Warmaster') /* Name */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (70712,   1, 0x02001909) /* Setup */
+VALUES (70712,   1, 0x02001919) /* Setup */
      , (70712,   2, 0x090001A8) /* MotionTable */
      , (70712,   3, 0x200000D3) /* SoundTable */
      , (70712,   4, 0x30000000) /* CombatTable */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/41545 Sir Yanov.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/41545 Sir Yanov.sql
@@ -251,4 +251,5 @@ VALUES (41545, 2, 32698,  0, 9, 0, False) /* Create Shield of Strathelar (32698)
      , (41545, 2, 33584,  0, 21, 0, False) /* Create Noble Relic Coat of Brilliance (33584) for Wield */
      , (41545, 2, 33587,  0, 21, 0, False) /* Create Noble Relic Leggings of Health (33587) for Wield */
      , (41545, 2, 33585,  0, 21, 0, False) /* Create Noble Relic Gauntlets of Strength (33585) for Wield */
-     , (41545, 2, 33588,  0, 21, 0, False) /* Create Noble Relic Sollerets of Speed (33588) for Wield */;
+     , (41545, 2, 33588,  0, 21, 0, False) /* Create Noble Relic Sollerets of Speed (33588) for Wield */
+     , (41545, 2, 44998,  0, 17, 1, False) /* Create Strathelar Royal Cloak (44998) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/41546 Dame Trielle.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/41546 Dame Trielle.sql
@@ -153,4 +153,5 @@ VALUES (41546, 2, 32698,  0, 9, 0, False) /* Create Shield of Strathelar (32698)
      , (41546, 2, 33586,  0, 21, 0, False) /* Create Noble Relic Helm of Will (33586) for Wield */
      , (41546, 2, 33587,  0, 21, 0, False) /* Create Noble Relic Leggings of Health (33587) for Wield */
      , (41546, 2, 33585,  0, 21, 0, False) /* Create Noble Relic Gauntlets of Strength (33585) for Wield */
-     , (41546, 2, 33588,  0, 21, 0, False) /* Create Noble Relic Sollerets of Speed (33588) for Wield */;
+     , (41546, 2, 33588,  0, 21, 0, False) /* Create Noble Relic Sollerets of Speed (33588) for Wield */
+     , (41546, 2, 44998,  0, 17, 1, False) /* Create Strathelar Royal Cloak (44998) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/42360 Sir Durnstad.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/42360 Sir Durnstad.sql
@@ -195,7 +195,13 @@ VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You must be at least level 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (42360, 2, 32698,  0, 9, 0, False) /* Create Shield of Strathelar (32698) for Wield */
      , (42360, 2, 31288,  0, 0, 0, False) /* Create Blade of the Realm (31288) for Wield */
-     , (42360, 2, 33584,  0, 21, 0, False) /* Create Noble Relic Coat of Brilliance (33584) for Wield */
-     , (42360, 2, 33587,  0, 21, 0, False) /* Create Noble Relic Leggings of Health (33587) for Wield */
-     , (42360, 2, 33585,  0, 21, 0, False) /* Create Noble Relic Gauntlets of Strength (33585) for Wield */
-     , (42360, 2, 33588,  0, 21, 0, False) /* Create Noble Relic Sollerets of Speed (33588) for Wield */;
+     , (42360, 2,  2587,  0, 14, 0, False) /* Create Shirt (2587) for Wield */
+     , (42360, 2,  2601,  0, 14, 0, False) /* Create Loose Pants (2601) for Wield */
+     , (42360, 2, 21150,  0, 21, 0.2857, False) /* Create Covenant Sollerets (21150) for Wield */
+     , (42360, 2, 21151,  0, 21, 0.2857, False) /* Create Covenant Bracers (21151) for Wield */
+     , (42360, 2, 21152,  0, 21, 0.2857, False) /* Create Covenant Breastplate (21152) for Wield */
+     , (42360, 2, 21153,  0, 21, 0.2857, False) /* Create Covenant Gauntlets (21153) for Wield */
+     , (42360, 2, 21154,  0, 21, 0.2857, False) /* Create Covenant Girth (21154) for Wield */
+     , (42360, 2, 21155,  0, 21, 0.2857, False) /* Create Covenant Greaves (21155) for Wield */
+     , (42360, 2, 21157,  0, 21, 0.2857, False) /* Create Covenant Pauldrons (21157) for Wield */
+     , (42360, 2, 21159,  0, 21, 0.2857, False) /* Create Covenant Tassets (21159) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/33542 Lanaith.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/33542 Lanaith.sql
@@ -14,7 +14,6 @@ VALUES (33542,   1,         16) /* ItemType - Creature */
      , (33542,  25,        150) /* Level */
      , (33542,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
      , (33542,  95,          8) /* RadarBlipColor - Yellow */
-     , (33542, 113,          2) /* Gender - Female */
      , (33542, 133,          4) /* ShowableOnRadar - ShowAlways */
      , (33542, 134,         16) /* PlayerKillerStatus - RubberGlue */;
 
@@ -136,6 +135,6 @@ VALUES (33542, 2, 33080,  1, 0, 0, False) /* Create Shadow Blade (33080) for Wie
      , (33542, 2, 21153,  0, 93, 1, False) /* Create Covenant Gauntlets (21153) for Wield */
      , (33542, 2, 21154,  0, 93, 1, False) /* Create Covenant Girth (21154) for Wield */
      , (33542, 2, 21155,  0, 93, 1, False) /* Create Covenant Greaves (21155) for Wield */
-     , (33542, 2, 33104,  0, 93, 1, False) /* Create Helm of Isin Dule (33104) for Wield */
+     , (33542, 2, 87038,  0, 93, 1, False) /* Create Helm of Isin Dule (87038) for Wield */
      , (33542, 2, 21157,  0, 93, 1, False) /* Create Covenant Pauldrons (21157) for Wield */
      , (33542, 2, 21159,  0, 93, 1, False) /* Create Covenant Tassets (21159) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32833 Escaped Thief.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32833 Escaped Thief.sql
@@ -13,7 +13,7 @@ VALUES (32833,   1,         16) /* ItemType - Creature */
      , (32833,  27,          0) /* ArmorType - None */
      , (32833,  40,          2) /* CombatMode - Melee */
      , (32833,  68,          9) /* TargetingTactic - Random, TopDamager */
-     , (32833,  72,         83) /* FriendType - ViamontianKnight */
+     , (32833,  72,         79) /* FriendType - Eater */
      , (32833,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (32833, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (32833, 113,          1) /* Gender - Male */


### PR DESCRIPTION
Updates clothing (mostly missing cloaks) of some Gearknight Direlands Invasion area NPCs, and setup of Iron Blade Warmaster, to match their appearance on a Loud Lou retail video. 

Adds missing clothing base and palette to Aun Oltra at Rynthid Infested Plains Camp. 

Escaped Thief in Sword of Belenesse quest now has friend type Eater, so his eaters will come to his aid when attacked from a distance, like in retail. Removes flamma and flare spawns in the Sword of Belenesse dungeon. All of these spawn from the Infernos and should not be in the linkable monster gen. 

Adds missing attuned, bonded, and description to Underminer Notes from Shield of Yanshi quest, and changes respawn to 5 min. This had been left with the default pcap gen (of about 13 min). The respawn was not that slow.