### PR TITLE
Fix Baktshay Keeper Health

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Anekshay/49571 Bak'tshay Keeper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Anekshay/49571 Bak'tshay Keeper.sql
@@ -88,7 +88,7 @@ VALUES (49571,   1, 330, 0, 0) /* Strength */
      , (49571,   6, 290, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (49571,   1,  8156, 0, 0, 18500) /* MaxHealth */
+VALUES (49571,   1, 18347, 0, 0, 18500) /* MaxHealth */
      , (49571,   3, 10110, 0, 0, 10415) /* MaxStamina */
      , (49571,   5,  9955, 0, 0, 10245) /* MaxMana */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Anekshay/49573 Bak'tshay Keeper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Anekshay/49573 Bak'tshay Keeper.sql
@@ -87,7 +87,7 @@ VALUES (49573,   1, 330, 0, 0) /* Strength */
      , (49573,   6, 290, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (49573,   1,  8156, 0, 0, 18500) /* MaxHealth */
+VALUES (49573,   1, 18347, 0, 0, 18500) /* MaxHealth */
      , (49573,   3, 10110, 0, 0, 10415) /* MaxStamina */
      , (49573,   5,  9955, 0, 0, 10245) /* MaxMana */;
 

--- a/Database/Patches/9 WeenieDefaults/Creature/Anekshay/49574 Bak'tshay Keeper.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Anekshay/49574 Bak'tshay Keeper.sql
@@ -87,7 +87,7 @@ VALUES (49574,   1, 330, 0, 0) /* Strength */
      , (49574,   6, 290, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (49574,   1,     0, 0, 0, 18500) /* MaxHealth */
+VALUES (49574,   1, 18347, 0, 0, 18500) /* MaxHealth */
      , (49574,   3, 10110, 0, 0, 10415) /* MaxStamina */
      , (49574,   5,  9955, 0, 0, 10245) /* MaxMana */;
 


### PR DESCRIPTION
Increase Init MaxHealth on Bak'tshay Keepers (4 corners boss versions) to match current/pcap value. 