### PR TITLE
Heritage Masks - Add heritage requirement, remove skill requirements

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/08204 King's Helm.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/08204 King's Helm.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8204;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8204, 'regaliaaluvian', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8204,   1,          2) /* ItemType - Armor */
+     , (8204,   3,          4) /* PaletteTemplate - Brown */
+     , (8204,   4,      16384) /* ClothingPriority - Head */
+     , (8204,   5,        800) /* EncumbranceVal */
+     , (8204,   8,         75) /* Mass */
+     , (8204,   9,          1) /* ValidLocations - HeadWear */
+     , (8204,  16,          1) /* ItemUseable - No */
+     , (8204,  18,          1) /* UiEffects - Magical */
+     , (8204,  19,       2000) /* Value */
+     , (8204,  27,          2) /* ArmorType - Leather */
+     , (8204,  28,        230) /* ArmorLevel */
+     , (8204,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (8204, 106,        200) /* ItemSpellcraft */
+     , (8204, 107,        200) /* ItemCurMana */
+     , (8204, 108,        200) /* ItemMaxMana */
+     , (8204, 109,          0) /* ItemDifficulty */
+     , (8204, 150,        103) /* HookPlacement - Hook */
+     , (8204, 151,          2) /* HookType - Wall */
+     , (8204, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8204,  22, True ) /* Inscribable */
+     , (8204,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8204,   5,  -0.033) /* ManaRate */
+     , (8204,  12,    0.66) /* Shade */
+     , (8204,  13,     1.4) /* ArmorModVsSlash */
+     , (8204,  14,     1.2) /* ArmorModVsPierce */
+     , (8204,  15,     1.4) /* ArmorModVsBludgeon */
+     , (8204,  16,     1.2) /* ArmorModVsCold */
+     , (8204,  17,     1.2) /* ArmorModVsFire */
+     , (8204,  18,     1.4) /* ArmorModVsAcid */
+     , (8204,  19,       1) /* ArmorModVsElectric */
+     , (8204, 110,       1) /* BulkMod */
+     , (8204, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8204,   1, 'King''s Helm') /* Name */
+     , (8204,  16, 'A finely crafted mask with the features of the legendary high king Pwyll upon it. It is a testament to the skill of its maker -- the features almost look life-like, and it is a comfortable fit on your head.') /* LongDesc */
+     , (8204,  19, 'Aluvian') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8204,   1, 0x0200097C) /* Setup */
+     , (8204,   3, 0x20000014) /* SoundTable */
+     , (8204,   6, 0x0400007E) /* PaletteBase */
+     , (8204,   7, 0x1000026E) /* ClothingBase */
+     , (8204,   8, 0x06001E9C) /* Icon */
+     , (8204,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (8204,   325,      2)  /* Finesse Weapon Mastery Self IV */
+     , (8204,   247,      2)  /* Invulnerability Self IV */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/08205 Shadow's Garb.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/08205 Shadow's Garb.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8205;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8205, 'regaliagharundim', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8205,   1,          2) /* ItemType - Armor */
+     , (8205,   3,          4) /* PaletteTemplate - Brown */
+     , (8205,   4,      16384) /* ClothingPriority - Head */
+     , (8205,   5,        600) /* EncumbranceVal */
+     , (8205,   8,         75) /* Mass */
+     , (8205,   9,          1) /* ValidLocations - HeadWear */
+     , (8205,  16,          1) /* ItemUseable - No */
+     , (8205,  18,          1) /* UiEffects - Magical */
+     , (8205,  19,       2000) /* Value */
+     , (8205,  27,          2) /* ArmorType - Leather */
+     , (8205,  28,        230) /* ArmorLevel */
+     , (8205,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (8205, 106,        200) /* ItemSpellcraft */
+     , (8205, 107,        200) /* ItemCurMana */
+     , (8205, 108,        200) /* ItemMaxMana */
+     , (8205, 109,          0) /* ItemDifficulty */
+     , (8205, 150,        103) /* HookPlacement - Hook */
+     , (8205, 151,          2) /* HookType - Wall */
+     , (8205, 188,          2) /* HeritageGroup - Gharundim */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8205,  22, True ) /* Inscribable */
+     , (8205,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8205,   5,  -0.033) /* ManaRate */
+     , (8205,  12,    0.66) /* Shade */
+     , (8205,  13,       1) /* ArmorModVsSlash */
+     , (8205,  14,     1.2) /* ArmorModVsPierce */
+     , (8205,  15,     1.2) /* ArmorModVsBludgeon */
+     , (8205,  16,    1.35) /* ArmorModVsCold */
+     , (8205,  17,    1.35) /* ArmorModVsFire */
+     , (8205,  18,    1.35) /* ArmorModVsAcid */
+     , (8205,  19,    1.35) /* ArmorModVsElectric */
+     , (8205, 110,       1) /* BulkMod */
+     , (8205, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8205,   1, 'Shadow''s Garb') /* Name */
+     , (8205,  16, 'A facial wrap that protects your face from sandstorms, and occludes your face from the eyes of others. It is rumored that these were the same masks worn by the Shagar Zharala during their assassination of King Laszko.') /* LongDesc */
+     , (8205,  19, 'Gharu''ndim') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8205,   1, 0x0200097D) /* Setup */
+     , (8205,   3, 0x20000014) /* SoundTable */
+     , (8205,   6, 0x0400007E) /* PaletteBase */
+     , (8205,   7, 0x1000026F) /* ClothingBase */
+     , (8205,   8, 0x06001E9D) /* Icon */
+     , (8205,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (8205,   397,      2)  /* Light Weapon Mastery Self IV */
+     , (8205,   247,      2)  /* Invulnerability Self IV */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/08206 Ogre Mask.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/08206 Ogre Mask.sql
@@ -1,0 +1,59 @@
+DELETE FROM `weenie` WHERE `class_Id` = 8206;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (8206, 'regaliasho', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (8206,   1,          2) /* ItemType - Armor */
+     , (8206,   3,          4) /* PaletteTemplate - Brown */
+     , (8206,   4,      16384) /* ClothingPriority - Head */
+     , (8206,   5,        700) /* EncumbranceVal */
+     , (8206,   8,         75) /* Mass */
+     , (8206,   9,          1) /* ValidLocations - HeadWear */
+     , (8206,  16,          1) /* ItemUseable - No */
+     , (8206,  18,          1) /* UiEffects - Magical */
+     , (8206,  19,       2000) /* Value */
+     , (8206,  27,          2) /* ArmorType - Leather */
+     , (8206,  28,        230) /* ArmorLevel */
+     , (8206,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (8206, 106,        200) /* ItemSpellcraft */
+     , (8206, 107,        200) /* ItemCurMana */
+     , (8206, 108,        200) /* ItemMaxMana */
+     , (8206, 109,          0) /* ItemDifficulty */
+     , (8206, 150,        103) /* HookPlacement - Hook */
+     , (8206, 151,          2) /* HookType - Wall */
+     , (8206, 188,          3) /* HeritageGroup - Sho */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (8206,  22, True ) /* Inscribable */
+     , (8206,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (8206,   5,  -0.033) /* ManaRate */
+     , (8206,  12,    0.66) /* Shade */
+     , (8206,  13,     1.3) /* ArmorModVsSlash */
+     , (8206,  14,     1.3) /* ArmorModVsPierce */
+     , (8206,  15,       1) /* ArmorModVsBludgeon */
+     , (8206,  16,     1.5) /* ArmorModVsCold */
+     , (8206,  17,       1) /* ArmorModVsFire */
+     , (8206,  18,     1.5) /* ArmorModVsAcid */
+     , (8206,  19,     1.2) /* ArmorModVsElectric */
+     , (8206, 110,       1) /* BulkMod */
+     , (8206, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (8206,   1, 'Ogre Mask') /* Name */
+     , (8206,  16, 'A traditional ogre mask of the Sho Culture, made with beautiful craftsmanship. It has been sculpted into the face of a fearsome creature that Koji once encountered on her travels.') /* LongDesc */
+     , (8206,  19, 'Sho') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (8206,   1, 0x0200097E) /* Setup */
+     , (8206,   3, 0x20000014) /* SoundTable */
+     , (8206,   6, 0x0400007E) /* PaletteBase */
+     , (8206,   7, 0x10000270) /* ClothingBase */
+     , (8206,   8, 0x06001E9E) /* Icon */
+     , (8206,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (8206,   247,      2)  /* Invulnerability Self IV */
+     , (8206,   446,      2)  /* Light Weapon Mastery Self IV */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/12212 Pwyll's Crown.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/12212 Pwyll's Crown.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 12212;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (12212, 'regaliaaluvianhi', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (12212,   1,          2) /* ItemType - Armor */
+     , (12212,   3,          4) /* PaletteTemplate - Brown */
+     , (12212,   4,      16384) /* ClothingPriority - Head */
+     , (12212,   5,        800) /* EncumbranceVal */
+     , (12212,   8,         75) /* Mass */
+     , (12212,   9,          1) /* ValidLocations - HeadWear */
+     , (12212,  16,          1) /* ItemUseable - No */
+     , (12212,  18,          1) /* UiEffects - Magical */
+     , (12212,  19,       4000) /* Value */
+     , (12212,  27,          2) /* ArmorType - Leather */
+     , (12212,  28,        250) /* ArmorLevel */
+     , (12212,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (12212, 106,        250) /* ItemSpellcraft */
+     , (12212, 107,        400) /* ItemCurMana */
+     , (12212, 108,        400) /* ItemMaxMana */
+     , (12212, 109,        100) /* ItemDifficulty */
+     , (12212, 150,        103) /* HookPlacement - Hook */
+     , (12212, 151,          2) /* HookType - Wall */
+     , (12212, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (12212,  22, True ) /* Inscribable */
+     , (12212,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (12212,   5,  -0.033) /* ManaRate */
+     , (12212,  12,    0.66) /* Shade */
+     , (12212,  13,     1.4) /* ArmorModVsSlash */
+     , (12212,  14,     1.2) /* ArmorModVsPierce */
+     , (12212,  15,     1.4) /* ArmorModVsBludgeon */
+     , (12212,  16,     1.2) /* ArmorModVsCold */
+     , (12212,  17,     1.2) /* ArmorModVsFire */
+     , (12212,  18,     1.4) /* ArmorModVsAcid */
+     , (12212,  19,       1) /* ArmorModVsElectric */
+     , (12212, 110,       1) /* BulkMod */
+     , (12212, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (12212,   1, 'Pwyll''s Crown') /* Name */
+     , (12212,  16, 'This masterfully crafted mask makes other masks look like child''s play. The features almost look alive, and it is a comfortable fit on your head.') /* LongDesc */
+     , (12212,  19, 'Aluvian') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (12212,   1, 0x02000B88) /* Setup */
+     , (12212,   3, 0x20000014) /* SoundTable */
+     , (12212,   6, 0x0400007E) /* PaletteBase */
+     , (12212,   7, 0x1000033F) /* ClothingBase */
+     , (12212,   8, 0x060022D8) /* Icon */
+     , (12212,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (12212,   326,      2)  /* Finesse Weapon Mastery Self V */
+     , (12212,  1311,      2)  /* Armor Self V */
+     , (12212,   680,      2)  /* Arcane Enlightenment Self III */
+     , (12212,   248,      2)  /* Invulnerability Self V */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/12213 Veil of Darkness.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/12213 Veil of Darkness.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 12213;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (12213, 'regaliagharundimhi', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (12213,   1,          2) /* ItemType - Armor */
+     , (12213,   3,          4) /* PaletteTemplate - Brown */
+     , (12213,   4,      16384) /* ClothingPriority - Head */
+     , (12213,   5,        600) /* EncumbranceVal */
+     , (12213,   8,         75) /* Mass */
+     , (12213,   9,          1) /* ValidLocations - HeadWear */
+     , (12213,  16,          1) /* ItemUseable - No */
+     , (12213,  18,          1) /* UiEffects - Magical */
+     , (12213,  19,       4000) /* Value */
+     , (12213,  27,          2) /* ArmorType - Leather */
+     , (12213,  28,        250) /* ArmorLevel */
+     , (12213,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (12213, 106,        250) /* ItemSpellcraft */
+     , (12213, 107,        400) /* ItemCurMana */
+     , (12213, 108,        400) /* ItemMaxMana */
+     , (12213, 109,        100) /* ItemDifficulty */
+     , (12213, 150,        103) /* HookPlacement - Hook */
+     , (12213, 151,          2) /* HookType - Wall */
+     , (12213, 188,          2) /* HeritageGroup - Gharundim */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (12213,  22, True ) /* Inscribable */
+     , (12213,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (12213,   5,  -0.033) /* ManaRate */
+     , (12213,  12,    0.66) /* Shade */
+     , (12213,  13,       1) /* ArmorModVsSlash */
+     , (12213,  14,     1.2) /* ArmorModVsPierce */
+     , (12213,  15,     1.2) /* ArmorModVsBludgeon */
+     , (12213,  16,    1.35) /* ArmorModVsCold */
+     , (12213,  17,    1.35) /* ArmorModVsFire */
+     , (12213,  18,    1.35) /* ArmorModVsAcid */
+     , (12213,  19,    1.35) /* ArmorModVsElectric */
+     , (12213, 110,       1) /* BulkMod */
+     , (12213, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (12213,   1, 'Veil of Darkness') /* Name */
+     , (12213,  16, 'A facial wrap that shields your face from sight. It is rumored that these were the same masks worn by the Elite Shagar Zharala that assassinated King Laszko.') /* LongDesc */
+     , (12213,  19, 'Gharu''ndim') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (12213,   1, 0x02000B89) /* Setup */
+     , (12213,   3, 0x20000014) /* SoundTable */
+     , (12213,   6, 0x0400007E) /* PaletteBase */
+     , (12213,   7, 0x10000340) /* ClothingBase */
+     , (12213,   8, 0x060022D9) /* Icon */
+     , (12213,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (12213,   876,      2)  /* Healing Mastery Self III */
+     , (12213,   398,      2)  /* Light Weapon Mastery Self V */
+     , (12213,  1311,      2)  /* Armor Self V */
+     , (12213,   248,      2)  /* Invulnerability Self V */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/12214 Koji's Beast.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/12214 Koji's Beast.sql
@@ -1,0 +1,61 @@
+DELETE FROM `weenie` WHERE `class_Id` = 12214;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (12214, 'regaliashohi', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (12214,   1,          2) /* ItemType - Armor */
+     , (12214,   3,          4) /* PaletteTemplate - Brown */
+     , (12214,   4,      16384) /* ClothingPriority - Head */
+     , (12214,   5,        700) /* EncumbranceVal */
+     , (12214,   8,         75) /* Mass */
+     , (12214,   9,          1) /* ValidLocations - HeadWear */
+     , (12214,  16,          1) /* ItemUseable - No */
+     , (12214,  18,          1) /* UiEffects - Magical */
+     , (12214,  19,       4000) /* Value */
+     , (12214,  27,          2) /* ArmorType - Leather */
+     , (12214,  28,        250) /* ArmorLevel */
+     , (12214,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (12214, 106,        250) /* ItemSpellcraft */
+     , (12214, 107,        400) /* ItemCurMana */
+     , (12214, 108,        400) /* ItemMaxMana */
+     , (12214, 109,        100) /* ItemDifficulty */
+     , (12214, 150,        103) /* HookPlacement - Hook */
+     , (12214, 151,          2) /* HookType - Wall */
+     , (12214, 188,          3) /* HeritageGroup - Sho */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (12214,  22, True ) /* Inscribable */
+     , (12214,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (12214,   5,  -0.033) /* ManaRate */
+     , (12214,  12,    0.66) /* Shade */
+     , (12214,  13,     1.3) /* ArmorModVsSlash */
+     , (12214,  14,     1.3) /* ArmorModVsPierce */
+     , (12214,  15,       1) /* ArmorModVsBludgeon */
+     , (12214,  16,     1.5) /* ArmorModVsCold */
+     , (12214,  17,       1) /* ArmorModVsFire */
+     , (12214,  18,     1.5) /* ArmorModVsAcid */
+     , (12214,  19,     1.2) /* ArmorModVsElectric */
+     , (12214, 110,       1) /* BulkMod */
+     , (12214, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (12214,   1, 'Koji''s Beast') /* Name */
+     , (12214,  16, 'A mask made with masterful craftsmanship. It has been sculpted into the face of a deadly Ogre Magi that Koji once encountered on her travels.') /* LongDesc */
+     , (12214,  19, 'Sho') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (12214,   1, 0x02000B8A) /* Setup */
+     , (12214,   3, 0x20000014) /* SoundTable */
+     , (12214,   6, 0x0400007E) /* PaletteBase */
+     , (12214,   7, 0x10000341) /* ClothingBase */
+     , (12214,   8, 0x060022DA) /* Icon */
+     , (12214,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (12214,   276,      2)  /* Magic Resistance Self III */
+     , (12214,  1311,      2)  /* Armor Self V */
+     , (12214,   447,      2)  /* Light Weapon Mastery Self V */
+     , (12214,   248,      2)  /* Invulnerability Self V */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/22015 Pwyll's Guard.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/22015 Pwyll's Guard.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 22015;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (22015, 'regaliaaluvianuber', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (22015,   1,          2) /* ItemType - Armor */
+     , (22015,   3,          4) /* PaletteTemplate - Brown */
+     , (22015,   4,      16384) /* ClothingPriority - Head */
+     , (22015,   5,        800) /* EncumbranceVal */
+     , (22015,   8,         75) /* Mass */
+     , (22015,   9,          1) /* ValidLocations - HeadWear */
+     , (22015,  16,          1) /* ItemUseable - No */
+     , (22015,  18,          1) /* UiEffects - Magical */
+     , (22015,  19,       6000) /* Value */
+     , (22015,  27,          2) /* ArmorType - Leather */
+     , (22015,  28,        270) /* ArmorLevel */
+     , (22015,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (22015, 106,        300) /* ItemSpellcraft */
+     , (22015, 107,        600) /* ItemCurMana */
+     , (22015, 108,        600) /* ItemMaxMana */
+     , (22015, 109,        130) /* ItemDifficulty */
+     , (22015, 150,        103) /* HookPlacement - Hook */
+     , (22015, 151,          2) /* HookType - Wall */
+     , (22015, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (22015,  22, True ) /* Inscribable */
+     , (22015,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (22015,   5,  -0.033) /* ManaRate */
+     , (22015,  12,    0.66) /* Shade */
+     , (22015,  13,     1.4) /* ArmorModVsSlash */
+     , (22015,  14,     1.2) /* ArmorModVsPierce */
+     , (22015,  15,     1.4) /* ArmorModVsBludgeon */
+     , (22015,  16,     1.2) /* ArmorModVsCold */
+     , (22015,  17,     1.2) /* ArmorModVsFire */
+     , (22015,  18,     1.4) /* ArmorModVsAcid */
+     , (22015,  19,       1) /* ArmorModVsElectric */
+     , (22015, 110,       1) /* BulkMod */
+     , (22015, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (22015,   1, 'Pwyll''s Guard') /* Name */
+     , (22015,  16, 'An ornate and flawless rendition of High King Pwyll. Alexander the Deft has captured the look and feel of the High King in exquisite fashion.') /* LongDesc */
+     , (22015,  19, 'Aluvian') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (22015,   1, 0x02000E41) /* Setup */
+     , (22015,   3, 0x20000014) /* SoundTable */
+     , (22015,   6, 0x0400007E) /* PaletteBase */
+     , (22015,   7, 0x10000409) /* ClothingBase */
+     , (22015,   8, 0x0600283B) /* Icon */
+     , (22015,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (22015,   327,      2)  /* Finesse Weapon Mastery Self VI */
+     , (22015,  2544,      2)  /* Minor Finesse Weapon Aptitude */
+     , (22015,   681,      2)  /* Arcane Enlightenment Self IV */
+     , (22015,  1484,      2)  /* Impenetrability IV */
+     , (22015,  1312,      2)  /* Armor Self VI */
+     , (22015,   249,      2)  /* Invulnerability Self VI */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/22016 Shroud of Night.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/22016 Shroud of Night.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 22016;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (22016, 'regaliagharundimuber', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (22016,   1,          2) /* ItemType - Armor */
+     , (22016,   3,          4) /* PaletteTemplate - Brown */
+     , (22016,   4,      16384) /* ClothingPriority - Head */
+     , (22016,   5,        600) /* EncumbranceVal */
+     , (22016,   8,         75) /* Mass */
+     , (22016,   9,          1) /* ValidLocations - HeadWear */
+     , (22016,  16,          1) /* ItemUseable - No */
+     , (22016,  18,          1) /* UiEffects - Magical */
+     , (22016,  19,       6000) /* Value */
+     , (22016,  27,          2) /* ArmorType - Leather */
+     , (22016,  28,        270) /* ArmorLevel */
+     , (22016,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (22016, 106,        300) /* ItemSpellcraft */
+     , (22016, 107,        600) /* ItemCurMana */
+     , (22016, 108,        600) /* ItemMaxMana */
+     , (22016, 109,        130) /* ItemDifficulty */
+     , (22016, 150,        103) /* HookPlacement - Hook */
+     , (22016, 151,          2) /* HookType - Wall */
+     , (22016, 188,          2) /* HeritageGroup - Gharundim */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (22016,  22, True ) /* Inscribable */
+     , (22016,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (22016,   5,  -0.033) /* ManaRate */
+     , (22016,  12,    0.66) /* Shade */
+     , (22016,  13,       1) /* ArmorModVsSlash */
+     , (22016,  14,     1.2) /* ArmorModVsPierce */
+     , (22016,  15,     1.2) /* ArmorModVsBludgeon */
+     , (22016,  16,    1.35) /* ArmorModVsCold */
+     , (22016,  17,    1.35) /* ArmorModVsFire */
+     , (22016,  18,    1.35) /* ArmorModVsAcid */
+     , (22016,  19,    1.35) /* ArmorModVsElectric */
+     , (22016, 110,       1) /* BulkMod */
+     , (22016, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (22016,   1, 'Shroud of Night') /* Name */
+     , (22016,  16, 'An enhanced version of Janda''s ever popular mask. This version of the mask worn by assassins of the Elite Shagar Zharala who dispatched King Laszko is a triumph of the mask making trade.') /* LongDesc */
+     , (22016,  19, 'Gharu''ndim') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (22016,   1, 0x02000E42) /* Setup */
+     , (22016,   3, 0x20000014) /* SoundTable */
+     , (22016,   6, 0x0400007E) /* PaletteBase */
+     , (22016,   7, 0x1000040A) /* ClothingBase */
+     , (22016,   8, 0x0600283C) /* Icon */
+     , (22016,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (22016,  1312,      2)  /* Armor Self VI */
+     , (22016,  2565,      2)  /* Minor Light Weapon Aptitude */
+     , (22016,  1484,      2)  /* Impenetrability IV */
+     , (22016,   399,      2)  /* Light Weapon Mastery Self VI */
+     , (22016,   877,      2)  /* Healing Mastery Self IV */
+     , (22016,   249,      2)  /* Invulnerability Self VI */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/22017 Koji's Fiend.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/22017 Koji's Fiend.sql
@@ -1,0 +1,63 @@
+DELETE FROM `weenie` WHERE `class_Id` = 22017;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (22017, 'regaliashouber', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (22017,   1,          2) /* ItemType - Armor */
+     , (22017,   3,          4) /* PaletteTemplate - Brown */
+     , (22017,   4,      16384) /* ClothingPriority - Head */
+     , (22017,   5,        700) /* EncumbranceVal */
+     , (22017,   8,         75) /* Mass */
+     , (22017,   9,          1) /* ValidLocations - HeadWear */
+     , (22017,  16,          1) /* ItemUseable - No */
+     , (22017,  18,          1) /* UiEffects - Magical */
+     , (22017,  19,       6000) /* Value */
+     , (22017,  27,          2) /* ArmorType - Leather */
+     , (22017,  28,        270) /* ArmorLevel */
+     , (22017,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (22017, 106,        300) /* ItemSpellcraft */
+     , (22017, 107,        600) /* ItemCurMana */
+     , (22017, 108,        600) /* ItemMaxMana */
+     , (22017, 109,        130) /* ItemDifficulty */
+     , (22017, 150,        103) /* HookPlacement - Hook */
+     , (22017, 151,          2) /* HookType - Wall */
+     , (22017, 188,          3) /* HeritageGroup - Sho */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (22017,  22, True ) /* Inscribable */
+     , (22017,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (22017,   5,  -0.033) /* ManaRate */
+     , (22017,  12,    0.66) /* Shade */
+     , (22017,  13,     1.3) /* ArmorModVsSlash */
+     , (22017,  14,     1.3) /* ArmorModVsPierce */
+     , (22017,  15,       1) /* ArmorModVsBludgeon */
+     , (22017,  16,     1.5) /* ArmorModVsCold */
+     , (22017,  17,       1) /* ArmorModVsFire */
+     , (22017,  18,     1.5) /* ArmorModVsAcid */
+     , (22017,  19,     1.2) /* ArmorModVsElectric */
+     , (22017, 110,       1) /* BulkMod */
+     , (22017, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (22017,   1, 'Koji''s Fiend') /* Name */
+     , (22017,  16, 'A finely detailed and crafted mask of an Ogre Magi. This work represents the demon-fiend faced by Koji as she traveled the world. ') /* LongDesc */
+     , (22017,  19, 'Sho') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (22017,   1, 0x02000E43) /* Setup */
+     , (22017,   3, 0x20000014) /* SoundTable */
+     , (22017,   6, 0x0400007E) /* PaletteBase */
+     , (22017,   7, 0x1000040B) /* ClothingBase */
+     , (22017,   8, 0x0600283A) /* Icon */
+     , (22017,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (22017,  1484,      2)  /* Impenetrability IV */
+     , (22017,   448,      2)  /* Light Weapon Mastery Self VI */
+     , (22017,  2568,      2)  /* Minor Light Weapon Aptitude */
+     , (22017,   277,      2)  /* Magic Resistance Self IV */
+     , (22017,  1312,      2)  /* Armor Self VI */
+     , (22017,   249,      2)  /* Invulnerability Self VI */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/25336 Alfric's Bull.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/25336 Alfric's Bull.sql
@@ -1,0 +1,64 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25336;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25336, 'regaliaaluvianextreme', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25336,   1,          2) /* ItemType - Armor */
+     , (25336,   3,          4) /* PaletteTemplate - Brown */
+     , (25336,   4,      16384) /* ClothingPriority - Head */
+     , (25336,   5,        800) /* EncumbranceVal */
+     , (25336,   8,         75) /* Mass */
+     , (25336,   9,          1) /* ValidLocations - HeadWear */
+     , (25336,  16,          1) /* ItemUseable - No */
+     , (25336,  18,          1) /* UiEffects - Magical */
+     , (25336,  19,       8000) /* Value */
+     , (25336,  27,          2) /* ArmorType - Leather */
+     , (25336,  28,        300) /* ArmorLevel */
+     , (25336,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (25336, 106,        325) /* ItemSpellcraft */
+     , (25336, 107,        800) /* ItemCurMana */
+     , (25336, 108,        800) /* ItemMaxMana */
+     , (25336, 109,        180) /* ItemDifficulty */
+     , (25336, 150,        103) /* HookPlacement - Hook */
+     , (25336, 151,          2) /* HookType - Wall */
+     , (25336, 188,          1) /* HeritageGroup - Aluvian */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25336,  22, True ) /* Inscribable */
+     , (25336,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25336,   5,  -0.033) /* ManaRate */
+     , (25336,  12,    0.66) /* Shade */
+     , (25336,  13,     1.4) /* ArmorModVsSlash */
+     , (25336,  14,     1.2) /* ArmorModVsPierce */
+     , (25336,  15,     1.4) /* ArmorModVsBludgeon */
+     , (25336,  16,     1.2) /* ArmorModVsCold */
+     , (25336,  17,     1.2) /* ArmorModVsFire */
+     , (25336,  18,     1.4) /* ArmorModVsAcid */
+     , (25336,  19,       1) /* ArmorModVsElectric */
+     , (25336, 110,       1) /* BulkMod */
+     , (25336, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25336,   1, 'Alfric''s Bull') /* Name */
+     , (25336,  16, 'An ornate representation of the heraldic bull of Viamont Royal Governor Alfric, who rounded up and executed the bloodline of High King Pwyll II during the reign of Alfrega the Mad.') /* LongDesc */
+     , (25336,  19, 'Aluvian') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25336,   1, 0x02000FAF) /* Setup */
+     , (25336,   3, 0x20000014) /* SoundTable */
+     , (25336,   6, 0x0400007E) /* PaletteBase */
+     , (25336,   7, 0x100004C6) /* ClothingBase */
+     , (25336,   8, 0x06002D36) /* Icon */
+     , (25336,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (25336,  2689,      2)  /* Moderate Finesse Weapon Aptitude */
+     , (25336,   682,      2)  /* Arcane Enlightenment Self V */
+     , (25336,   327,      2)  /* Finesse Weapon Mastery Self VI */
+     , (25336,  1485,      2)  /* Impenetrability V */
+     , (25336,  1312,      2)  /* Armor Self VI */
+     , (25336,  2550,      2)  /* Minor Invulnerability */
+     , (25336,   249,      2)  /* Invulnerability Self VI */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/25337 The Poet's Mask.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/25337 The Poet's Mask.sql
@@ -1,0 +1,64 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25337;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25337, 'regaliagharundimextreme', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25337,   1,          2) /* ItemType - Armor */
+     , (25337,   3,          4) /* PaletteTemplate - Brown */
+     , (25337,   4,      16384) /* ClothingPriority - Head */
+     , (25337,   5,        600) /* EncumbranceVal */
+     , (25337,   8,         75) /* Mass */
+     , (25337,   9,          1) /* ValidLocations - HeadWear */
+     , (25337,  16,          1) /* ItemUseable - No */
+     , (25337,  18,          1) /* UiEffects - Magical */
+     , (25337,  19,       8000) /* Value */
+     , (25337,  27,          2) /* ArmorType - Leather */
+     , (25337,  28,        300) /* ArmorLevel */
+     , (25337,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (25337, 106,        325) /* ItemSpellcraft */
+     , (25337, 107,        800) /* ItemCurMana */
+     , (25337, 108,        800) /* ItemMaxMana */
+     , (25337, 109,        180) /* ItemDifficulty */
+     , (25337, 150,        103) /* HookPlacement - Hook */
+     , (25337, 151,          2) /* HookType - Wall */
+     , (25337, 188,          2) /* HeritageGroup - Gharundim */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25337,  22, True ) /* Inscribable */
+     , (25337,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25337,   5,  -0.033) /* ManaRate */
+     , (25337,  12,    0.66) /* Shade */
+     , (25337,  13,       1) /* ArmorModVsSlash */
+     , (25337,  14,     1.2) /* ArmorModVsPierce */
+     , (25337,  15,     1.2) /* ArmorModVsBludgeon */
+     , (25337,  16,    1.35) /* ArmorModVsCold */
+     , (25337,  17,    1.35) /* ArmorModVsFire */
+     , (25337,  18,    1.35) /* ArmorModVsAcid */
+     , (25337,  19,    1.35) /* ArmorModVsElectric */
+     , (25337, 110,       1) /* BulkMod */
+     , (25337, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25337,   1, 'The Poet''s Mask') /* Name */
+     , (25337,  16, 'A finely detailed mask representing the visage of Yasif ibn Salayyar, the Poet and Royal Emissary of Gharu''n.') /* LongDesc */
+     , (25337,  19, 'Gharu''ndim') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25337,   1, 0x02000FB0) /* Setup */
+     , (25337,   3, 0x20000014) /* SoundTable */
+     , (25337,   6, 0x0400007E) /* PaletteBase */
+     , (25337,   7, 0x100004C5) /* ClothingBase */
+     , (25337,   8, 0x06002D37) /* Icon */
+     , (25337,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (25337,   878,      2)  /* Healing Mastery Self V */
+     , (25337,  1312,      2)  /* Armor Self VI */
+     , (25337,  2693,      2)  /* Moderate Light Weapon Aptitude */
+     , (25337,  1485,      2)  /* Impenetrability V */
+     , (25337,   399,      2)  /* Light Weapon Mastery Self VI */
+     , (25337,  2550,      2)  /* Minor Invulnerability */
+     , (25337,   249,      2)  /* Invulnerability Self VI */;

--- a/Database/Patches/9 WeenieDefaults/Clothing/Armor/25338 Koji's Visage.sql
+++ b/Database/Patches/9 WeenieDefaults/Clothing/Armor/25338 Koji's Visage.sql
@@ -1,0 +1,64 @@
+DELETE FROM `weenie` WHERE `class_Id` = 25338;
+
+INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
+VALUES (25338, 'regaliashoextreme', 2, '2005-02-09 10:00:00') /* Clothing */;
+
+INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
+VALUES (25338,   1,          2) /* ItemType - Armor */
+     , (25338,   3,          4) /* PaletteTemplate - Brown */
+     , (25338,   4,      16384) /* ClothingPriority - Head */
+     , (25338,   5,        700) /* EncumbranceVal */
+     , (25338,   8,         75) /* Mass */
+     , (25338,   9,          1) /* ValidLocations - HeadWear */
+     , (25338,  16,          1) /* ItemUseable - No */
+     , (25338,  18,          1) /* UiEffects - Magical */
+     , (25338,  19,       8000) /* Value */
+     , (25338,  27,          2) /* ArmorType - Leather */
+     , (25338,  28,        300) /* ArmorLevel */
+     , (25338,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */
+     , (25338, 106,        325) /* ItemSpellcraft */
+     , (25338, 107,        800) /* ItemCurMana */
+     , (25338, 108,        800) /* ItemMaxMana */
+     , (25338, 109,        180) /* ItemDifficulty */
+     , (25338, 150,        103) /* HookPlacement - Hook */
+     , (25338, 151,          2) /* HookType - Wall */
+     , (25338, 188,          3) /* HeritageGroup - Sho */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (25338,  22, True ) /* Inscribable */
+     , (25338,  23, True ) /* DestroyOnSell */;
+
+INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
+VALUES (25338,   5,  -0.033) /* ManaRate */
+     , (25338,  12,    0.66) /* Shade */
+     , (25338,  13,     1.3) /* ArmorModVsSlash */
+     , (25338,  14,     1.3) /* ArmorModVsPierce */
+     , (25338,  15,       1) /* ArmorModVsBludgeon */
+     , (25338,  16,     1.5) /* ArmorModVsCold */
+     , (25338,  17,       1) /* ArmorModVsFire */
+     , (25338,  18,     1.5) /* ArmorModVsAcid */
+     , (25338,  19,     1.2) /* ArmorModVsElectric */
+     , (25338, 110,       1) /* BulkMod */
+     , (25338, 111,       1) /* SizeMod */;
+
+INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
+VALUES (25338,   1, 'Koji''s Visage') /* Name */
+     , (25338,  16, 'A lovely and delicately detailed mask representing Koji herself. ') /* LongDesc */
+     , (25338,  19, 'Sho') /* ItemHeritageGroupRestriction */;
+
+INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
+VALUES (25338,   1, 0x02000FAE) /* Setup */
+     , (25338,   3, 0x20000014) /* SoundTable */
+     , (25338,   6, 0x0400007E) /* PaletteBase */
+     , (25338,   7, 0x100004C4) /* ClothingBase */
+     , (25338,   8, 0x06002D27) /* Icon */
+     , (25338,  22, 0x3400002B) /* PhysicsEffectTable */;
+
+INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
+VALUES (25338,   448,      2)  /* Light Weapon Mastery Self VI */
+     , (25338,  1485,      2)  /* Impenetrability V */
+     , (25338,  2696,      2)  /* Moderate Light Weapon Aptitude */
+     , (25338,  2550,      2)  /* Minor Invulnerability */
+     , (25338,   278,      2)  /* Magic Resistance Self V */
+     , (25338,  1312,      2)  /* Armor Self VI */
+     , (25338,   249,      2)  /* Invulnerability Self VI */;


### PR DESCRIPTION
Adds heritage requirements and removes skill requirements (apparently a MOA change). 
Not all were PCAPed, but matches the ones that were (e.g. The Poet's Mask). 
HeritageGroup shows activation requirement in client, but server doesn't seem to handle it so it doesn't really work yet. Something for the TODO list. 