### PR TITLE
update guardian of the deru

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/24C0.sql
+++ b/Database/Patches/6 LandBlockExtendedData/24C0.sql
@@ -1,485 +1,713 @@
 DELETE FROM `landblock_instance` WHERE `landblock` = 0x24C0;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0001,  7924, 0x24C0061B, 25.356, 83.7958, 130.384, 1, 0, 0, 0, False, '2022-01-08 18:29:57'); /* Linkable Monster Generator ( 5 Min.) */
+VALUES (0x724C0001,  7924, 0x24C0061B, 25.356, 83.7958, 130.384, 1, 0, 0, 0, False, '2019-02-10 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x24C0061B [25.356001 83.795799 130.384003] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
-VALUES (0x724C0001, 0x724C0004, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C000B, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C000E, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C0011, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C0014, '2022-01-08 18:29:57') /* Tall Tree (10931) */
-     , (0x724C0001, 0x724C0015, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C0018, '2022-01-08 18:29:57') /* Tall Tree (10930) */
-     , (0x724C0001, 0x724C0019, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C001D, '2022-01-08 18:29:57') /* Eye-covered Tentacles of T'thuun (38822) */
-     , (0x724C0001, 0x724C001E, '2022-01-08 18:29:57') /* Tall Tree (10932) */
-     , (0x724C0001, 0x724C001F, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C0020, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C0059, '2022-01-08 18:29:57') /* Eyestalk of T'thuun (38826) */
-     , (0x724C0001, 0x724C006D, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C006E, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C006F, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0070, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0071, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0072, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0073, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0074, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0075, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0076, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0077, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0078, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */
-     , (0x724C0001, 0x724C0079, '2022-01-08 18:29:57') /* Tendril of T'thuun (38827) */;
+VALUES (0x724C0001, 0x724C0004, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C000B, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C000E, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C0011, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C0014, '2019-02-10 00:00:00') /* Tall Tree (10931) */
+     , (0x724C0001, 0x724C0015, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C0018, '2019-02-10 00:00:00') /* Tall Tree (10930) */
+     , (0x724C0001, 0x724C0019, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C001D, '2019-02-10 00:00:00') /* Eye-covered Tentacles of T'thuun (38822) */
+     , (0x724C0001, 0x724C001E, '2019-02-10 00:00:00') /* Tall Tree (10932) */
+     , (0x724C0001, 0x724C001F, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C0020, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C0059, '2019-02-10 00:00:00') /* Eyestalk of T'thuun (38826) */
+     , (0x724C0001, 0x724C0068, '2025-07-19 11:20:30') /* Olthoi Larvae (35147) */
+     , (0x724C0001, 0x724C006B, '2025-07-19 11:21:10') /* Olthoi Larvae (35147) */
+     , (0x724C0001, 0x724C006C, '2025-07-19 11:21:15') /* Olthoi Larvae (35147) */
+     , (0x724C0001, 0x724C006D, '2025-07-19 11:22:32') /* Olthoi Larvae (35147) */
+     , (0x724C0001, 0x724C006E, '2025-07-19 11:22:47') /* Olthoi Larvae (35147) */
+     , (0x724C0001, 0x724C006F, '2025-07-19 11:25:51') /* Olthoi Larvae (35147) */
+     , (0x724C0001, 0x724C0070, '2025-07-19 11:27:29') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0071, '2025-07-19 11:30:50') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0072, '2025-07-19 11:31:17') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0073, '2025-07-19 11:31:27') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0074, '2025-07-19 11:31:36') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0075, '2025-07-19 11:32:08') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0077, '2025-07-19 11:33:36') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0078, '2025-07-19 11:33:51') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0079, '2025-07-19 11:35:17') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C007A, '2025-07-19 11:36:51') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C007B, '2025-07-19 11:36:53') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C007C, '2025-07-19 11:36:58') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C007D, '2025-07-19 11:37:04') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C007E, '2025-07-19 11:37:21') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C007F, '2025-07-19 11:37:27') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0080, '2025-07-19 11:37:33') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0082, '2025-07-19 11:37:46') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0083, '2025-07-19 11:37:52') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0084, '2025-07-19 11:37:59') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0085, '2025-07-19 11:38:04') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0086, '2025-07-19 11:39:08') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0089, '2025-07-19 11:40:16') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C008A, '2025-07-19 11:40:36') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C008B, '2025-07-19 11:40:41') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C008C, '2025-07-19 11:44:33') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C008D, '2025-07-19 11:44:35') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C008E, '2025-07-19 11:44:48') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C008F, '2025-07-19 11:44:59') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0090, '2025-07-19 11:45:13') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0091, '2025-07-19 11:45:53') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0092, '2025-07-19 11:47:31') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0093, '2025-07-19 11:49:00') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0094, '2025-07-19 11:49:06') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0095, '2025-07-19 11:49:08') /* Olthoi Slasher (35150) */
+     , (0x724C0001, 0x724C0096, '2025-07-19 11:49:29') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0097, '2025-07-19 11:49:37') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0098, '2025-07-19 11:49:43') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C0099, '2025-07-19 11:52:33') /* Olthoi Ripper (35149) */
+     , (0x724C0001, 0x724C009A, '2025-07-19 11:57:10') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C009B, '2025-07-19 11:57:19') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C009C, '2025-07-19 11:57:26') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C009E, '2025-07-19 11:58:58') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00A1, '2025-07-19 12:00:57') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00A2, '2025-07-19 12:01:22') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00A3, '2025-07-19 12:01:52') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00A5, '2025-07-19 12:02:17') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00A6, '2025-07-19 12:02:47') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00A7, '2025-07-19 12:03:19') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00A8, '2025-07-19 12:03:39') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00A9, '2025-07-19 12:03:52') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00AA, '2025-07-19 12:05:01') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00AB, '2025-07-19 12:05:18') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00AC, '2025-07-19 12:05:37') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00AD, '2025-07-19 12:06:00') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00AE, '2025-07-19 12:06:23') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00B1, '2025-07-19 12:09:36') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00B2, '2025-07-19 12:10:50') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00B3, '2025-07-19 12:11:07') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00B4, '2025-07-19 12:11:31') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00B5, '2025-07-19 12:12:44') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00B9, '2025-07-19 12:17:39') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00BA, '2025-07-19 12:17:42') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00BB, '2025-07-19 12:18:50') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00BC, '2025-07-19 12:19:23') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00BD, '2025-07-19 12:19:29') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00BE, '2025-07-19 12:20:10') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00BF, '2025-07-19 12:20:29') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00C0, '2025-07-19 12:20:55') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00C1, '2025-07-19 12:21:01') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00C4, '2025-07-19 12:22:10') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00C5, '2025-07-19 12:23:11') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00C6, '2025-07-19 12:23:24') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00C7, '2025-07-19 12:23:29') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00C8, '2025-07-19 12:23:44') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00C9, '2025-07-19 12:24:20') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00CA, '2025-07-19 12:24:45') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00CB, '2025-07-19 12:25:00') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00CC, '2025-07-19 12:25:12') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00CD, '2025-07-19 12:25:16') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00CE, '2025-07-19 12:26:08') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00CF, '2025-07-19 12:26:49') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00D0, '2025-07-19 12:27:06') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00D1, '2025-07-19 12:27:15') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00D2, '2025-07-19 12:27:25') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00D3, '2025-07-19 12:27:40') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00D4, '2025-07-19 12:27:53') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00D5, '2025-07-19 12:28:14') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00D6, '2025-07-19 12:28:25') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00D7, '2025-07-19 12:28:30') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00D8, '2025-07-19 12:29:30') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00D9, '2025-07-19 12:29:33') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00DA, '2025-07-19 12:29:41') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00DB, '2025-07-19 12:30:07') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00DC, '2025-07-19 12:30:14') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00DD, '2025-07-19 12:30:29') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00E1, '2025-07-19 12:31:51') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00E2, '2025-07-19 12:31:57') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00E3, '2025-07-19 12:32:12') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00E4, '2025-07-19 12:33:15') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00E5, '2025-07-19 12:33:21') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00E6, '2025-07-19 12:34:07') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00E8, '2025-07-19 12:34:29') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00E9, '2025-07-19 12:34:50') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00EA, '2025-07-19 12:35:51') /* Sclavus Acolyte of T'thuun (38876) */
+     , (0x724C0001, 0x724C00EB, '2025-07-19 12:35:55') /* Sclavus Acolyte of T'thuun (38875) */
+     , (0x724C0001, 0x724C00EC, '2025-07-19 12:36:10') /* Sclavus Acolyte of T'thuun (38877) */
+     , (0x724C0001, 0x724C00F1, '2025-07-19 13:57:57') /* Sclavus Acolyte of T'thuun (38875) */;
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0004, 38826, 0x24C00013, 58.8883, 71.1511, 144.209, -0.748238, 0, 0, 0.663431,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C0004, 38826, 0x24C00013, 58.8883, 71.1511, 144.209, -0.748238, 0, 0, 0.663431,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C00013 [58.888302 71.151100 144.209000] -0.748238 0.000000 0.000000 0.663431 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C000B, 38826, 0x24C00009, 30.0541, 10.4046, 140.989, -0.992324, 0, 0, -0.123662,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C000B, 38826, 0x24C00009, 30.0541, 10.4046, 140.989, -0.992324, 0, 0, -0.123662,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C00009 [30.054100 10.404600 140.988998] -0.992324 0.000000 0.000000 -0.123662 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C000E, 38826, 0x24C00012, 52.2227, 47.0616, 145.947, -0.991253, 0, 0, 0.131977,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C000E, 38826, 0x24C00012, 52.2227, 47.0616, 145.947, -0.991253, 0, 0, 0.131977,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C00012 [52.222698 47.061600 145.947006] -0.991253 0.000000 0.000000 0.131977 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0011, 38826, 0x24C0001C, 78.6926, 82.0924, 130.198, -0.36199, 0, 0, 0.932182,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C0011, 38826, 0x24C0001C, 78.6926, 82.0924, 130.198, -0.36199, 0, 0, 0.932182,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C0001C [78.692596 82.092400 130.197998] -0.361990 0.000000 0.000000 0.932182 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0014, 10931, 0x24C0001B, 86.4522, 57.9549, 134.796, -0.740239, 0, 0, -0.672343,  True, '2022-01-08 18:29:57'); /* Tall Tree */
+VALUES (0x724C0014, 10931, 0x24C0001B, 86.4522, 57.9549, 134.796, -0.740239, 0, 0, -0.672343,  True, '2019-02-10 00:00:00'); /* Tall Tree */
 /* @teleloc 0x24C0001B [86.452202 57.954899 134.796005] -0.740239 0.000000 0.000000 -0.672343 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0015, 38826, 0x24C0001B, 78.6942, 54.3401, 135.422, 0.603714, 0, 0, 0.797201,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C0015, 38826, 0x24C0001B, 78.6942, 54.3401, 135.422, 0.603714, 0, 0, 0.797201,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C0001B [78.694199 54.340099 135.421997] 0.603714 0.000000 0.000000 0.797201 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0018, 10930, 0x24C0001A, 86.1337, 39.8287, 135.503, -0.927507, 0, 0, -0.373805,  True, '2022-01-08 18:29:57'); /* Tall Tree */
+VALUES (0x724C0018, 10930, 0x24C0001A, 86.1337, 39.8287, 135.503, -0.927507, 0, 0, -0.373805,  True, '2019-02-10 00:00:00'); /* Tall Tree */
 /* @teleloc 0x24C0001A [86.133698 39.828701 135.503006] -0.927507 0.000000 0.000000 -0.373805 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0019, 38826, 0x24C0001A, 77.5567, 36.1593, 136.504, -0.850619, 0, 0, -0.525782,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C0019, 38826, 0x24C0001A, 77.5567, 36.1593, 136.504, -0.850619, 0, 0, -0.525782,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C0001A [77.556702 36.159302 136.503998] -0.850619 0.000000 0.000000 -0.525782 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C001D, 38822, 0x24C00023, 101.691, 52.6297, 135.425, 0.521786, 0, 0, 0.853076,  True, '2022-01-08 18:29:57'); /* Eye-covered Tentacles of T'thuun */
+VALUES (0x724C001D, 38822, 0x24C00023, 101.691, 52.6297, 135.425, 0.521786, 0, 0, 0.853076,  True, '2019-02-10 00:00:00'); /* Eye-covered Tentacles of T'thuun */
 /* @teleloc 0x24C00023 [101.691002 52.629700 135.425003] 0.521786 0.000000 0.000000 0.853076 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C001E, 10932, 0x24C00023, 108.82, 61.6457, 134, -0.370698, 0, 0, -0.928754,  True, '2022-01-08 18:29:57'); /* Tall Tree */
+VALUES (0x724C001E, 10932, 0x24C00023, 108.82, 61.6457, 134, -0.370698, 0, 0, -0.928754,  True, '2019-02-10 00:00:00'); /* Tall Tree */
 /* @teleloc 0x24C00023 [108.820000 61.645699 134.000000] -0.370698 0.000000 0.000000 -0.928754 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C001F, 38826, 0x24C00021, 117.617, 21.19, 126.306, 0.495351, 0, 0, 0.868693,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C001F, 38826, 0x24C00021, 117.617, 21.19, 126.306, 0.495351, 0, 0, 0.868693,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C00021 [117.616997 21.190001 126.306000] 0.495351 0.000000 0.000000 0.868693 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0020, 38826, 0x24C00023, 115.35, 68.0564, 133.98, 0.496757, 0, 0, 0.86789,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C0020, 38826, 0x24C00023, 115.35, 68.0564, 133.98, 0.496757, 0, 0, 0.86789,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C00023 [115.349998 68.056396 133.979996] 0.496757 0.000000 0.000000 0.867890 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0059, 38826, 0x24C00025, 100.414, 100.213, 108.174, -0.800212, 0, 0, 0.599717,  True, '2022-01-08 18:29:57'); /* Eyestalk of T'thuun */
+VALUES (0x724C0059, 38826, 0x24C00025, 100.414, 100.213, 108.174, -0.800212, 0, 0, 0.599717,  True, '2019-02-10 00:00:00'); /* Eyestalk of T'thuun */
 /* @teleloc 0x24C00025 [100.414001 100.212997 108.174004] -0.800212 0.000000 0.000000 0.599717 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C005A, 87822, 0x24C00150, -113.359, 63.2494, 112.1, 1, 0, 0, 0, False, '2022-01-08 18:29:57'); /* Pool of Goo */
-/* @teleloc 0x24C00150 [-113.359001 63.249401 112.099998] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x724C005A, 35929, 0x24C001B7, -44, 63, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:46:42'); /* Acid */
+/* @teleloc 0x24C001B7 [-44.000000 63.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C005B,  6122, 0x24C00150, -113.529, 63.2682, 111.6, -1, 0, 0, 0, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C00150 [-113.528999 63.268200 111.599998] -1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x724C005B, 35929, 0x24C001A6, -54, 63, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:47:58'); /* Acid */
+/* @teleloc 0x24C001A6 [-54.000000 63.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C005C,  6122, 0x24C0017A, -63.8246, 63.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C0017A [-63.824600 63.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C005C, 35929, 0x24C0017A, -64, 63, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:48:50'); /* Acid */
+/* @teleloc 0x24C0017A [-64.000000 63.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C005D,  6122, 0x24C00165, -73.8159, 63.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C00165 [-73.815903 63.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C005D, 35929, 0x24C00165, -74, 63, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:49:49'); /* Acid */
+/* @teleloc 0x24C00165 [-74.000000 63.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C005E,  6122, 0x24C001A6, -53.8159, 63.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C001A6 [-53.815899 63.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C005E, 35929, 0x24C001BE, -44, 53, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:50:46'); /* Acid */
+/* @teleloc 0x24C001BE [-44.000000 53.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C005F,  6122, 0x24C001B7, -43.8159, 63.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C001B7 [-43.815899 63.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C005F, 35929, 0x24C001A8, -54, 53, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:51:07'); /* Acid */
+/* @teleloc 0x24C001A8 [-54.000000 53.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0060,  6122, 0x24C0016A, -73.8159, 53.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C0016A [-73.815903 53.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0060, 35929, 0x24C00182, -64, 53, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:51:18'); /* Acid */
+/* @teleloc 0x24C00182 [-64.000000 53.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0061,  6122, 0x24C00182, -53.8159, 53.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C00182 [-53.815899 53.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0061, 35929, 0x24C0016A, -74, 53, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:51:46'); /* Acid */
+/* @teleloc 0x24C0016A [-74.000000 53.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0062,  6122, 0x24C00182, -63.8159, 53.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C00182 [-63.815899 53.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0062, 35929, 0x24C001C1, -44, 43, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:55:27'); /* Acid */
+/* @teleloc 0x24C001C1 [-44.000000 43.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0063,  6122, 0x24C001BE, -43.8159, 53.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C001BE [-43.815899 53.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0063, 35929, 0x24C001AA, -54, 43, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:58:51'); /* Acid */
+/* @teleloc 0x24C001AA [-54.000000 43.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0064,  6122, 0x24C0016D, -73.8159, 43.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C0016D [-73.815903 43.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0064, 35929, 0x24C0018A, -64, 43, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:59:03'); /* Acid */
+/* @teleloc 0x24C0018A [-64.000000 43.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0065,  6122, 0x24C0018A, -63.8159, 43.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C0018A [-63.815899 43.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0065, 35929, 0x24C0016D, -74, 43, 106.455, 1, 0, 0, 0, False, '2025-07-19 10:59:12'); /* Acid */
+/* @teleloc 0x24C0016D [-74.000000 43.000000 106.455002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0066,  6122, 0x24C001AA, -53.8159, 43.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C001AA [-53.815899 43.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0066, 35929, 0x24C00150, -114, 63, 111.655, 0.707107, 0, 0, 0.707107, False, '2025-07-19 11:10:56'); /* Acid */
+/* @teleloc 0x24C00150 [-114.000000 63.000000 111.654999] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0067,  6122, 0x24C001C1, -43.8159, 43.2076, 106.455, 0.707107, 0, 0, -0.707107, False, '2022-01-08 18:29:57'); /* Acid */
-/* @teleloc 0x24C001C1 [-43.815899 43.207600 106.455002] 0.707107 0.000000 0.000000 -0.707107 */
+VALUES (0x724C0067, 87822, 0x24C00150, -114.001, 62.9961, 112.1, 0, 0, 0, 1, False, '2025-07-19 11:13:22'); /* Pool of Goo */
+/* @teleloc 0x24C00150 [-114.000999 62.996101 112.099998] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0068, 87825, 0x24C00174, -74.0005, -7, 106.4, 1, 0, 0, 0, False, '2022-01-08 18:29:57'); /* Large Corrupted Mana Shard */
-/* @teleloc 0x24C00174 [-74.000504 -7.000000 106.400002] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x724C0068, 35147, 0x24C002A8, -106.273, 65.8564, 112.406, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:20:30'); /* Olthoi Larvae */
+/* @teleloc 0x24C002A8 [-106.273003 65.856400 112.405998] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0069, 87827, 0x24C0011F, -23.9175, 23, 94.4, 1, 0, 0, 0, False, '2022-01-08 18:29:57'); /* Altar of T'thuun */
-/* @teleloc 0x24C0011F [-23.917500 23.000000 94.400002] 1.000000 0.000000 0.000000 0.000000 */
+VALUES (0x724C006B, 35147, 0x24C0029F, -115.765, 69.3231, 112.406, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:21:10'); /* Olthoi Larvae */
+/* @teleloc 0x24C0029F [-115.764999 69.323097 112.405998] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C006A, 87828, 0x24C00582, 36.0358, 82.7156, 124.337, -0.028186, 0, 0, 0.999603, False, '2022-01-08 18:29:57'); /* Roots of Skuld, Urd and Verdandi */
-/* @teleloc 0x24C00582 [36.035801 82.715599 124.336998] -0.028186 0.000000 0.000000 0.999603 */
+VALUES (0x724C006C, 35147, 0x24C0029F, -111.401, 69.1895, 112.406, 1, 0, 0, 0,  True, '2025-07-19 11:21:15'); /* Olthoi Larvae */
+/* @teleloc 0x24C0029F [-111.401001 69.189499 112.405998] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C006B, 87831, 0x24C00261, 6, -17, 106.337, 0.707107, 0, 0, 0.707107, False, '2022-01-08 18:29:57'); /* Surface */
-/* @teleloc 0x24C00261 [6.000000 -17.000000 106.336998] 0.707107 0.000000 0.000000 0.707107 */
+VALUES (0x724C006D, 35147, 0x24C002A7, -107.375, 69.4308, 112.406, 0.92388, 0, 0, -0.382684,  True, '2025-07-19 11:22:32'); /* Olthoi Larvae */
+/* @teleloc 0x24C002A7 [-107.375000 69.430801 112.405998] 0.923880 0.000000 0.000000 -0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C006C, 87831, 0x24C0067B, -25.2651, 41.8008, 142.337, 0.92388, 0, 0, -0.382683, False, '2022-01-08 18:29:57'); /* Surface */
-/* @teleloc 0x24C0067B [-25.265100 41.800800 142.337006] 0.923880 0.000000 0.000000 -0.382683 */
+VALUES (0x724C006E, 35147, 0x24C002A8, -101.391, 63.9213, 112.406, 1, 0, 0, 0,  True, '2025-07-19 11:22:47'); /* Olthoi Larvae */
+/* @teleloc 0x24C002A8 [-101.390999 63.921299 112.405998] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C006D, 38827, 0x24C0010A, -53.8562, 62.1441, 94.384, -0.998227, 0, 0, 0.059516,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C0010A [-53.856201 62.144100 94.384003] -0.998227 0.000000 0.000000 0.059516 */
+VALUES (0x724C006F, 35147, 0x24C0029F, -111.936, 74.3875, 112.406, 0.382684, 0, 0, -0.92388,  True, '2025-07-19 11:25:51'); /* Olthoi Larvae */
+/* @teleloc 0x24C0029F [-111.935997 74.387497 112.405998] 0.382684 0.000000 0.000000 -0.923880 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C006E, 38827, 0x24C0010A, -53.8562, 62.1441, 94.384, -0.998227, 0, 0, 0.059516,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C0010A [-53.856201 62.144100 94.384003] -0.998227 0.000000 0.000000 0.059516 */
+VALUES (0x724C0070, 35149, 0x24C002B0, -92.9803, 83.0783, 112.384, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:27:29'); /* Olthoi Ripper */
+/* @teleloc 0x24C002B0 [-92.980301 83.078300 112.384003] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C006F, 38827, 0x24C00107, -53.9864, 93.1976, 94.384, -0.999775, 0, 0, -0.021215,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C00107 [-53.986401 93.197601 94.384003] -0.999775 0.000000 0.000000 -0.021215 */
+VALUES (0x724C0071, 35150, 0x24C002D3, -74.0251, 53.7435, 112.4, 0, 0, 0, 1,  True, '2025-07-19 11:30:50'); /* Olthoi Slasher */
+/* @teleloc 0x24C002D3 [-74.025101 53.743500 112.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0070, 38827, 0x24C00131, -73.6851, 99.7428, 100.384, -0.040437, 0, 0, -0.999182,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C00131 [-73.685097 99.742798 100.384003] -0.040437 0.000000 0.000000 -0.999182 */
+VALUES (0x724C0072, 35150, 0x24C002E0, -63.7961, 42.9459, 112.4, 1, 0, 0, 0,  True, '2025-07-19 11:31:17'); /* Olthoi Slasher */
+/* @teleloc 0x24C002E0 [-63.796101 42.945900 112.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0071, 38827, 0x24C00133, -73.9948, 95.9223, 100.384, -0.040437, 0, 0, -0.999182,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C00133 [-73.994797 95.922302 100.384003] -0.040437 0.000000 0.000000 -0.999182 */
+VALUES (0x724C0073, 35150, 0x24C002E7, -57.1707, 62.8725, 112.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:31:27'); /* Olthoi Slasher */
+/* @teleloc 0x24C002E7 [-57.170700 62.872501 112.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0072, 38827, 0x24C0019F, -53.9812, 95.9408, 106.384, 0.999792, 0, 0, -0.020389,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C0019F [-53.981201 95.940804 106.384003] 0.999792 0.000000 0.000000 -0.020389 */
+VALUES (0x724C0074, 35150, 0x24C002F1, -44.0051, 50.9338, 112.4, 0, 0, 0, 1,  True, '2025-07-19 11:31:36'); /* Olthoi Slasher */
+/* @teleloc 0x24C002F1 [-44.005100 50.933800 112.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0073, 38827, 0x24C0019C, -53.7748, 101, 106.384, 0.999792, 0, 0, -0.020389,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C0019C [-53.774799 101.000000 106.384003] 0.999792 0.000000 0.000000 -0.020389 */
+VALUES (0x724C0075, 35149, 0x24C00154, -83.9293, 43.097, 106.384, 1, 0, 0, 0,  True, '2025-07-19 11:32:08'); /* Olthoi Ripper */
+/* @teleloc 0x24C00154 [-83.929298 43.097000 106.384003] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0074, 38827, 0x24C002CA, -74.0401, 98.7222, 112.384, -0.026593, 0, 0, 0.999646,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C002CA [-74.040100 98.722198 112.384003] -0.026593 0.000000 0.000000 0.999646 */
+VALUES (0x724C0077, 35149, 0x24C00327, -28.4992, 52.9543, 112.384, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:33:36'); /* Olthoi Ripper */
+/* @teleloc 0x24C00327 [-28.499201 52.954300 112.384003] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0075, 38827, 0x24C002CC, -73.8946, 95.9896, 112.384, -0.026593, 0, 0, 0.999646,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C002CC [-73.894600 95.989601 112.384003] -0.026593 0.000000 0.000000 0.999646 */
+VALUES (0x724C0078, 35149, 0x24C00349, -11.0848, 52.8498, 112.384, 0.92388, 0, 0, -0.382684,  True, '2025-07-19 11:33:51'); /* Olthoi Ripper */
+/* @teleloc 0x24C00349 [-11.084800 52.849800 112.384003] 0.923880 0.000000 0.000000 -0.382684 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0076, 38827, 0x24C0044B, -54.0402, 96.3543, 118.384, -0.98826, 0, 0, -0.152781,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C0044B [-54.040199 96.354301 118.384003] -0.988260 0.000000 0.000000 -0.152781 */
+VALUES (0x724C0079, 35149, 0x24C00373, 9.16798, 63.0611, 112.384, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:35:17'); /* Olthoi Ripper */
+/* @teleloc 0x24C00373 [9.167980 63.061100 112.384003] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0077, 38827, 0x24C00447, -54.0118, 100.928, 118.384, -0.986824, 0, 0, -0.161798,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C00447 [-54.011799 100.928001 118.384003] -0.986824 0.000000 0.000000 -0.161798 */
+VALUES (0x724C007A, 35150, 0x24C0038E, 22.8283, 83.9331, 112.4, 0.705348, 0, 0, -0.708861,  True, '2025-07-19 11:36:51'); /* Olthoi Slasher */
+/* @teleloc 0x24C0038E [22.828300 83.933098 112.400002] 0.705348 0.000000 0.000000 -0.708861 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0078, 38827, 0x24C0052D, -73.4224, 100.634, 124.384, 0.030651, 0, 0, -0.99953,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C0052D [-73.422401 100.634003 124.384003] 0.030651 0.000000 0.000000 -0.999530 */
+VALUES (0x724C007B, 35150, 0x24C0038E, 24.4778, 82.1787, 112.4, 0.705348, 0, 0, -0.708861,  True, '2025-07-19 11:36:53'); /* Olthoi Slasher */
+/* @teleloc 0x24C0038E [24.477800 82.178703 112.400002] 0.705348 0.000000 0.000000 -0.708861 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0079, 38827, 0x24C00530, -74.0229, 95.6034, 124.384, 0.189126, 0, 0, -0.981953,  True, '2022-01-08 18:29:57'); /* Tendril of T'thuun */
-/* @teleloc 0x24C00530 [-74.022903 95.603401 124.384003] 0.189126 0.000000 0.000000 -0.981953 */
+VALUES (0x724C007C, 35149, 0x24C0038E, 30.4364, 82.9337, 112.384, 0.705348, 0, 0, -0.708861,  True, '2025-07-19 11:36:58'); /* Olthoi Ripper */
+/* @teleloc 0x24C0038E [30.436399 82.933701 112.384003] 0.705348 0.000000 0.000000 -0.708861 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C007A, 87832, 0x24C0066C, -45.2163, 42.5771, 136.455, 0.996854, 0, 0, -0.079254, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0066C [-45.216301 42.577099 136.455002] 0.996854 0.000000 0.000000 -0.079254 */
+VALUES (0x724C007D, 35149, 0x24C003A6, 36.103, 60.3996, 112.384, -0.010817, 0, 0, -0.999942,  True, '2025-07-19 11:37:04'); /* Olthoi Ripper */
+/* @teleloc 0x24C003A6 [36.103001 60.399601 112.384003] -0.010817 0.000000 0.000000 -0.999942 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C007B, 87832, 0x24C00660, -54.1748, 33.0644, 136.455, 0.996854, 0, 0, -0.079254, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00660 [-54.174801 33.064400 136.455002] 0.996854 0.000000 0.000000 -0.079254 */
+VALUES (0x724C007E, 35150, 0x24C00395, 30.2504, 43.0004, 112.4, 0.69542, 0, 0, -0.718604,  True, '2025-07-19 11:37:21'); /* Olthoi Slasher */
+/* @teleloc 0x24C00395 [30.250401 43.000401 112.400002] 0.695420 0.000000 0.000000 -0.718604 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C007C, 87832, 0x24C00655, -64.2158, 21.9429, 136.455, 0.996854, 0, 0, -0.079254, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00655 [-64.215797 21.942900 136.455002] 0.996854 0.000000 0.000000 -0.079254 */
+VALUES (0x724C007F, 35150, 0x24C003C7, 41.5709, 43.0132, 112.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:37:27'); /* Olthoi Slasher */
+/* @teleloc 0x24C003C7 [41.570900 43.013199 112.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C007D, 87832, 0x24C0063C, -93.9229, 17.0948, 136.455, 0.670028, 0, 0, -0.742336, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0063C [-93.922897 17.094801 136.455002] 0.670028 0.000000 0.000000 -0.742336 */
+VALUES (0x724C0080, 35150, 0x24C00396, 30.3845, 32.9937, 112.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:37:33'); /* Olthoi Slasher */
+/* @teleloc 0x24C00396 [30.384501 32.993698 112.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C007E, 87832, 0x24C0062B, -103.687, 28.5515, 136.455, 0.670028, 0, 0, -0.742336, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0062B [-103.686996 28.551500 136.455002] 0.670028 0.000000 0.000000 -0.742336 */
+VALUES (0x724C0082, 35150, 0x24C00397, 30.1659, 22.9038, 112.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:37:46'); /* Olthoi Slasher */
+/* @teleloc 0x24C00397 [30.165899 22.903799 112.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C007F, 87832, 0x24C00627, -103.655, 49.7892, 136.455, -0.978947, 0, 0, 0.204116, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00627 [-103.654999 49.789200 136.455002] -0.978947 0.000000 0.000000 0.204116 */
+VALUES (0x724C0083, 35150, 0x24C003C9, 41.6873, 23.0628, 112.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:37:52'); /* Olthoi Slasher */
+/* @teleloc 0x24C003C9 [41.687302 23.062799 112.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0080, 87832, 0x24C005D2, -52.7862, 43.7957, 130.455, 0.995381, 0, 0, 0.095999, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C005D2 [-52.786201 43.795700 130.455002] 0.995381 0.000000 0.000000 0.095999 */
+VALUES (0x724C0084, 35150, 0x24C00398, 30.1788, 13.1418, 112.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:37:59'); /* Olthoi Slasher */
+/* @teleloc 0x24C00398 [30.178801 13.141800 112.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0081, 87832, 0x24C005F5, -47.6429, 32.9513, 130.455, 0.995381, 0, 0, 0.095999, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C005F5 [-47.642899 32.951302 130.455002] 0.995381 0.000000 0.000000 0.095999 */
+VALUES (0x724C0085, 35150, 0x24C003CA, 41.8147, 13.2728, 112.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:38:04'); /* Olthoi Slasher */
+/* @teleloc 0x24C003CA [41.814701 13.272800 112.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0082, 87832, 0x24C005F9, -47.2564, 22.537, 130.455, 0.995381, 0, 0, 0.095999, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C005F9 [-47.256401 22.537001 130.455002] 0.995381 0.000000 0.000000 0.095999 */
+VALUES (0x724C0086, 35149, 0x24C00377, 9.86843, -4.44682, 112.384, 1, 0, 0, 0,  True, '2025-07-19 11:39:08'); /* Olthoi Ripper */
+/* @teleloc 0x24C00377 [9.868430 -4.446820 112.384003] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0083, 87832, 0x24C0060C, -24.3338, 38.3322, 130.455, 0.031381, 0, 0, 0.999508, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0060C [-24.333799 38.332199 130.455002] 0.031381 0.000000 0.000000 0.999508 */
+VALUES (0x724C0089, 35149, 0x24C00356, -14.0265, -16.966, 112.384, 0, 0, 0, 1,  True, '2025-07-19 11:40:16'); /* Olthoi Ripper */
+/* @teleloc 0x24C00356 [-14.026500 -16.966000 112.384003] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0084, 87832, 0x24C005EA, -42.3271, 62.087, 130.455, 0.506713, 0, 0, -0.862115, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C005EA [-42.327099 62.087002 130.455002] 0.506713 0.000000 0.000000 -0.862115 */
+VALUES (0x724C008A, 35150, 0x24C0036E, -0.745359, -27.6918, 112.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:40:36'); /* Olthoi Slasher */
+/* @teleloc 0x24C0036E [-0.745359 -27.691799 112.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0085, 87832, 0x24C005C7, -53.627, 73.1751, 130.455, 0.506713, 0, 0, -0.862115, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C005C7 [-53.626999 73.175102 130.455002] 0.506713 0.000000 0.000000 -0.862115 */
+VALUES (0x724C008B, 35150, 0x24C0036E, -4.08393, -26.3046, 112.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:40:41'); /* Olthoi Slasher */
+/* @teleloc 0x24C0036E [-4.083930 -26.304600 112.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0086, 87832, 0x24C00543, -23.6221, 101.402, 124.455, -0.765614, 0, 0, -0.6433, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00543 [-23.622101 101.402000 124.455002] -0.765614 0.000000 0.000000 -0.643300 */
+VALUES (0x724C008C, 35150, 0x24C00368, 0.298099, 10.1593, 112.4, 1, 0, 0, 0,  True, '2025-07-19 11:44:33'); /* Olthoi Slasher */
+/* @teleloc 0x24C00368 [0.298099 10.159300 112.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0087, 87832, 0x24C0054A, -13.2739, 99.3101, 124.455, -0.765614, 0, 0, -0.6433, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0054A [-13.273900 99.310097 124.455002] -0.765614 0.000000 0.000000 -0.643300 */
+VALUES (0x724C008D, 35150, 0x24C00369, -1.71396, 6.70463, 112.4, 1, 0, 0, 0,  True, '2025-07-19 11:44:35'); /* Olthoi Slasher */
+/* @teleloc 0x24C00369 [-1.713960 6.704630 112.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0088, 87832, 0x24C00552, -5.11597, 99.5427, 124.455, -0.765614, 0, 0, -0.6433, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00552 [-5.115970 99.542702 124.455002] -0.765614 0.000000 0.000000 -0.643300 */
+VALUES (0x724C008E, 35149, 0x24C004E5, 7.48904, 40.4267, 118.384, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:44:48'); /* Olthoi Ripper */
+/* @teleloc 0x24C004E5 [7.489040 40.426701 118.384003] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0089, 87832, 0x24C00560, 5.90316, 98.4675, 124.455, -0.765614, 0, 0, -0.6433, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00560 [5.903160 98.467499 124.455002] -0.765614 0.000000 0.000000 -0.643300 */
+VALUES (0x724C008F, 35150, 0x24C00502, 23.7122, 44.9874, 118.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:44:59'); /* Olthoi Slasher */
+/* @teleloc 0x24C00502 [23.712200 44.987400 118.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C008A, 87832, 0x24C00513, 43.8349, 92.1932, 118.455, 0.947358, 0, 0, -0.320177, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00513 [43.834900 92.193199 118.455002] 0.947358 0.000000 0.000000 -0.320177 */
+VALUES (0x724C0090, 35149, 0x24C00501, 24.3106, 49.7741, 118.384, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:45:13'); /* Olthoi Ripper */
+/* @teleloc 0x24C00501 [24.310600 49.774101 118.384003] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C008B, 87832, 0x24C00508, 36.1134, 82.0376, 118.455, 0.947358, 0, 0, -0.320177, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00508 [36.113400 82.037598 118.455002] 0.947358 0.000000 0.000000 -0.320177 */
+VALUES (0x724C0091, 35149, 0x24C003C3, 35.937, -17.31, 112.384, 1, 0, 0, 0,  True, '2025-07-19 11:45:53'); /* Olthoi Ripper */
+/* @teleloc 0x24C003C3 [35.937000 -17.309999 112.384003] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C008C, 87832, 0x24C004CD, -3.13444, 103.189, 118.455, -0.669162, 0, 0, 0.743116, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004CD [-3.134440 103.189003 118.455002] -0.669162 0.000000 0.000000 0.743116 */
+VALUES (0x724C0092, 35149, 0x24C004E1, 5.89201, 73.3178, 118.384, 0, 0, 0, 1,  True, '2025-07-19 11:47:31'); /* Olthoi Ripper */
+/* @teleloc 0x24C004E1 [5.892010 73.317802 118.384003] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C008D, 87832, 0x24C004D1, -3.3394, 93.6889, 118.455, -0.669162, 0, 0, 0.743116, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004D1 [-3.339400 93.688904 118.455002] -0.669162 0.000000 0.000000 0.743116 */
+VALUES (0x724C0093, 35149, 0x24C004C8, -17.5683, 63.0523, 118.384, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:49:00'); /* Olthoi Ripper */
+/* @teleloc 0x24C004C8 [-17.568300 63.052299 118.384003] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C008E, 87832, 0x24C004C3, -9.6214, 93.6717, 118.455, -0.669162, 0, 0, 0.743116, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004C3 [-9.621400 93.671700 118.455002] -0.669162 0.000000 0.000000 0.743116 */
+VALUES (0x724C0094, 35150, 0x24C004C8, -12.148, 62.1828, 118.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:49:06'); /* Olthoi Slasher */
+/* @teleloc 0x24C004C8 [-12.148000 62.182800 118.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C008F, 87832, 0x24C004AD, -23.4335, 94.3051, 118.455, -0.669162, 0, 0, 0.743116, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004AD [-23.433500 94.305099 118.455002] -0.669162 0.000000 0.000000 0.743116 */
+VALUES (0x724C0095, 35150, 0x24C004C8, -10.066, 63.8885, 118.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:49:08'); /* Olthoi Slasher */
+/* @teleloc 0x24C004C8 [-10.066000 63.888500 118.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0090, 87832, 0x24C0048F, -33.0707, 93.6329, 118.455, -0.669162, 0, 0, 0.743116, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0048F [-33.070702 93.632896 118.455002] -0.669162 0.000000 0.000000 0.743116 */
+VALUES (0x724C0096, 35149, 0x24C00471, -42.5377, 73.006, 118.384, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:49:29'); /* Olthoi Ripper */
+/* @teleloc 0x24C00471 [-42.537701 73.005997 118.384003] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0091, 87832, 0x24C0048B, -32.7952, 103.428, 118.455, -0.694829, 0, 0, 0.719175, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0048B [-32.795200 103.428001 118.455002] -0.694829 0.000000 0.000000 0.719175 */
+VALUES (0x724C0097, 35149, 0x24C00451, -53.961, 63.1785, 118.384, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:49:37'); /* Olthoi Ripper */
+/* @teleloc 0x24C00451 [-53.960999 63.178501 118.384003] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0092, 87832, 0x24C001CD, -33.2781, 103.028, 106.455, -0.726203, 0, 0, -0.68748, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C001CD [-33.278099 103.028000 106.455002] -0.726203 0.000000 0.000000 -0.687480 */
+VALUES (0x724C0098, 35149, 0x24C00475, -44.0763, 52.9107, 118.384, 0, 0, 0, 1,  True, '2025-07-19 11:49:43'); /* Olthoi Ripper */
+/* @teleloc 0x24C00475 [-44.076302 52.910702 118.384003] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0093, 87832, 0x24C001D9, -34.9232, 83.0862, 106.455, -0.729504, 0, 0, -0.683977, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C001D9 [-34.923199 83.086197 106.455002] -0.729504 0.000000 0.000000 -0.683977 */
+VALUES (0x724C0099, 35149, 0x24C003D8, -112.541, 74.6195, 118.384, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:52:33'); /* Olthoi Ripper */
+/* @teleloc 0x24C003D8 [-112.541000 74.619499 118.384003] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0094, 87832, 0x24C0021E, -14.3975, 83.1423, 106.455, -0.729504, 0, 0, -0.683977, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0021E [-14.397500 83.142303 106.455002] -0.729504 0.000000 0.000000 -0.683977 */
+VALUES (0x724C009A, 38875, 0x24C003F9, -91.9919, 50.6596, 118.4, 0, 0, 0, 1,  True, '2025-07-19 11:57:10'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C003F9 [-91.991898 50.659599 118.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0095, 87832, 0x24C00212, -14.4829, 103.26, 106.455, -0.729175, 0, 0, -0.684327, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00212 [-14.482900 103.260002 106.455002] -0.729175 0.000000 0.000000 -0.684327 */
+VALUES (0x724C009B, 38876, 0x24C0040F, -88.2237, 46.0457, 118.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 11:57:19'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0040F [-88.223701 46.045700 118.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0096, 87832, 0x24C001F1, -24.7651, 92.8547, 106.455, -0.755581, 0, 0, -0.655056, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C001F1 [-24.765100 92.854698 106.455002] -0.755581 0.000000 0.000000 -0.655056 */
+VALUES (0x724C009C, 38877, 0x24C003E9, -100.992, 40.9618, 118.4, 0, 0, 0, 1,  True, '2025-07-19 11:57:26'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C003E9 [-100.991997 40.961800 118.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0097, 87832, 0x24C00264, 18.5038, 102.912, 106.455, 0.712333, 0, 0, 0.701842, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00264 [18.503799 102.912003 106.455002] 0.712333 0.000000 0.000000 0.701842 */
+VALUES (0x724C009E, 38876, 0x24C00416, -84.8642, 12.8524, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 11:58:58'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00416 [-84.864197 12.852400 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0098, 87832, 0x24C0028A, 35.8413, 87.375, 106.455, 0.980655, 0, 0, -0.195743, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0028A [35.841301 87.375000 106.455002] 0.980655 0.000000 0.000000 -0.195743 */
+VALUES (0x724C00A1, 38876, 0x24C0041A, -85.702, -16.9529, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:00:57'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0041A [-85.702003 -16.952900 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C0099, 87832, 0x24C0026F, 16.0454, 45.4393, 106.455, 0.999666, 0, 0, -0.025851, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0026F [16.045401 45.439301 106.455002] 0.999666 0.000000 0.000000 -0.025851 */
+VALUES (0x724C00A2, 38877, 0x24C00400, -93.5483, -6.78805, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:01:22'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00400 [-93.548302 -6.788050 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C009A, 87832, 0x24C00201, -23.4871, 53.1072, 106.455, 0.599226, 0, 0, -0.80058, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00201 [-23.487101 53.107201 106.455002] 0.599226 0.000000 0.000000 -0.800580 */
+VALUES (0x724C00A3, 38875, 0x24C0046C, -58.4736, -23.7611, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:01:52'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0046C [-58.473598 -23.761101 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C009B, 87832, 0x24C00247, -7.96678, 2.8537, 106.455, -0.70708, 0, 0, -0.707133, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00247 [-7.966780 2.853700 106.455002] -0.707080 0.000000 0.000000 -0.707133 */
+VALUES (0x724C00A5, 38877, 0x24C00445, -60.8653, -18.5795, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:02:17'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00445 [-60.865299 -18.579500 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C009C, 87832, 0x24C00285, 27.3513, 13.3055, 106.455, 0.622421, 0, 0, -0.782683, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00285 [27.351299 13.305500 106.455002] 0.622421 0.000000 0.000000 -0.782683 */
+VALUES (0x724C00A6, 38876, 0x24C0046C, -55.099, -25.8056, 118.4, 1, 0, 0, 0,  True, '2025-07-19 12:02:47'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0046C [-55.098999 -25.805599 118.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C009D, 87832, 0x24C0022A, -14.1209, 27.9844, 106.455, 0.037981, 0, 0, 0.999279, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0022A [-14.120900 27.984400 106.455002] 0.037981 0.000000 0.000000 0.999279 */
+VALUES (0x724C00A7, 38876, 0x24C004A2, -35.6183, -12.5725, 118.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:03:19'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C004A2 [-35.618301 -12.572500 118.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C009E, 87832, 0x24C00266, 14.0942, 83.1172, 106.455, 0.756966, 0, 0, 0.653455, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00266 [14.094200 83.117203 106.455002] 0.756966 0.000000 0.000000 0.653455 */
+VALUES (0x724C00A8, 38875, 0x24C00463, -56.2436, 2.95176, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:03:39'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00463 [-56.243599 2.951760 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C009F, 87832, 0x24C00252, 10.4867, 92.4002, 106.455, -0.726984, 0, 0, 0.686654, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00252 [10.486700 92.400200 106.455002] -0.726984 0.000000 0.000000 0.686654 */
+VALUES (0x724C00A9, 38875, 0x24C004B6, -24.0856, 1.40694, 118.4, 0, 0, 0, 1,  True, '2025-07-19 12:03:52'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C004B6 [-24.085600 1.406940 118.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A0, 87832, 0x24C00297, 46.2973, 38.8574, 106.455, 0.999848, 0, 0, 0.017426, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00297 [46.297298 38.857399 106.455002] 0.999848 0.000000 0.000000 0.017426 */
+VALUES (0x724C00AA, 38875, 0x24C005BA, -64.0336, 8.37098, 130.4, 0, 0, 0, 1,  True, '2025-07-19 12:05:01'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C005BA [-64.033600 8.370980 130.399994] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A1, 87832, 0x24C00282, 25.8535, 32.7109, 106.455, 0.993197, 0, 0, -0.116444, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00282 [25.853500 32.710899 106.455002] 0.993197 0.000000 0.000000 -0.116444 */
+VALUES (0x724C00AB, 38876, 0x24C005BE, -61.7827, -6.93703, 130.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:05:18'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C005BE [-61.782700 -6.937030 130.399994] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A2, 87832, 0x24C005BE, -62.3635, -6.36967, 130.455, 0.7118, 0, 0, -0.702383, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C005BE [-62.363499 -6.369670 130.455002] 0.711800 0.000000 0.000000 -0.702383 */
+VALUES (0x724C00AC, 38876, 0x24C005DA, -53.4771, 23.0478, 130.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:05:37'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C005DA [-53.477100 23.047800 130.399994] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A3, 87832, 0x24C003FF, -94.1223, 12.4094, 118.455, -0.725968, 0, 0, 0.687729, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C003FF [-94.122299 12.409400 118.455002] -0.725968 0.000000 0.000000 0.687729 */
+VALUES (0x724C00AD, 38875, 0x24C005F5, -44.0167, 33.2591, 130.4, 0, 0, 0, 1,  True, '2025-07-19 12:06:00'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C005F5 [-44.016701 33.259102 130.399994] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A4, 87832, 0x24C003FB, -98.0161, 31.9344, 118.455, 0.287761, 0, 0, 0.957702, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C003FB [-98.016098 31.934401 118.455002] 0.287761 0.000000 0.000000 0.957702 */
+VALUES (0x724C00AE, 38876, 0x24C00645, -73.8612, 52.9312, 136.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:06:23'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00645 [-73.861198 52.931198 136.399994] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A5, 87832, 0x24C0040D, -88.9592, 51.9214, 118.455, 0.287761, 0, 0, 0.957702, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0040D [-88.959198 51.921398 118.455002] 0.287761 0.000000 0.000000 0.957702 */
+VALUES (0x724C00B1, 38875, 0x24C00644, -85.5388, 12.1648, 136.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:09:36'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00644 [-85.538803 12.164800 136.399994] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A6, 87832, 0x24C002AC, -103.841, 12.1368, 112.455, -0.999951, 0, 0, -0.009902, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C002AC [-103.841003 12.136800 112.455002] -0.999951 0.000000 0.000000 -0.009902 */
+VALUES (0x724C00B2, 38876, 0x24C0066C, -44.165, 43.6545, 136.4, 1, 0, 0, 0,  True, '2025-07-19 12:10:50'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0066C [-44.165001 43.654499 136.399994] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A7, 87832, 0x24C002C1, -84.9636, 14.6341, 112.455, 0.817336, 0, 0, 0.576161, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C002C1 [-84.963600 14.634100 112.455002] 0.817336 0.000000 0.000000 0.576161 */
+VALUES (0x724C00B3, 38875, 0x24C00660, -53.707, 33.0014, 136.4, 1, 0, 0, 0,  True, '2025-07-19 12:11:07'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00660 [-53.707001 33.001400 136.399994] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A8, 87832, 0x24C00425, -72.6099, 22.9806, 118.455, -0.692428, 0, 0, 0.721487, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00425 [-72.609901 22.980600 118.455002] -0.692428 0.000000 0.000000 0.721487 */
+VALUES (0x724C00B4, 38877, 0x24C00644, -88.7385, 13.5001, 136.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:11:31'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00644 [-88.738503 13.500100 136.399994] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00A9, 87832, 0x24C0047A, -43.4324, 44.8181, 118.455, -0.968957, 0, 0, -0.24723, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0047A [-43.432400 44.818100 118.455002] -0.968957 0.000000 0.000000 -0.247230 */
+VALUES (0x724C00B5, 38877, 0x24C00598, -93.9588, 33.7227, 130.4, 1, 0, 0, 0,  True, '2025-07-19 12:12:44'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00598 [-93.958801 33.722698 130.399994] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00AA, 87832, 0x24C00451, -53.2948, 63.5793, 118.455, -0.902812, 0, 0, -0.430036, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00451 [-53.294800 63.579300 118.455002] -0.902812 0.000000 0.000000 -0.430036 */
+VALUES (0x724C00B6, 87825, 0x24C00174, -74.0015, -7, 106.4, 1, 0, 0, 0, False, '2025-07-19 12:14:03'); /* Large Corrupted Mana Shard */
+/* @teleloc 0x24C00174 [-74.001503 -7.000000 106.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00AB, 87832, 0x24C004B2, -22.6149, 63.5473, 118.455, -0.65516, 0, 0, 0.75549, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004B2 [-22.614901 63.547298 118.455002] -0.655160 0.000000 0.000000 0.755490 */
+VALUES (0x724C00B9, 38875, 0x24C00193, -64.6956, -8.29338, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:17:39'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00193 [-64.695602 -8.293380 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00AC, 87832, 0x24C004E1, 5.16534, 73.4948, 118.455, -0.995714, 0, 0, -0.092486, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004E1 [5.165340 73.494797 118.455002] -0.995714 0.000000 0.000000 -0.092486 */
+VALUES (0x724C00BA, 38876, 0x24C00193, -63.0849, -6.6674, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:17:42'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00193 [-63.084900 -6.667400 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00AD, 87832, 0x24C004EE, 17.8607, 70.2857, 118.455, 0.010116, 0, 0, 0.999949, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004EE [17.860701 70.285698 118.455002] 0.010116 0.000000 0.000000 0.999949 */
+VALUES (0x724C00BB, 38877, 0x24C00177, -69.7226, -16.9006, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:18:50'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00177 [-69.722603 -16.900600 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00AE, 87832, 0x24C004F2, 18.7859, 47.5681, 118.455, 0.269252, 0, 0, 0.96307, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004F2 [18.785900 47.568100 118.455002] 0.269252 0.000000 0.000000 0.963070 */
+VALUES (0x724C00BC, 38876, 0x24C0015C, -83.2827, -2.2756, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:19:23'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0015C [-83.282700 -2.275600 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00AF, 87832, 0x24C004E6, 10.9911, 36.7233, 118.455, 0.346075, 0, 0, 0.938207, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004E6 [10.991100 36.723301 118.455002] 0.346075 0.000000 0.000000 0.938207 */
+VALUES (0x724C00BD, 38875, 0x24C0015B, -84.3947, -0.253916, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:19:29'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0015B [-84.394699 -0.253916 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B0, 87832, 0x24C004D7, 0.847572, 22.9584, 115.51, 0.210455, 0, 0, 0.977604, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C004D7 [0.847572 22.958401 115.510002] 0.210455 0.000000 0.000000 0.977604 */
+VALUES (0x724C00BE, 38875, 0x24C001B3, -54.0193, -27.0913, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:20:10'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001B3 [-54.019299 -27.091299 106.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B1, 87832, 0x24C00376, 3.4001, 4.02756, 112.455, -0.621485, 0, 0, 0.783426, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00376 [3.400100 4.027560 112.455002] -0.621485 0.000000 0.000000 0.783426 */
+VALUES (0x724C00BF, 38876, 0x24C001C4, -43.9809, -7.30953, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:20:29'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001C4 [-43.980900 -7.309530 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B2, 87832, 0x24C00386, 20.3401, -2.9496, 112.455, -0.73354, 0, 0, 0.679647, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00386 [20.340099 -2.949600 112.455002] -0.733540 0.000000 0.000000 0.679647 */
+VALUES (0x724C00C0, 38876, 0x24C0020F, -23.927, -26.6361, 106.4, 0.999982, 0, 0, -0.006025,  True, '2025-07-19 12:20:55'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0020F [-23.927000 -26.636101 106.400002] 0.999982 0.000000 0.000000 -0.006025 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B3, 87832, 0x24C003A6, 36.0694, 63.4818, 112.455, 0.006767, 0, 0, 0.999977, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C003A6 [36.069401 63.481800 112.455002] 0.006767 0.000000 0.000000 0.999977 */
+VALUES (0x724C00C1, 38875, 0x24C00209, -24.0953, -6.48708, 106.4, 0.002271, 0, 0, -0.999997,  True, '2025-07-19 12:21:01'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00209 [-24.095301 -6.487080 106.400002] 0.002271 0.000000 0.000000 -0.999997 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B4, 87832, 0x24C003AD, 37.2982, 33.6172, 112.455, 0.107519, 0, 0, 0.994203, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C003AD [37.298199 33.617199 112.455002] 0.107519 0.000000 0.000000 0.994203 */
+VALUES (0x724C00C4, 38876, 0x24C00248, -4.00484, -7.11592, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:22:10'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00248 [-4.004840 -7.115920 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B5, 87832, 0x24C003B7, 35.5165, 14.2058, 112.455, 0.067292, 0, 0, 0.997733, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C003B7 [35.516499 14.205800 112.455002] 0.067292 0.000000 0.000000 0.997733 */
+VALUES (0x724C00C5, 38876, 0x24C001FE, -22.5403, 72.9968, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:23:11'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001FE [-22.540300 72.996803 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B6, 87832, 0x24C0037F, 12.7601, 62.4501, 112.455, 0.753529, 0, 0, 0.657415, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0037F [12.760100 62.450100 112.455002] 0.753529 0.000000 0.000000 0.657415 */
+VALUES (0x724C00C6, 38876, 0x24C001E3, -33.3614, 42.5568, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:23:24'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001E3 [-33.361401 42.556801 106.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B7, 87832, 0x24C00349, -10.7207, 52.7712, 112.455, 0.704205, 0, 0, 0.709997, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00349 [-10.720700 52.771198 112.455002] 0.704205 0.000000 0.000000 0.709997 */
+VALUES (0x724C00C7, 38875, 0x24C001E3, -34.4663, 40.2138, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:23:29'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001E3 [-34.466301 40.213799 106.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B8, 87832, 0x24C00327, -26.0741, 52.9674, 112.455, 0.142837, 0, 0, 0.989746, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C00327 [-26.074100 52.967400 112.455002] 0.142837 0.000000 0.000000 0.989746 */
+VALUES (0x724C00C8, 38877, 0x24C001E7, -33.9799, 7.79285, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:23:44'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001E7 [-33.979900 7.792850 106.400002] 1.000000 0.000000 0.000000 0.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00B9, 87832, 0x24C003C3, 35.8832, -20.1987, 112.455, 0.015142, 0, 0, -0.999885, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C003C3 [35.883202 -20.198700 112.455002] 0.015142 0.000000 0.000000 -0.999885 */
+VALUES (0x724C00C9, 38876, 0x24C00227, -11.2093, 52.9337, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:24:20'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00227 [-11.209300 52.933701 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00BA, 87832, 0x24C0036E, 0.032381, -26.4658, 112.455, -0.665449, 0, 0, -0.746443, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0036E [0.032381 -26.465799 112.455002] -0.665449 0.000000 0.000000 -0.746443 */
+VALUES (0x724C00CA, 38875, 0x24C0022A, -13.9624, 21.2579, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:24:45'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0022A [-13.962400 21.257900 106.400002] 0.000000 0.000000 0.000000 1.000000 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00BB, 87832, 0x24C0036C, -3.92194, -11.9382, 112.455, 0.999811, 0, 0, 0.019427, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0036C [-3.921940 -11.938200 112.455002] 0.999811 0.000000 0.000000 0.019427 */
+VALUES (0x724C00CB, 38875, 0x24C00285, 28.5113, 13.0088, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:25:00'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00285 [28.511299 13.008800 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00BC, 87832, 0x24C0059E, -79.9418, 52.2569, 130.455, 0.500008, 0, 0, 0.866021, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0059E [-79.941803 52.256901 130.455002] 0.500008 0.000000 0.000000 0.866021 */
+VALUES (0x724C00CC, 38875, 0x24C00247, -4.65453, 2.51251, 106.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:25:12'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00247 [-4.654530 2.512510 106.400002] 0.707107 0.000000 0.000000 0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x724C00BD, 87832, 0x24C0059B, -98.4255, 22.9817, 130.455, 0.7621, 0, 0, -0.647459, False, '2022-01-08 18:29:57'); /* Roots of Skuld Generator */
-/* @teleloc 0x24C0059B [-98.425499 22.981701 130.455002] 0.762100 0.000000 0.000000 -0.647459 */
+VALUES (0x724C00CD, 38876, 0x24C00247, -7.0069, 3.58643, 106.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:25:16'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00247 [-7.006900 3.586430 106.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00CE, 38877, 0x24C00204, -24.0891, 32.4318, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:26:08'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00204 [-24.089100 32.431801 106.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00CF, 38875, 0x24C0025D, 10.5827, 32.8862, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:26:49'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0025D [10.582700 32.886200 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D0, 38876, 0x24C00243, -3.9019, 32.3866, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:27:06'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00243 [-3.901900 32.386600 106.400002] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D1, 38875, 0x24C0025E, 5.06586, 23.1111, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:27:15'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0025E [5.065860 23.111099 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D2, 38877, 0x24C00282, 26.0259, 30.6949, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:27:25'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00282 [26.025900 30.694901 106.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D3, 38875, 0x24C00298, 46.0569, 31.4924, 106.4, 0, 0, 0, 1,  True, '2025-07-19 12:27:40'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00298 [46.056900 31.492399 106.400002] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D4, 38875, 0x24C00297, 45.9123, 44.5516, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:27:53'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00297 [45.912300 44.551601 106.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D5, 38875, 0x24C0027C, 26.8304, 72.9092, 106.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:28:14'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0027C [26.830400 72.909203 106.400002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D6, 38875, 0x24C00277, 28.531, 103.006, 106.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:28:25'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00277 [28.531000 103.005997 106.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D7, 38877, 0x24C00251, 7.84784, 103.037, 106.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:28:30'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00251 [7.847840 103.037003 106.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D8, 38877, 0x24C0054A, -15.1171, 103.404, 124.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:29:30'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0054A [-15.117100 103.403999 124.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00D9, 38875, 0x24C0054A, -12.9594, 102.095, 124.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:29:33'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0054A [-12.959400 102.095001 124.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00DA, 38877, 0x24C00561, 4.76077, 93.0809, 124.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:29:41'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00561 [4.760770 93.080902 124.400002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00DB, 38877, 0x24C00513, 46.508, 92.559, 118.4, 1, 0, 0, 0,  True, '2025-07-19 12:30:07'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00513 [46.507999 92.558998 118.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00DC, 38875, 0x24C00513, 45.0919, 94.2145, 118.4, 1, 0, 0, 0,  True, '2025-07-19 12:30:14'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00513 [45.091900 94.214500 118.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00DD, 38876, 0x24C004FA, 26.6423, 83.0307, 118.4, 0.707107, 0, 0, -0.707107,  True, '2025-07-19 12:30:29'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C004FA [26.642300 83.030701 118.400002] 0.707107 0.000000 0.000000 -0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E1, 38877, 0x24C001D9, -34.1647, 83.1684, 106.4, 1, 0, 0, 0,  True, '2025-07-19 12:31:51'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001D9 [-34.164700 83.168404 106.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E2, 38875, 0x24C0021E, -14.1292, 82.8087, 106.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:31:57'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0021E [-14.129200 82.808701 106.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E3, 38876, 0x24C001EB, -23.4283, 102.763, 106.4, 0.707107, 0, 0, 0.707107,  True, '2025-07-19 12:32:12'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C001EB [-23.428301 102.763000 106.400002] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E4, 38876, 0x24C004D1, -5.00929, 93.2287, 118.4, 1, 0, 0, 0,  True, '2025-07-19 12:33:15'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C004D1 [-5.009290 93.228699 118.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E5, 38875, 0x24C004D1, -3.62671, 95.5959, 118.4, 1, 0, 0, 0,  True, '2025-07-19 12:33:21'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C004D1 [-3.626710 95.595901 118.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E6, 38875, 0x24C005C3, -54.2931, 84.065, 130.4, 0, 0, 0, 1,  True, '2025-07-19 12:34:07'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C005C3 [-54.293098 84.065002 130.399994] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E8, 38877, 0x24C005EA, -44.4781, 61.9694, 130.4, 0, 0, 0, 1,  True, '2025-07-19 12:34:29'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C005EA [-44.478100 61.969398 130.399994] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00E9, 38875, 0x24C0060C, -24.0075, 47.4528, 130.4, 0, 0, 0, 1,  True, '2025-07-19 12:34:50'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C0060C [-24.007500 47.452801 130.399994] 0.000000 0.000000 0.000000 1.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00EA, 38876, 0x24C00107, -53.2239, 90.8295, 94.4, 1, 0, 0, 0,  True, '2025-07-19 12:35:51'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00107 [-53.223900 90.829498 94.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00EB, 38875, 0x24C00107, -54.6991, 88.3679, 94.4, 1, 0, 0, 0,  True, '2025-07-19 12:35:55'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00107 [-54.699100 88.367897 94.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00EC, 38877, 0x24C00108, -53.8414, 83.1966, 94.4, 1, 0, 0, 0,  True, '2025-07-19 12:36:10'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00108 [-53.841400 83.196602 94.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00ED, 87827, 0x24C0011F, -23.9185, 23, 94.4, 1, 0, 0, 0, False, '2025-07-19 12:36:40'); /* Altar of T'thuun */
+/* @teleloc 0x24C0011F [-23.918501 23.000000 94.400002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00EE, 87831, 0x24C00261, 5.99902, -17, 106.337, 0.707107, 0, 0, 0.707107, False, '2025-07-19 12:38:00'); /* Surface */
+/* @teleloc 0x24C00261 [5.999020 -17.000000 106.336998] 0.707107 0.000000 0.000000 0.707107 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00EF, 87831, 0x24C0067B, -25.2661, 41.8008, 142.337, 1, 0, 0, 0, False, '2025-07-19 12:38:25'); /* Surface */
+/* @teleloc 0x24C0067B [-25.266100 41.800800 142.337006] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00F0, 87828, 0x24C00582, 36, 82.5, 124.19, 1, 0, 0, 0, False, '2025-07-19 13:55:21'); /* Roots of Skuld, Urd and Verdandi */
+/* @teleloc 0x24C00582 [36.000000 82.500000 124.190002] 1.000000 0.000000 0.000000 0.000000 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x724C00F1, 38875, 0x24C00585, 35.8815, 78.6358, 124.4, 0, 0, 0, 1,  True, '2025-07-19 13:57:57'); /* Sclavus Acolyte of T'thuun */
+/* @teleloc 0x24C00585 [35.881500 78.635803 124.400002] 0.000000 0.000000 0.000000 1.000000 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Slithis/38826 Eyestalk of T'thuun.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Slithis/38826 Eyestalk of T'thuun.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 38826;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (38826, 'ace38826-eyestalkoftthuun', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (38826, 'ace38826-eyestalkoftthuun', 10, '2025-07-19 12:53:27') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (38826,   1,         16) /* ItemType - Creature */
@@ -62,7 +62,8 @@ VALUES (38826,   1,       5) /* HeartbeatInterval */
      , (38826, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (38826,   1, 'Eyestalk of T''thuun') /* Name */;
+VALUES (38826,   1, 'Eyestalk of T''thuun') /* Name */
+     , (38826,  45, 'KillTaskTentacleofTthuun_0908') /* KillQuest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (38826,   1, 0x02001855) /* Setup */
@@ -87,35 +88,31 @@ VALUES (38826,   1,  1050, 0, 0, 1230) /* MaxHealth */
      , (38826,   5,   950, 0, 0, 1350) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (38826,  6, 0, 2, 0, 380, 0, 0) /* MeleeDefense        Trained */
-     , (38826,  7, 0, 2, 0, 480, 0, 0) /* MissileDefense      Trained */
-     , (38826, 15, 0, 2, 0, 330, 0, 0) /* MagicDefense        Trained */
-     , (38826, 16, 0, 2, 0, 350, 0, 0) /* ManaConversion      Trained */
-     , (38826, 31, 0, 2, 0, 280, 0, 0) /* CreatureEnchantment Trained */
-     , (38826, 33, 0, 2, 0, 280, 0, 0) /* LifeMagic           Trained */
-     , (38826, 34, 0, 2, 0, 280, 0, 0) /* WarMagic            Trained */
-     , (38826, 41, 0, 2, 0, 406, 0, 0) /* TwoHandedCombat     Trained */
-     , (38826, 43, 0, 2, 0, 280, 0, 0) /* VoidMagic           Trained */
-     , (38826, 44, 0, 2, 0, 406, 0, 0) /* HeavyWeapons        Trained */
-     , (38826, 45, 0, 2, 0, 406, 0, 0) /* LightWeapons        Trained */
-     , (38826, 46, 0, 2, 0, 433, 0, 0) /* FinesseWeapons      Trained */
-     , (38826, 47, 0, 2, 0, 260, 0, 0) /* MissileWeapons      Trained */;
+VALUES (38826,  6, 0, 2, 0, 440, 0, 0) /* MeleeDefense        Trained */
+     , (38826,  7, 0, 2, 0, 430, 0, 0) /* MissileDefense      Trained */
+     , (38826, 15, 0, 2, 0, 340, 0, 0) /* MagicDefense        Trained */
+     , (38826, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
+     , (38826, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (38826, 34, 0, 2, 0, 245, 0, 0) /* WarMagic            Trained */
+     , (38826, 45, 0, 2, 0, 350, 0, 0) /* LightWeapons        Trained */
+     , (38826, 47, 0, 2, 0, 220, 0, 0) /* MissileWeapons      Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (38826,  0, 16, 20, 0.75,  150,  128,  128,  150,  135,  150,  143,   75,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (38826, 23,  4,  0,    0,  160,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
-     , (38826, 24,  4,  0,    0,  160,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
-     , (38826, 25,  4, 10, 0.75,  180,  153,  153,  180,  162,  180,  171,   90,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
+VALUES (38826,  0, 16, 200, 0.75,  470,  235,  235,  235,  235,  235,  235,  235,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (38826, 23,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
+     , (38826, 24,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
+     , (38826, 25,  4, 200, 0.75,  470,  235,  235,  235,  235,  235,  235,  235,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (38826,  2765,   2.02)  /* Martyr's Hecatomb VI */
-     , (38826,  2790,   2.02)  /* Weight of the World */
-     , (38826,  4489,   2.02)  /* Incantation of Fester Other */;
+VALUES (38826,  4308,   2.04)  /* Incantation of Harm Other */
+     , (38826,  4489,   2.04)  /* Incantation of Fester Other */
+     , (38826,  4643,   2.04)  /* Incantation of Drain Health Other */
+     , (38826,  4644,   2.05)  /* Incantation of Drain Mana Other */
+     , (38826,  2765,   2.05)  /* Martyr's Hecatomb VI */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (38826, 2, 33459,  1, 0, 0, False) /* Create Shadow Bolt (33459) for Wield */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (38826, 0.24, 38827, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tendril of T'thuun (38827) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (38826, 0.77, 38828, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tentacle of T'thuun (38828) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (38826, 0.24, 39040, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tendril of T'thuun (39040) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (38826, -1, 38828, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tentacle of T'thuun (38828) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (38826, -1, 38827, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tendril of T'thuun (38827) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Slithis/38827 Tendril of T'thuun.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Slithis/38827 Tendril of T'thuun.sql
@@ -58,7 +58,8 @@ VALUES (38827,   1,       5) /* HeartbeatInterval */
      , (38827, 125,       1) /* ResistHealthDrain */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (38827,   1, 'Tendril of T''thuun') /* Name */;
+VALUES (38827,   1, 'Tendril of T''thuun') /* Name */
+     , (38827,  45, 'KillTaskTentacleofTthuun_0908') /* KillQuest */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (38827,   1, 0x02001855) /* Setup */
@@ -83,32 +84,27 @@ VALUES (38827,   1,   650, 0, 0, 810) /* MaxHealth */
      , (38827,   5,   550, 0, 0, 910) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (38827,  6, 0, 2, 0, 330, 0, 0) /* MeleeDefense        Trained */
-     , (38827,  7, 0, 2, 0, 400, 0, 0) /* MissileDefense      Trained */
-     , (38827, 15, 0, 2, 0, 250, 0, 0) /* MagicDefense        Trained */
-     , (38827, 16, 0, 2, 0, 235, 0, 0) /* ManaConversion      Trained */
+VALUES (38827,  6, 0, 2, 0, 430, 0, 0) /* MeleeDefense        Trained */
+     , (38827,  7, 0, 2, 0, 420, 0, 0) /* MissileDefense      Trained */
+     , (38827, 15, 0, 2, 0, 330, 0, 0) /* MagicDefense        Trained */
      , (38827, 31, 0, 2, 0, 235, 0, 0) /* CreatureEnchantment Trained */
      , (38827, 33, 0, 2, 0, 235, 0, 0) /* LifeMagic           Trained */
      , (38827, 34, 0, 2, 0, 235, 0, 0) /* WarMagic            Trained */
-     , (38827, 41, 0, 2, 0, 300, 0, 0) /* TwoHandedCombat     Trained */
-     , (38827, 43, 0, 2, 0, 235, 0, 0) /* VoidMagic           Trained */
-     , (38827, 44, 0, 2, 0, 320, 0, 0) /* HeavyWeapons        Trained */
-     , (38827, 45, 0, 2, 0, 320, 0, 0) /* LightWeapons        Trained */
-     , (38827, 46, 0, 2, 0, 320, 0, 0) /* FinesseWeapons      Trained */
-     , (38827, 47, 0, 2, 0, 260, 0, 0) /* MissileWeapons      Trained */;
+     , (38827, 45, 0, 2, 0, 340, 0, 0) /* LightWeapons        Trained */
+     , (38827, 47, 0, 2, 0, 210, 0, 0) /* MissileWeapons      Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (38827,  0, 16, 20, 0.75,  150,  128,  128,  150,  135,  150,  143,   75,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (38827, 23,  4,  0,    0,  160,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
-     , (38827, 24,  4,  0,    0,  160,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
-     , (38827, 25,  4, 10, 0.75,  180,  153,  153,  180,  162,  180,  171,   90,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
+VALUES (38827,  0, 16, 200, 0.75,  470,  128,  128,  150,  135,  150,  143,   75,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (38827, 23,  4,  0,    0,  470,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
+     , (38827, 24,  4,  0,    0,  470,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
+     , (38827, 25,  4, 200, 0.75,  470,  153,  153,  180,  162,  180,  171,   90,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (38827,  2070,   2.02)  /* Heart Rend */
-     , (38827,  2178,   2.02)  /* Decrepitude's Grasp */
-     , (38827,  2328,   2.02)  /* Vitality Siphon */
-     , (38827,  2329,   2.02)  /* Essence Void */
-     , (38827,  2764,   2.02)  /* Martyr's Hecatomb V */;
+VALUES (38827,  2070,   2.04)  /* Heart Rend */
+     , (38827,  2178,   2.04)  /* Decrepitude's Grasp */
+     , (38827,  2328,   2.04)  /* Vitality Siphon */
+     , (38827,  2329,   2.05)  /* Essence Void */
+     , (38827,  2764,   2.05)  /* Martyr's Hecatomb V */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (38827, 2, 33459,  1, 0, 0, False) /* Create Shadow Bolt (33459) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Slithis/38828 Tentacle of T'thuun.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Slithis/38828 Tentacle of T'thuun.sql
@@ -85,31 +85,26 @@ VALUES (38828,   1,   850, 0, 0, 1020) /* MaxHealth */
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (38828,  6, 0, 2, 0, 440, 0, 0) /* MeleeDefense        Trained */
-     , (38828,  7, 0, 2, 0, 504, 0, 0) /* MissileDefense      Trained */
-     , (38828, 15, 0, 2, 0, 354, 0, 0) /* MagicDefense        Trained */
-     , (38828, 16, 0, 2, 0, 275, 0, 0) /* ManaConversion      Trained */
-     , (38828, 31, 0, 2, 0, 275, 0, 0) /* CreatureEnchantment Trained */
-     , (38828, 33, 0, 2, 0, 275, 0, 0) /* LifeMagic           Trained */
-     , (38828, 34, 0, 2, 0, 275, 0, 0) /* WarMagic            Trained */
-     , (38828, 41, 0, 2, 0, 383, 0, 0) /* TwoHandedCombat     Trained */
-     , (38828, 43, 0, 2, 0, 275, 0, 0) /* VoidMagic           Trained */
-     , (38828, 44, 0, 2, 0, 383, 0, 0) /* HeavyWeapons        Trained */
-     , (38828, 45, 0, 2, 0, 383, 0, 0) /* LightWeapons        Trained */
-     , (38828, 46, 0, 2, 0, 410, 0, 0) /* FinesseWeapons      Trained */
-     , (38828, 47, 0, 2, 0, 260, 0, 0) /* MissileWeapons      Trained */;
+     , (38828,  7, 0, 2, 0, 430, 0, 0) /* MissileDefense      Trained */
+     , (38828, 15, 0, 2, 0, 340, 0, 0) /* MagicDefense        Trained */
+     , (38828, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
+     , (38828, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (38828, 34, 0, 2, 0, 245, 0, 0) /* WarMagic            Trained */
+     , (38828, 45, 0, 2, 0, 350, 0, 0) /* LightWeapons        Trained */
+     , (38828, 47, 0, 2, 0, 220, 0, 0) /* MissileWeapons      Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (38828,  0, 16, 20, 0.75,  150,  128,  128,  150,  135,  150,  143,   75,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
-     , (38828, 23,  4,  0,    0,  160,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
-     , (38828, 24,  4,  0,    0,  160,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
-     , (38828, 25,  4, 10, 0.75,  180,  153,  153,  180,  162,  180,  171,   90,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
+VALUES (38828,  0, 16, 200, 0.75,  470,  128,  128,  150,  135,  150,  143,   75,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (38828, 23,  4,  0,    0,  470,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
+     , (38828, 24,  4,  0,    0,  470,  136,  136,  160,  144,  160,  152,   80,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
+     , (38828, 25,  4, 200, 0.75,  470,  153,  153,  180,  162,  180,  171,   90,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (38828,  2070,   2.02)  /* Heart Rend */
-     , (38828,  2178,   2.02)  /* Decrepitude's Grasp */
-     , (38828,  2328,   2.02)  /* Vitality Siphon */
-     , (38828,  2329,   2.02)  /* Essence Void */
-     , (38828,  2764,   2.02)  /* Martyr's Hecatomb V */;
+VALUES (38828,  2070,   2.04)  /* Heart Rend */
+     , (38828,  2178,   2.04)  /* Decrepitude's Grasp */
+     , (38828,  2328,   2.04)  /* Vitality Siphon */
+     , (38828,  2329,   2.05)  /* Essence Void */
+     , (38828,  2764,   2.05)  /* Martyr's Hecatomb V */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (38828, 2, 33459,  1, 0, 0, False) /* Create Shadow Bolt (33459) for Wield */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Slithis/73256 Eyestalk of T'thuun.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Slithis/73256 Eyestalk of T'thuun.sql
@@ -1,0 +1,120 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73256;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73256, 'ace73256-eyestalkoftthuun', 10, '2025-07-19 12:53:27') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73256,   1,         16) /* ItemType - Creature */
+     , (73256,   2,         36) /* CreatureType - Slithis */
+     , (73256,   6,         -1) /* ItemsCapacity */
+     , (73256,   7,         -1) /* ContainersCapacity */
+     , (73256,  16,          1) /* ItemUseable - No */
+     , (73256,  25,        160) /* Level */
+     , (73256,  27,          0) /* ArmorType - None */
+     , (73256,  40,          2) /* CombatMode - Melee */
+     , (73256,  68,         13) /* TargetingTactic - Random, LastDamager, TopDamager */
+     , (73256,  81,          4) /* MaxGeneratedObjects */
+     , (73256,  82,          4) /* InitGeneratedObjects */
+     , (73256,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (73256, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (73256, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (73256, 146,     500000) /* XpOverride */
+     , (73256, 281,          8) /* Faction1Bits - 8 */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73256,   1, True ) /* Stuck */
+     , (73256,   6, True ) /* AiUsesMana */
+     , (73256,  11, False) /* IgnoreCollisions */
+     , (73256,  12, True ) /* ReportCollisions */
+     , (73256,  13, False) /* Ethereal */
+     , (73256,  14, True ) /* GravityStatus */
+     , (73256,  19, True ) /* Attackable */
+     , (73256,  50, True ) /* NeverFailCasting */
+     , (73256,  52, True ) /* AiImmobile */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (73256,   1,       5) /* HeartbeatInterval */
+     , (73256,   2,       0) /* HeartbeatTimestamp */
+     , (73256,   3,     0.6) /* HealthRate */
+     , (73256,   4,     0.5) /* StaminaRate */
+     , (73256,   5,       2) /* ManaRate */
+     , (73256,  13,    0.85) /* ArmorModVsSlash */
+     , (73256,  14,    0.85) /* ArmorModVsPierce */
+     , (73256,  15,       1) /* ArmorModVsBludgeon */
+     , (73256,  16,     0.9) /* ArmorModVsCold */
+     , (73256,  17,       1) /* ArmorModVsFire */
+     , (73256,  18,    0.95) /* ArmorModVsAcid */
+     , (73256,  19,     0.5) /* ArmorModVsElectric */
+     , (73256,  31,      15) /* VisualAwarenessRange */
+     , (73256,  34,     0.9) /* PowerupTime */
+     , (73256,  36,       1) /* ChargeSpeed */
+     , (73256,  39,       2) /* DefaultScale */
+     , (73256,  41,     300) /* RegenerationInterval */
+     , (73256,  43,     1.5) /* GeneratorRadius */
+     , (73256,  64,    0.55) /* ResistSlash */
+     , (73256,  65,    0.55) /* ResistPierce */
+     , (73256,  66,    0.75) /* ResistBludgeon */
+     , (73256,  67,    0.75) /* ResistFire */
+     , (73256,  68,    0.25) /* ResistCold */
+     , (73256,  69,    0.65) /* ResistAcid */
+     , (73256,  70,    0.15) /* ResistElectric */
+     , (73256,  80,       3) /* AiUseMagicDelay */
+     , (73256, 104,      10) /* ObviousRadarRange */
+     , (73256, 122,       2) /* AiAcquireHealth */
+     , (73256, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73256,   1, 'Eyestalk of T''thuun') /* Name */
+     , (73256,  45, 'KillTaskTentacleofTthuun_0908') /* KillQuest */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73256,   1, 0x02001855) /* Setup */
+     , (73256,   2, 0x0900007B) /* MotionTable */
+     , (73256,   3, 0x20000067) /* SoundTable */
+     , (73256,   4, 0x30000024) /* CombatTable */
+     , (73256,   8, 0x06001ED2) /* Icon */
+     , (73256,  22, 0x34000064) /* PhysicsEffectTable */
+     , (73256,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (73256,   1, 340, 0, 0) /* Strength */
+     , (73256,   2, 360, 0, 0) /* Endurance */
+     , (73256,   3, 340, 0, 0) /* Quickness */
+     , (73256,   4, 360, 0, 0) /* Coordination */
+     , (73256,   5, 360, 0, 0) /* Focus */
+     , (73256,   6, 400, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (73256,   1,  1050, 0, 0, 1230) /* MaxHealth */
+     , (73256,   3,   900, 0, 0, 1260) /* MaxStamina */
+     , (73256,   5,   950, 0, 0, 1350) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (73256,  6, 0, 2, 0, 440, 0, 0) /* MeleeDefense        Trained */
+     , (73256,  7, 0, 2, 0, 430, 0, 0) /* MissileDefense      Trained */
+     , (73256, 15, 0, 2, 0, 340, 0, 0) /* MagicDefense        Trained */
+     , (73256, 31, 0, 2, 0, 245, 0, 0) /* CreatureEnchantment Trained */
+     , (73256, 33, 0, 2, 0, 245, 0, 0) /* LifeMagic           Trained */
+     , (73256, 34, 0, 2, 0, 245, 0, 0) /* WarMagic            Trained */
+     , (73256, 45, 0, 2, 0, 350, 0, 0) /* LightWeapons        Trained */
+     , (73256, 47, 0, 2, 0, 220, 0, 0) /* MissileWeapons      Trained */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (73256,  0, 16, 200, 0.75,  470,  235,  235,  235,  235,  235,  235,  235,    0, 1,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Head */
+     , (73256, 23,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* Tentacle */
+     , (73256, 24,  4,  0,    0,  470,  235,  235,  235,  235,  235,  235,  235,    0, 2,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4,  0.4) /* UpperTentacle */
+     , (73256, 25,  4, 200, 0.75,  470,  235,  235,  235,  235,  235,  235,  235,    0, 3,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2,  0.2) /* LowerTentacle */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (73256,  4308,   2.04)  /* Incantation of Harm Other */
+     , (73256,  4489,   2.04)  /* Incantation of Fester Other */
+     , (73256,  4643,   2.04)  /* Incantation of Drain Health Other */
+     , (73256,  4644,   2.05)  /* Incantation of Drain Mana Other */
+     , (73256,  2765,   2.05)  /* Martyr's Hecatomb VI */;
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (73256, 2, 33459,  1, 0, 0, False) /* Create Shadow Bolt (33459) for Wield */;
+
+INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (73256, -1, 38828, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tentacle of T'thuun (38828) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (73256, -1, 38827, 5, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Tendril of T'thuun (38827) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/87827 Altar of T'thuun.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/87827 Altar of T'thuun.sql
@@ -8,7 +8,7 @@ VALUES (87827,   1,         16) /* ItemType - Creature */
      , (87827,   6,         -1) /* ItemsCapacity */
      , (87827,   7,         -1) /* ContainersCapacity */
      , (87827,  16,         32) /* ItemUseable - Remote */
-     , (87827,  81,         10) /* MaxGeneratedObjects */
+     , (87827,  81,          4) /* MaxGeneratedObjects */
      , (87827,  82,          0) /* InitGeneratedObjects */
      , (87827,  93,    6292504) /* PhysicsState - ReportCollisions, IgnoreCollisions, Gravity, ReportCollisionsAsEnvironment, EdgeSlide */
      , (87827,  95,          3) /* RadarBlipColor - White */;
@@ -70,5 +70,7 @@ VALUES (@parent_id,  0,  18 /* DirectBroadcast */, 0, 1, NULL, 'As you touch the
      , (@parent_id,  1,  19 /* CastSpellInstant */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 4725 /* The Pit of Heretics */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87827, -1, 87829, 1, 5, 5, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sclavus Acolyte of T'thuun (87829) (x5 up to max of 5) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87827, -1, 87830, 1, 5, 5, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Olthoi Slasher (87830) (x5 up to max of 5) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87827, -1, 73255, 0, 1, 1, 1, 4, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Wharu Fetish (87826) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (87827, -1, 87832, 10, 1, 1, 1, 4, -1, 0, 0, 0x24C00126, -12, 23, 94.455, 1, 0, 0, 0) /* Generate Roots of Skuld Generator (87832) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (87827, -1, 87832, 10, 1, 1, 1, 4, -1, 0, 0, 0x24C00117, -35, 35, 94.455, 1, 0, 0, 0) /* Generate Roots of Skuld Generator (87832) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */
+     , (87827, -1, 87832, 10, 1, 1, 1, 4, -1, 0, 0, 0x24C00119, -35, 10, 94.455, 1, 0, 0, 0) /* Generate Roots of Skuld Generator (87832) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Specific */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Unsorted/87827.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Unsorted/87827.es
@@ -1,8 +1,9 @@
-Use:
-    - DirectBroadcast: As you touch the altar, you are engulfed by portalspace and hurled into the depths.
-    - CastSpellInstant: 4725
-
 Give: Wharu Fetish (87826)
     - DirectBroadcast: As you place the fetish upon the Altar of T'thuun, you can feel the pulse of power and hear both the commotion of guards coming to stop you and the rapid approach of the Olthoi, drawn to its call.
     - StampQuest: GuardianoftheDeruTrees_FetishHandedIn
     - Generate
+
+Use:
+    - DirectBroadcast: As you touch the altar, you are engulfed by portalspace and hurled into the depths.
+    - CastSpellInstant: 4725 - The Pit of Heretics
+

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/73255 Wharu Fetish.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/73255 Wharu Fetish.sql
@@ -1,0 +1,29 @@
+DELETE FROM `weenie` WHERE `class_Id` = 73255;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (73255, 'ace73255-wharufetish', 1, '2022-01-08 18:29:57') /* Generic */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (73255,   1,        128) /* ItemType - Misc */
+     , (73255,   5,        250) /* EncumbranceVal */
+     , (73255,   8,         10) /* Mass */
+     , (73255,   9,          0) /* ValidLocations - None */
+     , (73255,  16,          1) /* ItemUseable - No */
+     , (73255,  18,         32) /* UiEffects - Fire */
+     , (73255,  19,          0) /* Value */
+     , (73255,  33,          1) /* Bonded - Bonded */
+     , (73255,  93,       3092) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity, LightingOn */
+     , (73255, 114,          1) /* Attuned - Attuned */
+     , (73255, 267,         60) /* Lifespan */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (73255,   1, True ) /* Stuck */
+     , (73255,  24, True ) /* UiHidden */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (73255,   1, 'Wharu Fetish') /* Name */
+     , (73255,  16, 'A fetish of Wharu, crafted by Aun Kimintari from the Royal Olthoi Jelly, a Corrupted Mana Shard, and wood from Timaru''s Akiekie Fire.') /* LongDesc */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (73255,   1, 0x0200186E) /* Setup */
+     , (73255,   8, 0x0600697A) /* Icon */;

--- a/Database/Patches/9 WeenieDefaults/Generic/Misc/87826 Wharu Fetish.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/Misc/87826 Wharu Fetish.sql
@@ -27,5 +27,5 @@ VALUES (87826,   1, 'Wharu Fetish') /* Name */
      , (87826,  16, 'A fetish of Wharu, crafted by Aun Kimintari from the Royal Olthoi Jelly, a Corrupted Mana Shard, and wood from Timaru''s Akiekie Fire.') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (87826,   1, 0x020004B9) /* Setup */
+VALUES (87826,   1, 0x0200186E) /* Setup */
      , (87826,   8, 0x0600697A) /* Icon */;

--- a/Database/Patches/9 WeenieDefaults/Generic/None/87832 Roots of Skuld Generator.sql
+++ b/Database/Patches/9 WeenieDefaults/Generic/None/87832 Roots of Skuld Generator.sql
@@ -1,12 +1,14 @@
 DELETE FROM `weenie` WHERE `class_Id` = 87832;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (87832, 'ace87832-rootsofskuldgenerator', 1, '2022-01-08 18:29:57') /* Generic */;
+VALUES (87832, 'ace87832-rootsofskuldgenerator', 1, '2025-07-19 02:03:22') /* Generic */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
-VALUES (87832,  81,          1) /* MaxGeneratedObjects */
-     , (87832,  82,          1) /* InitGeneratedObjects */
-     , (87832,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+VALUES (87832,  81,          8) /* MaxGeneratedObjects */
+     , (87832,  82,          0) /* InitGeneratedObjects */
+     , (87832,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (87832, 103,          2) /* GeneratorDestructionType - Destroy */
+     , (87832, 267,         60) /* Lifespan */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (87832,   1, True ) /* Stuck */
@@ -14,8 +16,8 @@ VALUES (87832,   1, True ) /* Stuck */
      , (87832,  18, True ) /* Visibility */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
-VALUES (87832,  41,     300) /* RegenerationInterval */
-     , (87832,  43,       1) /* GeneratorRadius */;
+VALUES (87832,  41,       0) /* RegenerationInterval */
+     , (87832,  43,       5) /* GeneratorRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (87832,   1, 'Roots of Skuld Generator') /* Name */;
@@ -24,8 +26,18 @@ INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (87832,   1, 0x0200026B) /* Setup */
      , (87832,   8, 0x06001066) /* Icon */;
 
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (87832,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,  72 /* Generate */, 5, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (87832, 0.25, 35147, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Olthoi Larvae (35147) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87832, 0.5, 35149, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Olthoi Ripper (35149) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87832, 0.75, 35150, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Olthoi Slasher (35150) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
-     , (87832, 1, 38412, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sclavus Acolyte of T'thuun (38412) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;
+VALUES (87832, -1, 73256, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Eyestalk of T'thuun (38826) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87832, -1, 38875, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sclavus Acolyte of T'thuun (38875) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87832, -1, 38876, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sclavus Acolyte of T'thuun (38876) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87832, -1, 38877, 1, 1, 1, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Sclavus Acolyte of T'thuun (38877) (x1 up to max of 1) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87832, -1, 35149, 1, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Olthoi Ripper (35149) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */
+     , (87832, -1, 35150, 1, 2, 2, 1, 2, -1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Olthoi Slasher (35150) (x2 up to max of 2) - Regenerate upon Destruction - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Portal/Portal/87828 Roots of Skuld, Urd and Verdandi.sql
+++ b/Database/Patches/9 WeenieDefaults/Portal/Portal/87828 Roots of Skuld, Urd and Verdandi.sql
@@ -6,7 +6,7 @@ VALUES (87828, 'ace87828-rootsofskuldurdandverdandi', 7, '2022-01-08 18:29:57') 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (87828,   1,      65536) /* ItemType - Portal */
      , (87828,  16,         32) /* ItemUseable - Remote */
-     , (87828,  86,         90) /* MinLevel */
+     , (87828,  86,        150) /* MinLevel */
      , (87828,  93,       3084) /* PhysicsState - Ethereal, ReportCollisions, Gravity, LightingOn */
      , (87828, 111,         17) /* PortalBitmask - Unrestricted, NoSummon */
      , (87828, 133,          4) /* ShowableOnRadar - ShowAlways */;
@@ -22,8 +22,8 @@ VALUES (87828,   1, 'Roots of Skuld, Urd and Verdandi') /* Name */
      , (87828,  37, 'GuardianoftheDeruTrees_Flag') /* QuestRestriction */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
-VALUES (87828,   1, 0x020001B3) /* Setup */
-     , (87828,   2, 0x09000003) /* MotionTable */
+VALUES (87828,   1, 0x02001698) /* Setup */
+     , (87828,   2, 0x09000172) /* MotionTable */
      , (87828,   8, 0x0600106B) /* Icon */;
 
 INSERT INTO `weenie_properties_position` (`object_Id`, `position_Type`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)


### PR DESCRIPTION
Updates the quest: https://acpedia.org/wiki/Guardian_of_the_Deru_Trees_of_Marae_Lassel

Revises dungeon spawns for a closer match to retail (sclavus in areas with olthoi corpses, olthoi in organic areas).

All tentacles of tthuun outside now count for the kill task (not just those with tentacle in the name) as seen in retail screenshots.

Corrects spells, armor levels, and skills of the tentacles to match the pcap, wiki, and screenshots.

Removed weight of the world from eyestalks (this was limited to eyestalks on moar city, and the tthuun boss fight).

Added missing wharu fetish effect to the tthuun altar (fetish spawns above the altar) as seen in retail screenshots.

Revised the final scene (where olthoi, tentacles, and sclavus fight each other) to match retail screenshot.

Corrected appearance of the dungeon portal to match teaser screenshot.