### PR TITLE
Increase Listening Range for Thick Rock Wall (Empyrean Rescue)

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/51646 Thick Rock Wall.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/51646 Thick Rock Wall.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 51646;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (51646, 'ace51646-thickrockwall', 10, '2021-11-17 16:56:08') /* Creature */;
+VALUES (51646, 'ace51646-thickrockwall', 10, '2025-03-11 02:32:17') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (51646,   1,         16) /* ItemType - Creature */
@@ -11,7 +11,7 @@ VALUES (51646,   1,         16) /* ItemType - Creature */
      , (51646,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
      , (51646, 133,          1) /* ShowableOnRadar - ShowNever */
      , (51646, 290,          1) /* HearLocalSignals */
-     , (51646, 291,         40) /* HearLocalSignalsRadius */;
+     , (51646, 291,         60) /* HearLocalSignalsRadius */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (51646,   1, True ) /* Stuck */
@@ -66,24 +66,6 @@ VALUES (51646,   1, 0x020017EE) /* Setup */
      , (51646,   8, 0x060067DD) /* Icon */
      , (51646,  22, 0x3400005D) /* PhysicsEffectTable */;
 
-INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (51646,   1,  90, 0, 0) /* Strength */
-     , (51646,   2, 100, 0, 0) /* Endurance */
-     , (51646,   3,  75, 0, 0) /* Quickness */
-     , (51646,   4, 120, 0, 0) /* Coordination */
-     , (51646,   5, 140, 0, 0) /* Focus */
-     , (51646,   6, 130, 0, 0) /* Self */;
-
-INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (51646,   1,    10, 0, 0, 60) /* MaxHealth */
-     , (51646,   3,    10, 0, 0, 110) /* MaxStamina */
-     , (51646,   5,    10, 0, 0, 140) /* MaxMana */;
-
-INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (51646,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
-     , (51646,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
-     , (51646, 13, 0, 2, 0,   1, 0, 0) /* UnarmedCombat       Trained */;
-
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
 VALUES (51646,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
      , (51646,  1,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
@@ -95,10 +77,29 @@ VALUES (51646,  0,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,
      , (51646,  7,  4,  0,    0,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
      , (51646,  8,  4,  2, 0.75,    0,    0,    0,    0,    0,    0,    0,    0,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (51646,   1,  90, 0, 0) /* Strength */
+     , (51646,   2, 100, 0, 0) /* Endurance */
+     , (51646,   3,  75, 0, 0) /* Quickness */
+     , (51646,   4, 120, 0, 0) /* Coordination */
+     , (51646,   5, 140, 0, 0) /* Focus */
+     , (51646,   6, 130, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (51646,   1,    10, 0, 0,   60) /* MaxHealth */
+     , (51646,   3,    10, 0, 0,  110) /* MaxStamina */
+     , (51646,   5,    10, 0, 0,  140) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (51646,  6, 0, 2, 0,   1, 0, 0) /* MeleeDefense        Trained */
+     , (51646,  7, 0, 2, 0,   1, 0, 0) /* MissileDefense      Trained */
+     , (51646, 13, 0, 2, 0,   1, 0, 0) /* UnarmedCombat       Trained */;
+
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (51646, 37 /* ReceiveLocalSignal */,      1, NULL, NULL, NULL, 'BloodstoneDead', NULL, NULL, NULL);
+VALUES (51646, 37 /* ReceiveLocalSignal */, 1, NULL, NULL, NULL, 'BloodstoneDead', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id, 0, 77 /* DeleteSelf */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+


### PR DESCRIPTION
The Thick Rock Wall in Empyrean Rescue wasn't being deleted if the Engorged Bloodstone died in the (roughly) back third of the room. This increases the HearLocalSignalsRadius to reach the entire room. 