### PR TITLE
Update Hoshino Fort Main Gate

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46457 Lock.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46457 Lock.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 46457;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (46457, 'ace46457-lock', 10, '2021-11-17 16:56:08') /* Creature */;
+VALUES (46457, 'ace46457-lock', 10, '2024-10-15 11:49:26') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (46457,   1,         16) /* ItemType - Creature */
@@ -10,6 +10,8 @@ VALUES (46457,   1,         16) /* ItemType - Creature */
      , (46457,   7,         -1) /* ContainersCapacity */
      , (46457,  16,         32) /* ItemUseable - Remote */
      , (46457,  19,          0) /* Value */
+     , (46457,  81,          1) /* MaxGeneratedObjects */
+     , (46457,  82,          0) /* InitGeneratedObjects */
      , (46457,  93,    2097180) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, ReportCollisionsAsEnvironment */
      , (46457,  95,          3) /* RadarBlipColor - White */;
 
@@ -22,7 +24,8 @@ VALUES (46457,   1, True ) /* Stuck */
      , (46457,  83, True ) /* NpcLooksLikeObject */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46457,  54,      11) /* UseRadius */;
+VALUES (46457,  43,      10) /* GeneratorRadius */
+     , (46457,  54,      11) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (46457,   1, 'Lock') /* Name */;
@@ -40,5 +43,9 @@ VALUES (46457,  6 /* Give */,      1, 46459 /* Main Gate Key */, NULL, NULL, NUL
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You place the key in the lock and turn it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  18 /* DirectBroadcast */, 0, 1, NULL, 'You place the key in the lock and turn it.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (46457, -1, 73210, 1, 1, 1, 1, 4, 0, 0, 0, 0x4BE20023, 118.586, 53.4795, 172.055, 1, 0, 0, 0) /* Generate Landblock KeepAlive Gen (73210) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46457.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/46457.es
@@ -1,3 +1,4 @@
-Give: 46459
+Give: Main Gate Key (46459)
+    - Generate
     - DirectBroadcast: You place the key in the lock and turn it.
     - Activate

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/46310 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/46310 Door.sql
@@ -16,7 +16,7 @@ VALUES (46310,   1, True ) /* Stuck */
      , (46310,  34, False) /* DefaultOpen */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46310,  11,     600) /* ResetInterval */
+VALUES (46310,  11,    1800) /* ResetInterval */
      , (46310,  54,       2) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/46311 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/46311 Door.sql
@@ -16,7 +16,7 @@ VALUES (46311,   1, True ) /* Stuck */
      , (46311,  34, False) /* DefaultOpen */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46311,  11,     600) /* ResetInterval */
+VALUES (46311,  11,    1800) /* ResetInterval */
      , (46311,  54,       2) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Door/Misc/46312 Door.sql
+++ b/Database/Patches/9 WeenieDefaults/Door/Misc/46312 Door.sql
@@ -15,7 +15,7 @@ VALUES (46312,   1, True ) /* Stuck */
      , (46312,  34, False) /* DefaultOpen */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (46312,  11,     300) /* ResetInterval */
+VALUES (46312,  11,    1800) /* ResetInterval */
      , (46312,  54,       2) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73210 Landblock KeepAlive Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73210 Landblock KeepAlive Gen.sql
@@ -1,0 +1,30 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73210;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73210, 'ace73210-landblockkeepalivegen', 1, '2024-07-15 02:34:18') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73210,  81,          1) /* MaxGeneratedObjects */
+     , (73210,  82,          1) /* InitGeneratedObjects */
+     , (73210,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73210, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73210, 267,       1500) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73210,   1, True ) /* Stuck */
+     , (73210,  11, True ) /* IgnoreCollisions */
+     , (73210,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73210,  41,     300) /* RegenerationInterval */
+     , (73210,  43,       3) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73210,   1, 'Landblock KeepAlive Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73210,   1, 0x0200026B) /* Setup */
+     , (73210,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73210, 1, 80007, 0, 9, 9, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Landblock KeepAlive (80007) (x9 up to max of 9) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;


### PR DESCRIPTION
In retail, the main gate of Hoshino Fort would stay open for a longer period of time (around 30 min), as far as I remember, even when no one was around to keep the landblock active.

To replicate this behavior, when activated, the lock now spawns a Landblock KeepAlive with a lifespan of 25 min, and the reset interval on the gate is set to 30 min.