### PR TITLE
Add Damaged Shadow Blade and recipes to tailor it onto swords

### DIFF
--- a/Database/Patches/4 CraftTable/09234 Damaged Shadow Blade.sql
+++ b/Database/Patches/4 CraftTable/09234 Damaged Shadow Blade.sql
@@ -1,0 +1,42 @@
+DELETE FROM `recipe` WHERE `id` = 9234;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9234, 0, 0, 0, 0, 0, 1, 'You tailor the appearance onto a different weapon.', 0, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, 0, '', 0, '2022-12-04 19:04:52');
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (9234, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_int` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,  18, 32, 8, 1) /* On Source.SuccessTarget SetBitsOn UiEffects - Fire to Target */;
+
+INSERT INTO `recipe_mods_d_i_d` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 33559902, 1, 1) /* On Source.SuccessTarget SetValue Setup to Target */
+     , (@parent_id, 0,   8, 100688904, 1, 1) /* On Source.SuccessTarget SetValue Icon to Target */;
+
+INSERT INTO `recipe_mods_string` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 'Shadow Blade', 1, 1) /* On Source.SuccessTarget SetValue Name to Target */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9234;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9234, 51914 /* Damaged Shadow Blade */,   324 /* Kaskara */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   327 /* Ken */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   339 /* Scimitar */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   340 /* Shamshir */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   345 /* Simi */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   350 /* Broad Sword */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   351 /* Long Sword */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   352 /* Short Sword */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   353 /* Tachi */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   354 /* Takuba */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */,   361 /* Yaoji */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 30566 /* Sabra */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 30571 /* Spada */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 30576 /* Flamberge */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 31759 /* Dericost Blade */, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 45396, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 45401, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 45406, '2025-04-16 23:45:11')
+     , (9234, 51914 /* Damaged Shadow Blade */, 45411 /* Spada */, '2025-04-16 23:45:11');

--- a/Database/Patches/4 CraftTable/09235 Damaged Shadow Blade.sql
+++ b/Database/Patches/4 CraftTable/09235 Damaged Shadow Blade.sql
@@ -1,0 +1,39 @@
+DELETE FROM `recipe` WHERE `id` = 9235;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9235, 0, 0, 0, 0, 0, 1, 'You tailor the appearance onto a different weapon.', 0, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, 0, '', 0, '2022-12-04 19:04:52');
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (9235, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_d_i_d` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 33559903, 1, 1) /* On Source.SuccessTarget SetValue Setup to Target */
+     , (@parent_id, 0,   8, 100688904, 1, 1) /* On Source.SuccessTarget SetValue Icon to Target */;
+
+INSERT INTO `recipe_mods_string` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 'Shadow Blade of Acid', 1, 1) /* On Source.SuccessTarget SetValue Name to Target */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9235;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9235, 51914 /* Damaged Shadow Blade */,  3810 /* Acid Kaskara */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3822 /* Acid Ken */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3849 /* Acid Scimitar */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3853 /* Acid Shamshir */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3869 /* Acid Simi */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3877 /* Acid Broad Sword */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3881 /* Acid Long Sword */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3885 /* Acid Short Sword */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3889 /* Acid Tachi */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3893 /* Acid Takuba */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */,  3909 /* Acid Yaoji */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 30570 /* Acid Sabra */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 30575 /* Acid Spada */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 30579 /* Acid Flamberge */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 31760 /* Acid Dericost Blade */, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 45397, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 45402, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 45407, '2025-04-16 23:45:11')
+     , (9235, 51914 /* Damaged Shadow Blade */, 45412 /* Acid Spada */, '2025-04-16 23:45:11');

--- a/Database/Patches/4 CraftTable/09236 Damaged Shadow Blade.sql
+++ b/Database/Patches/4 CraftTable/09236 Damaged Shadow Blade.sql
@@ -1,0 +1,39 @@
+DELETE FROM `recipe` WHERE `id` = 9236;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9236, 0, 0, 0, 0, 0, 1, 'You tailor the appearance onto a different weapon.', 0, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, 0, '', 0, '2022-12-04 19:04:52');
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (9236, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_d_i_d` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 33559904, 1, 1) /* On Source.SuccessTarget SetValue Setup to Target */
+     , (@parent_id, 0,   8, 100688904, 1, 1) /* On Source.SuccessTarget SetValue Icon to Target */;
+
+INSERT INTO `recipe_mods_string` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 'Shadow Blade of Lightning', 1, 1) /* On Source.SuccessTarget SetValue Name to Target */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9236;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9236, 51914 /* Damaged Shadow Blade */,  3811 /* Lightning Kaskara */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3823 /* Lightning Ken */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3850 /* Lightning Scimitar */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3854 /* Lightning Shamshir */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3870 /* Lightning Simi */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3878 /* Lightning Broad Sword */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3882 /* Lightning Long Sword */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3886 /* Lightning Short Sword */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3890 /* Lightning Tachi */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3894 /* Lightning Takuba */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */,  3910 /* Lightning Yaoji */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 30567 /* Lightning Sabra */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 30572 /* Lightning Spada */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 30580 /* Lightning Flamberge */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 31761 /* Lightning Dericost Blade */, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 45398, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 45403, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 45408, '2025-04-16 23:45:11')
+     , (9236, 51914 /* Damaged Shadow Blade */, 45413 /* Lightning Spada */, '2025-04-16 23:45:11');

--- a/Database/Patches/4 CraftTable/09237 Damaged Shadow Blade.sql
+++ b/Database/Patches/4 CraftTable/09237 Damaged Shadow Blade.sql
@@ -1,0 +1,39 @@
+DELETE FROM `recipe` WHERE `id` = 9237;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9237, 0, 0, 0, 0, 0, 1, 'You tailor the appearance onto a different weapon.', 0, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, 0, '', 0, '2022-12-04 19:04:52');
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (9237, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_d_i_d` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 33559905, 1, 1) /* On Source.SuccessTarget SetValue Setup to Target */
+     , (@parent_id, 0,   8, 100688904, 1, 1) /* On Source.SuccessTarget SetValue Icon to Target */;
+
+INSERT INTO `recipe_mods_string` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 'Shadow Blade of Flame', 1, 1) /* On Source.SuccessTarget SetValue Name to Target */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9237;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9237, 51914 /* Damaged Shadow Blade */,  3812 /* Flaming Kaskara */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3824 /* Flaming Ken */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3851 /* Flaming Scimitar */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3855 /* Flaming Shamshir */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3871 /* Flaming Simi */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3879 /* Flaming Broad Sword */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3883 /* Flaming Long Sword */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3887 /* Flaming Short Sword */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3891 /* Flaming Tachi */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3895 /* Flaming Takuba */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */,  3911 /* Flaming Yaoji */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 30568 /* Flaming Sabra */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 30574 /* Flaming Spada */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 30577 /* Flaming Flamberge */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 31762 /* Flaming Dericost Blade */, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 45399, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 45404, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 45409, '2025-04-16 23:45:11')
+     , (9237, 51914 /* Damaged Shadow Blade */, 45414 /* Flaming Spada */, '2025-04-16 23:45:11');

--- a/Database/Patches/4 CraftTable/09238 Damaged Shadow Blade.sql
+++ b/Database/Patches/4 CraftTable/09238 Damaged Shadow Blade.sql
@@ -1,0 +1,39 @@
+DELETE FROM `recipe` WHERE `id` = 9238;
+
+INSERT INTO `recipe` (`id`, `unknown_1`, `skill`, `difficulty`, `salvage_Type`, `success_W_C_I_D`, `success_Amount`, `success_Message`, `fail_W_C_I_D`, `fail_Amount`, `fail_Message`, `success_Destroy_Source_Chance`, `success_Destroy_Source_Amount`, `success_Destroy_Source_Message`, `success_Destroy_Target_Chance`, `success_Destroy_Target_Amount`, `success_Destroy_Target_Message`, `fail_Destroy_Source_Chance`, `fail_Destroy_Source_Amount`, `fail_Destroy_Source_Message`, `fail_Destroy_Target_Chance`, `fail_Destroy_Target_Amount`, `fail_Destroy_Target_Message`, `data_Id`, `last_Modified`)
+VALUES (9238, 0, 0, 0, 0, 0, 1, 'You tailor the appearance onto a different weapon.', 0, 1, '', 1, 1, '', 0, 0, '', 1, 1, '', 0, 0, '', 0, '2022-12-04 19:04:52');
+
+INSERT INTO `recipe_mod` (`recipe_Id`, `executes_On_Success`, `health`, `stamina`, `mana`, `unknown_7`, `data_Id`, `unknown_9`, `instance_Id`)
+VALUES (9238, True, 0, 0, 0, False, 0, 0, 0);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `recipe_mods_d_i_d` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 33559906, 1, 1) /* On Source.SuccessTarget SetValue Setup to Target */
+     , (@parent_id, 0,   8, 100688904, 1, 1) /* On Source.SuccessTarget SetValue Icon to Target */;
+
+INSERT INTO `recipe_mods_string` (`recipe_Mod_Id`, `index`, `stat`, `value`, `enum`, `source`)
+VALUES (@parent_id, 0,   1, 'Shadow Blade of Frost', 1, 1) /* On Source.SuccessTarget SetValue Name to Target */;
+
+DELETE FROM `cook_book` WHERE `recipe_Id` = 9238;
+
+INSERT INTO `cook_book` (`recipe_Id`, `source_W_C_I_D`, `target_W_C_I_D`, `last_Modified`)
+VALUES (9238, 51914 /* Damaged Shadow Blade */,  3813 /* Frost Kaskara */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3825 /* Frost Ken */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3852 /* Frost Scimitar */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3856 /* Frost Shamshir */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3872 /* Frost Simi */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3880 /* Frost Broad Sword */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3884 /* Frost Long Sword */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3888 /* Frost Short Sword */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3892 /* Frost Tachi */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3896 /* Frost Takuba */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */,  3912 /* Frost Yaoji */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 30569 /* Frost Sabra */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 30573 /* Frost Spada */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 30578 /* Frost Flamberge */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 31758 /* Frost Dericost Blade */, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 45400, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 45405, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 45410, '2025-04-16 23:45:11')
+     , (9238, 51914 /* Damaged Shadow Blade */, 45415 /* Frost Spada */, '2025-04-16 23:45:11');

--- a/Database/Patches/9 WeenieDefaults/CraftTool/Gem/51914 Damaged Shadow Blade.sql
+++ b/Database/Patches/9 WeenieDefaults/CraftTool/Gem/51914 Damaged Shadow Blade.sql
@@ -1,0 +1,35 @@
+DELETE FROM `weenie` WHERE `class_Id` = 51914;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (51914, 'ace51914-damagedshadowblade', 44, '2019-02-10 00:00:00') /* CraftTool */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (51914,   1,       2048) /* ItemType - Gem */
+     , (51914,   3,         39) /* PaletteTemplate - Black */
+     , (51914,   5,        350) /* EncumbranceVal */
+     , (51914,  11,          1) /* MaxStackSize */
+     , (51914,  12,          1) /* StackSize */
+     , (51914,  13,        350) /* StackUnitEncumbrance */
+     , (51914,  15,         50) /* StackUnitValue */
+     , (51914,  16,     524296) /* ItemUseable - SourceContainedTargetContained */
+     , (51914,  19,         50) /* Value */
+     , (51914,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (51914,  94,      33025) /* TargetType - WeaponOrCaster */
+     , (51914, 8041,        101) /* PCAPRecordedPlacement - Resting */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (51914,  22, True ) /* Inscribable */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (51914,   1, 'Damaged Shadow Blade') /* Name */
+     , (51914,  14, 'Use this applier to tailor this weapon''s look onto any tailorable sword.') /* Use */
+     , (51914,  16, 'A damaged Shadow Blade, useless for combat, but still intact enough to be used in weapon tailoring.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (51914,   1, 0x0200155E) /* Setup */
+     , (51914,   3, 0x20000014) /* SoundTable */
+     , (51914,   6, 0x04000BEF) /* PaletteBase */
+     , (51914,   7, 0x10000863) /* ClothingBase */
+     , (51914,   8, 0x06006408) /* Icon */
+     , (51914,  22, 0x3400002B) /* PhysicsEffectTable */
+     , (51914,  50, 0x060011F7) /* IconOverlay */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/44805 Void Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/44805 Void Lord.sql
@@ -159,4 +159,6 @@ VALUES (44805,   234,   2.02)  /* Vulnerability Other VI */
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44805, 9, 48908,  1, 0, 0.02, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
-     , (44805, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (44805, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (44805, 9, 51914,  1, 0, 0.01, False) /* Create Damaged Shadow Blade (51914) for ContainTreasure */
+     , (44805, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/44806 Panumbris Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/44806 Panumbris Shadow.sql
@@ -181,4 +181,6 @@ VALUES (44806,  2264,   2.02)  /* Wrath of Harlune */
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (44806, 9, 48908,  1, 0, 0.02, False) /* Create Shattered Legendary Key (48908) for ContainTreasure */
-     , (44806, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */;
+     , (44806, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (44806, 9, 51914,  1, 0, 0.01, False) /* Create Damaged Shadow Blade (51914) for ContainTreasure */
+     , (44806, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/44807 Panumbris Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/44807 Panumbris Shadow.sql
@@ -151,3 +151,7 @@ VALUES (44807,  2264,   2.02)  /* Wrath of Harlune */
      , (44807,  5385,   2.07)  /* Weakening Curse VII */
      , (44807,  5392,   2.09)  /* Corrosion VI */
      , (44807,  5401,   2.07)  /* Corruption VII */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (44807, 9, 51914,  1, 0, 0.01, False) /* Create Damaged Shadow Blade (51914) for ContainTreasure */
+     , (44807, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/44808 Panumbris Shadow.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/44808 Panumbris Shadow.sql
@@ -150,3 +150,7 @@ VALUES (44808,  2264,   2.02)  /* Wrath of Harlune */
      , (44808,  5385,   2.07)  /* Weakening Curse VII */
      , (44808,  5392,   2.09)  /* Corrosion VI */
      , (44808,  5401,   2.07)  /* Corruption VII */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (44808, 9, 51914,  1, 0, 0.01, False) /* Create Damaged Shadow Blade (51914) for ContainTreasure */
+     , (44808, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/52275 Void Lord.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/52275 Void Lord.sql
@@ -154,3 +154,7 @@ VALUES (52275,   234,   2.02)  /* Vulnerability Other VI */
      , (52275,  5385,   2.02)  /* Weakening Curse VII */
      , (52275,  5392,   2.02)  /* Corrosion VI */
      , (52275,  5401,   2.02)  /* Corruption VII */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (52275, 9, 51914,  1, 0, 0.01, False) /* Create Damaged Shadow Blade (51914) for ContainTreasure */
+     , (52275, 9,     0,  0, 0, 0.99, False) /* Create nothing for ContainTreasure */;


### PR DESCRIPTION
I did a pcap dive and added the Damaged Shadow Blade as a 1% drop on all the mobs that dropped it in the pcaps (Tou Tou mobs, mix of Panumbris Shadows and Void Lords). I did not validate that drop rate in pcaps, but as a purely cosmetic/tailor item I figure it did not matter too much.

Some of the Cookbook items do not currently exist; that's because the loot gen is currently dropping the wrong weenies for some of these items and they may or may not be added later.