### PR TITLE
Fix Blackfire Shimmering Isparian Dagger recipe

### DIFF
--- a/Database/Patches/4 CraftTable/06637 Blackfire Shimmering Isparian Dagger.sql
+++ b/Database/Patches/4 CraftTable/06637 Blackfire Shimmering Isparian Dagger.sql
@@ -6,4 +6,4 @@ VALUES (6637, 0, 0, 0, 0, 46206 /* Blackfire Shimmering Isparian Dagger */, 1, '
 DELETE FROM `cook_book` WHERE `recipe_Id` = 6637;
 
 INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6637, 46035 /* Enhanced Black Fire Atlan Stone */, 46191 /* Shimmering Isparian Dagger */, '2022-02-20 02:53:49');
+VALUES (6637, 7469 /* Black Fire Atlan Stone */, 46191 /* Shimmering Isparian Dagger */, '2022-02-20 02:53:49');

--- a/Database/Patches/4 CraftTable/06638 Black Fire Atlan Stone.sql
+++ b/Database/Patches/4 CraftTable/06638 Black Fire Atlan Stone.sql
@@ -1,9 +1,0 @@
-DELETE FROM `recipe` WHERE `id` = 6638;
-
-INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
-VALUES (6638, 0, 0, 0, 0, 46207, 1, 'You insert the stone into the weapon, Imbuing the stones power into the Isparian weapon', 46207, 0, 'You insert the stone into the weapon, Imbuing the stones power into the Isparian weapon', 0, 0, NULL, 1, 1, NULL, 0, 0, NULL, 1, 1, NULL, 0, '2021-11-01 00:00:00');
-
-DELETE FROM `cook_book` WHERE `recipe_Id` = 6638;
-
-INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
-VALUES (6638, 7469 /* Black Fire Atlan Stone */, 46191 /* Shimmering Isparian Dagger */, '2021-11-01 00:00:00');


### PR DESCRIPTION
Blackfire Shimmering Isparian Dagger recipe was using the enhanced stone. Fixes it to use the regular stone. 
Also removes a nonfunctional recipe that would otherwise override it, which tries to make the nonexistent wcid 46207 (don't really know what's going on with this recipe). 