### PR TITLE
Add Present Raids

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/7D64.sql
+++ b/Database/Patches/6 LandBlockExtendedData/7D64.sql
@@ -349,3 +349,7 @@ VALUES (0x77D64076, 37518, 0x7D64002C, 140.955, 87.8733, 15.4975, 0.759906, 0, 0
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x77D64077, 37518, 0x7D640019, 83.6504, 4.37371, 12.005, 0.321405, 0, 0, -0.946942, False, '2022-12-04 19:04:52'); /* Royal Guard */
 /* @teleloc 0x7D640019 [83.650398 4.373710 12.005000] 0.321405 0.000000 0.000000 -0.946942 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x77D64078, 73230, 0x7D640033, 157.233, 53.5103, 15.1578, 0.707107, 0, 0, 0.707107, False, '2024-12-11 21:27:19'); /* Drudge Present Raids Yaraq Gen */
+/* @teleloc 0x7D640033 [157.233002 53.510300 15.157800] 0.707107 0.000000 0.000000 0.707107 */

--- a/Database/Patches/6 LandBlockExtendedData/866C.sql
+++ b/Database/Patches/6 LandBlockExtendedData/866C.sql
@@ -82,3 +82,7 @@ VALUES (0x7866C01B, 19716, 0x866C010A, 134.402, 149.122, 4.805, -0.332007, 0, 0,
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
 VALUES (0x7866C023, 43066, 0x866C002F, 139.232, 162.06, 10.198, 0.928359, 0, 0, -0.371686, False, '2021-12-14 05:15:31'); /* Portal to Town Network */
 /* @teleloc 0x866C002F [139.231995 162.059998 10.198000] 0.928359 0.000000 0.000000 -0.371686 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7866C024, 73219, 0x866C001F, 90.4732, 167.825, 14.055, 0.707107, 0, 0, -0.707107, False, '2024-12-11 16:10:13'); /* Gurog Present Raids Tufa Gen */
+/* @teleloc 0x866C001F [90.473198 167.824997 14.055000] 0.707107 0.000000 0.000000 -0.707107 */

--- a/Database/Patches/8 QuestDefDB/DrudgePresentRaidsWait.sql
+++ b/Database/Patches/8 QuestDefDB/DrudgePresentRaidsWait.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'DrudgePresentRaidsWait';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('DrudgePresentRaidsWait', 72000, -1, 'Player wait timer for Drudge Present Raids', '2021-11-08 06:01:47');

--- a/Database/Patches/8 QuestDefDB/GurogPresentRaidsWait.sql
+++ b/Database/Patches/8 QuestDefDB/GurogPresentRaidsWait.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'GurogPresentRaidsWait';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('GurogPresentRaidsWait', 72000, -1, 'Player wait timer for Gurog Present Raids', '2021-11-08 06:01:47');

--- a/Database/Patches/8 QuestDefDB/presentraidscounter.sql
+++ b/Database/Patches/8 QuestDefDB/presentraidscounter.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'presentraidscounter';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('presentraidscounter', 0, 9, 'quest timer', '2021-11-01 00:00:00');

--- a/Database/Patches/8 QuestDefDB/presentraidsreset.sql
+++ b/Database/Patches/8 QuestDefDB/presentraidsreset.sql
@@ -1,0 +1,4 @@
+DELETE FROM `quest` WHERE `name` = 'presentraidsreset';
+
+INSERT INTO `quest` (`name`, `min_Delta`, `max_Solves`, `message`, `last_Modified`)
+VALUES ('presentraidsreset', 300, -1, 'Reward giver reset timer', '2023-12-20 05:21:40');

--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/73225 Drudge Balloon.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/73225 Drudge Balloon.sql
@@ -1,0 +1,137 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73225;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73225, 'ace73225-drudgeballoon', 10, '2024-12-12 01:25:09') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73225,   1,         16) /* ItemType - Creature */
+     , (73225,   2,          3) /* CreatureType - Drudge */
+     , (73225,   6,         -1) /* ItemsCapacity */
+     , (73225,   7,         -1) /* ContainersCapacity */
+     , (73225,  16,          1) /* ItemUseable - No */
+     , (73225,  25,        115) /* Level */
+     , (73225,  27,          0) /* ArmorType - None */
+     , (73225,  40,          2) /* CombatMode - Melee */
+     , (73225,  81,          3) /* MaxGeneratedObjects */
+     , (73225,  82,          0) /* InitGeneratedObjects */
+     , (73225,  83,       2048) /* ActivationResponse - Emote */
+     , (73225,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73225, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73225, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (73225, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (73225, 146,     125000) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73225,   1, True ) /* Stuck */
+     , (73225,  13, True ) /* Ethereal */
+     , (73225,  19, False) /* Attackable */
+     , (73225,  29, True ) /* NoCorpse */
+     , (73225,  52, True ) /* AiImmobile */
+     , (73225,  83, True ) /* NpcLooksLikeObject */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73225,   1,       5) /* HeartbeatInterval */
+     , (73225,   2,       0) /* HeartbeatTimestamp */
+     , (73225,   3,     0.9) /* HealthRate */
+     , (73225,   4,       3) /* StaminaRate */
+     , (73225,   5,       1) /* ManaRate */
+     , (73225,  12,     0.5) /* Shade */
+     , (73225,  13,    0.82) /* ArmorModVsSlash */
+     , (73225,  14,    0.44) /* ArmorModVsPierce */
+     , (73225,  15,    0.83) /* ArmorModVsBludgeon */
+     , (73225,  16,    0.72) /* ArmorModVsCold */
+     , (73225,  17,    0.83) /* ArmorModVsFire */
+     , (73225,  18,    0.72) /* ArmorModVsAcid */
+     , (73225,  19,     0.9) /* ArmorModVsElectric */
+     , (73225,  31,      18) /* VisualAwarenessRange */
+     , (73225,  34,       1) /* PowerupTime */
+     , (73225,  36,       1) /* ChargeSpeed */
+     , (73225,  41,      60) /* RegenerationInterval */
+     , (73225,  43,       5) /* GeneratorRadius */
+     , (73225,  64,     0.9) /* ResistSlash */
+     , (73225,  65,    0.56) /* ResistPierce */
+     , (73225,  66,    0.96) /* ResistBludgeon */
+     , (73225,  67,    0.96) /* ResistFire */
+     , (73225,  68,    0.85) /* ResistCold */
+     , (73225,  69,    0.85) /* ResistAcid */
+     , (73225,  70,    0.18) /* ResistElectric */
+     , (73225,  71,       1) /* ResistHealthBoost */
+     , (73225,  72,       1) /* ResistStaminaDrain */
+     , (73225,  73,       1) /* ResistStaminaBoost */
+     , (73225,  74,       1) /* ResistManaDrain */
+     , (73225,  75,       1) /* ResistManaBoost */
+     , (73225,  80,       3) /* AiUseMagicDelay */
+     , (73225, 104,      10) /* ObviousRadarRange */
+     , (73225, 122,       2) /* AiAcquireHealth */
+     , (73225, 125,       1) /* ResistHealthDrain */
+     , (73225, 131,       1) /* EmotePriority */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73225,   1, 'Drudge Balloon') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73225,   1, 0x020016F1) /* Setup */
+     , (73225,   2, 0x090001CD) /* MotionTable */
+     , (73225,   3, 0x20000049) /* SoundTable */
+     , (73225,   4, 0x30000004) /* CombatTable */
+     , (73225,   8, 0x06003711) /* Icon */
+     , (73225,  22, 0x34000063) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73225,   1, 180, 0, 0) /* Strength */
+     , (73225,   2, 205, 0, 0) /* Endurance */
+     , (73225,   3, 190, 0, 0) /* Quickness */
+     , (73225,   4, 170, 0, 0) /* Coordination */
+     , (73225,   5, 160, 0, 0) /* Focus */
+     , (73225,   6, 160, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73225,   1,   500, 0, 0, 603) /* MaxHealth */
+     , (73225,   3,  1000, 0, 0, 1205) /* MaxStamina */
+     , (73225,   5,  1000, 0, 0, 1160) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73225,  6, 0, 3, 0, 280, 0, 0) /* MeleeDefense        Specialized */
+     , (73225,  7, 0, 3, 0, 215, 0, 0) /* MissileDefense      Specialized */
+     , (73225, 14, 0, 3, 0, 350, 0, 0) /* ArcaneLore          Specialized */
+     , (73225, 15, 0, 3, 0, 249, 0, 0) /* MagicDefense        Specialized */
+     , (73225, 20, 0, 3, 0, 120, 0, 0) /* Deception           Specialized */
+     , (73225, 24, 0, 3, 0,  55, 0, 0) /* Run                 Specialized */
+     , (73225, 31, 0, 3, 0, 100, 0, 0) /* CreatureEnchantment Specialized */
+     , (73225, 33, 0, 3, 0, 180, 0, 0) /* LifeMagic           Specialized */
+     , (73225, 34, 0, 3, 0, 180, 0, 0) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73225,  0,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73225,  1,  4,  0,    0,  345,  172,  172,  172,  172,  172,  172,  172,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73225,  2,  4,  0,    0,  345,  172,  172,  172,  172,  172,  172,  172,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73225,  3,  4,  0,    0,  345,  172,  172,  172,  172,  172,  172,  172,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73225,  4,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73225,  5,  4, 35, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73225,  6,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73225,  7,  4,  0,    0,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73225,  8,  4, 35, 0.75,  340,  170,  170,  170,  170,  170,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73225,  8 /* Activation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  81 /* StampMyQuest */, 0, 1, NULL, 'presentraidscounter', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  82 /* InqMyQuestSolves */, 0, 1, NULL, 'presentraidscounter@9-9', NULL, 9, 9, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73225, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'presentraidscounter@9-9', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  83 /* EraseMyQuest */, 0, 1, NULL, 'presentraidscounter', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,   5 /* Motion */, 0, 1, 0x40000011 /* Dead */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  77 /* DeleteSelf */, 2, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73225, -1, 73227, 0, 1, 1, 1, 4, -1, 0, 0, 0, -2, 0, 10, 1, 0, 0, 0) /* Generate Drudge Pilferer (73227) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (73225, -1, 73227, 0, 1, 1, 1, 4, -1, 0, 0, 0, 0, 2, 10, 1, 0, 0, 0) /* Generate Drudge Pilferer (73227) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (73225, -1, 73227, 0, 1, 1, 1, 4, -1, 0, 0, 0, 2, 0, 10, 1, 0, 0, 0) /* Generate Drudge Pilferer (73227) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/73225.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/73225.es
@@ -1,0 +1,7 @@
+Activation:
+    - StampMyQuest: presentraidscounter
+    - InqMyQuestSolves: presentraidscounter, 9 - 9
+        QuestSuccess:
+            - EraseMyQuest: presentraidscounter
+            - Motion: Dead
+            - Delay: 2, DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/73227 Drudge Pilferer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/73227 Drudge Pilferer.sql
@@ -1,0 +1,207 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73227;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73227, 'ace73227-drudgepilferer', 10, '2024-12-12 11:56:25') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73227,   1,         16) /* ItemType - Creature */
+     , (73227,   2,          3) /* CreatureType - Drudge */
+     , (73227,   3,          1) /* PaletteTemplate - AquaBlue */
+     , (73227,   6,         -1) /* ItemsCapacity */
+     , (73227,   7,         -1) /* ContainersCapacity */
+     , (73227,  16,          1) /* ItemUseable - No */
+     , (73227,  25,        200) /* Level */
+     , (73227,  27,          0) /* ArmorType - None */
+     , (73227,  40,          2) /* CombatMode - Melee */
+     , (73227,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (73227,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73227, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (73227, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73227, 140,          1) /* AiOptions - CanOpenDoors */
+     , (73227, 146,    1100000) /* XpOverride */
+     , (73227, 281,         16) /* Faction1Bits - 16 */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73227,   1, True ) /* Stuck */
+     , (73227,   6, True ) /* AiUsesMana */
+     , (73227,  11, False) /* IgnoreCollisions */
+     , (73227,  12, True ) /* ReportCollisions */
+     , (73227,  13, False) /* Ethereal */
+     , (73227,  14, True ) /* GravityStatus */
+     , (73227,  19, True ) /* Attackable */
+     , (73227,  29, True ) /* NoCorpse */
+     , (73227,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73227,   1,       5) /* HeartbeatInterval */
+     , (73227,   2,       0) /* HeartbeatTimestamp */
+     , (73227,   3,     0.7) /* HealthRate */
+     , (73227,   4,       3) /* StaminaRate */
+     , (73227,   5,       1) /* ManaRate */
+     , (73227,  12,     0.5) /* Shade */
+     , (73227,  13,       1) /* ArmorModVsSlash */
+     , (73227,  14,       1) /* ArmorModVsPierce */
+     , (73227,  15,       1) /* ArmorModVsBludgeon */
+     , (73227,  16,       1) /* ArmorModVsCold */
+     , (73227,  17,       1) /* ArmorModVsFire */
+     , (73227,  18,       1) /* ArmorModVsAcid */
+     , (73227,  19,       1) /* ArmorModVsElectric */
+     , (73227,  31,      25) /* VisualAwarenessRange */
+     , (73227,  34,       1) /* PowerupTime */
+     , (73227,  36,       1) /* ChargeSpeed */
+     , (73227,  39,       1) /* DefaultScale */
+     , (73227,  64,     0.6) /* ResistSlash */
+     , (73227,  65,     0.6) /* ResistPierce */
+     , (73227,  66,     0.6) /* ResistBludgeon */
+     , (73227,  67,     0.6) /* ResistFire */
+     , (73227,  68,     0.6) /* ResistCold */
+     , (73227,  69,     0.6) /* ResistAcid */
+     , (73227,  70,     0.6) /* ResistElectric */
+     , (73227,  71,       1) /* ResistHealthBoost */
+     , (73227,  72,       1) /* ResistStaminaDrain */
+     , (73227,  73,       1) /* ResistStaminaBoost */
+     , (73227,  74,       1) /* ResistManaDrain */
+     , (73227,  75,       1) /* ResistManaBoost */
+     , (73227,  80,       3) /* AiUseMagicDelay */
+     , (73227, 104,      10) /* ObviousRadarRange */
+     , (73227, 122,       2) /* AiAcquireHealth */
+     , (73227, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73227,   1, 'Drudge Pilferer') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73227,   1, 0x020007DD) /* Setup */
+     , (73227,   2, 0x09000008) /* MotionTable */
+     , (73227,   3, 0x20000007) /* SoundTable */
+     , (73227,   4, 0x30000004) /* CombatTable */
+     , (73227,   6, 0x04000F6C) /* PaletteBase */
+     , (73227,   7, 0x10000486) /* ClothingBase */
+     , (73227,   8, 0x06001035) /* Icon */
+     , (73227,  22, 0x3400001A) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73227,   1, 220, 0, 0) /* Strength */
+     , (73227,   2, 215, 0, 0) /* Endurance */
+     , (73227,   3, 250, 0, 0) /* Quickness */
+     , (73227,   4, 180, 0, 0) /* Coordination */
+     , (73227,   5, 145, 0, 0) /* Focus */
+     , (73227,   6, 145, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73227,   1,   600, 0, 0, 708) /* MaxHealth */
+     , (73227,   3,   700, 0, 0, 915) /* MaxStamina */
+     , (73227,   5,   300, 0, 0, 445) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73227,  6, 0, 3, 0, 580, 0, 0) /* MeleeDefense        Specialized */
+     , (73227,  7, 0, 3, 0, 560, 0, 0) /* MissileDefense      Specialized */
+     , (73227, 15, 0, 3, 0, 350, 0, 0) /* MagicDefense        Specialized */
+     , (73227, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
+     , (73227, 24, 0, 2, 0,  55, 0, 0) /* Run                 Trained */
+     , (73227, 31, 0, 3, 0, 320, 0, 0) /* CreatureEnchantment Specialized */
+     , (73227, 33, 0, 3, 0, 320, 0, 0) /* LifeMagic           Specialized */
+     , (73227, 34, 0, 3, 0, 320, 0, 0) /* WarMagic            Specialized */
+     , (73227, 45, 0, 3, 0, 620, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73227,  0,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73227,  1,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73227,  2,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73227,  3,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73227,  4,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73227,  5,  4, 400, 0.75,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73227,  6,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73227,  7,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73227,  8,  4, 600, 0.75,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73227,  2140,  2.075)  /* Alset's Coil */
+     , (73227,  2056,   2.03)  /* Ataxia */
+     , (73227,  2073,  2.008)  /* Adja's Intervention */
+     , (73227,  2074,   2.03)  /* Gossamer Flesh */
+     , (73227,  2084,   2.03)  /* Belly of Lead */
+     , (73227,  2088,   2.03)  /* Senescence */
+     , (73227,  2172,   2.03)  /* Astyrrian's Gift */
+     , (73227,  2328,  2.008)  /* Vitality Siphon */
+     , (73227,  4451,   2.05)  /* Incantation of Lightning Bolt */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  15 /* Activate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,   0.07, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,   0.07, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73227,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/73227.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/73227.es
@@ -1,0 +1,29 @@
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.025
+    - Motion: Twitch4
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.07
+    - Motion: Twitch3
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.095
+    - Motion: Twitch2
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch1
+
+HeartBeat: Style: SwordCombat, Substyle: Ready, Probability: 0.05
+    - Motion: Twitch1
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.025
+    - Motion: Twitch4
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.07
+    - Motion: Twitch3
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.095
+    - Motion: Twitch2
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch1
+
+Death:
+    - Activate

--- a/Database/Patches/9 WeenieDefaults/Creature/Drudge/73228 Drudge Pilferer.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Drudge/73228 Drudge Pilferer.sql
@@ -1,0 +1,201 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73228;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73228, 'ace73228-drudgepilferer', 10, '2024-12-12 11:56:43') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73228,   1,         16) /* ItemType - Creature */
+     , (73228,   2,          3) /* CreatureType - Drudge */
+     , (73228,   3,          1) /* PaletteTemplate - AquaBlue */
+     , (73228,   6,         -1) /* ItemsCapacity */
+     , (73228,   7,         -1) /* ContainersCapacity */
+     , (73228,  16,          1) /* ItemUseable - No */
+     , (73228,  25,        200) /* Level */
+     , (73228,  27,          0) /* ArmorType - None */
+     , (73228,  40,          2) /* CombatMode - Melee */
+     , (73228,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (73228,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73228, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (73228, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73228, 140,          1) /* AiOptions - CanOpenDoors */
+     , (73228, 146,    1100000) /* XpOverride */
+     , (73228, 281,         16) /* Faction1Bits - 16 */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73228,   1, True ) /* Stuck */
+     , (73228,   6, True ) /* AiUsesMana */
+     , (73228,  11, False) /* IgnoreCollisions */
+     , (73228,  12, True ) /* ReportCollisions */
+     , (73228,  13, False) /* Ethereal */
+     , (73228,  14, True ) /* GravityStatus */
+     , (73228,  19, True ) /* Attackable */
+     , (73228,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73228,   1,       5) /* HeartbeatInterval */
+     , (73228,   2,       0) /* HeartbeatTimestamp */
+     , (73228,   3,     0.7) /* HealthRate */
+     , (73228,   4,       3) /* StaminaRate */
+     , (73228,   5,       1) /* ManaRate */
+     , (73228,  12,     0.5) /* Shade */
+     , (73228,  13,       1) /* ArmorModVsSlash */
+     , (73228,  14,       1) /* ArmorModVsPierce */
+     , (73228,  15,       1) /* ArmorModVsBludgeon */
+     , (73228,  16,       1) /* ArmorModVsCold */
+     , (73228,  17,       1) /* ArmorModVsFire */
+     , (73228,  18,       1) /* ArmorModVsAcid */
+     , (73228,  19,       1) /* ArmorModVsElectric */
+     , (73228,  31,      25) /* VisualAwarenessRange */
+     , (73228,  34,       1) /* PowerupTime */
+     , (73228,  36,       1) /* ChargeSpeed */
+     , (73228,  39,       1) /* DefaultScale */
+     , (73228,  64,     0.6) /* ResistSlash */
+     , (73228,  65,     0.6) /* ResistPierce */
+     , (73228,  66,     0.6) /* ResistBludgeon */
+     , (73228,  67,     0.6) /* ResistFire */
+     , (73228,  68,     0.6) /* ResistCold */
+     , (73228,  69,     0.6) /* ResistAcid */
+     , (73228,  70,     0.6) /* ResistElectric */
+     , (73228,  71,       1) /* ResistHealthBoost */
+     , (73228,  72,       1) /* ResistStaminaDrain */
+     , (73228,  73,       1) /* ResistStaminaBoost */
+     , (73228,  74,       1) /* ResistManaDrain */
+     , (73228,  75,       1) /* ResistManaBoost */
+     , (73228,  80,       3) /* AiUseMagicDelay */
+     , (73228, 104,      10) /* ObviousRadarRange */
+     , (73228, 122,       2) /* AiAcquireHealth */
+     , (73228, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73228,   1, 'Drudge Pilferer') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73228,   1, 0x020007DD) /* Setup */
+     , (73228,   2, 0x09000008) /* MotionTable */
+     , (73228,   3, 0x20000007) /* SoundTable */
+     , (73228,   4, 0x30000004) /* CombatTable */
+     , (73228,   6, 0x04000F6C) /* PaletteBase */
+     , (73228,   7, 0x10000486) /* ClothingBase */
+     , (73228,   8, 0x06001035) /* Icon */
+     , (73228,  22, 0x3400001A) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73228,   1, 220, 0, 0) /* Strength */
+     , (73228,   2, 215, 0, 0) /* Endurance */
+     , (73228,   3, 250, 0, 0) /* Quickness */
+     , (73228,   4, 180, 0, 0) /* Coordination */
+     , (73228,   5, 145, 0, 0) /* Focus */
+     , (73228,   6, 145, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73228,   1,   600, 0, 0, 708) /* MaxHealth */
+     , (73228,   3,   700, 0, 0, 915) /* MaxStamina */
+     , (73228,   5,   300, 0, 0, 445) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73228,  6, 0, 3, 0, 580, 0, 0) /* MeleeDefense        Specialized */
+     , (73228,  7, 0, 3, 0, 560, 0, 0) /* MissileDefense      Specialized */
+     , (73228, 15, 0, 3, 0, 350, 0, 0) /* MagicDefense        Specialized */
+     , (73228, 20, 0, 2, 0,  40, 0, 0) /* Deception           Trained */
+     , (73228, 24, 0, 2, 0,  55, 0, 0) /* Run                 Trained */
+     , (73228, 31, 0, 3, 0, 320, 0, 0) /* CreatureEnchantment Specialized */
+     , (73228, 33, 0, 3, 0, 320, 0, 0) /* LifeMagic           Specialized */
+     , (73228, 34, 0, 3, 0, 320, 0, 0) /* WarMagic            Specialized */
+     , (73228, 45, 0, 3, 0, 620, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73228,  0,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73228,  1,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73228,  2,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73228,  3,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73228,  4,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73228,  5,  4, 400, 0.75,  430,  215,  215,  215,  215,  215,  215,  215,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73228,  6,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73228,  7,  4,  0,    0,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73228,  8,  4, 600, 0.75,  430,  215,  215,  215,  215,  215,  215,  215,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73228,  2140,  2.075)  /* Alset's Coil */
+     , (73228,  2056,   2.03)  /* Ataxia */
+     , (73228,  2073,  2.008)  /* Adja's Intervention */
+     , (73228,  2074,   2.03)  /* Gossamer Flesh */
+     , (73228,  2084,   2.03)  /* Belly of Lead */
+     , (73228,  2088,   2.03)  /* Senescence */
+     , (73228,  2172,   2.03)  /* Astyrrian's Gift */
+     , (73228,  2328,  2.008)  /* Vitality Siphon */
+     , (73228,  4451,   2.05)  /* Incantation of Lightning Bolt */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,   0.07, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,  0.095, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000054 /* Twitch4 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,   0.07, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,  0.095, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73228,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (73228, 1, 52445,  0, 0, 1, False) /* Create Pack Pilferer (52445) for Contain */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Gurog/73214 Gurog Grump.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Gurog/73214 Gurog Grump.sql
@@ -1,0 +1,116 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73214;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73214, 'ace73214-guroggrump', 10, '2023-07-25 23:55:26') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73214,   1,         16) /* ItemType - Creature */
+     , (73214,   2,        100) /* CreatureType - Gurog */
+     , (73214,   6,         -1) /* ItemsCapacity */
+     , (73214,   7,         -1) /* ContainersCapacity */
+     , (73214,  16,          1) /* ItemUseable - No */
+     , (73214,  25,        220) /* Level */
+     , (73214,  27,          0) /* ArmorType - None */
+     , (73214,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (73214,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73214, 101,          2) /* AiAllowedCombatStyle - OneHanded */
+     , (73214, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73214, 146,    1400000) /* XpOverride */
+     , (73214, 281,         16) /* Faction1Bits - 16 */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73214,   1, True ) /* Stuck */
+     , (73214,   6, False) /* AiUsesMana */
+     , (73214,  11, False) /* IgnoreCollisions */
+     , (73214,  12, True ) /* ReportCollisions */
+     , (73214,  13, False) /* Ethereal */
+     , (73214,  29, True ) /* NoCorpse */
+     , (73214,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73214,   1,       5) /* HeartbeatInterval */
+     , (73214,   2,       0) /* HeartbeatTimestamp */
+     , (73214,   3,     0.8) /* HealthRate */
+     , (73214,   4,     0.8) /* StaminaRate */
+     , (73214,   5,       2) /* ManaRate */
+     , (73214,  12,       0) /* Shade */
+     , (73214,  13,       1) /* ArmorModVsSlash */
+     , (73214,  14,     0.8) /* ArmorModVsPierce */
+     , (73214,  15,       1) /* ArmorModVsBludgeon */
+     , (73214,  16,       1) /* ArmorModVsCold */
+     , (73214,  17,     0.8) /* ArmorModVsFire */
+     , (73214,  18,       1) /* ArmorModVsAcid */
+     , (73214,  19,       1) /* ArmorModVsElectric */
+     , (73214,  31,      16) /* VisualAwarenessRange */
+     , (73214,  34,       1) /* PowerupTime */
+     , (73214,  36,       1) /* ChargeSpeed */
+     , (73214,  39,     0.8) /* DefaultScale */
+     , (73214,  64,     0.4) /* ResistSlash */
+     , (73214,  65,     0.8) /* ResistPierce */
+     , (73214,  66,     0.4) /* ResistBludgeon */
+     , (73214,  67,     0.8) /* ResistFire */
+     , (73214,  68,     0.4) /* ResistCold */
+     , (73214,  69,     0.4) /* ResistAcid */
+     , (73214,  70,     0.4) /* ResistElectric */
+     , (73214,  71,       1) /* ResistHealthBoost */
+     , (73214,  72,       1) /* ResistStaminaDrain */
+     , (73214,  73,       1) /* ResistStaminaBoost */
+     , (73214,  74,       1) /* ResistManaDrain */
+     , (73214,  75,       1) /* ResistManaBoost */
+     , (73214,  80,       1) /* AiUseMagicDelay */
+     , (73214, 104,      10) /* ObviousRadarRange */
+     , (73214, 122,       2) /* AiAcquireHealth */
+     , (73214, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73214,   1, 'Gurog Grump') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73214,   1, 0x02001A2C) /* Setup */
+     , (73214,   2, 0x090001A8) /* MotionTable */
+     , (73214,   3, 0x200000D5) /* SoundTable */
+     , (73214,   4, 0x30000000) /* CombatTable */
+     , (73214,   8, 0x06002B2E) /* Icon */
+     , (73214,  22, 0x340000CD) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73214,   1, 550, 0, 0) /* Strength */
+     , (73214,   2, 490, 0, 0) /* Endurance */
+     , (73214,   3, 380, 0, 0) /* Quickness */
+     , (73214,   4, 520, 0, 0) /* Coordination */
+     , (73214,   5, 410, 0, 0) /* Focus */
+     , (73214,   6, 410, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73214,   1,  1955, 0, 0, 2200) /* MaxHealth */
+     , (73214,   3,  3500, 0, 0, 3990) /* MaxStamina */
+     , (73214,   5,  1000, 0, 0, 1410) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73214,  6, 0, 3, 0, 471, 0, 0) /* MeleeDefense        Specialized */
+     , (73214,  7, 0, 3, 0, 212, 0, 0) /* MissileDefense      Specialized */
+     , (73214, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (73214, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
+     , (73214, 33, 0, 3, 0, 190, 0, 0) /* LifeMagic           Specialized */
+     , (73214, 34, 0, 3, 0, 190, 0, 0) /* WarMagic            Specialized */
+     , (73214, 41, 0, 3, 0, 430, 0, 0) /* TwoHandedCombat     Specialized */
+     , (73214, 45, 0, 3, 0, 430, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73214,  0,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73214,  1,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73214,  2,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73214,  3,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73214,  4,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73214,  5,  4, 200,  0.5,  500,  500,  275,  500,  500,  275,  500,  500,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73214,  6,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73214,  7,  4,  0,    0,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73214,  8,  4, 200,  0.5,  500,  500,  275,  500,  500,  275,  500,  500,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73214,  4312,   2.02)  /* Incantation of Imperil Other */
+     , (73214,  4446,   2.02)  /* Incantation of Frost Blast */
+     , (73214,  4447,   2.25)  /* Incantation of Frost Bolt */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (73214, 10, 43397,  0, 0, 1, False) /* Create Frost Greataxe (43397) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Gurog/73215 Gurog Mastermind.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Gurog/73215 Gurog Mastermind.sql
@@ -1,0 +1,124 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73215;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73215, 'ace73215-gurogmastermind', 10, '2024-12-11 01:41:16') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73215,   1,         16) /* ItemType - Creature */
+     , (73215,   2,        100) /* CreatureType - Gurog */
+     , (73215,   6,         -1) /* ItemsCapacity */
+     , (73215,   7,         -1) /* ContainersCapacity */
+     , (73215,  16,          1) /* ItemUseable - No */
+     , (73215,  25,        300) /* Level */
+     , (73215,  27,          0) /* ArmorType - None */
+     , (73215,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (73215,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73215, 101,          2) /* AiAllowedCombatStyle - OneHanded */
+     , (73215, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73215, 146,    4000000) /* XpOverride */
+     , (73215, 281,         16) /* Faction1Bits - 16 */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73215,   1, True ) /* Stuck */
+     , (73215,   6, False) /* AiUsesMana */
+     , (73215,  11, False) /* IgnoreCollisions */
+     , (73215,  12, True ) /* ReportCollisions */
+     , (73215,  13, False) /* Ethereal */
+     , (73215,  50, True ) /* NeverFailCasting */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73215,   1,       5) /* HeartbeatInterval */
+     , (73215,   2,       0) /* HeartbeatTimestamp */
+     , (73215,   3,     0.8) /* HealthRate */
+     , (73215,   4,     0.8) /* StaminaRate */
+     , (73215,   5,       2) /* ManaRate */
+     , (73215,  12,       0) /* Shade */
+     , (73215,  13,       1) /* ArmorModVsSlash */
+     , (73215,  14,     0.8) /* ArmorModVsPierce */
+     , (73215,  15,       1) /* ArmorModVsBludgeon */
+     , (73215,  16,       1) /* ArmorModVsCold */
+     , (73215,  17,     0.8) /* ArmorModVsFire */
+     , (73215,  18,       1) /* ArmorModVsAcid */
+     , (73215,  19,       1) /* ArmorModVsElectric */
+     , (73215,  31,      16) /* VisualAwarenessRange */
+     , (73215,  34,       1) /* PowerupTime */
+     , (73215,  36,       1) /* ChargeSpeed */
+     , (73215,  39,     1.3) /* DefaultScale */
+     , (73215,  64,     0.4) /* ResistSlash */
+     , (73215,  65,     0.8) /* ResistPierce */
+     , (73215,  66,     0.4) /* ResistBludgeon */
+     , (73215,  67,     0.8) /* ResistFire */
+     , (73215,  68,     0.4) /* ResistCold */
+     , (73215,  69,     0.4) /* ResistAcid */
+     , (73215,  70,     0.4) /* ResistElectric */
+     , (73215,  71,       1) /* ResistHealthBoost */
+     , (73215,  72,       1) /* ResistStaminaDrain */
+     , (73215,  73,       1) /* ResistStaminaBoost */
+     , (73215,  74,       1) /* ResistManaDrain */
+     , (73215,  75,       1) /* ResistManaBoost */
+     , (73215,  80,       1) /* AiUseMagicDelay */
+     , (73215, 104,      10) /* ObviousRadarRange */
+     , (73215, 122,       2) /* AiAcquireHealth */
+     , (73215, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73215,   1, 'Gurog Mastermind') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73215,   1, 0x02001A2C) /* Setup */
+     , (73215,   2, 0x090001A8) /* MotionTable */
+     , (73215,   3, 0x200000D5) /* SoundTable */
+     , (73215,   4, 0x30000000) /* CombatTable */
+     , (73215,   8, 0x06002B2E) /* Icon */
+     , (73215,  22, 0x340000CD) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73215,   1, 560, 0, 0) /* Strength */
+     , (73215,   2, 450, 0, 0) /* Endurance */
+     , (73215,   3, 450, 0, 0) /* Quickness */
+     , (73215,   4, 460, 0, 0) /* Coordination */
+     , (73215,   5, 450, 0, 0) /* Focus */
+     , (73215,   6, 450, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73215,   1, 95975, 0, 0, 96200) /* MaxHealth */
+     , (73215,   3,  3500, 0, 0, 3950) /* MaxStamina */
+     , (73215,   5,     0, 0, 0, 450) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73215,  6, 0, 3, 0, 468, 0, 0) /* MeleeDefense        Specialized */
+     , (73215,  7, 0, 3, 0, 210, 0, 0) /* MissileDefense      Specialized */
+     , (73215, 15, 0, 3, 0, 320, 0, 0) /* MagicDefense        Specialized */
+     , (73215, 20, 0, 3, 0,  80, 0, 0) /* Deception           Specialized */
+     , (73215, 33, 0, 3, 0, 170, 0, 0) /* LifeMagic           Specialized */
+     , (73215, 34, 0, 3, 0, 170, 0, 0) /* WarMagic            Specialized */
+     , (73215, 41, 0, 3, 0, 447, 0, 0) /* TwoHandedCombat     Specialized */
+     , (73215, 45, 0, 3, 0, 447, 0, 0) /* LightWeapons        Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73215,  0,  4,  0,    0,  500,  130,  130,  130,  130,  130,  130,  130,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73215,  1,  4,  0,    0,  500,  135,  135,  135,  135,  135,  135,  135,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73215,  2,  4,  0,    0,  500,  140,  140,  140,  140,  140,  140,  140,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73215,  3,  4,  0,    0,  500,  135,  135,  135,  135,  135,  135,  135,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73215,  4,  4,  0,    0,  500,  117,  117,  117,  117,  117,  117,  117,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73215,  5,  4, 200,  0.5,  500,  120,  120,  120,  120,  120,  120,  120,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73215,  6,  4,  0,    0,  500,  130,  130,  130,  130,  130,  130,  130,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73215,  7,  4,  0,    0,  500,  120,  120,  120,  120,  120,  120,  120,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73215,  8,  4, 200,  0.5,  500,  145,  145,  145,  145,  145,  145,  145,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73215,  4312,   2.02)  /* Incantation of Imperil Other */
+     , (73215,  4446,   2.02)  /* Incantation of Frost Blast */
+     , (73215,  4447,   2.25)  /* Incantation of Frost Bolt */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73215,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   8 /* Say */, 0, 0, NULL, 'If you want something done right, do it yourself! Come Max!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (73215, 1, 52367,  0, 0, 1, False) /* Create Pack Gurog (52367) for Contain */
+     , (73215, 10, 43397,  0, 0, 1, False) /* Create Frost Greataxe (43397) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Gurog/73215.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Gurog/73215.es
@@ -1,0 +1,3 @@
+Generation:
+    - Say: If you want something done right, do it yourself! Come Max!
+

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73221 Gurog Present Raids Reset Stopgap.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73221 Gurog Present Raids Reset Stopgap.sql
@@ -1,0 +1,160 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73221;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73221, 'ace73221-gurogpresentraidsresetstopgap', 10, '2024-12-12 10:54:36') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73221,   1,         16) /* ItemType - Creature */
+     , (73221,   2,         31) /* CreatureType - Human */
+     , (73221,   6,         -1) /* ItemsCapacity */
+     , (73221,   7,         -1) /* ContainersCapacity */
+     , (73221,   8,        120) /* Mass */
+     , (73221,  16,         32) /* ItemUseable - Remote */
+     , (73221,  25,         15) /* Level */
+     , (73221,  27,          0) /* ArmorType - None */
+     , (73221,  81,          1) /* MaxGeneratedObjects */
+     , (73221,  82,          0) /* InitGeneratedObjects */
+     , (73221,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (73221,  95,          8) /* RadarBlipColor - Yellow */
+     , (73221, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73221, 133,          0) /* ShowableOnRadar - Undefined */
+     , (73221, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (73221, 146,        307) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73221,   1, True ) /* Stuck */
+     , (73221,   8, True ) /* AllowGive */
+     , (73221,  12, True ) /* ReportCollisions */
+     , (73221,  13, True ) /* Ethereal */
+     , (73221,  18, True ) /* Visibility */
+     , (73221,  19, False) /* Attackable */
+     , (73221,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (73221,  42, True ) /* AllowEdgeSlide */
+     , (73221,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73221,   1,       5) /* HeartbeatInterval */
+     , (73221,   2,       0) /* HeartbeatTimestamp */
+     , (73221,   3,    0.16) /* HealthRate */
+     , (73221,   4,       5) /* StaminaRate */
+     , (73221,   5,       1) /* ManaRate */
+     , (73221,  13,     0.9) /* ArmorModVsSlash */
+     , (73221,  14,       1) /* ArmorModVsPierce */
+     , (73221,  15,     1.1) /* ArmorModVsBludgeon */
+     , (73221,  16,     0.4) /* ArmorModVsCold */
+     , (73221,  17,     0.4) /* ArmorModVsFire */
+     , (73221,  18,       1) /* ArmorModVsAcid */
+     , (73221,  19,     0.6) /* ArmorModVsElectric */
+     , (73221,  54,       3) /* UseRadius */
+     , (73221,  64,       1) /* ResistSlash */
+     , (73221,  65,       1) /* ResistPierce */
+     , (73221,  66,       1) /* ResistBludgeon */
+     , (73221,  67,       1) /* ResistFire */
+     , (73221,  68,       1) /* ResistCold */
+     , (73221,  69,       1) /* ResistAcid */
+     , (73221,  70,       1) /* ResistElectric */
+     , (73221,  71,       1) /* ResistHealthBoost */
+     , (73221,  72,       1) /* ResistStaminaDrain */
+     , (73221,  73,       1) /* ResistStaminaBoost */
+     , (73221,  74,       1) /* ResistManaDrain */
+     , (73221,  75,       1) /* ResistManaBoost */
+     , (73221, 104,      10) /* ObviousRadarRange */
+     , (73221, 125,       1) /* ResistHealthDrain */
+     , (73221, 131,       1) /* EmotePriority */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73221,   1, 'Gurog Present Raids Reset Stopgap') /* Name */
+     , (73221,   3, 'Male') /* Sex */
+     , (73221,   4, 'Sho') /* HeritageGroup */
+     , (73221,   5, 'Stopgap') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73221,   1, 0x02000001) /* Setup */
+     , (73221,   2, 0x09000001) /* MotionTable */
+     , (73221,   3, 0x20000001) /* SoundTable */
+     , (73221,   4, 0x30000000) /* CombatTable */
+     , (73221,   8, 0x06001036) /* Icon */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73221,   1,  90, 0, 0) /* Strength */
+     , (73221,   2, 100, 0, 0) /* Endurance */
+     , (73221,   3,  75, 0, 0) /* Quickness */
+     , (73221,   4, 120, 0, 0) /* Coordination */
+     , (73221,   5, 140, 0, 0) /* Focus */
+     , (73221,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73221,   1,    10, 0, 0, 60) /* MaxHealth */
+     , (73221,   3,    10, 0, 0, 110) /* MaxStamina */
+     , (73221,   5,    10, 0, 0, 140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73221,  6, 0, 2, 0,   1, 0, 633.3804321289062) /* MeleeDefense        Trained */
+     , (73221,  7, 0, 2, 0,   1, 0, 633.3804321289062) /* MissileDefense      Trained */
+     , (73221, 13, 0, 2, 0,   1, 0, 633.3804321289062) /* UnarmedCombat       Trained */
+     , (73221, 34, 0, 3, 0, 800, 0, 1525.90308952149) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73221,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73221,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73221,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73221,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73221,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73221,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73221,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73221,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73221,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73221,  5 /* HeartBeat */,      1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  80 /* InqMyQuest */, 0, 1, NULL, 'presentraidsreset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73221,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  51 /* InqEvent */, 0, 1, NULL, 'PresentRaidsDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73221, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'presentraidsreset', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'Reset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73221, 27 /* EventSuccess */,      1, NULL, NULL, NULL, 'PresentRaidsDead', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 10, 1, 0x13000087 /* Wave */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  67 /* Goto */, 0, 1, NULL, 'Reset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73221, 28 /* EventFailure */,      1, NULL, NULL, NULL, 'PresentRaidsDead', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  81 /* StampMyQuest */, 0, 1, NULL, 'presentraidsreset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73221, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'Reset', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  24 /* StopEvent */, 0, 1, NULL, 'PresentRaidsDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  24 /* StopEvent */, 0, 1, NULL, 'PresentRaidsTufa', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73221, -1, 73217, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Holiday Present (73217) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73221.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73221.es
@@ -1,0 +1,17 @@
+HeartBeat: Style: NonCombat, Substyle: Ready
+    - InqMyQuest: presentraidsreset
+        QuestFailure:
+            - Goto: Reset
+
+Generation:
+    - InqEvent: PresentRaidsDead
+        EventSuccess:
+            - Delay: 10, Motion: Wave
+            - Goto: Reset
+        EventFailure:
+            - Generate
+            - StampMyQuest: presentraidsreset
+
+GotoSet: Reset
+    - StopEvent: PresentRaidsDead
+    - StopEvent: PresentRaidsTufa

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73223 Delete Signal Stopgap.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73223 Delete Signal Stopgap.sql
@@ -1,0 +1,112 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73223;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73223, 'ace73223-deletesignalstopgap', 10, '2024-12-11 06:12:34') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73223,   1,         16) /* ItemType - Creature */
+     , (73223,   2,         31) /* CreatureType - Human */
+     , (73223,   6,         -1) /* ItemsCapacity */
+     , (73223,   7,         -1) /* ContainersCapacity */
+     , (73223,   8,        120) /* Mass */
+     , (73223,  16,         32) /* ItemUseable - Remote */
+     , (73223,  25,         15) /* Level */
+     , (73223,  27,          0) /* ArmorType - None */
+     , (73223,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (73223,  95,          8) /* RadarBlipColor - Yellow */
+     , (73223, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73223, 133,          0) /* ShowableOnRadar - Undefined */
+     , (73223, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (73223, 146,        307) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73223,   1, True ) /* Stuck */
+     , (73223,   8, True ) /* AllowGive */
+     , (73223,  12, True ) /* ReportCollisions */
+     , (73223,  13, True ) /* Ethereal */
+     , (73223,  18, True ) /* Visibility */
+     , (73223,  19, False) /* Attackable */
+     , (73223,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (73223,  42, True ) /* AllowEdgeSlide */
+     , (73223,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73223,   1,       5) /* HeartbeatInterval */
+     , (73223,   2,       0) /* HeartbeatTimestamp */
+     , (73223,   3,    0.16) /* HealthRate */
+     , (73223,   4,       5) /* StaminaRate */
+     , (73223,   5,       1) /* ManaRate */
+     , (73223,  13,     0.9) /* ArmorModVsSlash */
+     , (73223,  14,       1) /* ArmorModVsPierce */
+     , (73223,  15,     1.1) /* ArmorModVsBludgeon */
+     , (73223,  16,     0.4) /* ArmorModVsCold */
+     , (73223,  17,     0.4) /* ArmorModVsFire */
+     , (73223,  18,       1) /* ArmorModVsAcid */
+     , (73223,  19,     0.6) /* ArmorModVsElectric */
+     , (73223,  54,       3) /* UseRadius */
+     , (73223,  64,       1) /* ResistSlash */
+     , (73223,  65,       1) /* ResistPierce */
+     , (73223,  66,       1) /* ResistBludgeon */
+     , (73223,  67,       1) /* ResistFire */
+     , (73223,  68,       1) /* ResistCold */
+     , (73223,  69,       1) /* ResistAcid */
+     , (73223,  70,       1) /* ResistElectric */
+     , (73223,  71,       1) /* ResistHealthBoost */
+     , (73223,  72,       1) /* ResistStaminaDrain */
+     , (73223,  73,       1) /* ResistStaminaBoost */
+     , (73223,  74,       1) /* ResistManaDrain */
+     , (73223,  75,       1) /* ResistManaBoost */
+     , (73223, 104,      10) /* ObviousRadarRange */
+     , (73223, 125,       1) /* ResistHealthDrain */
+     , (73223, 131,       1) /* EmotePriority */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73223,   1, 'Delete Signal Stopgap') /* Name */
+     , (73223,   3, 'Male') /* Sex */
+     , (73223,   4, 'Sho') /* HeritageGroup */
+     , (73223,   5, 'Stopgap') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73223,   1, 0x02000001) /* Setup */
+     , (73223,   2, 0x09000001) /* MotionTable */
+     , (73223,   3, 0x20000001) /* SoundTable */
+     , (73223,   4, 0x30000000) /* CombatTable */
+     , (73223,   8, 0x06001036) /* Icon */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73223,   1,  90, 0, 0) /* Strength */
+     , (73223,   2, 100, 0, 0) /* Endurance */
+     , (73223,   3,  75, 0, 0) /* Quickness */
+     , (73223,   4, 120, 0, 0) /* Coordination */
+     , (73223,   5, 140, 0, 0) /* Focus */
+     , (73223,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73223,   1,    10, 0, 0, 60) /* MaxHealth */
+     , (73223,   3,    10, 0, 0, 110) /* MaxStamina */
+     , (73223,   5,    10, 0, 0, 140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73223,  6, 0, 2, 0,   1, 0, 633.3804321289062) /* MeleeDefense        Trained */
+     , (73223,  7, 0, 2, 0,   1, 0, 633.3804321289062) /* MissileDefense      Trained */
+     , (73223, 13, 0, 2, 0,   1, 0, 633.3804321289062) /* UnarmedCombat       Trained */
+     , (73223, 34, 0, 3, 0, 800, 0, 1525.90308952149) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73223,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73223,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73223,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73223,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73223,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73223,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73223,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73223,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73223,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73223,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  88 /* LocalSignal */, 10, 1, NULL, 'DeleteMe', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73223.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73223.es
@@ -1,0 +1,3 @@
+Generation:
+    - LocalSignal: DeleteReceiver
+    - DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73224 Present Raids Stopgap.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73224 Present Raids Stopgap.sql
@@ -1,0 +1,134 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73224;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73224, 'ace73224-presentraidsstopgap', 10, '2024-12-12 10:42:53') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73224,   1,         16) /* ItemType - Creature */
+     , (73224,   2,         31) /* CreatureType - Human */
+     , (73224,   6,         -1) /* ItemsCapacity */
+     , (73224,   7,         -1) /* ContainersCapacity */
+     , (73224,   8,        120) /* Mass */
+     , (73224,  16,         32) /* ItemUseable - Remote */
+     , (73224,  25,         15) /* Level */
+     , (73224,  27,          0) /* ArmorType - None */
+     , (73224,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (73224,  95,          8) /* RadarBlipColor - Yellow */
+     , (73224, 133,          0) /* ShowableOnRadar - Undefined */
+     , (73224, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (73224, 146,        307) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73224,   1, True ) /* Stuck */
+     , (73224,   8, True ) /* AllowGive */
+     , (73224,  12, True ) /* ReportCollisions */
+     , (73224,  13, True ) /* Ethereal */
+     , (73224,  18, True ) /* Visibility */
+     , (73224,  19, False) /* Attackable */
+     , (73224,  29, True ) /* NoCorpse */
+     , (73224,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (73224,  42, True ) /* AllowEdgeSlide */
+     , (73224,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73224,   1,       5) /* HeartbeatInterval */
+     , (73224,   2,       0) /* HeartbeatTimestamp */
+     , (73224,   3,    0.16) /* HealthRate */
+     , (73224,   4,       5) /* StaminaRate */
+     , (73224,   5,       1) /* ManaRate */
+     , (73224,  13,     0.9) /* ArmorModVsSlash */
+     , (73224,  14,       1) /* ArmorModVsPierce */
+     , (73224,  15,     1.1) /* ArmorModVsBludgeon */
+     , (73224,  16,     0.4) /* ArmorModVsCold */
+     , (73224,  17,     0.4) /* ArmorModVsFire */
+     , (73224,  18,       1) /* ArmorModVsAcid */
+     , (73224,  19,     0.6) /* ArmorModVsElectric */
+     , (73224,  54,       3) /* UseRadius */
+     , (73224,  64,       1) /* ResistSlash */
+     , (73224,  65,       1) /* ResistPierce */
+     , (73224,  66,       1) /* ResistBludgeon */
+     , (73224,  67,       1) /* ResistFire */
+     , (73224,  68,       1) /* ResistCold */
+     , (73224,  69,       1) /* ResistAcid */
+     , (73224,  70,       1) /* ResistElectric */
+     , (73224,  71,       1) /* ResistHealthBoost */
+     , (73224,  72,       1) /* ResistStaminaDrain */
+     , (73224,  73,       1) /* ResistStaminaBoost */
+     , (73224,  74,       1) /* ResistManaDrain */
+     , (73224,  75,       1) /* ResistManaBoost */
+     , (73224, 104,      10) /* ObviousRadarRange */
+     , (73224, 125,       1) /* ResistHealthDrain */
+     , (73224, 131,       1) /* EmotePriority */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73224,   1, 'Present Raids Stopgap') /* Name */
+     , (73224,   3, 'Male') /* Sex */
+     , (73224,   4, 'Sho') /* HeritageGroup */
+     , (73224,   5, 'Stopgap') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73224,   1, 0x02000001) /* Setup */
+     , (73224,   2, 0x09000001) /* MotionTable */
+     , (73224,   3, 0x20000001) /* SoundTable */
+     , (73224,   4, 0x30000000) /* CombatTable */
+     , (73224,   8, 0x06001036) /* Icon */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73224,   1,  90, 0, 0) /* Strength */
+     , (73224,   2, 100, 0, 0) /* Endurance */
+     , (73224,   3,  75, 0, 0) /* Quickness */
+     , (73224,   4, 120, 0, 0) /* Coordination */
+     , (73224,   5, 140, 0, 0) /* Focus */
+     , (73224,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73224,   1,    10, 0, 0, 60) /* MaxHealth */
+     , (73224,   3,    10, 0, 0, 110) /* MaxStamina */
+     , (73224,   5,    10, 0, 0, 140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73224,  6, 0, 2, 0,   1, 0, 633.380416853002) /* MeleeDefense        Trained */
+     , (73224,  7, 0, 2, 0,   1, 0, 633.380416853002) /* MissileDefense      Trained */
+     , (73224, 13, 0, 2, 0,   1, 0, 633.380416853002) /* UnarmedCombat       Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73224,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73224,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73224,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73224,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73224,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73224,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73224,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73224,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73224,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73224,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 5, 1, 0x13000087 /* Wave */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  24 /* StopEvent */, 0, 1, NULL, 'PresentRaidsTufa', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  24 /* StopEvent */, 0, 1, NULL, 'PresentRaidsYaraq', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  67 /* Goto */, 900, 1, NULL, 'ChooseTown', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73224, 32 /* GotoSet */,    0.5, NULL, NULL, NULL, 'ChooseTown', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  16 /* WorldBroadcast */, 0, 1, NULL, 'A large pack of angry Gurogs have been spotted advancing on Tufa.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  23 /* StartEvent */, 0, 1, NULL, 'PresentRaidsTufa', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73224, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'ChooseTown', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  16 /* WorldBroadcast */, 0, 1, NULL, 'Panic has gripped the citizens of Yaraq as a group of balloons drift towards the town!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  23 /* StartEvent */, 0, 1, NULL, 'PresentRaidsYaraq', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73224.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73224.es
@@ -1,0 +1,15 @@
+Generation:
+    - Delay: 5, Motion: Wave
+    - StopEvent: PresentRaidsTufa
+    - StopEvent: PresentRaidsYaraq
+    - Delay: 900, Goto: ChooseTown
+
+GotoSet: ChooseTown, Probability: 0.5
+    - WorldBroadcast: A large pack of angry Gurogs have been spotted advancing on Tufa.
+    - StartEvent: PresentRaidsTufa
+    - DeleteSelf
+
+GotoSet: ChooseTown, Probability: 1
+    - WorldBroadcast: Panic has gripped the citizens of Yaraq as a group of balloons drift towards the town!
+    - StartEvent: PresentRaidsYaraq
+    - DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73232 Drudge Present Raids Reset Stopgap.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73232 Drudge Present Raids Reset Stopgap.sql
@@ -1,0 +1,160 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73232;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73232, 'ace73232-drudgepresentraidsresetstopgap', 10, '2024-12-12 10:54:36') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73232,   1,         16) /* ItemType - Creature */
+     , (73232,   2,         31) /* CreatureType - Human */
+     , (73232,   6,         -1) /* ItemsCapacity */
+     , (73232,   7,         -1) /* ContainersCapacity */
+     , (73232,   8,        120) /* Mass */
+     , (73232,  16,         32) /* ItemUseable - Remote */
+     , (73232,  25,         15) /* Level */
+     , (73232,  27,          0) /* ArmorType - None */
+     , (73232,  81,          1) /* MaxGeneratedObjects */
+     , (73232,  82,          0) /* InitGeneratedObjects */
+     , (73232,  93,    6292508) /* PhysicsState - Ethereal, ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (73232,  95,          8) /* RadarBlipColor - Yellow */
+     , (73232, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73232, 133,          0) /* ShowableOnRadar - Undefined */
+     , (73232, 134,         16) /* PlayerKillerStatus - RubberGlue */
+     , (73232, 146,        307) /* XpOverride */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73232,   1, True ) /* Stuck */
+     , (73232,   8, True ) /* AllowGive */
+     , (73232,  12, True ) /* ReportCollisions */
+     , (73232,  13, True ) /* Ethereal */
+     , (73232,  18, True ) /* Visibility */
+     , (73232,  19, False) /* Attackable */
+     , (73232,  41, True ) /* ReportCollisionsAsEnvironment */
+     , (73232,  42, True ) /* AllowEdgeSlide */
+     , (73232,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73232,   1,       5) /* HeartbeatInterval */
+     , (73232,   2,       0) /* HeartbeatTimestamp */
+     , (73232,   3,    0.16) /* HealthRate */
+     , (73232,   4,       5) /* StaminaRate */
+     , (73232,   5,       1) /* ManaRate */
+     , (73232,  13,     0.9) /* ArmorModVsSlash */
+     , (73232,  14,       1) /* ArmorModVsPierce */
+     , (73232,  15,     1.1) /* ArmorModVsBludgeon */
+     , (73232,  16,     0.4) /* ArmorModVsCold */
+     , (73232,  17,     0.4) /* ArmorModVsFire */
+     , (73232,  18,       1) /* ArmorModVsAcid */
+     , (73232,  19,     0.6) /* ArmorModVsElectric */
+     , (73232,  54,       3) /* UseRadius */
+     , (73232,  64,       1) /* ResistSlash */
+     , (73232,  65,       1) /* ResistPierce */
+     , (73232,  66,       1) /* ResistBludgeon */
+     , (73232,  67,       1) /* ResistFire */
+     , (73232,  68,       1) /* ResistCold */
+     , (73232,  69,       1) /* ResistAcid */
+     , (73232,  70,       1) /* ResistElectric */
+     , (73232,  71,       1) /* ResistHealthBoost */
+     , (73232,  72,       1) /* ResistStaminaDrain */
+     , (73232,  73,       1) /* ResistStaminaBoost */
+     , (73232,  74,       1) /* ResistManaDrain */
+     , (73232,  75,       1) /* ResistManaBoost */
+     , (73232, 104,      10) /* ObviousRadarRange */
+     , (73232, 125,       1) /* ResistHealthDrain */
+     , (73232, 131,       1) /* EmotePriority */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73232,   1, 'Drudge Present Raids Reset Stopgap') /* Name */
+     , (73232,   3, 'Male') /* Sex */
+     , (73232,   4, 'Sho') /* HeritageGroup */
+     , (73232,   5, 'Stopgap') /* Template */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73232,   1, 0x02000001) /* Setup */
+     , (73232,   2, 0x09000001) /* MotionTable */
+     , (73232,   3, 0x20000001) /* SoundTable */
+     , (73232,   4, 0x30000000) /* CombatTable */
+     , (73232,   8, 0x06001036) /* Icon */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73232,   1,  90, 0, 0) /* Strength */
+     , (73232,   2, 100, 0, 0) /* Endurance */
+     , (73232,   3,  75, 0, 0) /* Quickness */
+     , (73232,   4, 120, 0, 0) /* Coordination */
+     , (73232,   5, 140, 0, 0) /* Focus */
+     , (73232,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73232,   1,    10, 0, 0, 60) /* MaxHealth */
+     , (73232,   3,    10, 0, 0, 110) /* MaxStamina */
+     , (73232,   5,    10, 0, 0, 140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73232,  6, 0, 2, 0,   1, 0, 633.3804321289062) /* MeleeDefense        Trained */
+     , (73232,  7, 0, 2, 0,   1, 0, 633.3804321289062) /* MissileDefense      Trained */
+     , (73232, 13, 0, 2, 0,   1, 0, 633.3804321289062) /* UnarmedCombat       Trained */
+     , (73232, 34, 0, 3, 0, 800, 0, 1525.90308952149) /* WarMagic            Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73232,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73232,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73232,  2,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73232,  3,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73232,  4,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73232,  5,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73232,  6,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73232,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73232,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73232,  5 /* HeartBeat */,      1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  80 /* InqMyQuest */, 0, 1, NULL, 'presentraidsreset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73232,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  51 /* InqEvent */, 0, 1, NULL, 'PresentRaidsDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73232, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'presentraidsreset', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  67 /* Goto */, 0, 1, NULL, 'Reset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73232, 27 /* EventSuccess */,      1, NULL, NULL, NULL, 'PresentRaidsDead', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 10, 1, 0x13000087 /* Wave */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  67 /* Goto */, 0, 1, NULL, 'Reset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73232, 28 /* EventFailure */,      1, NULL, NULL, NULL, 'PresentRaidsDead', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  81 /* StampMyQuest */, 0, 1, NULL, 'presentraidsreset', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73232, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'Reset', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  24 /* StopEvent */, 0, 1, NULL, 'PresentRaidsDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  24 /* StopEvent */, 0, 1, NULL, 'PresentRaidsYaraq', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73232, -1, 73229, 0, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Holiday Present (73229) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/73232.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/73232.es
@@ -1,0 +1,17 @@
+HeartBeat: Style: NonCombat, Substyle: Ready
+    - InqMyQuest: presentraidsreset
+        QuestFailure:
+            - Goto: Reset
+
+Generation:
+    - InqEvent: PresentRaidsDead
+        EventSuccess:
+            - Delay: 10, Motion: Wave
+            - Goto: Reset
+        EventFailure:
+            - Generate
+            - StampMyQuest: presentraidsreset
+
+GotoSet: Reset
+    - StopEvent: PresentRaidsDead
+    - StopEvent: PresentRaidsYaraq

--- a/Database/Patches/9 WeenieDefaults/Creature/Rat/73216 Max.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Rat/73216 Max.sql
@@ -1,0 +1,127 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73216;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73216, 'ace73216-max', 10, '2024-05-26 19:09:10') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73216,   1,         16) /* ItemType - Creature */
+     , (73216,   2,         10) /* CreatureType - Rat */
+     , (73216,   3,          4) /* PaletteTemplate - Brown */
+     , (73216,   6,         -1) /* ItemsCapacity */
+     , (73216,   7,         -1) /* ContainersCapacity */
+     , (73216,  16,          1) /* ItemUseable - No */
+     , (73216,  25,        300) /* Level */
+     , (73216,  40,          2) /* CombatMode - Melee */
+     , (73216,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (73216,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73216, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73216, 146,    4000000) /* XpOverride */
+     , (73216, 281,         16) /* Faction1Bits - 8 */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73216,   1, True ) /* Stuck */
+     , (73216,  11, False) /* IgnoreCollisions */
+     , (73216,  12, True ) /* ReportCollisions */
+     , (73216,  13, False) /* Ethereal */
+     , (73216,  14, True ) /* GravityStatus */
+     , (73216,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73216,   1,       5) /* HeartbeatInterval */
+     , (73216,   2,       0) /* HeartbeatTimestamp */
+     , (73216,   3,   0.067) /* HealthRate */
+     , (73216,   4,       5) /* StaminaRate */
+     , (73216,   5,       2) /* ManaRate */
+     , (73216,  12,     0.5) /* Shade */
+     , (73216,  13,     1.2) /* ArmorModVsSlash */
+     , (73216,  14,       1) /* ArmorModVsPierce */
+     , (73216,  15,       1) /* ArmorModVsBludgeon */
+     , (73216,  16,     1.2) /* ArmorModVsCold */
+     , (73216,  17,     0.8) /* ArmorModVsFire */
+     , (73216,  18,       1) /* ArmorModVsAcid */
+     , (73216,  19,       1) /* ArmorModVsElectric */
+     , (73216,  31,      15) /* VisualAwarenessRange */
+     , (73216,  34,       2) /* PowerupTime */
+     , (73216,  36,       1) /* ChargeSpeed */
+     , (73216,  39,       2) /* DefaultScale */
+     , (73216,  64,     0.6) /* ResistSlash */
+     , (73216,  65,     0.8) /* ResistPierce */
+     , (73216,  66,     0.8) /* ResistBludgeon */
+     , (73216,  67,       1) /* ResistFire */
+     , (73216,  68,     0.4) /* ResistCold */
+     , (73216,  69,     0.6) /* ResistAcid */
+     , (73216,  70,     0.6) /* ResistElectric */
+     , (73216, 104,      10) /* ObviousRadarRange */
+     , (73216, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73216,   1, 'Max') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73216,   1, 0x0200003D) /* Setup */
+     , (73216,   2, 0x0900000E) /* MotionTable */
+     , (73216,   3, 0x2000000F) /* SoundTable */
+     , (73216,   4, 0x30000009) /* CombatTable */
+     , (73216,   6, 0x040001B4) /* PaletteBase */
+     , (73216,   7, 0x10000063) /* ClothingBase */
+     , (73216,   8, 0x0600103B) /* Icon */
+     , (73216,  22, 0x34000023) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73216,   1, 320, 0, 0) /* Strength */
+     , (73216,   2, 300, 0, 0) /* Endurance */
+     , (73216,   3, 380, 0, 0) /* Quickness */
+     , (73216,   4, 400, 0, 0) /* Coordination */
+     , (73216,   5, 200, 0, 0) /* Focus */
+     , (73216,   6, 190, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73216,   1, 66050, 0, 0, 66200) /* MaxHealth */
+     , (73216,   3,  4850, 0, 0, 5150) /* MaxStamina */
+     , (73216,   5,   870, 0, 0, 1060) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73216,  6, 0, 2, 0, 450, 0, 0) /* MeleeDefense        Trained */
+     , (73216,  7, 0, 2, 0, 540, 0, 0) /* MissileDefense      Trained */
+     , (73216, 15, 0, 2, 0, 380, 0, 0) /* MagicDefense        Trained */
+     , (73216, 45, 0, 2, 0, 480, 0, 0) /* LightWeapons        Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73216,  0,  2, 400, 0.75,  480,  421,  421,  280,  421,  421,  421,  280,    0, 1, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0, 0.33,  0.4,    0) /* Head */
+     , (73216, 16,  4, 400, 0.75,  480,  421,  421,  280,  421,  421,  421,  280,    0, 2, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75, 0.67,  0.4, 0.75) /* Torso */
+     , (73216, 17,  4, 400,    0,  480,  421,  421,  280,  421,  421,  421,  280,    0, 3,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25,    0,  0.2, 0.25) /* Tail */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73216,  5 /* HeartBeat */,    0.1, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73216,  5 /* HeartBeat */,  0.175, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73216,  5 /* HeartBeat */,    0.1, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73216,  5 /* HeartBeat */,  0.175, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (73216, 1, 52397,  0, 0, 1, False) /* Create Pack Max (52397) for Contain */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73217 Holiday Present.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73217 Holiday Present.sql
@@ -1,0 +1,118 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73217;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73217, 'ace73217-holidaypresent', 10, '2024-12-12 12:22:31') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73217,   1,         16) /* ItemType - Creature */
+     , (73217,   6,         -1) /* ItemsCapacity */
+     , (73217,   7,         -1) /* ContainersCapacity */
+     , (73217,   8,        120) /* Mass */
+     , (73217,  16,         32) /* ItemUseable - Remote */
+     , (73217,  25,        710) /* Level */
+     , (73217,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (73217,  95,          8) /* RadarBlipColor - Yellow */
+     , (73217, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73217,  19, False) /* Attackable */
+     , (73217,  52, True ) /* AiImmobile */
+     , (73217,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (73217,  83, True ) /* NpcLooksLikeObject */
+     , (73217,  90, True ) /* NpcInteractsSilently */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73217,   1, 'Holiday Present') /* Name */
+     , (73217,  15, 'A large holiday present wrapped up neatly with a bow.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73217,   1, 0x02000E74) /* Setup */
+     , (73217,   2, 0x0900011C) /* MotionTable */
+     , (73217,   3, 0x20000059) /* SoundTable */
+     , (73217,   8, 0x06002975) /* Icon */
+     , (73217,  22, 0x34000074) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  21 /* InqQuest */, 0, 1, NULL, 'GurogPresentRaidsWait', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'GurogPresentRaidsWait', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You must wait %tqt before you can receive another present.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'GurogPresentRaidsWait', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  22 /* StampQuest */, 0, 1, NULL, 'GurogPresentRaidsWait', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  34 /* AddCharacterTitle */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 857 /* PresentProtector */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have been awarded the title of "Present Protector"!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 100000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.19999999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  67 /* Goto */, 0, 1, NULL, 'RandomRewards', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */, 0.1429, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52367 /* Pack Gurog */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */, 0.2858, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52397 /* Pack Max */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */, 0.4287, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52582 /* Holiday Chimney */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */, 0.5716, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52576 /* Holiday Garland */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */, 0.7145, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52444 /* Holiday Present */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */, 0.8574, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52580 /* Holiday Sweater */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73217, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52581 /* Mistletoe */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73217.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73217.es
@@ -1,0 +1,32 @@
+Use:
+    - InqQuest: GurogPresentRaidsWait
+        QuestSuccess:
+            - DirectBroadcast: You must wait %tqt before you can receive another present.
+        QuestFailure:
+            - StampQuest: GurogPresentRaidsWait
+            - AddCharacterTitle: PresentProtector
+            - DirectBroadcast: You have been awarded the title of "Present Protector"!
+            - AwardLevelProportionalXP: 20%, 0 - 100,000,000
+            - AwardLuminance: 5000
+            - Goto: RandomRewards
+
+GotoSet: RandomRewards, Probability: 0.1429
+    - Give: 52367
+            
+GotoSet: RandomRewards, Probability: 0.2858
+    - Give: 52397
+
+GotoSet: RandomRewards, Probability: 0.4287
+    - Give: 52582
+
+GotoSet: RandomRewards, Probability: 0.5716
+    - Give: 52576
+
+GotoSet: RandomRewards, Probability: 0.7145
+    - Give: 52444
+
+GotoSet: RandomRewards, Probability: 0.8574
+    - Give: 52580
+    
+GotoSet: RandomRewards, Probability: 1
+    - Give: 52581

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73218 Holiday Present.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73218 Holiday Present.sql
@@ -1,0 +1,123 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73218;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73218, 'ace73218-holidaypresent', 10, '2024-12-11 06:14:39') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73218,   1,         16) /* ItemType - Creature */
+     , (73218,   3,         14) /* PaletteTemplate - Red */
+     , (73218,   6,         -1) /* ItemsCapacity */
+     , (73218,   7,         -1) /* ContainersCapacity */
+     , (73218,  16,          1) /* ItemUseable - No */
+     , (73218,  25,        999) /* Level */
+     , (73218,  67,          1) /* Tolerance - NoAttack */
+     , (73218,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (73218,  81,          1) /* MaxGeneratedObjects */
+     , (73218,  82,          0) /* InitGeneratedObjects */
+     , (73218,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73218,  95,          8) /* RadarBlipColor - Yellow */
+     , (73218, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73218, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (73218, 281,          8) /* Faction1Bits - 8 */
+     , (73218, 290,          1) /* HearLocalSignals */
+     , (73218, 291,          5) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73218,   1, True ) /* Stuck */
+     , (73218,  29, True ) /* NoCorpse */
+     , (73218,  52, True ) /* AiImmobile */
+     , (73218,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (73218,  83, True ) /* NpcLooksLikeObject */
+     , (73218, 103, True ) /* NonProjectileMagicImmune */
+     , (73218, 118, True ) /* NeverAttack */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73218,   1,       5) /* HeartbeatInterval */
+     , (73218,   2,       0) /* HeartbeatTimestamp */
+     , (73218,   3,   0.067) /* HealthRate */
+     , (73218,   4,       5) /* StaminaRate */
+     , (73218,   5,       1) /* ManaRate */
+     , (73218,  13,     1.5) /* ArmorModVsSlash */
+     , (73218,  14,     1.5) /* ArmorModVsPierce */
+     , (73218,  15,     1.5) /* ArmorModVsBludgeon */
+     , (73218,  16,     1.5) /* ArmorModVsCold */
+     , (73218,  17,     1.5) /* ArmorModVsFire */
+     , (73218,  18,     1.5) /* ArmorModVsAcid */
+     , (73218,  19,     1.5) /* ArmorModVsElectric */
+     , (73218,  31,     0.3) /* VisualAwarenessRange */
+     , (73218,  34,       1) /* PowerupTime */
+     , (73218,  36,       1) /* ChargeSpeed */
+     , (73218,  39,       1) /* DefaultScale */
+     , (73218,  41,      60) /* RegenerationInterval */
+     , (73218,  43,      15) /* GeneratorRadius */
+     , (73218,  64,     0.5) /* ResistSlash */
+     , (73218,  65,     0.5) /* ResistPierce */
+     , (73218,  66,     0.5) /* ResistBludgeon */
+     , (73218,  67,     0.5) /* ResistFire */
+     , (73218,  68,     0.5) /* ResistCold */
+     , (73218,  69,     0.5) /* ResistAcid */
+     , (73218,  70,     0.5) /* ResistElectric */
+     , (73218,  71,       1) /* ResistHealthBoost */
+     , (73218,  72,       1) /* ResistStaminaDrain */
+     , (73218,  73,       1) /* ResistStaminaBoost */
+     , (73218,  74,       1) /* ResistManaDrain */
+     , (73218,  75,       1) /* ResistManaBoost */
+     , (73218, 104,      10) /* ObviousRadarRange */
+     , (73218, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73218,   1, 'Holiday Present') /* Name */
+     , (73218,  15, 'A large holiday present wrapped up neatly with a bow.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73218,   1, 0x02000E74) /* Setup */
+     , (73218,   2, 0x0900011C) /* MotionTable */
+     , (73218,   3, 0x20000059) /* SoundTable */
+     , (73218,   8, 0x06002975) /* Icon */
+     , (73218,  22, 0x34000074) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73218,   1, 200, 0, 0) /* Strength */
+     , (73218,   2, 660, 0, 0) /* Endurance */
+     , (73218,   3, 290, 0, 0) /* Quickness */
+     , (73218,   4, 200, 0, 0) /* Coordination */
+     , (73218,   5, 690, 0, 0) /* Focus */
+     , (73218,   6, 690, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73218,   1, 49670, 0, 0, 50000) /* MaxHealth */
+     , (73218,   3,  4340, 0, 0, 5000) /* MaxStamina */
+     , (73218,   5,  9310, 0, 0, 10000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73218,  0,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73218,  1,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73218,  2,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73218,  3,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73218,  4,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73218,  5,  4,  1, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73218,  6,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73218,  7,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73218,  8,  4,  1, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73218,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  23 /* StartEvent */, 0, 1, NULL, 'PresentRaidsDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73218, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DeleteMe', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73218, -1, 73220, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gurog Grump Gen (73220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (73218, -1, 73220, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gurog Grump Gen (73220) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (73218, -1, 73222, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gurog Mastermind Gen (73222) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (73218, -1, 73223, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Delete Signal Stopgap (73223) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73218.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73218.es
@@ -1,0 +1,5 @@
+Death:
+    - StartEvent: GurogPresentDead
+
+ReceiveLocalSignal: DeleteReceiver 
+    - DeleteSelf

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73226 Holiday Presents.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73226 Holiday Presents.sql
@@ -1,0 +1,120 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73226;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73226, 'ace73226-pileofpresents', 10, '2024-12-11 06:14:39') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73226,   1,         16) /* ItemType - Creature */
+     , (73226,   3,         14) /* PaletteTemplate - Red */
+     , (73226,   6,         -1) /* ItemsCapacity */
+     , (73226,   7,         -1) /* ContainersCapacity */
+     , (73226,  16,          1) /* ItemUseable - No */
+     , (73226,  25,        999) /* Level */
+     , (73226,  67,          1) /* Tolerance - NoAttack */
+     , (73226,  68,          5) /* TargetingTactic - Random, LastDamager */
+     , (73226,  81,          1) /* MaxGeneratedObjects */
+     , (73226,  82,          0) /* InitGeneratedObjects */
+     , (73226,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73226,  95,          8) /* RadarBlipColor - Yellow */
+     , (73226, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73226, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (73226, 281,          8) /* Faction1Bits - 8 */
+     , (73226, 290,          1) /* HearLocalSignals */
+     , (73226, 291,          5) /* HearLocalSignalsRadius */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73226,   1, True ) /* Stuck */
+     , (73226,  29, True ) /* NoCorpse */
+     , (73226,  52, True ) /* AiImmobile */
+     , (73226,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (73226,  83, True ) /* NpcLooksLikeObject */
+     , (73226, 103, True ) /* NonProjectileMagicImmune */
+     , (73226, 118, True ) /* NeverAttack */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73226,   1,       5) /* HeartbeatInterval */
+     , (73226,   2,       0) /* HeartbeatTimestamp */
+     , (73226,   3,   0.067) /* HealthRate */
+     , (73226,   4,       5) /* StaminaRate */
+     , (73226,   5,       1) /* ManaRate */
+     , (73226,  13,     1.5) /* ArmorModVsSlash */
+     , (73226,  14,     1.5) /* ArmorModVsPierce */
+     , (73226,  15,     1.5) /* ArmorModVsBludgeon */
+     , (73226,  16,     1.5) /* ArmorModVsCold */
+     , (73226,  17,     1.5) /* ArmorModVsFire */
+     , (73226,  18,     1.5) /* ArmorModVsAcid */
+     , (73226,  19,     1.5) /* ArmorModVsElectric */
+     , (73226,  31,     0.3) /* VisualAwarenessRange */
+     , (73226,  34,       1) /* PowerupTime */
+     , (73226,  36,       1) /* ChargeSpeed */
+     , (73226,  39,       1) /* DefaultScale */
+     , (73226,  41,      60) /* RegenerationInterval */
+     , (73226,  43,      15) /* GeneratorRadius */
+     , (73226,  64,     0.5) /* ResistSlash */
+     , (73226,  65,     0.5) /* ResistPierce */
+     , (73226,  66,     0.5) /* ResistBludgeon */
+     , (73226,  67,     0.5) /* ResistFire */
+     , (73226,  68,     0.5) /* ResistCold */
+     , (73226,  69,     0.5) /* ResistAcid */
+     , (73226,  70,     0.5) /* ResistElectric */
+     , (73226,  71,       1) /* ResistHealthBoost */
+     , (73226,  72,       1) /* ResistStaminaDrain */
+     , (73226,  73,       1) /* ResistStaminaBoost */
+     , (73226,  74,       1) /* ResistManaDrain */
+     , (73226,  75,       1) /* ResistManaBoost */
+     , (73226, 104,      10) /* ObviousRadarRange */
+     , (73226, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73226,   1, 'Holiday Presents') /* Name */
+     , (73226,  15, 'A pile of present boxes. All glued shut to preserve the mystery.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73226,   1, 0x02001769) /* Setup */
+     , (73226,   3, 0x20000014) /* SoundTable */
+     , (73226,   8, 0x0600675B) /* Icon */
+     , (73226,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73226,   1, 200, 0, 0) /* Strength */
+     , (73226,   2, 660, 0, 0) /* Endurance */
+     , (73226,   3, 290, 0, 0) /* Quickness */
+     , (73226,   4, 200, 0, 0) /* Coordination */
+     , (73226,   5, 690, 0, 0) /* Focus */
+     , (73226,   6, 690, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73226,   1, 49670, 0, 0, 50000) /* MaxHealth */
+     , (73226,   3,  4340, 0, 0, 5000) /* MaxStamina */
+     , (73226,   5,  9310, 0, 0, 10000) /* MaxMana */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73226,  0,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (73226,  1,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (73226,  2,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (73226,  3,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (73226,  4,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (73226,  5,  4,  1, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (73226,  6,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (73226,  7,  4,  0,    0,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (73226,  8,  4,  1, 0.75,  500,  250,  250,  250,  250,  250,  250,  250,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73226,  3 /* Death */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  23 /* StartEvent */, 0, 1, NULL, 'PresentRaidsDead', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73226, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'DeleteMe', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73226, -1, 73231, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Drudge Pilferer Gen (73231) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (73226, -1, 73223, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Delete Signal Stopgap (73223) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73229 Holiday Presents.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73229 Holiday Presents.sql
@@ -1,0 +1,109 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73229;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73229, 'ace73229-holidaypresents', 10, '2024-12-12 12:21:52') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73229,   1,         16) /* ItemType - Creature */
+     , (73229,   6,         -1) /* ItemsCapacity */
+     , (73229,   7,         -1) /* ContainersCapacity */
+     , (73229,   8,        120) /* Mass */
+     , (73229,  16,         32) /* ItemUseable - Remote */
+     , (73229,  25,        710) /* Level */
+     , (73229,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
+     , (73229,  95,          8) /* RadarBlipColor - Yellow */
+     , (73229, 133,          4) /* ShowableOnRadar - ShowAlways */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73229,  19, False) /* Attackable */
+     , (73229,  52, True ) /* AiImmobile */
+     , (73229,  82, True ) /* DontTurnOrMoveWhenGiving */
+     , (73229,  83, True ) /* NpcLooksLikeObject */
+     , (73229,  90, True ) /* NpcInteractsSilently */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73229,   1, 'Holiday Present') /* Name */
+     , (73229,  15, 'A pile of present boxes. All glued shut to preserve the mystery.') /* ShortDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73229,   1, 0x02001769) /* Setup */
+     , (73229,   3, 0x20000014) /* SoundTable */
+     , (73229,   8, 0x0600675B) /* Icon */
+     , (73229,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229,  7 /* Use */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  21 /* InqQuest */, 0, 1, NULL, 'DrudgePresentRaidsWait', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 12 /* QuestSuccess */,      1, NULL, NULL, NULL, 'DrudgePresentRaidsWait', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'You must wait %tqt before you can receive another present.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'DrudgePresentRaidsWait', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  22 /* StampQuest */, 0, 1, NULL, 'DrudgePresentRaidsWait', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  1,  34 /* AddCharacterTitle */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 859 /* LossPrevention */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  2,  18 /* DirectBroadcast */, 0, 1, NULL, 'You have been awarded the title of "Loss Prevention"!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  3,  49 /* AwardLevelProportionalXP */, 0, 1, NULL, NULL, NULL, NULL, NULL, 0, 100000000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0.19999999, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  4, 113 /* AwardLuminance */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 5000, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL)
+     , (@parent_id,  5,  67 /* Goto */, 0, 1, NULL, 'RandomRewards', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 32 /* GotoSet */, 0.1667, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52445 /* Pack Pilferer */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 32 /* GotoSet */, 0.3334, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52582 /* Holiday Chimney */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 32 /* GotoSet */, 0.5001, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52576 /* Holiday Garland */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 32 /* GotoSet */, 0.6668, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52444 /* Holiday Present */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 32 /* GotoSet */, 0.8335, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52580 /* Holiday Sweater */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (73229, 32 /* GotoSet */,      1, NULL, NULL, NULL, 'RandomRewards', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   3 /* Give */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 52581 /* Mistletoe */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73229 Holiday Presents.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73229 Holiday Presents.sql
@@ -22,7 +22,7 @@ VALUES (73229,  19, False) /* Attackable */
      , (73229,  90, True ) /* NpcInteractsSilently */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (73229,   1, 'Holiday Present') /* Name */
+VALUES (73229,   1, 'Holiday Presents') /* Name */
      , (73229,  15, 'A pile of present boxes. All glued shut to preserve the mystery.') /* ShortDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73229.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/73229.es
@@ -1,0 +1,29 @@
+Use:
+    - InqQuest: DrudgePresentRaidsWait
+        QuestSuccess:
+            - DirectBroadcast: You must wait %tqt before you can receive another present.
+        QuestFailure:
+            - StampQuest: DrudgePresentRaidsWait
+            - AddCharacterTitle: LossPrevention
+            - DirectBroadcast: You have been awarded the title of "Loss Prevention"!
+            - AwardLevelProportionalXP: 20%, 0 - 100,000,000
+            - AwardLuminance: 5000
+            - Goto: RandomRewards
+
+GotoSet: RandomRewards, Probability: 0.1667
+    - Give: 52445
+
+GotoSet: RandomRewards, Probability: 0.3334
+    - Give: 52582
+
+GotoSet: RandomRewards, Probability: 0.5001
+    - Give: 52576
+
+GotoSet: RandomRewards, Probability: 0.6668
+    - Give: 52444
+
+GotoSet: RandomRewards, Probability: 0.8335
+    - Give: 52580
+    
+GotoSet: RandomRewards, Probability: 1
+    - Give: 52581

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/52445 Pack Pilferer.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/52445 Pack Pilferer.sql
@@ -1,0 +1,33 @@
+DELETE FROM `weenie` WHERE `class_Id` = 52445;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (52445, 'ace52445-packpilferer', 1, '2019-02-10 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (52445,   1,        128) /* ItemType - Misc */
+     , (52445,   3,          1) /* PaletteTemplate - AquaBlue */
+     , (52445,   5,         10) /* EncumbranceVal */
+     , (52445,  16,          1) /* ItemUseable - No */
+     , (52445,  19,         10) /* Value */
+     , (52445,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (52445, 151,          9) /* HookType - Floor, Yard */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (52445,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (52445,  12,     0.5) /* Shade */
+     , (52445,  39,     0.3) /* DefaultScale */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (52445,   1, 'Pack Pilferer') /* Name */
+     , (52445,  14, 'Pack Pilferer can be placed on floor and yard hooks, if you trust it alone in your home...') /* Use */
+     , (52445,  16, 'A sneaky, present thieving, little Drudge.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (52445,   1, 0x020007DD) /* Setup */
+     , (52445,   2, 0x090000A9) /* MotionTable */
+     , (52445,   6, 0x04000F6C) /* PaletteBase */
+     , (52445,   7, 0x10000486) /* ClothingBase */
+     , (52445,   8, 0x06007520) /* Icon */
+     , (52445,  22, 0x3400001A) /* PhysicsEffectTable */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73219 Present Raids Tufa Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73219 Present Raids Tufa Gen.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73219;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73219, 'ace73219-presentraidstufagen', 1, '2022-06-21 15:22:25') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73219,  81,          1) /* MaxGeneratedObjects */
+     , (73219,  82,          1) /* InitGeneratedObjects */
+     , (73219,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73219, 142,          3) /* GeneratorTimeType - Event */
+     , (73219, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73219,   1, True ) /* Stuck */
+     , (73219,  11, True ) /* IgnoreCollisions */
+     , (73219,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73219,  41,       5) /* RegenerationInterval */
+     , (73219,  43,       0) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73219,   1, 'Present Raids Tufa Gen') /* Name */
+     , (73219,  34, 'PresentRaidsTufa') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73219,   1, 0x0200026B) /* Setup */
+     , (73219,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73219, -1, 73218, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Holiday Present (73218) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (73219, -1, 73221, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Gurog Present Raids Reset Stopgap (73221) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73220 Gurog Grump Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73220 Gurog Grump Gen.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73220;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73220, 'ace73220-guroggrumpgen', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73220,  81,          9) /* MaxGeneratedObjects */
+     , (73220,  82,          9) /* InitGeneratedObjects */
+     , (73220,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73220, 103,          2) /* GeneratorDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73220,   1, True ) /* Stuck */
+     , (73220,  11, True ) /* IgnoreCollisions */
+     , (73220,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73220,  41,  999999) /* RegenerationInterval */
+     , (73220,  43,      15) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73220,   1, 'Gurog Grump Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73220,   1, 0x0200026B) /* Setup */
+     , (73220,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73220, -1, 73214, 0, 9, 9, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gurog Grump (73214) (x9 up to max of 9) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73222 Gurog Mastermind Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73222 Gurog Mastermind Gen.sql
@@ -1,0 +1,31 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73222;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73222, 'ace73222-gurogmastermindgen', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73222,  81,          9) /* MaxGeneratedObjects */
+     , (73222,  82,          9) /* InitGeneratedObjects */
+     , (73222,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73222, 103,          2) /* GeneratorDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73222,   1, True ) /* Stuck */
+     , (73222,  11, True ) /* IgnoreCollisions */
+     , (73222,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73222,  41,  999999) /* RegenerationInterval */
+     , (73222,  43,      15) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73222,   1, 'Gurog Mastermind Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73222,   1, 0x0200026B) /* Setup */
+     , (73222,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73222, -1, 73214, 0, 7, 7, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gurog Grump (73214) (x7 up to max of 7) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73222, -1, 73215, 0, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Gurog Mastermind (73215) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73222, -1, 73216, 0, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Max (73216) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73230 Present Raids Yaraq Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73230 Present Raids Yaraq Gen.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73230;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73230, 'ace73230-presentraidsyaraqgen', 1, '2022-06-21 15:22:25') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73230,  81,          1) /* MaxGeneratedObjects */
+     , (73230,  82,          1) /* InitGeneratedObjects */
+     , (73230,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73230, 142,          3) /* GeneratorTimeType - Event */
+     , (73230, 145,          2) /* GeneratorEndDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73230,   1, True ) /* Stuck */
+     , (73230,  11, True ) /* IgnoreCollisions */
+     , (73230,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73230,  41,       5) /* RegenerationInterval */
+     , (73230,  43,       0) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73230,   1, 'Present Raids Yaraq Gen') /* Name */
+     , (73230,  34, 'PresentRaidsYaraq') /* GeneratorEvent */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73230,   1, 0x0200026B) /* Setup */
+     , (73230,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73230, -1, 73226, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Holiday Present (73218) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */
+     , (73230, -1, 73232, 3600, 1, 1, 1, 1, -1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0) /* Generate Present Raids Reset Stopgap (73221) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: OnTop */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/73231 Drudge Pilferer Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/73231 Drudge Pilferer Gen.sql
@@ -1,0 +1,32 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73231;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73231, 'ace73231-drudgepilferergen', 1, '2021-11-01 00:00:00') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73231,  81,          3) /* MaxGeneratedObjects */
+     , (73231,  82,          3) /* InitGeneratedObjects */
+     , (73231,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (73231, 103,          2) /* GeneratorDestructionType - Destroy */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73231,   1, True ) /* Stuck */
+     , (73231,  11, True ) /* IgnoreCollisions */
+     , (73231,  18, True ) /* Visibility */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73231,  41,       5) /* RegenerationInterval */
+     , (73231,  43,      20) /* GeneratorRadius */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73231,   1, 'Drudge Pilferer Gen') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73231,   1, 0x0200026B) /* Setup */
+     , (73231,   8, 0x06001066) /* Icon */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73231, -1, 73225, 3600, 1, 1, 1, 4, -1, 0, 0, 0, -20, 0, 1, 1, 0, 0, 0) /* Generate Drudge Balloon (73225) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (73231, -1, 73225, 3600, 1, 1, 1, 4, -1, 0, 0, 0, 0, -20, 1, 1, 0, 0, 0) /* Generate Drudge Balloon (73225) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (73231, -1, 73225, 3600, 1, 1, 1, 4, -1, 0, 0, 0, 20, 0, 1, 1, 0, 0, 0) /* Generate Drudge Balloon (73225) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (73231, -1, 73228, 3600, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Drudge Pilferer (73228) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/80018 Holiday Events Stopgap Gen.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/80018 Holiday Events Stopgap Gen.sql
@@ -4,8 +4,8 @@ INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
 VALUES (80018, 'ace80018-holidayeventsstopgapgen', 1, '2024-03-15 04:03:05') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (80018,  81,          1) /* MaxGeneratedObjects */
-     , (80018,  82,          1) /* InitGeneratedObjects */
+VALUES (80018,  81,          2) /* MaxGeneratedObjects */
+     , (80018,  82,          2) /* InitGeneratedObjects */
      , (80018,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
      , (80018, 142,          1) /* GeneratorTimeType - RealTime */
      , (80018, 143, 1733288460) /* GeneratorStartTime - 12/04/2024 05:01:00 */
@@ -30,4 +30,5 @@ VALUES (80018,   1, 0x0200026B) /* Setup */
      , (80018,   8, 0x06001066) /* Icon */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (80018, -1, 80017, 1, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Holiday Events Stopgap! (80017) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;
+VALUES (80018, -1, 80017, 1, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Holiday Events Stopgap! (80017) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (80018, -1, 73224, 14400, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Present Raids Stopgap (73224) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/B GameEventDefDB/PresentRaidsDead.sql
+++ b/Database/Patches/B GameEventDefDB/PresentRaidsDead.sql
@@ -1,0 +1,4 @@
+DELETE FROM `event` WHERE `name` = 'PresentRaidsDead';
+
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('PresentRaidsDead', -1, -1, 3, '2020-01-24 19:57:17');

--- a/Database/Patches/B GameEventDefDB/PresentRaidsTufa.sql
+++ b/Database/Patches/B GameEventDefDB/PresentRaidsTufa.sql
@@ -1,0 +1,4 @@
+DELETE FROM `event` WHERE `name` = 'PresentRaidsTufa';
+
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('PresentRaidsTufa', -1, -1, 3, '2020-01-24 19:57:17');

--- a/Database/Patches/B GameEventDefDB/PresentRaidsYaraq.sql
+++ b/Database/Patches/B GameEventDefDB/PresentRaidsYaraq.sql
@@ -1,0 +1,4 @@
+DELETE FROM `event` WHERE `name` = 'PresentRaidsYaraq';
+
+INSERT INTO `event` (`name`, `start_Time`, `end_Time`, `state`, `last_Modified`)
+VALUES ('PresentRaidsYaraq', -1, -1, 3, '2020-01-24 19:57:17');


### PR DESCRIPTION
Adds Drudge and Gurog Present Raids, currently only to Yaraq (for Drudge) and Tufa (for Gurog).

A random raid is set to occur 15 min after a server restart, and then every 4 hours.

The landblocks 7D64 and 866C are modified.

http://acpedia.org/wiki/Drudge_Present_Raids

http://acpedia.org/wiki/Gurog_Present_Raids