### PR TITLE
Add Crit Multiplier for Renegade Kalindans

### DIFF
--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/40425 Renegade Kalindan of the Mountains.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/40425 Renegade Kalindan of the Mountains.sql
@@ -49,7 +49,7 @@ VALUES (40425,   5,  -0.033) /* ManaRate */
      , (40425,  29,    1.15) /* WeaponDefense */
      , (40425,  62,     1.2) /* WeaponOffense */
      , (40425,  63,    2.65) /* DamageMod */
-     , (40425, 136,       1) /* CriticalMultiplier */
+     , (40425, 136,       3) /* CriticalMultiplier */
      , (40425, 157,       1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88177 Renegade Kalindan of the Chase.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88177 Renegade Kalindan of the Chase.sql
@@ -49,7 +49,7 @@ VALUES (88177,   5,  -0.033) /* ManaRate */
      , (88177,  29,    1.15) /* WeaponDefense */
      , (88177,  62,     1.2) /* WeaponOffense */
      , (88177,  63,    2.65) /* DamageMod */
-     , (88177, 136,       1) /* CriticalMultiplier */
+     , (88177, 136,       3) /* CriticalMultiplier */
      , (88177, 157,       1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88178 Renegade Kalindan of the Forests.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88178 Renegade Kalindan of the Forests.sql
@@ -49,7 +49,7 @@ VALUES (88178,   5,  -0.033) /* ManaRate */
      , (88178,  29,    1.15) /* WeaponDefense */
      , (88178,  62,     1.2) /* WeaponOffense */
      , (88178,  63,    2.65) /* DamageMod */
-     , (88178, 136,       1) /* CriticalMultiplier */
+     , (88178, 136,       3) /* CriticalMultiplier */
      , (88178, 157,       1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88179 Renegade Kalindan of the Heights.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88179 Renegade Kalindan of the Heights.sql
@@ -49,7 +49,7 @@ VALUES (88179,   5,  -0.033) /* ManaRate */
      , (88179,  29,    1.15) /* WeaponDefense */
      , (88179,  62,     1.2) /* WeaponOffense */
      , (88179,  63,    2.65) /* DamageMod */
-     , (88179, 136,       1) /* CriticalMultiplier */
+     , (88179, 136,       3) /* CriticalMultiplier */
      , (88179, 157,       1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88248 Renegade Kalindan of the Vortex.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88248 Renegade Kalindan of the Vortex.sql
@@ -49,7 +49,7 @@ VALUES (88248,   5,  -0.033) /* ManaRate */
      , (88248,  29,    1.15) /* WeaponDefense */
      , (88248,  62,     1.2) /* WeaponOffense */
      , (88248,  63,    2.65) /* DamageMod */
-     , (88248, 136,       1) /* CriticalMultiplier */
+     , (88248, 136,       3) /* CriticalMultiplier */
      , (88248, 157,       1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)

--- a/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88249 Renegade Kalindan of the Rivers.sql
+++ b/Database/Patches/9 WeenieDefaults/MissileLauncher/MissileWeapon/88249 Renegade Kalindan of the Rivers.sql
@@ -49,7 +49,7 @@ VALUES (88249,   5,  -0.033) /* ManaRate */
      , (88249,  29,    1.15) /* WeaponDefense */
      , (88249,  62,     1.2) /* WeaponOffense */
      , (88249,  63,    2.65) /* DamageMod */
-     , (88249, 136,       1) /* CriticalMultiplier */
+     , (88249, 136,       3) /* CriticalMultiplier */
      , (88249, 157,       1) /* ResistanceModifier */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)


### PR DESCRIPTION
Renegade kalindans (crossbows) had a useless value set for CriticalMultiplier. Changed it to match the other renegade weapons. 