### PR TITLE
Misc Fixes October

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Ammunition/MissileWeapon/47513 Arrow.sql
+++ b/Database/Patches/9 WeenieDefaults/Ammunition/MissileWeapon/47513 Arrow.sql
@@ -15,8 +15,8 @@ VALUES (47513,   1,        256) /* ItemType - MissileWeapon */
      , (47513,  16,          1) /* ItemUseable - No */
      , (47513,  19,          7) /* Value */
      , (47513,  33,         -2) /* Bonded - Destroy */
-     , (47513,  44,         10) /* Damage */
-     , (47513,  45,          0) /* DamageType - Undef */
+     , (47513,  44,        200) /* Damage */
+     , (47513,  45,          2) /* DamageType - Pierce */
      , (47513,  48,          0) /* WeaponSkill - None */
      , (47513,  49,         -1) /* WeaponTime */
      , (47513,  50,          1) /* AmmoType - Arrow */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/46563 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/46563 Spectral Archer.sql
@@ -11,9 +11,9 @@ VALUES (46563,   1,         16) /* ItemType - Creature */
      , (46563,  16,          1) /* ItemUseable - No */
      , (46563,  25,        240) /* Level */
      , (46563,  40,          2) /* CombatMode - Melee */
-     , (46563,  48,         47) /* WeaponSkill - MissileWeapons */
      , (46563,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
      , (46563,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
+     , (46563, 101,     524288) /* AiAllowedCombatStyle - StubbornMissile */
      , (46563, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (46563, 146,    1850000) /* XpOverride */
      , (46563, 307,         10) /* DamageRating */

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/47217 Ensorcelled Weapon.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/47217 Ensorcelled Weapon.sql
@@ -107,6 +107,6 @@ VALUES (47217,  0,  4,  0,    0,  400,  400,  360,  300,  400,  400,  268,  400,
      , (47217,  8,  4, 600, 0.75,  400,  400,  360,  300,  400,  400,  268,  400,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (47217, 10, 47219,  1, 0, 0.33, False) /* Create Ensorcelled Sword (47219) for WieldTreasure */
-     , (47217, 10, 47220,  1, 0, 0.33, False) /* Create Ensorcelled Dagger (47220) for WieldTreasure */
-     , (47217, 10, 47222,  1, 0, 0.34, False) /* Create Ensorcelled Mace (47222) for WieldTreasure */;
+VALUES (47217, 10, 47222,  1, 0, 0.5, False) /* Create Ensorcelled Mace (47222) for WieldTreasure */
+     , (47217, 10, 47219,  1, 0, 0.5, False) /* Create Ensorcelled Dagger (47220) for WieldTreasure */
+     , (47217, 10, 47220,  1, 0, 0.5, False) /* Create Ensorcelled Sword (47219) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/47226 Ensorcelled Weapon.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/47226 Ensorcelled Weapon.sql
@@ -88,11 +88,8 @@ VALUES (47226,  6, 0, 2, 0, 400, 0, 0) /* MeleeDefense        Trained */
      , (47226,  7, 0, 2, 0, 350, 0, 0) /* MissileDefense      Trained */
      , (47226, 15, 0, 2, 0, 330, 0, 0) /* MagicDefense        Trained */
      , (47226, 24, 0, 2, 0, 200, 0, 0) /* Run                 Trained */
-     , (47226, 33, 0, 2, 0, 380, 0, 0) /* LifeMagic           Trained */
-     , (47226, 34, 0, 2, 0, 380, 0, 0) /* WarMagic            Trained */
      , (47226, 45, 0, 3, 0, 395, 0, 0) /* LightWeapons        Specialized */
      , (47226, 46, 0, 3, 0, 395, 0, 0) /* FinesseWeapons      Specialized */
-     , (47226, 48, 0, 3, 0, 395, 0, 0) /* Shield              Specialized */
      , (47226, 49, 0, 3, 0, 395, 0, 0) /* DualWield           Specialized */
      , (47226, 51, 0, 3, 0, 395, 0, 0) /* SneakAttack         Specialized */;
 
@@ -108,6 +105,5 @@ VALUES (47226,  0,  4,  0,    0,  400,  400,  360,  300,  400,  400,  268,  400,
      , (47226,  8,  4, 600, 0.75,  400,  400,  360,  300,  400,  400,  268,  400,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (47226, 2, 47219,  1, 0, 0.33, False) /* Create Ensorcelled Sword (47219) for Wield */
-     , (47226, 2, 47220,  1, 0, 0.33, False) /* Create Ensorcelled Dagger (47220) for Wield */
-     , (47226, 2, 47222,  1, 0, 0.33, False) /* Create Ensorcelled Mace (47222) for Wield */;
+VALUES (47226, 10, 47219,  1, 0, 1, False) /* Create Ensorcelled Sword (47219) for WieldTreasure */
+     , (47226, 10, 47227,  1, 0, 0.5, False) /* Create Ensorcelled Mace (47227) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Ghost/88084 Spectral Archer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Ghost/88084 Spectral Archer.sql
@@ -11,7 +11,6 @@ VALUES (88084,   1,         16) /* ItemType - Creature */
      , (88084,  16,          1) /* ItemUseable - No */
      , (88084,  25,        240) /* Level */
      , (88084,  40,          2) /* CombatMode - Melee */
-     , (88084,  48,         47) /* WeaponSkill - MissileWeapons */
      , (88084,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
      , (88084,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (88084, 101,     524288) /* AiAllowedCombatStyle - StubbornMissile */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/45692 Geraine.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/45692 Geraine.sql
@@ -45,7 +45,6 @@ VALUES (45692,   1,       5) /* HeartbeatInterval */
      , (45692,  34,       2) /* PowerupTime */
      , (45692,  36,       1) /* ChargeSpeed */
      , (45692,  39,     1.2) /* DefaultScale */
-     , (45692,  41,     180) /* RegenerationInterval */
      , (45692,  64,    0.75) /* ResistSlash */
      , (45692,  65,    0.75) /* ResistPierce */
      , (45692,  66,     0.5) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/44347 Filinuvekta Emissary.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/44347 Filinuvekta Emissary.sql
@@ -12,9 +12,10 @@ VALUES (44347,   1,         16) /* ItemType - Creature */
      , (44347,  25,        425) /* Level */
      , (44347,  27,          0) /* ArmorType - None */
      , (44347,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
-     , (44347,  81,         10) /* MaxGeneratedObjects */
-     , (44347,  82,         10) /* InitGeneratedObjects */
+     , (44347,  81,          1) /* MaxGeneratedObjects */
+     , (44347,  82,          1) /* InitGeneratedObjects */
      , (44347,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (44347, 103,          2) /* GeneratorDestructionType - Destroy */
      , (44347, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (44347, 146,    1850000) /* XpOverride */
      , (44347, 332,        100) /* LuminanceAward */;
@@ -47,6 +48,8 @@ VALUES (44347,   1,       5) /* HeartbeatInterval */
      , (44347,  34,       1) /* PowerupTime */
      , (44347,  36,       1) /* ChargeSpeed */
      , (44347,  39,     1.3) /* DefaultScale */
+     , (44347,  41,      60) /* RegenerationInterval */
+     , (44347,  43,       7) /* GeneratorRadius */
      , (44347,  64,    0.65) /* ResistSlash */
      , (44347,  65,    0.65) /* ResistPierce */
      , (44347,  66,     0.5) /* ResistBludgeon */
@@ -63,8 +66,7 @@ VALUES (44347,   1,       5) /* HeartbeatInterval */
      , (44347, 104,      10) /* ObviousRadarRange */
      , (44347, 117,     0.5) /* FocusedProbability */
      , (44347, 122,       2) /* AiAcquireHealth */
-     , (44347, 125,       1) /* ResistHealthDrain */
-     , (44347, 166,       1) /* ResistNether */;
+     , (44347, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (44347,   1, 'Filinuvekta Emissary') /* Name */;
@@ -94,30 +96,25 @@ VALUES (44347,   1, 14005, 0, 0, 15000) /* MaxHealth */
      , (44347,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (44347,  6, 0, 3, 0, 365, 0, 0) /* MeleeDefense        Specialized */
+VALUES (44347,  6, 0, 3, 0, 180, 0, 0) /* MeleeDefense        Specialized */
      , (44347,  7, 0, 3, 0, 397, 0, 0) /* MissileDefense      Specialized */
-     , (44347, 14, 0, 3, 0, 240, 0, 0) /* ArcaneLore          Specialized */
-     , (44347, 15, 0, 3, 0, 440, 0, 0) /* MagicDefense        Specialized */
+     , (44347, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
      , (44347, 20, 0, 3, 0,  90, 0, 0) /* Deception           Specialized */
-     , (44347, 31, 0, 3, 0, 490, 0, 0) /* CreatureEnchantment Specialized */
-     , (44347, 33, 0, 3, 0, 460, 0, 0) /* LifeMagic           Specialized */
-     , (44347, 34, 0, 3, 0, 460, 0, 0) /* WarMagic            Specialized */
-     , (44347, 44, 0, 3, 0, 290, 0, 0) /* HeavyWeapons        Specialized */
-     , (44347, 45, 0, 3, 0, 290, 0, 0) /* LightWeapons        Specialized */
-     , (44347, 46, 0, 3, 0, 280, 0, 0) /* FinesseWeapons      Specialized */
-     , (44347, 47, 0, 3, 0, 350, 0, 0) /* MissileWeapons      Specialized */
-     , (44347, 48, 0, 3, 0, 290, 0, 0) /* Shield              Specialized */;
+     , (44347, 31, 0, 3, 0, 248, 0, 0) /* CreatureEnchantment Specialized */
+     , (44347, 33, 0, 3, 0, 248, 0, 0) /* LifeMagic           Specialized */
+     , (44347, 34, 0, 3, 0, 248, 0, 0) /* WarMagic            Specialized */
+     , (44347, 45, 0, 3, 0, 312, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (44347,  0,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (44347,  1,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (44347,  2,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (44347,  3,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (44347,  4,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (44347,  5,  4, 500, 0.75,  380,  228,  228,  255,  380,  152,  361,  380,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (44347,  6,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (44347,  7,  4,  0,    0,  380,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (44347,  8,  4, 500, 0.75,  380,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (44347,  0,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (44347,  1,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (44347,  2,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (44347,  3,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (44347,  4,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (44347,  5,  4, 500, 0.75,  650,  228,  228,  255,  380,  152,  361,  380,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (44347,  6,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (44347,  7,  4,  0,    0,  650,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (44347,  8,  4, 500, 0.75,  650,  228,  228,  255,  380,  152,  361,  380,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (44347,  3878,   2.06)  /* Incendiary Strike */
@@ -134,13 +131,17 @@ VALUES (44347,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, '"The intrepid adventurer, %tn, has killed the Filinuvekta Emissary!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, ' "Fool! My demise will not stop anything set in motion here! I''ll be back for you..."', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'The intrepid adventurer, %tn, has killed the Filinuvekta Emissary!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Fool! My demise will not stop anything set in motion here! I''ll be back for you...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44347, 2, 12211,  0, 0, 1, False) /* Create Zombie Mask (12211) for Wield */
      , (44347, 2,    55,  0, 14, 1, False) /* Create Chainmail Gauntlets (55) for Wield */
-     , (44347, 9, 44240,  3, 0, 0.9, False) /* Create A'nekshay Token (44240) for ContainTreasure */
+     , (44347, 9, 44240,  1, 0, 0.9, False) /* Create A'nekshay Token (44240) for ContainTreasure */
+     , (44347, 9,     0,  0, 0, 0.1, False) /* Create nothing for ContainTreasure */
+     , (44347, 9, 44240,  1, 0, 0.9, False) /* Create A'nekshay Token (44240) for ContainTreasure */
+     , (44347, 9,     0,  0, 0, 0.1, False) /* Create nothing for ContainTreasure */
+     , (44347, 9, 44240,  1, 0, 0.9, False) /* Create A'nekshay Token (44240) for ContainTreasure */
      , (44347, 9,     0,  0, 0, 0.1, False) /* Create nothing for ContainTreasure */
      , (44347, 9, 48908,  3, 0, 0.9, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
      , (44347, 9,     0,  0, 0, 0.1, False) /* Create nothing for ContainTreasure */
@@ -153,4 +154,4 @@ VALUES (44347, 2, 12211,  0, 0, 1, False) /* Create Zombie Mask (12211) for Wiel
      , (44347, 10, 22123,  0, 14, 1, False) /* Create Empyrean Robe (22123) for WieldTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (44347, -1, 43252, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Undead Commander (43252) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (44347, -1, 43269, 300, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Undead Commander (43269) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/45703 Geraine.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/45703 Geraine.sql
@@ -45,7 +45,6 @@ VALUES (45703,   1,       5) /* HeartbeatInterval */
      , (45703,  34,       2) /* PowerupTime */
      , (45703,  36,       1) /* ChargeSpeed */
      , (45703,  39,     1.2) /* DefaultScale */
-     , (45703,  41,     180) /* RegenerationInterval */
      , (45703,  64,    0.75) /* ResistSlash */
      , (45703,  65,    0.75) /* ResistPierce */
      , (45703,  66,     0.5) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72493 Enchanted Mnemosyne.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72493 Enchanted Mnemosyne.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72493;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72493, 'ace72493-enchantedmnemosyne', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (72493, 'ace72493-enchantedmnemosyne', 10, '2024-10-17 10:13:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72493,   1,         16) /* ItemType - Creature */
@@ -50,6 +50,22 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  21 /* InqQuest */, 0, 1, NULL, 'HoshinoMnemosynesDone', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72493, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosynesDone', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have already gathered information from all three mnemosynes.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72493, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosyne1', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have already gained all you can from this mnemosyne.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72493, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosyne2', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72493.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72493.es
@@ -1,7 +1,11 @@
 Use:
     - InqQuest: HoshinoMnemosynesDone
+        QuestSuccess:
+            - DirectBroadcast: You have already gathered information from all three mnemosynes.
         QuestFailure:
             - InqQuest: HoshinoMnemosyne1
+                QuestSuccess:
+                    - DirectBroadcast: You have already gained all you can from this mnemosyne.
                 QuestFailure:
                     - Motion: Twitch1
                     - StampQuest: HoshinoMnemosyne1

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72494 Enchanted Mnemosyne.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72494 Enchanted Mnemosyne.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72494;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72494, 'ace72494-enchantedmnemosyne', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (72494, 'ace72494-enchantedmnemosyne', 10, '2024-10-17 10:13:07') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72494,   1,         16) /* ItemType - Creature */
@@ -50,6 +50,22 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  21 /* InqQuest */, 0, 1, NULL, 'HoshinoMnemosynesDone@2', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72494, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosynesDone@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have already gathered information from all three mnemosynes.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72494, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosyne2@2', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have already gained all you can from this mnemosyne.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72494, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosyne1@2', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72494.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72494.es
@@ -1,7 +1,11 @@
 Use:
     - InqQuest: HoshinoMnemosynesDone
+        QuestSuccess:
+            - DirectBroadcast: You have already gathered information from all three mnemosynes.
         QuestFailure:
             - InqQuest: HoshinoMnemosyne2
+                QuestSuccess:
+                    - DirectBroadcast: You have already gained all you can from this mnemosyne.
                 QuestFailure:
                     - Motion: Twitch1
                     - StampQuest: HoshinoMnemosyne2

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72495 Enchanted Mnemosyne.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72495 Enchanted Mnemosyne.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 72495;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (72495, 'ace72495-enchantedmnemosyne', 10, '2021-11-01 00:00:00') /* Creature */;
+VALUES (72495, 'ace72495-enchantedmnemosyne', 10, '2024-10-17 10:13:16') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (72495,   1,         16) /* ItemType - Creature */
@@ -50,6 +50,22 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  21 /* InqQuest */, 0, 1, NULL, 'HoshinoMnemosynesDone@3', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72495, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosynesDone@3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have already gathered information from all three mnemosynes.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (72495, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosyne3@3', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have already gained all you can from this mnemosyne.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (72495, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'HoshinoMnemosyne1@3', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72495.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/72495.es
@@ -1,7 +1,11 @@
 Use:
     - InqQuest: HoshinoMnemosynesDone
+        QuestSuccess:
+            - DirectBroadcast: You have already gathered information from all three mnemosynes.
         QuestFailure:
             - InqQuest: HoshinoMnemosyne3
+                QuestSuccess:
+                    - DirectBroadcast: You have already gained all you can from this mnemosyne.
                 QuestFailure:
                     - Motion: Twitch1
                     - StampQuest: HoshinoMnemosyne3

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/87530 Summoning Chamber Adept.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/87530 Summoning Chamber Adept.sql
@@ -45,7 +45,7 @@ VALUES (87530,   1,       5) /* HeartbeatInterval */
      , (87530,  31,      31) /* VisualAwarenessRange */
      , (87530,  34,       1) /* PowerupTime */
      , (87530,  36,       1) /* ChargeSpeed */
-     , (87530,  39,     1.2) /* DefaultScale */
+     , (87530,  39,       1) /* DefaultScale */
      , (87530,  64,     0.8) /* ResistSlash */
      , (87530,  65,     0.8) /* ResistPierce */
      , (87530,  66,     0.9) /* ResistBludgeon */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47219 Ensorcelled Sword.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47219 Ensorcelled Sword.sql
@@ -6,7 +6,7 @@ VALUES (47219, 'ace47219-ensorcelledsword', 6, '2021-11-01 00:00:00') /* MeleeWe
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (47219,   1,          1) /* ItemType - MeleeWeapon */
      , (47219,   5,        550) /* EncumbranceVal */
-     , (47219,   9,    2097152) /* ValidLocations - Shield */
+     , (47219,   9,    1048576) /* ValidLocations - MeleeWeapon */
      , (47219,  16,          1) /* ItemUseable - No */
      , (47219,  18,          1) /* UiEffects - Magical */
      , (47219,  19,        340) /* Value */
@@ -15,7 +15,7 @@ VALUES (47219,   1,          1) /* ItemType - MeleeWeapon */
      , (47219,  44,        300) /* Damage */
      , (47219,  45,          3) /* DamageType - Slash, Pierce */
      , (47219,  46,          2) /* DefaultCombatStyle - OneHanded */
-     , (47219,  47,        130) /* AttackType - Thrust, DoubleThrust */
+     , (47219,  47,         34) /* AttackType - Thrust, DoubleSlash */
      , (47219,  48,         45) /* WeaponSkill - LightWeapons */
      , (47219,  49,          0) /* WeaponTime */
      , (47219,  51,          1) /* CombatUse - Melee */

--- a/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47227 Ensorcelled Mace.sql
+++ b/Database/Patches/9 WeenieDefaults/MeleeWeapon/MeleeWeapon/47227 Ensorcelled Mace.sql
@@ -6,7 +6,7 @@ VALUES (47227, 'ace47227-ensorcelledmace', 6, '2021-11-17 16:56:08') /* MeleeWea
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (47227,   1,          1) /* ItemType - MeleeWeapon */
      , (47227,   5,        350) /* EncumbranceVal */
-     , (47227,   9,    1048576) /* ValidLocations - MeleeWeapon */
+     , (47227,   9,    2097152) /* ValidLocations - Shield */
      , (47227,  16,          1) /* ItemUseable - No */
      , (47227,  18,          1) /* UiEffects - Magical */
      , (47227,  19,        340) /* Value */


### PR DESCRIPTION
Fixes dual wielding ghost weapons based on Loud Lou retail video. Previously, it was possible for a ghost weapon to spawn unarmed or wield only in its left hand, which was incorrect.

Corrects undefined damage type on bow wielding ghost weapons. It is now set to pierce, as seen in the video.

Sets scale of Summoning Chamber Adept to 1 to match retail screenshot.

Adds missing stubborn missile to a spectral archer in the Hoshino Fortress Infiltration quest, which could cause it to become stuck and unable to attack.

Fixes bug with two Geraines, where guards would spawn after some period of time, even if Geraine had not been attacked.

Corrects generator and skill levels for Filinuvekta Emissary (rare spawn in Neftet). Also increases armor to match other similar mobs.

Added quest success text to the Hoshino Must Die flag mnemosynes to indicate when they have already been clicked.