### PR TITLE
Fix junk data in 5 fellowship life vuln spells

### DIFF
--- a/Database/Patches/2 SpellTableExtendedData/03875 Acidic Curse.sql
+++ b/Database/Patches/2 SpellTableExtendedData/03875 Acidic Curse.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3875;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3875, 'Acidic Curse', 36865 /* Attribute, SingleStat, Additive */, 3 /* Quickness */, 2.85, '2021-11-01 00:00:00');
+VALUES (3875, 'Acidic Curse', 20488 /* Float, SingleStat, Multiplicative */, 69 /* RESIST_ACID_FLOAT  */, 2.85, '2026-03-24 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/03876 Curse of the Blades.sql
+++ b/Database/Patches/2 SpellTableExtendedData/03876 Curse of the Blades.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3876;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3876, 'Curse of the Blades', 36865 /* Attribute, SingleStat, Additive */, 3 /* Quickness */, 2.85, '2021-11-01 00:00:00');
+VALUES (3876, 'Curse of the Blades', 20488 /* Float, SingleStat, Multiplicative */, 64 /* RESIST_SLASH_FLOAT  */, 2.85, '2026-03-24 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/03917 Numbing Chill.sql
+++ b/Database/Patches/2 SpellTableExtendedData/03917 Numbing Chill.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3917;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3917, 'Numbing Chill', 36865 /* Attribute, SingleStat, Additive */, 3 /* Quickness */, 2.85, '2021-11-01 00:00:00');
+ALUES (3917, 'Numbing Chill', 20488 /* Float, SingleStat, Multiplicative */, 68 /* RESIST_COLD_FLOAT  */, 2.85, '2026-03-24 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/03917 Numbing Chill.sql
+++ b/Database/Patches/2 SpellTableExtendedData/03917 Numbing Chill.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3917;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-ALUES (3917, 'Numbing Chill', 20488 /* Float, SingleStat, Multiplicative */, 68 /* RESIST_COLD_FLOAT  */, 2.85, '2026-03-24 00:00:00');
+VALUES (3917, 'Numbing Chill', 20488 /* Float, SingleStat, Multiplicative */, 68 /* RESIST_COLD_FLOAT  */, 2.85, '2026-03-24 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/03918 Flammable.sql
+++ b/Database/Patches/2 SpellTableExtendedData/03918 Flammable.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3918;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3918, 'Flammable', 36865 /* Attribute, SingleStat, Additive */, 3 /* Quickness */, 2.85, '2021-11-01 00:00:00');
+VALUES (3918, 'Flammable', 20488 /* Float, SingleStat, Multiplicative */, 67 /* RESIST_FIRE_FLOAT  */, 2.85, '2026-03-24 00:00:00');

--- a/Database/Patches/2 SpellTableExtendedData/03919 Lightning Rod.sql
+++ b/Database/Patches/2 SpellTableExtendedData/03919 Lightning Rod.sql
@@ -1,4 +1,4 @@
 DELETE FROM `spell` WHERE `id` = 3919;
 
 INSERT INTO `spell` (`id`, `name`, `stat_Mod_Type`, `stat_Mod_Key`, `stat_Mod_Val`, `last_Modified`)
-VALUES (3919, 'Lightning Rod', 36865 /* Attribute, SingleStat, Additive */, 3 /* Quickness */, 2.85, '2021-11-01 00:00:00');
+VALUES (3919, 'Lightning Rod', 20488 /* Float, SingleStat, Multiplicative */, 70 /* Resist_electic_float */, 2.85, '2026-03-24 00:00:00');


### PR DESCRIPTION
Fixed the stat mod type and stat mod keys of several fellowship vuln spells to be consistent with the respective life vuln spells.