### PR TITLE
Fix Renegade Fortress Surface

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/88185 Surface.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/88185 Surface.sql
@@ -6,7 +6,6 @@ VALUES (88185, 'ace88185-surface', 7, '2022-07-13 15:31:07') /* Portal */;
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (88185,   1,      65536) /* ItemType - Portal */
      , (88185,  16,         32) /* ItemUseable - Remote */
-     , (88185,  86,        200) /* MinLevel */
      , (88185,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
      , (88185, 111,         49) /* PortalBitmask - Unrestricted, NoSummon, NoRecall */
      , (88185, 133,          4) /* ShowableOnRadar - ShowAlways */;


### PR DESCRIPTION
Renegade Fortress 120+. Surface portal wasn't pcaped, it wasn't appraised on the video I found, and the wiki has no info, but a 200+ level restriction on the surface portal seems unlikely. Don't see where else that would have come from, so just assuming it was mistakenly carried over from the portal it was copied from. 