### PR TITLE
Update Ithaenc Quiddity Seed

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Book/Misc/36930 Thief of Dreams Message Shard.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Misc/36930 Thief of Dreams Message Shard.sql
@@ -27,4 +27,7 @@ VALUES (36930,   1, 0x020003BF) /* Setup */
      , (36930,  22, 0x3400002B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
-VALUES (36930, 0, 1000);
+VALUES (36930, 1, 1000);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (36930, 0, 0xFFFFFFFF, '', 'prewritten', False, '[You cannot understand the writing on this.]');

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/36926 Shade of Dule.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/36926 Shade of Dule.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 36926;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36926, 'ace36926-shadeofdule', 10, '2022-08-22 03:09:27') /* Creature */;
+VALUES (36926, 'ace36926-shadeofdule', 10, '2025-05-25 12:35:33') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (36926,   1,         16) /* ItemType - Creature */
@@ -99,12 +99,20 @@ VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'I''ve sent you through this
      , (@parent_id,  3,   5 /* Motion */, 0, 1, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (36926, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'shadeofduleportalfellow', NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Human! You can help end my bizarre imprisonment here by that unjumped bag of air Aerbax. Some half-formed shade of the Hopeslayer himself awaits in the chambers below! An agent of Aerbax, a creature known as the Thief of Dreams, has taken the skull of Avoren Palacost, and seeks to destroy humanity''s accomplishment in defeating Bael''Zharon! You must act quickly, and stop the Thief of Dreams from coming through here with the skull! Take the skull from him and bring it to me, and I shall open the way for you and your comrades to assault the shade of the Hopeslayer...', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (36926, 13 /* QuestFailure */,      1, NULL, NULL, NULL, 'shadeofduleportal', NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  76 /* InqOwnsItems */, 0, 1, NULL, 'OwnsItem-36924', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0 /* Undef */, 36924 /* Avoren's Skull */, 1, 0 /* Undef */, 0, False, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  76 /* InqOwnsItems */, 0, 1, NULL, 'OwnsItem-36924', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 36924 /* Avoren's Skull */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (36926, 22 /* TestSuccess */,      1, NULL, NULL, NULL, 'OwnsItem-36924', NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/Shadow/36926.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Shadow/36926.es
@@ -1,0 +1,34 @@
+Give: Avoren's Skull (36924)
+    - Motion: Ready
+    - TurnToTarget
+    - Tell: Well done! The skull of poor young Avoren. Ilservian's rage was so great... But this sentimentality serves no one, does it? I am now one step closer to freedom from this prison realm that Aerbax constructed. The Hopeslayer of this dream realm will never recover this skull, and will thus remain vulnerable... But you all have more work to do. You must defeat this shade of my former master. I believe your agent of Asheron waiting in the "real" world seeks some trophy of the encounter... A claw will do, and there ought to be enough claws on that beast to supply all of you...
+    - Motion: CastSpell
+    - CastSpellInstant: 157 - Summon Primary Portal I
+    - Motion: Ready
+    - StampFellowQuest: shadeofduleportalfellow
+    - StampQuest: shadeofduleportal
+
+Use:
+    - Motion: Ready
+    - TurnToTarget
+    - InqFellowQuest: shadeofduleportalfellow
+        QuestSuccess:
+            - Tell: I've sent you through this portal once before, have I?  What happened, did the paroxysms of this half-realized Hopeslayer send you back to your mortal mooring?  Whatever the problem, I suppose I can re-open the portal for you...
+            - Motion: CastSpell
+            - CastSpellInstant: 157 - Summon Primary Portal I
+            - Motion: Ready
+        QuestFailure:
+            - Tell: Human! You can help end my bizarre imprisonment here by that unjumped bag of air Aerbax. Some half-formed shade of the Hopeslayer himself awaits in the chambers below! An agent of Aerbax, a creature known as the Thief of Dreams, has taken the skull of Avoren Palacost, and seeks to destroy humanity's accomplishment in defeating Bael'Zharon! You must act quickly, and stop the Thief of Dreams from coming through here with the skull! Take the skull from him and bring it to me, and I shall open the way for you and your comrades to assault the shade of the Hopeslayer...
+        QuestNoFellow:
+            - InqQuest: shadeofduleportal
+                QuestSuccess:
+                    - Tell: I've sent you through this portal once before, have I?  What happened, did the paroxysms of this half-realized Hopeslayer send you back to your mortal mooring?  Whatever the problem, I suppose I can re-open the portal for you...
+                    - Motion: CastSpell
+                    - CastSpellInstant: 157 - Summon Primary Portal I
+                    - Motion: Ready
+                QuestFailure:
+                    - InqOwnsItems: Avoren's Skull (36924)
+                        TestSuccess:
+                            - Tell: Yes... you have the skull of little Avoren Palacost. Such a sweet-natured boy he was, the light of his father's life. What lengths we go to, for the sake of our offspring. But I suppose I would not know. Hand me the skull and I can help you find the Hopeslayer's lair, and hopefully you will be able to interrupt the schemes of this Aerbax upstart and free me from this ungracious prison.
+                        TestFailure:
+                            - Tell: Human! You can help end my bizarre imprisonment here by that unjumped bag of air Aerbax. Some half-formed shade of the Hopeslayer himself awaits in the chambers below! An agent of Aerbax, a creature known as the Thief of Dreams, has taken the skull of Avoren Palacost, and seeks to destroy humanity's accomplishment in defeating Bael'Zharon! You must act quickly, and stop the Thief of Dreams from coming through here with the skull! Take the skull from him and bring it to me, and I shall open the way for you and your comrades to assault the shade of the Hopeslayer...


### PR DESCRIPTION
Corrected an issue with the Shade of Dule emote where the on use text was missing if the player was in a fellow.

Added the standard "you cannot read the writing on this" text on the untranslated Thief of Dreams Message Shard.