### PR TITLE
Update Masonry Mobs

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/008B.sql
+++ b/Database/Patches/6 LandBlockExtendedData/008B.sql
@@ -729,8 +729,7 @@ VALUES (0x7008B132, 0x7008B133, '2023-03-23 00:00:00') /* Masonry Golem (33033) 
      , (0x7008B132, 0x7008B1A4, '2023-03-23 00:00:00') /* Masonry Golem (33033) */
      , (0x7008B132, 0x7008B1A8, '2023-03-23 00:00:00') /* Masonry Golem (33033) */
      , (0x7008B132, 0x7008B1A9, '2023-03-23 00:00:00') /* Masonry Golem (33033) */
-     , (0x7008B132, 0x7008B1AE, '2023-03-23 00:00:00') /* Wretched Architect (32955) */
-     , (0x7008B132, 0x7008B1AF, '2023-03-23 00:00:00') /* Masonry Golem (33033) */;
+     , (0x7008B132, 0x7008B1AE, '2023-03-23 00:00:00') /* Wretched Architect (32955) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7008B133, 33033, 0x008B0153, 50, -210, 0.011, 0, 0, 0, -1,  True, '2023-03-23 00:00:00'); /* Masonry Golem */
@@ -1135,10 +1134,6 @@ VALUES (0x7008B1A9, 33033, 0x008B01D0, 152.516, -118.041, 0.011, 0.449908, 0, 0,
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7008B1AE, 32955, 0x008B0219, 190.01, -231.123, 0.009, -0.999306, 0, 0, -0.037238,  True, '2023-03-23 00:00:00'); /* Wretched Architect */
 /* @teleloc 0x008B0219 [190.009995 -231.123001 0.009000] -0.999306 0.000000 0.000000 -0.037238 */
-
-INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7008B1AF, 33033, 0x008B01C9, 143.777, -193.306, 0.011, 0.722279, 0, 0, -0.691602,  True, '2023-03-23 00:00:00'); /* Masonry Golem */
-/* @teleloc 0x008B01C9 [143.776993 -193.306000 0.011000] 0.722279 0.000000 0.000000 -0.691602 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7008B1B0, 15759, 0x008B01C6, 125.143, -224.361, 0, 0.903067, 0, 0, 0.429499, False, '2023-03-23 00:00:00'); /* Linkable Item Generator */

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/33033 Masonry Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/33033 Masonry Golem.sql
@@ -1,12 +1,12 @@
 DELETE FROM `weenie` WHERE `class_Id` = 33033;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (33033, 'ace33033-masonrygolem', 10, '2023-12-16 16:37:49') /* Creature */;
+VALUES (33033, 'ace33033-masonrygolem', 10, '2024-10-20 12:50:11') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (33033,   1,         16) /* ItemType - Creature */
      , (33033,   2,         13) /* CreatureType - Golem */
-     , (33033,   3,         61) /* PaletteTemplate - White */
+     , (33033,   3,          4) /* PaletteTemplate - Brown */
      , (33033,   6,         -1) /* ItemsCapacity */
      , (33033,   7,         -1) /* ContainersCapacity */
      , (33033,  16,          1) /* ItemUseable - No */
@@ -47,12 +47,12 @@ VALUES (33033,   1,       5) /* HeartbeatInterval */
      , (33033,  34,     2.3) /* PowerupTime */
      , (33033,  39,     1.1) /* DefaultScale */
      , (33033,  64,    0.33) /* ResistSlash */
-     , (33033,  65,    0.33) /* ResistPierce */
+     , (33033,  65,    0.67) /* ResistPierce */
      , (33033,  66,     0.8) /* ResistBludgeon */
-     , (33033,  67,    0.75) /* ResistFire */
-     , (33033,  68,    0.75) /* ResistCold */
+     , (33033,  67,     0.5) /* ResistFire */
+     , (33033,  68,     0.5) /* ResistCold */
      , (33033,  69,     0.8) /* ResistAcid */
-     , (33033,  70,    0.75) /* ResistElectric */
+     , (33033,  70,     0.5) /* ResistElectric */
      , (33033,  71,       1) /* ResistHealthBoost */
      , (33033,  72,       1) /* ResistStaminaDrain */
      , (33033,  73,       1) /* ResistStaminaBoost */
@@ -93,32 +93,24 @@ VALUES (33033,   1,  1350, 0, 0, 1500) /* MaxHealth */
      , (33033,   5,  1000, 0, 0, 1190) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (33033,  6, 0, 3, 0, 300, 0, 1981.298860289) /* MeleeDefense        Specialized */
-     , (33033,  7, 0, 3, 0, 429, 0, 1981.298860289) /* MissileDefense      Specialized */
-     , (33033, 13, 0, 3, 0, 275, 0, 1981.298860289) /* UnarmedCombat       Specialized */
-     , (33033, 14, 0, 3, 0, 300, 0, 1981.298860289) /* ArcaneLore          Specialized */
-     , (33033, 15, 0, 3, 0, 265, 0, 1981.298860289) /* MagicDefense        Specialized */
-     , (33033, 20, 0, 3, 0, 100, 0, 1981.298860289) /* Deception           Specialized */
-     , (33033, 22, 0, 3, 0,  10, 0, 1981.298860289) /* Jump                Specialized */
-     , (33033, 24, 0, 3, 0,  10, 0, 1981.298860289) /* Run                 Specialized */
-     , (33033, 31, 0, 3, 0, 190, 0, 1981.298860289) /* CreatureEnchantment Specialized */
-     , (33033, 33, 0, 3, 0, 190, 0, 1981.298860289) /* LifeMagic           Specialized */
-     , (33033, 34, 0, 3, 0, 190, 0, 1981.298860289) /* WarMagic            Specialized */;
+VALUES (33033,  6, 0, 3, 0, 530, 0, 0) /* MeleeDefense        Specialized */
+     , (33033,  7, 0, 3, 0, 310, 0, 0) /* MissileDefense      Specialized */
+     , (33033, 15, 0, 3, 0, 260, 0, 0) /* MagicDefense        Specialized */
+     , (33033, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
+     , (33033, 22, 0, 2, 0,  10, 0, 0) /* Jump                Trained */
+     , (33033, 24, 0, 2, 0,  10, 0, 0) /* Run                 Trained */
+     , (33033, 45, 0, 3, 0, 490, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (33033,  0,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (33033,  1,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (33033,  2,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (33033,  3,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (33033,  4,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (33033,  5,  4, 130, 0.75,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (33033,  6,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (33033,  7,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (33033,  8,  4, 130, 0.75,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
-
-INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (33033,  94) /* ATTACK_NOTIFICATION_EVENT */
-     , (33033, 414) /* PLAYER_DEATH_EVENT */;
+VALUES (33033,  0,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (33033,  1,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (33033,  2,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (33033,  3,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (33033,  4,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (33033,  5,  4, 200, 0.75,  380,  150,  150,  150,  150,  150,  150,  150,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (33033,  6,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (33033,  7,  4,  0,    0,  380,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (33033,  8,  4, 200, 0.75,  380,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (33033,  5 /* HeartBeat */,  0.075, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -136,3 +128,35 @@ SET @parent_id = LAST_INSERT_ID();
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x41000014 /* Sleeping */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (33033, 17 /* NewEnemy */,   0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'I work the stone. I know Masons. You are no Mason.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (33033, 17 /* NewEnemy */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Leave the Masonry now strange one.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (33033, 17 /* NewEnemy */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You do not belong in the Masonry.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (33033, 17 /* NewEnemy */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You are not Empyrean.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/33033.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/33033.es
@@ -1,0 +1,18 @@
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.075
+    - Motion: Twitch1
+
+HeartBeat: Style: NonCombat, Substyle: Ready
+    - Motion: Ready
+    - Motion: Sleeping
+
+NewEnemy: Probability: 0.05
+    - Tell: I work the stone. I know Masons. You are no Mason.
+
+NewEnemy: Probability: 0.1
+    - Tell: Leave the Masonry now strange one.
+
+NewEnemy: Probability: 0.15
+    - Tell: You do not belong in the Masonry.
+
+NewEnemy: Probability: 0.2
+    - Tell: You are not Empyrean.

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40775 Ancient Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40775 Ancient Golem.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 40775;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (40775, 'ace40775-ancientgolem', 10, '2024-07-15 02:34:18') /* Creature */;
+VALUES (40775, 'ace40775-ancientgolem', 10, '2024-10-20 02:28:50') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (40775,   1,         16) /* ItemType - Creature */
@@ -15,15 +15,13 @@ VALUES (40775,   1,         16) /* ItemType - Creature */
      , (40775,  40,          2) /* CombatMode - Melee */
      , (40775,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (40775, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (40775, 146,    1140000) /* XpOverride */;
+     , (40775, 146,     800000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (40775,   1, True ) /* Stuck */
-     , (40775,   6, True ) /* AiUsesMana */
      , (40775,  11, False) /* IgnoreCollisions */
      , (40775,  12, True ) /* ReportCollisions */
-     , (40775,  13, False) /* Ethereal */
-     , (40775,  50, True ) /* NeverFailCasting */;
+     , (40775,  13, False) /* Ethereal */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (40775,   1,       5) /* HeartbeatInterval */
@@ -46,12 +44,12 @@ VALUES (40775,   1,       5) /* HeartbeatInterval */
      , (40775,  34,     2.3) /* PowerupTime */
      , (40775,  39,     0.8) /* DefaultScale */
      , (40775,  64,    0.33) /* ResistSlash */
-     , (40775,  65,    0.33) /* ResistPierce */
+     , (40775,  65,    0.67) /* ResistPierce */
      , (40775,  66,     0.8) /* ResistBludgeon */
-     , (40775,  67,    0.75) /* ResistFire */
-     , (40775,  68,    0.75) /* ResistCold */
+     , (40775,  67,     0.5) /* ResistFire */
+     , (40775,  68,     0.5) /* ResistCold */
      , (40775,  69,     0.8) /* ResistAcid */
-     , (40775,  70,    0.75) /* ResistElectric */
+     , (40775,  70,     0.5) /* ResistElectric */
      , (40775,  71,       1) /* ResistHealthBoost */
      , (40775,  72,       1) /* ResistStaminaDrain */
      , (40775,  73,       1) /* ResistStaminaBoost */
@@ -98,21 +96,18 @@ VALUES (40775,  6, 0, 3, 0, 530, 0, 0) /* MeleeDefense        Specialized */
      , (40775, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
      , (40775, 22, 0, 2, 0,  10, 0, 0) /* Jump                Trained */
      , (40775, 24, 0, 2, 0,  10, 0, 0) /* Run                 Trained */
-     , (40775, 31, 0, 3, 0, 230, 0, 0) /* CreatureEnchantment Specialized */
-     , (40775, 33, 0, 3, 0, 230, 0, 0) /* LifeMagic           Specialized */
-     , (40775, 34, 0, 3, 0, 230, 0, 0) /* WarMagic            Specialized */
      , (40775, 45, 0, 3, 0, 490, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40775,  0,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40775,  1,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40775,  2,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40775,  3,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40775,  4,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40775,  5,  4, 130, 0.75,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40775,  6,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40775,  7,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40775,  8,  4, 130, 0.75,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40775,  0,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40775,  1,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40775,  2,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40775,  3,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40775,  4,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40775,  5,  4, 200, 0.75,  380,  190,  190,  190,  190,  190,  190,  190,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40775,  6,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40775,  7,  4,  0,    0,  380,  190,  190,  190,  190,  190,  190,  190,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40775,  8,  4, 200, 0.75,  380,  190,  190,  190,  190,  190,  190,  190,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (40775,  5 /* HeartBeat */,      1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -124,28 +119,33 @@ VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NU
      , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x41000014 /* Sleeping */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (40775,  5 /* HeartBeat */,  0.041, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (40775, 17 /* NewEnemy */,   0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'You are not Empyrean.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'The Steward has not permitted you access to the Facility.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (40775,  5 /* HeartBeat */,  0.032, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (40775, 17 /* NewEnemy */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'You do not belong in the Facility.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Leave the Facility now strange one.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (40775,  5 /* HeartBeat */,  0.023, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+VALUES (40775, 17 /* NewEnemy */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
-     , (@parent_id,  1,  10 /* Tell */, 0, 1, NULL, 'Leave the Facility now strange one.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You do not belong in the Facility.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40775, 17 /* NewEnemy */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You are not Empyrean.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40775.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40775.es
@@ -1,0 +1,16 @@
+HeartBeat: Style: NonCombat, Substyle: Ready
+    - Motion: Ready
+    - Motion: Sleeping
+
+NewEnemy: Probability: 0.05
+    - Tell: The Steward has not permitted you access to the Facility.
+
+NewEnemy: Probability: 0.1
+    - Tell: Leave the Facility now strange one.
+
+NewEnemy: Probability: 0.15
+    - Tell: You do not belong in the Facility.
+
+NewEnemy: Probability: 0.2
+    - Tell: You are not Empyrean.
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40861 Ancient Golem.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40861 Ancient Golem.sql
@@ -15,15 +15,13 @@ VALUES (40861,   1,         16) /* ItemType - Creature */
      , (40861,  40,          2) /* CombatMode - Melee */
      , (40861,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (40861, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (40861, 146,    1140000) /* XpOverride */;
+     , (40861, 146,     800000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (40861,   1, True ) /* Stuck */
-     , (40861,   6, True ) /* AiUsesMana */
      , (40861,  11, False) /* IgnoreCollisions */
      , (40861,  12, True ) /* ReportCollisions */
-     , (40861,  13, False) /* Ethereal */
-     , (40861,  50, True ) /* NeverFailCasting */;
+     , (40861,  13, False) /* Ethereal */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (40861,   1,       5) /* HeartbeatInterval */
@@ -46,12 +44,12 @@ VALUES (40861,   1,       5) /* HeartbeatInterval */
      , (40861,  34,     2.3) /* PowerupTime */
      , (40861,  39,     0.8) /* DefaultScale */
      , (40861,  64,    0.33) /* ResistSlash */
-     , (40861,  65,    0.33) /* ResistPierce */
+     , (40861,  65,    0.67) /* ResistPierce */
      , (40861,  66,     0.8) /* ResistBludgeon */
-     , (40861,  67,    0.75) /* ResistFire */
-     , (40861,  68,    0.75) /* ResistCold */
+     , (40861,  67,     0.5) /* ResistFire */
+     , (40861,  68,     0.5) /* ResistCold */
      , (40861,  69,     0.8) /* ResistAcid */
-     , (40861,  70,    0.75) /* ResistElectric */
+     , (40861,  70,     0.5) /* ResistElectric */
      , (40861,  71,       1) /* ResistHealthBoost */
      , (40861,  72,       1) /* ResistStaminaDrain */
      , (40861,  73,       1) /* ResistStaminaBoost */
@@ -92,28 +90,24 @@ VALUES (40861,   1,  1350, 0, 0, 1500) /* MaxHealth */
      , (40861,   5,  1000, 0, 0, 1190) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (40861,  6, 0, 3, 0, 300, 0, 1981.298860289) /* MeleeDefense        Specialized */
-     , (40861,  7, 0, 3, 0, 429, 0, 1981.298860289) /* MissileDefense      Specialized */
-     , (40861, 13, 0, 3, 0, 275, 0, 1981.298860289) /* UnarmedCombat       Specialized */
-     , (40861, 14, 0, 3, 0, 300, 0, 1981.298860289) /* ArcaneLore          Specialized */
-     , (40861, 15, 0, 3, 0, 265, 0, 1981.298860289) /* MagicDefense        Specialized */
-     , (40861, 20, 0, 3, 0, 100, 0, 1981.298860289) /* Deception           Specialized */
-     , (40861, 22, 0, 3, 0,  10, 0, 1981.298860289) /* Jump                Specialized */
-     , (40861, 24, 0, 3, 0,  10, 0, 1981.298860289) /* Run                 Specialized */
-     , (40861, 31, 0, 3, 0, 190, 0, 1981.298860289) /* CreatureEnchantment Specialized */
-     , (40861, 33, 0, 3, 0, 190, 0, 1981.298860289) /* LifeMagic           Specialized */
-     , (40861, 34, 0, 3, 0, 190, 0, 1981.298860289) /* WarMagic            Specialized */;
+VALUES (40861,  6, 0, 3, 0, 530, 0, 0) /* MeleeDefense        Specialized */
+     , (40861,  7, 0, 3, 0, 310, 0, 0) /* MissileDefense      Specialized */
+     , (40861, 15, 0, 3, 0, 260, 0, 0) /* MagicDefense        Specialized */
+     , (40861, 20, 0, 2, 0, 100, 0, 0) /* Deception           Trained */
+     , (40861, 22, 0, 2, 0,  10, 0, 0) /* Jump                Trained */
+     , (40861, 24, 0, 2, 0,  10, 0, 0) /* Run                 Trained */
+     , (40861, 45, 0, 3, 0, 490, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (40861,  0,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (40861,  1,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (40861,  2,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (40861,  3,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (40861,  4,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (40861,  5,  4, 130, 0.75,  300,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (40861,  6,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (40861,  7,  4,  0,    0,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (40861,  8,  4, 130, 0.75,  300,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (40861,  0,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (40861,  1,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (40861,  2,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (40861,  3,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (40861,  4,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (40861,  5,  4, 200, 0.75,  380,  240,  240,  240,  300,  300,  300,  300,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (40861,  6,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (40861,  7,  4,  0,    0,  380,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (40861,  8,  4, 200, 0.75,  380,  240,  240,  240,  300,  300,  300,  300,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (40861,  5 /* HeartBeat */,      1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -123,3 +117,35 @@ SET @parent_id = LAST_INSERT_ID();
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
      , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x41000014 /* Sleeping */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40861, 17 /* NewEnemy */,   0.05, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'The Steward has not permitted you access to the Facility.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40861, 17 /* NewEnemy */,    0.1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Leave the Facility now strange one.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40861, 17 /* NewEnemy */,   0.15, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You do not belong in the Facility.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (40861, 17 /* NewEnemy */,    0.2, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'You are not Empyrean.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Golem/40861.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Golem/40861.es
@@ -1,0 +1,16 @@
+HeartBeat: Style: NonCombat, Substyle: Ready
+    - Motion: Ready
+    - Motion: Sleeping
+
+NewEnemy: Probability: 0.05
+    - Tell: The Steward has not permitted you access to the Facility.
+
+NewEnemy: Probability: 0.1
+    - Tell: Leave the Facility now strange one.
+
+NewEnemy: Probability: 0.15
+    - Tell: You do not belong in the Facility.
+
+NewEnemy: Probability: 0.2
+    - Tell: You are not Empyrean.
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/32952 Ancient Steward.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/32952 Ancient Steward.sql
@@ -91,31 +91,33 @@ VALUES (32952,   1,  1250, 0, 0, 1345) /* MaxHealth */
      , (32952,   5,  1000, 0, 0, 1235) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (32952,  6, 0, 3, 0, 230, 0, 0) /* MeleeDefense        Specialized */
-     , (32952,  7, 0, 3, 0, 199, 0, 0) /* MissileDefense      Specialized */
-     , (32952, 15, 0, 3, 0, 192, 0, 0) /* MagicDefense        Specialized */
-     , (32952, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (32952, 33, 0, 3, 0, 250, 0, 0) /* LifeMagic           Specialized */
-     , (32952, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (32952, 44, 0, 3, 0, 237, 0, 0) /* HeavyWeapons        Specialized */
-     , (32952, 45, 0, 3, 0, 277, 0, 0) /* LightWeapons        Specialized */;
+VALUES (32952,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
+     , (32952,  7, 0, 3, 0, 420, 0, 0) /* MissileDefense      Specialized */
+     , (32952, 15, 0, 3, 0, 210, 0, 0) /* MagicDefense        Specialized */
+     , (32952, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (32952, 33, 0, 3, 0, 172, 0, 0) /* LifeMagic           Specialized */
+     , (32952, 34, 0, 3, 0, 172, 0, 0) /* WarMagic            Specialized */
+     , (32952, 44, 0, 3, 0, 398, 0, 0) /* HeavyWeapons        Specialized */
+     , (32952, 45, 0, 3, 0, 398, 0, 0) /* LightWeapons        Specialized */
+     , (32952, 46, 0, 3, 0, 398, 0, 0) /* FinesseWeapons      Specialized */
+     , (32952, 47, 0, 3, 0, 248, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32952,  0,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32952,  1,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32952,  2,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32952,  3,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32952,  4,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32952,  5,  4,  5, 0.75,  255,   94,   94,  128,   77,  153,  102,   84,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32952,  6,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32952,  7,  4,  0,    0,  255,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32952,  8,  4,  5, 0.75,  255,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32952,  0,  4,  0,    0,  320,   94,   94,  128,   77,  153,  102,   84,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32952,  1,  4,  0,    0,  330,   94,   94,  128,   77,  153,  102,   84,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32952,  2,  4,  0,    0,  370,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32952,  3,  4,  0,    0,  340,   94,   94,  128,   77,  153,  102,   84,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32952,  4,  4,  0,    0,  370,   94,   94,  128,   77,  153,  102,   84,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32952,  5,  4, 150, 0.75,  350,   94,   94,  128,   77,  153,  102,   84,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32952,  6,  4,  0,    0,  330,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32952,  7,  4,  0,    0,  370,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32952,  8,  4, 200, 0.75,  370,   94,   94,  128,   77,  153,  102,   84,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (32952,  2074,   2.01)  /* Gossamer Flesh */
-     , (32952,  2122,   2.01)  /* Disintegration */
-     , (32952,  2132,   2.01)  /* The Spike */
-     , (32952,  2174,   2.01)  /* Archer's Gift */;
+VALUES (32952,  1327,   2.05)  /* Imperil Other VI */
+     , (32952,    97,   2.05)  /* Whirling Blade VI */
+     , (32952,  2146,   2.06)  /* Evisceration */
+     , (32952,  1132,   2.06)  /* Blade Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (32952,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/32954 Foul Mason.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/32954 Foul Mason.sql
@@ -125,34 +125,33 @@ VALUES (32954,   1,  1250, 0, 0, 1345) /* MaxHealth */
      , (32954,   5,  1000, 0, 0, 1245) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (32954,  6, 0, 3, 0, 220, 0, 0) /* MeleeDefense        Specialized */
-     , (32954,  7, 0, 3, 0, 192, 0, 0) /* MissileDefense      Specialized */
-     , (32954, 15, 0, 3, 0, 189, 0, 0) /* MagicDefense        Specialized */
-     , (32954, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (32954, 33, 0, 3, 0, 250, 0, 0) /* LifeMagic           Specialized */
-     , (32954, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (32954, 41, 0, 3, 0, 237, 0, 0) /* TwoHandedCombat     Specialized */
-     , (32954, 44, 0, 3, 0, 247, 0, 0) /* HeavyWeapons        Specialized */
-     , (32954, 45, 0, 3, 0, 249, 0, 0) /* LightWeapons        Specialized */
-     , (32954, 46, 0, 3, 0, 237, 0, 0) /* FinesseWeapons      Specialized */
+VALUES (32954,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
+     , (32954,  7, 0, 3, 0, 420, 0, 0) /* MissileDefense      Specialized */
+     , (32954, 15, 0, 3, 0, 210, 0, 0) /* MagicDefense        Specialized */
+     , (32954, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (32954, 33, 0, 3, 0, 172, 0, 0) /* LifeMagic           Specialized */
+     , (32954, 34, 0, 3, 0, 172, 0, 0) /* WarMagic            Specialized */
+     , (32954, 44, 0, 3, 0, 398, 0, 0) /* HeavyWeapons        Specialized */
+     , (32954, 45, 0, 3, 0, 398, 0, 0) /* LightWeapons        Specialized */
+     , (32954, 46, 0, 3, 0, 398, 0, 0) /* FinesseWeapons      Specialized */
      , (32954, 47, 0, 3, 0, 248, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32954,  0,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32954,  1,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32954,  2,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32954,  3,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32954,  4,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32954,  5,  4,  5, 0.75,  205,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32954,  6,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32954,  7,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32954,  8,  4,  5, 0.75,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32954,  0,  4,  0,    0,  320,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32954,  1,  4,  0,    0,  330,   76,   76,  103,   62,  123,   82,   68,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32954,  2,  4,  0,    0,  370,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32954,  3,  4,  0,    0,  340,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32954,  4,  4,  0,    0,  370,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32954,  5,  4, 150, 0.75,  350,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32954,  6,  4,  0,    0,  330,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32954,  7,  4,  0,    0,  370,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32954,  8,  4, 200, 0.75,  370,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (32954,  2074,   2.01)  /* Gossamer Flesh */
-     , (32954,  2122,   2.01)  /* Disintegration */
-     , (32954,  2132,   2.01)  /* The Spike */
-     , (32954,  2174,   2.01)  /* Archer's Gift */;
+VALUES (32954,  1327,   2.05)  /* Imperil Other VI */
+     , (32954,  2128,   2.05)  /* Ilservian's Flame */
+     , (32954,  2144,   2.06)  /* Crushing Shame */
+     , (32954,  1108,   2.06)  /* Fire Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32954, 9,  9310,  1, 0, 0.04, False) /* Create A Large Mnemosyne (9310) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/32955 Wretched Architect.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/32955 Wretched Architect.sql
@@ -125,34 +125,33 @@ VALUES (32955,   1,  1250, 0, 0, 1345) /* MaxHealth */
      , (32955,   5,  1000, 0, 0, 1245) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (32955,  6, 0, 3, 0, 220, 0, 0) /* MeleeDefense        Specialized */
-     , (32955,  7, 0, 3, 0, 192, 0, 0) /* MissileDefense      Specialized */
-     , (32955, 15, 0, 3, 0, 189, 0, 0) /* MagicDefense        Specialized */
-     , (32955, 20, 0, 3, 0, 420, 0, 0) /* Deception           Specialized */
-     , (32955, 33, 0, 3, 0, 250, 0, 0) /* LifeMagic           Specialized */
-     , (32955, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (32955, 41, 0, 3, 0, 237, 0, 0) /* TwoHandedCombat     Specialized */
-     , (32955, 44, 0, 3, 0, 247, 0, 0) /* HeavyWeapons        Specialized */
-     , (32955, 45, 0, 3, 0, 259, 0, 0) /* LightWeapons        Specialized */
-     , (32955, 46, 0, 3, 0, 237, 0, 0) /* FinesseWeapons      Specialized */
-     , (32955, 47, 0, 3, 0, 258, 0, 0) /* MissileWeapons      Specialized */;
+VALUES (32955,  6, 0, 3, 0, 380, 0, 0) /* MeleeDefense        Specialized */
+     , (32955,  7, 0, 3, 0, 420, 0, 0) /* MissileDefense      Specialized */
+     , (32955, 15, 0, 3, 0, 210, 0, 0) /* MagicDefense        Specialized */
+     , (32955, 20, 0, 3, 0, 100, 0, 0) /* Deception           Specialized */
+     , (32955, 33, 0, 3, 0, 172, 0, 0) /* LifeMagic           Specialized */
+     , (32955, 34, 0, 3, 0, 172, 0, 0) /* WarMagic            Specialized */
+     , (32955, 44, 0, 3, 0, 398, 0, 0) /* HeavyWeapons        Specialized */
+     , (32955, 45, 0, 3, 0, 398, 0, 0) /* LightWeapons        Specialized */
+     , (32955, 46, 0, 3, 0, 398, 0, 0) /* FinesseWeapons      Specialized */
+     , (32955, 47, 0, 3, 0, 248, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32955,  0,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32955,  1,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32955,  2,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32955,  3,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32955,  4,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32955,  5,  4,  5, 0.75,  205,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32955,  6,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32955,  7,  4,  0,    0,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32955,  8,  4,  5, 0.75,  205,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32955,  0,  4,  0,    0,  320,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32955,  1,  4,  0,    0,  330,   76,   76,  103,   62,  123,   82,   68,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32955,  2,  4,  0,    0,  370,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32955,  3,  4,  0,    0,  340,   76,   76,  103,   62,  123,   82,   68,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32955,  4,  4,  0,    0,  370,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32955,  5,  4, 150, 0.75,  350,   76,   76,  103,   62,  123,   82,   68,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32955,  6,  4,  0,    0,  330,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32955,  7,  4,  0,    0,  370,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32955,  8,  4, 200, 0.75,  370,   76,   76,  103,   62,  123,   82,   68,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (32955,  2074,   2.01)  /* Gossamer Flesh */
-     , (32955,  2122,   2.01)  /* Disintegration */
-     , (32955,  2132,   2.01)  /* The Spike */
-     , (32955,  2174,   2.01)  /* Archer's Gift */;
+VALUES (32955,  1327,   2.05)  /* Imperil Other VI */
+     , (32955,  2128,   2.05)  /* Ilservian's Flame */
+     , (32955,  2144,   2.06)  /* Crushing Shame */
+     , (32955,  1053,   2.06)  /* Bludgeoning Vulnerability Other VI */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32955, 9,  9310,  1, 0, 0.04, False) /* Create A Large Mnemosyne (9310) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/Undead/32956 Heavy Builder.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Undead/32956 Heavy Builder.sql
@@ -6,7 +6,7 @@ VALUES (32956, 'ace32956-heavybuilder', 10, '2022-12-04 19:04:52') /* Creature *
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32956,   1,         16) /* ItemType - Creature */
      , (32956,   2,         14) /* CreatureType - Undead */
-     , (32956,   3,         70) /* PaletteTemplate - PurpleSlime */
+     , (32956,   3,          8) /* PaletteTemplate - PurpleSlime */
      , (32956,   6,         -1) /* ItemsCapacity */
      , (32956,   7,         -1) /* ContainersCapacity */
      , (32956,  16,          1) /* ItemUseable - No */
@@ -16,7 +16,7 @@ VALUES (32956,   1,         16) /* ItemType - Creature */
      , (32956,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (32956, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (32956, 133,          2) /* ShowableOnRadar - ShowMovement */
-     , (32956, 146,     800000) /* XpOverride */;
+     , (32956, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32956,   1, True ) /* Stuck */;
@@ -68,7 +68,7 @@ VALUES (32956,   1, 0x02000197) /* Setup */
      , (32956,   7, 0x10000066) /* ClothingBase */
      , (32956,   8, 0x06001226) /* Icon */
      , (32956,  22, 0x34000028) /* PhysicsEffectTable */
-     , (32956,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
+     , (32956,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (32956,   1, 210, 0, 0) /* Strength */
@@ -84,22 +84,22 @@ VALUES (32956,   1,   700, 0, 0, 790) /* MaxHealth */
      , (32956,   5,   550, 0, 0, 760) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (32956,  6, 0, 3, 0, 244, 0, 0) /* MeleeDefense        Specialized */
-     , (32956,  7, 0, 3, 0, 189, 0, 0) /* MissileDefense      Specialized */
-     , (32956, 15, 0, 3, 0, 181, 0, 0) /* MagicDefense        Specialized */
-     , (32956, 20, 0, 3, 0, 250, 0, 0) /* Deception           Specialized */
-     , (32956, 45, 0, 3, 0, 266, 0, 0) /* LightWeapons        Specialized */;
+VALUES (32956,  6, 0, 3, 0, 400, 0, 0) /* MeleeDefense        Specialized */
+     , (32956,  7, 0, 3, 0, 445, 0, 0) /* MissileDefense      Specialized */
+     , (32956, 15, 0, 3, 0, 261, 0, 0) /* MagicDefense        Specialized */
+     , (32956, 20, 0, 3, 0,  75, 0, 0) /* Deception           Specialized */
+     , (32956, 45, 0, 3, 0, 415, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32956,  0,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32956,  1,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32956,  2,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32956,  3,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32956,  4,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32956,  5,  4,  5, 0.75,  250,   93,   93,  125,   75,  150,  100,   83,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32956,  6,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32956,  7,  4,  0,    0,  250,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32956,  8,  4,  5, 0.75,  250,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32956,  0,  4,  0,    0,  340,   93,   93,  125,   75,  150,  100,   83,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32956,  1,  4,  0,    0,  350,   93,   93,  125,   75,  150,  100,   83,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32956,  2,  4,  0,    0,  360,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32956,  3,  4,  0,    0,  395,   93,   93,  125,   75,  150,  100,   83,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32956,  4,  4,  0,    0,  360,   93,   93,  125,   75,  150,  100,   83,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32956,  5,  4, 150, 0.75,  375,   93,   93,  125,   75,  150,  100,   83,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32956,  6,  4,  0,    0,  350,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32956,  7,  4,  0,    0,  375,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32956,  8,  4, 200, 0.75,  375,   93,   93,  125,   75,  150,  100,   83,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32956, 9,  9310,  1, 0, 0.04, False) /* Create A Large Mnemosyne (9310) for ContainTreasure */


### PR DESCRIPTION
Adjusts armor, skills and spells from the pcaps. Overall, this makes the creatures tougher.

Corrects appearance of Masonry Golem and Heavy Builder.

Adds missing new enemy flavor text to Masonry and Ancient Golem.

Removes a duplicate mob from the Ancient Masonry.