### PR TITLE
update plateau village transit

### DIFF
--- a/Database/Patches/6 LandBlockExtendedData/4198.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4198.sql
@@ -57,7 +57,7 @@ VALUES (0x7419801C,   412, 0x41980120, 149.592, 85.4684, 140.082, -0.707107, 0, 
 /* @teleloc 0x41980120 [149.591995 85.468399 140.082001] -0.707107 0.000000 0.000000 -0.707107 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x7419801D,  1154, 0x41980133, 179.28, 109.164, 140.005, -0.687348, 0, 0, 0.726328, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator */
+VALUES (0x7419801D,  7924, 0x41980133, 179.28, 109.164, 140.005, -0.687348, 0, 0, 0.726328, False, '2021-11-01 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
 /* @teleloc 0x41980133 [179.279999 109.164001 140.005005] -0.687348 0.000000 0.000000 0.726328 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
@@ -408,7 +408,7 @@ VALUES (0x74198062, 32768, 0x41980029, 143.752, 5.92835, 140.006, 0.025938, 0, 0
 /* @teleloc 0x41980029 [143.751999 5.928350 140.005997] 0.025938 0.000000 0.000000 0.999663 */
 
 INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
-VALUES (0x74198063,  1542, 0x4198011D, 152.124, 81.9055, 140.07, 0.221268, 0, 0, -0.975213, False, '2021-11-01 00:00:00'); /* Linkable Item Generator */
+VALUES (0x74198063,  5085, 0x4198011D, 152.124, 81.9055, 140.07, 0.221268, 0, 0, -0.975213, False, '2021-11-01 00:00:00'); /* Linkable Item Gen - 25 seconds */
 /* @teleloc 0x4198011D [152.123993 81.905502 140.070007] 0.221268 0.000000 0.000000 -0.975213 */
 
 INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)

--- a/Database/Patches/6 LandBlockExtendedData/4298.sql
+++ b/Database/Patches/6 LandBlockExtendedData/4298.sql
@@ -1,0 +1,57 @@
+DELETE FROM `landblock_instance` WHERE `landblock` = 0x4298;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298001,  7924, 0x42980010, 30.4437, 171.5, 138.931, -0.690883, 0, 0, 0.722967, False, '2019-02-10 00:00:00'); /* Linkable Monster Generator ( 5 Min.) */
+/* @teleloc 0x42980010 [30.443701 171.500000 138.931000] -0.690883 0.000000 0.000000 0.722967 */
+
+INSERT INTO `landblock_instance_link` (`parent_GUID`, `child_GUID`, `last_Modified`)
+VALUES (0x74298001, 0x74298002, '2019-02-10 00:00:00') /* Mercenary (11504) */
+     , (0x74298001, 0x74298003, '2019-02-10 00:00:00') /* Mercenary Mage (32699) */
+     , (0x74298001, 0x74298004, '2019-02-10 00:00:00') /* Mercenary (11504) */
+     , (0x74298001, 0x74298005, '2019-02-10 00:00:00') /* Mercenary (11504) */
+     , (0x74298001, 0x74298006, '2019-02-10 00:00:00') /* Mercenary (11504) */
+     , (0x74298001, 0x74298007, '2019-02-10 00:00:00') /* Mercenary Mage (32699) */
+     , (0x74298001, 0x74298008, '2019-02-10 00:00:00') /* Mercenary Mage (32699) */
+     , (0x74298001, 0x74298009, '2019-02-10 00:00:00') /* Viamontian Footman (32768) */
+     , (0x74298001, 0x7429800A, '2019-02-10 00:00:00') /* Viamontian Footman (32768) */
+     , (0x74298001, 0x7429800B, '2019-02-10 00:00:00') /* Viamontian Footman (32768) */;
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298002, 11504, 0x42980010, 30.4437, 171.5, 138.931, -0.690883, 0, 0, 0.722967,  True, '2019-02-10 00:00:00'); /* Mercenary */
+/* @teleloc 0x42980010 [30.443701 171.500000 138.931000] -0.690883 0.000000 0.000000 0.722967 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298003, 32699, 0x42980010, 27.9443, 170.417, 139.348, -0.672594, 0, 0, 0.740011,  True, '2019-02-10 00:00:00'); /* Mercenary Mage */
+/* @teleloc 0x42980010 [27.944300 170.417007 139.348007] -0.672594 0.000000 0.000000 0.740011 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298004, 11504, 0x4298000F, 30.0833, 160.348, 138.991, -0.690883, 0, 0, 0.722967,  True, '2019-02-10 00:00:00'); /* Mercenary */
+/* @teleloc 0x4298000F [30.083300 160.348007 138.990997] -0.690883 0.000000 0.000000 0.722967 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298005, 11504, 0x4298000F, 30.2862, 164.103, 138.957, -0.690883, 0, 0, 0.722967,  True, '2019-02-10 00:00:00'); /* Mercenary */
+/* @teleloc 0x4298000F [30.286200 164.102997 138.957001] -0.690883 0.000000 0.000000 0.722967 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298006, 11504, 0x4298000F, 30.4953, 168, 138.922, -0.690883, 0, 0, 0.722967,  True, '2019-02-10 00:00:00'); /* Mercenary */
+/* @teleloc 0x4298000F [30.495300 168.000000 138.921997] -0.690883 0.000000 0.000000 0.722967 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298007, 32699, 0x4298000F, 27.6809, 166.201, 139.391, -0.672594, 0, 0, 0.740011,  True, '2019-02-10 00:00:00'); /* Mercenary Mage */
+/* @teleloc 0x4298000F [27.680901 166.201004 139.391006] -0.672594 0.000000 0.000000 0.740011 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298008, 32699, 0x4298000F, 27.0321, 161.612, 139.5, -0.690883, 0, 0, 0.722967,  True, '2019-02-10 00:00:00'); /* Mercenary Mage */
+/* @teleloc 0x4298000F [27.032101 161.612000 139.500000] -0.690883 0.000000 0.000000 0.722967 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x74298009, 32768, 0x42980008, 18.7451, 174.03, 140.006, 0.039163, 0, 0, 0.999233,  True, '2019-02-10 00:00:00'); /* Viamontian Footman */
+/* @teleloc 0x42980008 [18.745100 174.029999 140.005997] 0.039163 0.000000 0.000000 0.999233 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7429800A, 32768, 0x42980007, 18.4655, 161.669, 140.006, -0.99995, 0, 0, 0.009969,  True, '2019-02-10 00:00:00'); /* Viamontian Footman */
+/* @teleloc 0x42980007 [18.465500 161.669006 140.005997] -0.999950 0.000000 0.000000 0.009969 */
+
+INSERT INTO `landblock_instance` (`guid`, `weenie_Class_Id`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`, `is_Link_Child`, `last_Modified`)
+VALUES (0x7429800B, 32768, 0x42980007, 20.9277, 167.712, 140.006, -0.695201, 0, 0, 0.718815,  True, '2019-02-10 00:00:00'); /* Viamontian Footman */
+/* @teleloc 0x42980007 [20.927700 167.712006 140.005997] -0.695201 0.000000 0.000000 0.718815 */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/11504 Mercenary.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/11504 Mercenary.sql
@@ -18,7 +18,8 @@ VALUES (11504,   1,         16) /* ItemType - Creature */
      , (11504, 113,          1) /* Gender - Male */
      , (11504, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (11504, 146,      30000) /* XpOverride */
-     , (11504, 188,          1) /* HeritageGroup - Aluvian */;
+     , (11504, 188,          1) /* HeritageGroup - Aluvian */
+     , (11504, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (11504,   1, True ) /* Stuck */

--- a/Database/Patches/9 WeenieDefaults/Creature/Human/32699 Mercenary Mage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Human/32699 Mercenary Mage.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 32699;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (32699, 'ace32699-mercenarymage', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (32699, 'ace32699-mercenarymage', 10, '2025-07-26 09:18:38') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32699,   1,         16) /* ItemType - Creature */
@@ -18,7 +18,8 @@ VALUES (32699,   1,         16) /* ItemType - Creature */
      , (32699, 113,          1) /* Gender - Male */
      , (32699, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (32699, 146,      30000) /* XpOverride */
-     , (32699, 188,          1) /* HeritageGroup - Aluvian */;
+     , (32699, 188,          1) /* HeritageGroup - Aluvian */
+     , (32699, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32699,   1, True ) /* Stuck */
@@ -438,50 +439,45 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (32699,  6, 0, 3, 0, 210, 0, 0) /* MeleeDefense        Specialized */
      , (32699,  7, 0, 3, 0, 315, 0, 0) /* MissileDefense      Specialized */
      , (32699, 15, 0, 3, 0, 210, 0, 0) /* MagicDefense        Specialized */
-     , (32699, 20, 0, 3, 0, 150, 0, 0) /* Deception           Specialized */
+     , (32699, 20, 0, 3, 0,  40, 0, 0) /* Deception           Specialized */
      , (32699, 24, 0, 3, 0,   5, 0, 0) /* Run                 Specialized */
-     , (32699, 31, 0, 3, 0,  95, 0, 0) /* CreatureEnchantment Specialized */
-     , (32699, 33, 0, 3, 0,  95, 0, 0) /* LifeMagic           Specialized */
-     , (32699, 34, 0, 3, 0,  95, 0, 0) /* WarMagic            Specialized */
-     , (32699, 44, 0, 3, 0, 160, 0, 0) /* HeavyWeapons        Specialized */
-     , (32699, 45, 0, 3, 0, 160, 0, 0) /* LightWeapons        Specialized */
-     , (32699, 46, 0, 3, 0, 160, 0, 0) /* FinesseWeapons      Specialized */
+     , (32699, 31, 0, 3, 0, 125, 0, 0) /* CreatureEnchantment Specialized */
+     , (32699, 33, 0, 3, 0, 125, 0, 0) /* LifeMagic           Specialized */
+     , (32699, 34, 0, 3, 0, 125, 0, 0) /* WarMagic            Specialized */
+     , (32699, 44, 0, 3, 0, 220, 0, 0) /* HeavyWeapons        Specialized */
+     , (32699, 45, 0, 3, 0, 220, 0, 0) /* LightWeapons        Specialized */
+     , (32699, 46, 0, 3, 0, 220, 0, 0) /* FinesseWeapons      Specialized */
      , (32699, 47, 0, 3, 0, 170, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32699,  0,  4,  0,    0,  260,  231,  260,  286,  104,  104,  260,  156,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32699,  1,  4,  0,    0,  250,  223,  250,  275,  100,  100,  250,  150,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32699,  2,  4,  0,    0,  250,  223,  250,  275,  100,  100,  250,  150,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32699,  3,  4,  0,    0,  240,  214,  240,  264,   96,   96,  240,  144,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32699,  4,  4,  0,    0,  240,  214,  240,  264,   96,   96,  240,  144,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32699,  5,  4,  2, 0.75,  240,  214,  240,  264,   96,   96,  240,  144,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32699,  6,  4,  0,    0,  260,  231,  260,  286,  104,  104,  260,  156,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32699,  7,  4,  0,    0,  250,  223,  250,  275,  100,  100,  250,  150,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32699,  8,  4,  2, 0.75,  245,  218,  245,  270,   98,   98,  245,  147,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32699,  0,  4,  0,    0,  260,  130,  130,  130,  130,  130,  130,  130,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32699,  1,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32699,  2,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32699,  3,  4,  0,    0,  240,  120,  120,  120,  120,  120,  120,  120,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32699,  4,  4,  0,    0,  240,  120,  120,  120,  120,  120,  120,  120,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32699,  5,  4,  2, 0.75,  240,  120,  120,  120,  120,  120,  120,  120,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32699,  6,  4,  0,    0,  260,  130,  130,  130,  130,  130,  130,  130,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32699,  7,  4,  0,    0,  250,  125,  125,  125,  125,  125,  125,  125,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32699,  8,  4,  2, 0.75,  245,  122,  122,  122,  122,  122,  122,  122,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (32699,    61,   2.01)  /* Acid Stream IV */
-     , (32699,    67,   2.01)  /* Shock Wave IV */
-     , (32699,    72,   2.01)  /* Frost Bolt IV */
-     , (32699,    78,   2.01)  /* Lightning Bolt IV */
-     , (32699,    83,   2.01)  /* Flame Bolt IV */
-     , (32699,    89,   2.01)  /* Force Bolt IV */
-     , (32699,    95,   2.01)  /* Whirling Blade IV */
-     , (32699,   128,   2.01)  /* Acid Volley IV */
-     , (32699,   136,   2.01)  /* Frost Volley IV */
-     , (32699,   140,   2.01)  /* Lightning Volley IV */
-     , (32699,   144,   2.01)  /* Flame Volley IV */
-     , (32699,   168,  2.025)  /* Regeneration Self IV */
-     , (32699,   174,  2.011)  /* Fester Other IV */
-     , (32699,  1240,  2.025)  /* Drain Health Other IV */
-     , (32699,  1252,  2.025)  /* Drain Stamina Other IV */
-     , (32699,  1263,  2.025)  /* Drain Mana Other IV */
-     , (32699,  1341,  2.011)  /* Weakness Other IV */
-     , (32699,  1370,  2.011)  /* Frailty Other IV */
-     , (32699,  1394,  2.011)  /* Clumsiness Other IV */
-     , (32699,  1418,  2.011)  /* Slowness Other IV */
-     , (32699,  1442,  2.011)  /* Bafflement Other IV */
-     , (32699,  1466,  2.011)  /* Feeblemind Other IV */;
+VALUES (32699,    61,   2.04)  /* Acid Stream IV */
+     , (32699,    67,   2.04)  /* Shock Wave IV */
+     , (32699,    72,   2.04)  /* Frost Bolt IV */
+     , (32699,    78,   2.05)  /* Lightning Bolt IV */
+     , (32699,    83,   2.05)  /* Flame Bolt IV */
+     , (32699,    89,   2.05)  /* Force Bolt IV */
+     , (32699,    95,   2.05)  /* Whirling Blade IV */
+     , (32699,   524,   2.04)  /* Acid Vulnerability Other IV */
+     , (32699,  1051,   2.04)  /* Bludgeoning Vulnerability Other IV */
+     , (32699,  1325,   2.05)  /* Imperil Other IV */
+     , (32699,   232,   2.04)  /* Vulnerability Other IV */
+     , (32699,  1106,   2.05)  /* Fire Vulnerability Other IV */
+     , (32699,   283,   2.05)  /* Magic Yield Other IV */
+     , (32699,  1087,   2.06)  /* Lightning Vulnerability Other IV */
+     , (32699,  1154,   2.06)  /* Piercing Vulnerability Other IV */
+     , (32699,  1130,   2.07)  /* Blade Vulnerability Other IV */
+     , (32699,  1063,   2.07)  /* Cold Vulnerability Other IV */;
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
 VALUES (32699, 9,  6876,  0, 0, 0.02, False) /* Create Sturdy Iron Key (6876) for ContainTreasure */

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32700 Viamontian Portal Mage.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32700 Viamontian Portal Mage.sql
@@ -1,7 +1,7 @@
 DELETE FROM `weenie` WHERE `class_Id` = 32700;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (32700, 'ace32700-viamontianportalmage', 10, '2024-05-26 19:09:10') /* Creature */;
+VALUES (32700, 'ace32700-viamontianportalmage', 10, '2025-07-26 08:43:00') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (32700,   1,         16) /* ItemType - Creature */
@@ -20,7 +20,8 @@ VALUES (32700,   1,         16) /* ItemType - Creature */
      , (32700, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (32700, 140,          1) /* AiOptions - CanOpenDoors */
      , (32700, 146,      31500) /* XpOverride */
-     , (32700, 188,          4) /* HeritageGroup - Viamontian */;
+     , (32700, 188,          4) /* HeritageGroup - Viamontian */
+     , (32700, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32700,   1, True ) /* Stuck */;
@@ -85,34 +86,35 @@ VALUES (32700,   1,   350, 0, 0, 430) /* MaxHealth */
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
 VALUES (32700,  6, 0, 3, 0, 225, 0, 0) /* MeleeDefense        Specialized */
-     , (32700,  7, 0, 3, 0, 285, 0, 0) /* MissileDefense      Specialized */
+     , (32700,  7, 0, 3, 0, 330, 0, 0) /* MissileDefense      Specialized */
      , (32700, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
      , (32700, 33, 0, 3, 0, 235, 0, 0) /* LifeMagic           Specialized */
      , (32700, 34, 0, 3, 0, 200, 0, 0) /* WarMagic            Specialized */
-     , (32700, 44, 0, 3, 0, 255, 0, 0) /* HeavyWeapons        Specialized */
-     , (32700, 45, 0, 3, 0, 255, 0, 0) /* LightWeapons        Specialized */
-     , (32700, 46, 0, 3, 0, 215, 0, 0) /* FinesseWeapons      Specialized */
-     , (32700, 47, 0, 3, 0, 160, 0, 0) /* MissileWeapons      Specialized */;
+     , (32700, 44, 0, 3, 0, 240, 0, 0) /* HeavyWeapons        Specialized */
+     , (32700, 45, 0, 3, 0, 240, 0, 0) /* LightWeapons        Specialized */
+     , (32700, 46, 0, 3, 0, 225, 0, 0) /* FinesseWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32700,  0,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32700,  1,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32700,  2,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32700,  3,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32700,  4,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32700,  5,  4, 115,  0.4,  490,  588,  588,  490,  490,  392,  490,  392,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32700,  6,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32700,  7,  4,  0,    0,  490,  588,  588,  490,  490,  392,  490,  392,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32700,  8,  4, 115,  0.4,  490,  588,  588,  490,  490,  392,  490,  392,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32700,  0,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32700,  1,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32700,  2,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32700,  3,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32700,  4,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32700,  5,  4, 115,  0.4,  450,  225,  225,  225,  225,  225,  225,  225,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32700,  6,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32700,  7,  4,  0,    0,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32700,  8,  4, 115,  0.4,  300,  150,  150,  150,  150,  150,  150,  150,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (32700,   113,   2.42)  /* Lightning Blast V */
-     , (32700,   121,   2.42)  /* Force Blast V */
-     , (32700,   125,   2.42)  /* Blade Blast V */
-     , (32700,   153,   2.42)  /* Blade Volley V */
-     , (32700,  1051,   2.42)  /* Bludgeoning Vulnerability Other IV */
-     , (32700,  1087,   2.42)  /* Lightning Vulnerability Other IV */
-     , (32700,  1154,   2.42)  /* Piercing Vulnerability Other IV */;
+VALUES (32700,   113,    2.1)  /* Lightning Blast V */
+     , (32700,   121,   2.11)  /* Force Blast V */
+     , (32700,   125,   2.12)  /* Blade Blast V */
+     , (32700,   153,   2.14)  /* Blade Volley V */
+     , (32700,  1051,   2.08)  /* Bludgeoning Vulnerability Other IV */
+     , (32700,  1087,   2.09)  /* Lightning Vulnerability Other IV */
+     , (32700,  1154,    2.1)  /* Piercing Vulnerability Other IV */
+     , (32700,  1130,   2.11)  /* Blade Vulnerability Other IV */
+     , (32700,   232,   2.12)  /* Vulnerability Other IV */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (32700,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32702 Captain Vietre Lasallia.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32702 Captain Vietre Lasallia.sql
@@ -19,7 +19,8 @@ VALUES (32702,   1,         16) /* ItemType - Creature */
      , (32702, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (32702, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (32702, 140,          1) /* AiOptions - CanOpenDoors */
-     , (32702, 146,      30000) /* XpOverride */;
+     , (32702, 146,      30000) /* XpOverride */
+     , (32702, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32702,   1, True ) /* Stuck */

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32767 Viamontian Footman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32767 Viamontian Footman.sql
@@ -1,0 +1,159 @@
+DELETE FROM `weenie` WHERE `class_Id` = 32767;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (32767, 'ace32767-viamontianfootman', 10, '2019-02-10 00:00:00') /* Creature */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (32767,   1,         16) /* ItemType - Creature */
+     , (32767,   2,         83) /* CreatureType - ViamontianKnight */
+     , (32767,   3,         38) /* PaletteTemplate - LightSilverMetal */
+     , (32767,   6,         -1) /* ItemsCapacity */
+     , (32767,   7,         -1) /* ContainersCapacity */
+     , (32767,  16,          1) /* ItemUseable - No */
+     , (32767,  25,         60) /* Level */
+     , (32767,  27,          0) /* ArmorType - None */
+     , (32767,  40,          2) /* CombatMode - Melee */
+     , (32767,  68,          9) /* TargetingTactic - Random, TopDamager */
+     , (32767,  72,         83) /* FriendType - ViamontianKnight */
+     , (32767,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
+     , (32767, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (32767, 133,          2) /* ShowableOnRadar - ShowMovement */
+     , (32767, 140,          1) /* AiOptions - CanOpenDoors */
+     , (32767, 146,      30000) /* XpOverride */
+     , (32767, 307,          5) /* DamageRating */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (32767,   1, True ) /* Stuck */
+     , (32767,  12, True ) /* ReportCollisions */
+     , (32767,  14, True ) /* GravityStatus */
+     , (32767,  19, True ) /* Attackable */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (32767,   1,       5) /* HeartbeatInterval */
+     , (32767,   2,       0) /* HeartbeatTimestamp */
+     , (32767,   3,   0.067) /* HealthRate */
+     , (32767,   4,       3) /* StaminaRate */
+     , (32767,   5,       1) /* ManaRate */
+     , (32767,  12,       0) /* Shade */
+     , (32767,  13,     1.2) /* ArmorModVsSlash */
+     , (32767,  14,     1.2) /* ArmorModVsPierce */
+     , (32767,  15,       1) /* ArmorModVsBludgeon */
+     , (32767,  16,       1) /* ArmorModVsCold */
+     , (32767,  17,     0.8) /* ArmorModVsFire */
+     , (32767,  18,       1) /* ArmorModVsAcid */
+     , (32767,  19,     0.8) /* ArmorModVsElectric */
+     , (32767,  31,      24) /* VisualAwarenessRange */
+     , (32767,  34,       1) /* PowerupTime */
+     , (32767,  36,       1) /* ChargeSpeed */
+     , (32767,  39,     1.2) /* DefaultScale */
+     , (32767,  64,     0.8) /* ResistSlash */
+     , (32767,  65,     0.8) /* ResistPierce */
+     , (32767,  66,     0.9) /* ResistBludgeon */
+     , (32767,  67,     1.2) /* ResistFire */
+     , (32767,  68,     0.9) /* ResistCold */
+     , (32767,  69,     0.9) /* ResistAcid */
+     , (32767,  70,     1.2) /* ResistElectric */
+     , (32767,  71,       1) /* ResistHealthBoost */
+     , (32767,  72,       1) /* ResistStaminaDrain */
+     , (32767,  73,       1) /* ResistStaminaBoost */
+     , (32767,  74,       1) /* ResistManaDrain */
+     , (32767,  75,       1) /* ResistManaBoost */
+     , (32767, 104,      10) /* ObviousRadarRange */
+     , (32767, 125,       1) /* ResistHealthDrain */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (32767,   1, 'Viamontian Footman') /* Name */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (32767,   1, 0x02001255) /* Setup */
+     , (32767,   2, 0x09000186) /* MotionTable */
+     , (32767,   3, 0x200000BE) /* SoundTable */
+     , (32767,   4, 0x30000000) /* CombatTable */
+     , (32767,   6, 0x040019CC) /* PaletteBase */
+     , (32767,   7, 0x100005AB) /* ClothingBase */
+     , (32767,   8, 0x060036FB) /* Icon */
+     , (32767,  22, 0x34000025) /* PhysicsEffectTable */
+     , (32767,  35,        448) /* DeathTreasureType - Loot Tier: 4 */;
+
+INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
+VALUES (32767,   1, 260, 0, 0) /* Strength */
+     , (32767,   2, 230, 0, 0) /* Endurance */
+     , (32767,   3, 220, 0, 0) /* Quickness */
+     , (32767,   4, 230, 0, 0) /* Coordination */
+     , (32767,   5,  70, 0, 0) /* Focus */
+     , (32767,   6,  70, 0, 0) /* Self */;
+
+INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
+VALUES (32767,   1,   220, 0, 0, 335) /* MaxHealth */
+     , (32767,   3,   160, 0, 0, 390) /* MaxStamina */
+     , (32767,   5,     0, 0, 0, 70) /* MaxMana */;
+
+INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
+VALUES (32767,  6, 0, 3, 0, 195, 0, 0) /* MeleeDefense        Specialized */
+     , (32767,  7, 0, 2, 0, 320, 0, 0) /* MissileDefense      Trained */
+     , (32767, 15, 0, 3, 0, 234, 0, 0) /* MagicDefense        Specialized */
+     , (32767, 41, 0, 3, 0, 190, 0, 0) /* TwoHandedCombat     Specialized */
+     , (32767, 44, 0, 3, 0, 190, 0, 0) /* HeavyWeapons        Specialized */
+     , (32767, 45, 0, 3, 0, 190, 0, 0) /* LightWeapons        Specialized */
+     , (32767, 46, 0, 3, 0, 200, 0, 0) /* FinesseWeapons      Specialized */
+     , (32767, 47, 0, 3, 0, 160, 0, 0) /* MissileWeapons      Specialized */;
+
+INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
+VALUES (32767,  0,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32767,  1,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32767,  2,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32767,  3,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32767,  4,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32767,  5,  4, 50,  0.4,  250,  432,  432,  360,  360,  288,  360,  288,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32767,  6,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32767,  7,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32767,  8,  4, 50,  0.4,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (32767,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (32767,  5 /* HeartBeat */,   0.03, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (32767,  5 /* HeartBeat */,   0.05, NULL, 0x8000003E /* SwordCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (32767,  5 /* HeartBeat */,  0.025, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000052 /* Twitch2 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
+VALUES (32767,  5 /* HeartBeat */,   0.03, NULL, 0x8000003D /* NonCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
+
+SET @parent_id = LAST_INSERT_ID();
+
+INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
+VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000051 /* Twitch1 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
+VALUES (32767, 9, 40522,  0, 0, 0.01, False) /* Create Contact Instructions (40522) for ContainTreasure */
+     , (32767, 9, 40523,  0, 0, 0.01, False) /* Create Contact Instructions (40523) for ContainTreasure */
+     , (32767, 9, 40524,  0, 0, 0.01, False) /* Create Contact Instructions (40524) for ContainTreasure */
+     , (32767, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */
+     , (32767, 10, 29977,  1, 0, 0.25, False) /* Create Spadone (29977) for WieldTreasure */
+     , (32767, 10, 29981, -1, 0, 0.25, False) /* Create Throwing Axe (29981) for WieldTreasure */
+     , (32767, 10, 29967,  1, 0, 0.5, False) /* Create Quadrelle (29967) for WieldTreasure */;

--- a/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32768 Viamontian Footman.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/ViamontianKnight/32768 Viamontian Footman.sql
@@ -19,13 +19,15 @@ VALUES (32768,   1,         16) /* ItemType - Creature */
      , (32768, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
      , (32768, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (32768, 140,          1) /* AiOptions - CanOpenDoors */
-     , (32768, 146,      30000) /* XpOverride */;
+     , (32768, 146,      30000) /* XpOverride */
+     , (32768, 307,          5) /* DamageRating */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (32768,   1, True ) /* Stuck */
      , (32768,  12, True ) /* ReportCollisions */
      , (32768,  14, True ) /* GravityStatus */
-     , (32768,  19, True ) /* Attackable */;
+     , (32768,  19, True ) /* Attackable */
+     , (32768,  42, True ) /* AllowEdgeSlide */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (32768,   1,       5) /* HeartbeatInterval */
@@ -91,22 +93,22 @@ INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s
 VALUES (32768,  6, 0, 3, 0, 195, 0, 0) /* MeleeDefense        Specialized */
      , (32768,  7, 0, 2, 0, 320, 0, 0) /* MissileDefense      Trained */
      , (32768, 15, 0, 3, 0, 234, 0, 0) /* MagicDefense        Specialized */
-     , (32768, 41, 0, 3, 0, 225, 0, 0) /* TwoHandedCombat     Specialized */
-     , (32768, 44, 0, 3, 0, 225, 0, 0) /* HeavyWeapons        Specialized */
-     , (32768, 45, 0, 3, 0, 225, 0, 0) /* LightWeapons        Specialized */
-     , (32768, 46, 0, 3, 0, 239, 0, 0) /* FinesseWeapons      Specialized */
+     , (32768, 41, 0, 3, 0, 190, 0, 0) /* TwoHandedCombat     Specialized */
+     , (32768, 44, 0, 3, 0, 190, 0, 0) /* HeavyWeapons        Specialized */
+     , (32768, 45, 0, 3, 0, 190, 0, 0) /* LightWeapons        Specialized */
+     , (32768, 46, 0, 3, 0, 200, 0, 0) /* FinesseWeapons      Specialized */
      , (32768, 47, 0, 3, 0, 160, 0, 0) /* MissileWeapons      Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (32768,  0,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (32768,  1,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (32768,  2,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (32768,  3,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (32768,  4,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (32768,  5,  4, 50,  0.4,  360,  432,  432,  360,  360,  288,  360,  288,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (32768,  6,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (32768,  7,  4,  0,    0,  360,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (32768,  8,  4, 50,  0.4,  360,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (32768,  0,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (32768,  1,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (32768,  2,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (32768,  3,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (32768,  4,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (32768,  5,  4, 50,  0.4,  250,  432,  432,  360,  360,  288,  360,  288,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (32768,  6,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (32768,  7,  4,  0,    0,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (32768,  8,  4, 50,  0.4,  250,  432,  432,  360,  360,  288,  360,  288,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (32768,  5 /* HeartBeat */,  0.025, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Adds missing mob 32767 Viamontian Footman.

Adjusts mob armor levels, skills, spells and missing damage rating based on the pcap.

Replaces the default monster and item gens with 5 min and 25 sec gens, respectively.

Adds missing spawns in landblock 4298.