### PR TITLE
Centered Redspire Portal on platform

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/32D7.sql
+++ b/Database/Patches/6 LandBlockExtendedData/32D7.sql
@@ -1,5 +1,5 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x32D7;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x732D7000, 11960, 0x32D70001, 17.5596, 6.5876, 80.3032, 0.979301, 0, 0, -0.20241, False, '2021-11-01 00:00:00'); /* Destroyed Portal to Redspire */
-/* @teleloc 0x32D70001 [17.559601 6.587600 80.303200] 0.979301 0.000000 0.000000 -0.202410 */
+VALUES (0x732D7000, 11960, 0x32D70001, 17.261520, 6.654186, 80.518997, 1, 0, 0, -0.20241, False, '2025-06-26 12:00:00'); /* Destroyed Portal to Redspire */
+/* @teleloc 0x32D70001 [17.261520 6.654186 80.518997] 1 0 0 -0.20241 */


### PR DESCRIPTION
Cosmetic change south of Sanamar
/tele 70.1N, 61.8W
"Destroyed Portal to Redspire" was not centered correctly on portal platform.