### PR TITLE
misc updates august 26

### DIFF
--- a/Database/Patches/9 WeenieDefaults/Book/Writable/38246 Scroll of Prophecy.sql
+++ b/Database/Patches/9 WeenieDefaults/Book/Writable/38246 Scroll of Prophecy.sql
@@ -7,13 +7,20 @@ INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (38246,   1,       8192) /* ItemType - Writable */
      , (38246,   5,         25) /* EncumbranceVal */
      , (38246,  16,          8) /* ItemUseable - Contained */
+     , (38246,  19,          0) /* Value */
      , (38246,  93,       1044) /* PhysicsState - Ethereal, IgnoreCollisions, Gravity */;
+
+INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
+VALUES (38246,  22, True ) /* Inscribable */
+     , (38246,  69, False) /* IsSellable */;
 
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (38246,  54,     1.5) /* UseRadius */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
-VALUES (38246,   1, 'Scroll of Prophecy') /* Name */;
+VALUES (38246,   1, 'Scroll of Prophecy') /* Name */
+     , (38246,  14, 'Return this and the other nine artifacts to your Task Master to complete the quest.') /* Use */
+     , (38246,  16, 'A scroll of prophecy dictated to Tirianji, one of the three Falatacot believers, by he who speaks for our god, the High Priest of T''thuun. ') /* LongDesc */;
 
 INSERT INTO `weenie_properties_d_i_d` (`object_Id`, `type`, `value`)
 VALUES (38246,   1, 0x02000158) /* Setup */
@@ -22,4 +29,7 @@ VALUES (38246,   1, 0x02000158) /* Setup */
      , (38246,  22, 0x3400002B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_book` (`object_Id`, `max_Num_Pages`, `max_Num_Chars_Per_Page`)
-VALUES (38246, 0, 1000);
+VALUES (38246, 1, 1000);
+
+INSERT INTO `weenie_properties_book_page_data` (`object_Id`, `page_Id`, `author_Id`, `author_Name`, `author_Account`, `ignore_Author`, `page_Text`)
+VALUES (38246, 0, 0xFFFFFFFF, '', 'prewritten', False, '[You cannot understand the writing on this.]');

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/31827 Incendiary Knight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/31827 Incendiary Knight.sql
@@ -9,15 +9,15 @@ VALUES (31827,   1,         16) /* ItemType - Creature */
      , (31827,   3,         14) /* PaletteTemplate - Red */
      , (31827,   6,         -1) /* ItemsCapacity */
      , (31827,   7,         -1) /* ContainersCapacity */
-     , (31827,  16,         32) /* ItemUseable - Remote */
-     , (31827,  25,        165) /* Level */
+     , (31827,  16,          1) /* ItemUseable - No */
+     , (31827,  25,        160) /* Level */
      , (31827,  27,          0) /* ArmorType - None */
      , (31827,  68,          5) /* TargetingTactic - Random, LastDamager */
-     , (31827,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (31827,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (31827, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (31827, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (31827, 140,          1) /* AiOptions - CanOpenDoors */
-     , (31827, 146,     450000) /* XpOverride */;
+     , (31827, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (31827,   1, True ) /* Stuck */
@@ -33,9 +33,9 @@ VALUES (31827,   1,       5) /* HeartbeatInterval */
      , (31827,  14,       1) /* ArmorModVsPierce */
      , (31827,  15,       1) /* ArmorModVsBludgeon */
      , (31827,  16,       1) /* ArmorModVsCold */
-     , (31827,  17,       1) /* ArmorModVsFire */
-     , (31827,  18,     1.1) /* ArmorModVsAcid */
-     , (31827,  19,     1.1) /* ArmorModVsElectric */
+     , (31827,  17,     100) /* ArmorModVsFire */
+     , (31827,  18,       1) /* ArmorModVsAcid */
+     , (31827,  19,       1) /* ArmorModVsElectric */
      , (31827,  31,      20) /* VisualAwarenessRange */
      , (31827,  39,     1.3) /* DefaultScale */
      , (31827,  64,     0.3) /* ResistSlash */
@@ -70,45 +70,45 @@ VALUES (31827,   1, 0x02001483) /* Setup */
      , (31827,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (31827,   1, 250, 0, 0) /* Strength */
-     , (31827,   2, 260, 0, 0) /* Endurance */
-     , (31827,   3, 250, 0, 0) /* Quickness */
-     , (31827,   4, 250, 0, 0) /* Coordination */
-     , (31827,   5, 350, 0, 0) /* Focus */
-     , (31827,   6, 350, 0, 0) /* Self */;
+VALUES (31827,   1, 170, 0, 0) /* Strength */
+     , (31827,   2, 180, 0, 0) /* Endurance */
+     , (31827,   3, 160, 0, 0) /* Quickness */
+     , (31827,   4, 160, 0, 0) /* Coordination */
+     , (31827,   5, 270, 0, 0) /* Focus */
+     , (31827,   6, 270, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (31827,   1,  6000, 0, 0, 6130) /* MaxHealth */
-     , (31827,   3,  5000, 0, 0, 5260) /* MaxStamina */
-     , (31827,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (31827,   1,  1910, 0, 0, 2000) /* MaxHealth */
+     , (31827,   3,  2500, 0, 0, 2680) /* MaxStamina */
+     , (31827,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (31827,  6, 0, 3, 0, 395, 0, 0) /* MeleeDefense        Specialized */
-     , (31827,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (31827, 14, 0, 3, 0, 170, 0, 0) /* ArcaneLore          Specialized */
-     , (31827, 15, 0, 3, 0, 205, 0, 0) /* MagicDefense        Specialized */
-     , (31827, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (31827, 31, 0, 3, 0, 115, 0, 0) /* CreatureEnchantment Specialized */
-     , (31827, 33, 0, 3, 0, 115, 0, 0) /* LifeMagic           Specialized */
-     , (31827, 34, 0, 3, 0, 115, 0, 0) /* WarMagic            Specialized */
-     , (31827, 45, 0, 3, 0, 410, 0, 0) /* LightWeapons        Specialized */;
+VALUES (31827,  6, 0, 2, 0, 393, 0, 0) /* MeleeDefense        Trained */
+     , (31827,  7, 0, 2, 0, 486, 0, 0) /* MissileDefense      Trained */
+     , (31827, 15, 0, 2, 0, 223, 0, 0) /* MagicDefense        Trained */
+     , (31827, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (31827, 24, 0, 2, 0,  40, 0, 0) /* Run                 Trained */
+     , (31827, 31, 0, 2, 0, 165, 0, 0) /* CreatureEnchantment Trained */
+     , (31827, 33, 0, 2, 0, 165, 0, 0) /* LifeMagic           Trained */
+     , (31827, 34, 0, 2, 0, 165, 0, 0) /* WarMagic            Trained */
+     , (31827, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (31827,  0, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (31827,  1, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (31827,  2, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (31827,  3, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (31827,  4, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (31827,  5, 16, 85, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (31827,  6, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (31827,  7, 16,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (31827,  8, 16, 85, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (31827,  0, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31827,  1, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31827,  2, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31827,  3, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31827,  4, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31827,  5, 16, 85, 0.75,  300,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31827,  6, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31827,  7, 16,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31827,  8, 16, 85, 0.75,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (31827,   276,  2.008)  /* Magic Resistance Self III */
      , (31827,  1033,  2.008)  /* Cold Protection Self IV */
      , (31827,  1160,  2.013)  /* Heal Self V */
-     , (31827,  1237,  2.008)  /* Drain Health Other I */
+     , (31827,  1241,  2.008)  /* Drain Health Other V */
      , (31827,  1785,  2.004)  /* Cassius' Ring of Fire */
      , (31827,  2074,  2.017)  /* Gossamer Flesh */
      , (31827,  2088,  2.017)  /* Senescence */
@@ -117,7 +117,3 @@ VALUES (31827,   276,  2.008)  /* Magic Resistance Self III */
      , (31827,  2170,  2.017)  /* Inferno's Gift */
      , (31827,  2228,  2.017)  /* Broadside of a Barn */
      , (31827,  2318,  2.017)  /* Gravity Well */;
-
-INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (31827,  94) /* ATTACK_NOTIFICATION_EVENT */
-     , (31827, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/31828 Glacial Knight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/31828 Glacial Knight.sql
@@ -9,15 +9,15 @@ VALUES (31828,   1,         16) /* ItemType - Creature */
      , (31828,   3,          2) /* PaletteTemplate - Blue */
      , (31828,   6,         -1) /* ItemsCapacity */
      , (31828,   7,         -1) /* ContainersCapacity */
-     , (31828,  16,         32) /* ItemUseable - Remote */
-     , (31828,  25,        165) /* Level */
+     , (31828,  16,          1) /* ItemUseable - No */
+     , (31828,  25,        160) /* Level */
      , (31828,  27,          0) /* ArmorType - None */
      , (31828,  68,          5) /* TargetingTactic - Random, LastDamager */
-     , (31828,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (31828,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (31828, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (31828, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (31828, 140,          1) /* AiOptions - CanOpenDoors */
-     , (31828, 146,     450000) /* XpOverride */;
+     , (31828, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (31828,   1, True ) /* Stuck */
@@ -32,13 +32,12 @@ VALUES (31828,   1,       5) /* HeartbeatInterval */
      , (31828,  13,    0.85) /* ArmorModVsSlash */
      , (31828,  14,    0.85) /* ArmorModVsPierce */
      , (31828,  15,    0.85) /* ArmorModVsBludgeon */
-     , (31828,  16,       1) /* ArmorModVsCold */
+     , (31828,  16,     100) /* ArmorModVsCold */
      , (31828,  17,       1) /* ArmorModVsFire */
      , (31828,  18,    0.85) /* ArmorModVsAcid */
      , (31828,  19,    0.85) /* ArmorModVsElectric */
      , (31828,  31,      20) /* VisualAwarenessRange */
      , (31828,  39,     1.3) /* DefaultScale */
-     , (31828,  41,     300) /* RegenerationInterval */
      , (31828,  64,    0.45) /* ResistSlash */
      , (31828,  65,    0.45) /* ResistPierce */
      , (31828,  66,    0.45) /* ResistBludgeon */
@@ -71,45 +70,45 @@ VALUES (31828,   1, 0x02001482) /* Setup */
      , (31828,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (31828,   1, 250, 0, 0) /* Strength */
-     , (31828,   2, 260, 0, 0) /* Endurance */
-     , (31828,   3, 250, 0, 0) /* Quickness */
-     , (31828,   4, 250, 0, 0) /* Coordination */
-     , (31828,   5, 350, 0, 0) /* Focus */
-     , (31828,   6, 350, 0, 0) /* Self */;
+VALUES (31828,   1, 170, 0, 0) /* Strength */
+     , (31828,   2, 180, 0, 0) /* Endurance */
+     , (31828,   3, 160, 0, 0) /* Quickness */
+     , (31828,   4, 160, 0, 0) /* Coordination */
+     , (31828,   5, 270, 0, 0) /* Focus */
+     , (31828,   6, 270, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (31828,   1,  6000, 0, 0, 6130) /* MaxHealth */
-     , (31828,   3,  5000, 0, 0, 5260) /* MaxStamina */
-     , (31828,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (31828,   1,  1910, 0, 0, 2000) /* MaxHealth */
+     , (31828,   3,  2500, 0, 0, 2680) /* MaxStamina */
+     , (31828,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (31828,  6, 0, 3, 0, 395, 0, 0) /* MeleeDefense        Specialized */
-     , (31828,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (31828, 14, 0, 3, 0, 170, 0, 0) /* ArcaneLore          Specialized */
-     , (31828, 15, 0, 3, 0, 205, 0, 0) /* MagicDefense        Specialized */
-     , (31828, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (31828, 31, 0, 3, 0, 115, 0, 0) /* CreatureEnchantment Specialized */
-     , (31828, 33, 0, 3, 0, 115, 0, 0) /* LifeMagic           Specialized */
-     , (31828, 34, 0, 3, 0, 115, 0, 0) /* WarMagic            Specialized */
-     , (31828, 45, 0, 3, 0, 410, 0, 0) /* LightWeapons        Specialized */;
+VALUES (31828,  6, 0, 2, 0, 393, 0, 0) /* MeleeDefense        Trained */
+     , (31828,  7, 0, 2, 0, 486, 0, 0) /* MissileDefense      Trained */
+     , (31828, 15, 0, 2, 0, 223, 0, 0) /* MagicDefense        Trained */
+     , (31828, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (31828, 24, 0, 2, 0,  40, 0, 0) /* Run                 Trained */
+     , (31828, 31, 0, 2, 0, 165, 0, 0) /* CreatureEnchantment Trained */
+     , (31828, 33, 0, 2, 0, 165, 0, 0) /* LifeMagic           Trained */
+     , (31828, 34, 0, 2, 0, 165, 0, 0) /* WarMagic            Trained */
+     , (31828, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (31828,  0,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (31828,  1,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (31828,  2,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (31828,  3,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (31828,  4,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (31828,  5,  8, 85, 0.75,  200,  170,  170,  170,  200,  200,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (31828,  6,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (31828,  7,  8,  0,    0,  200,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (31828,  8,  8, 85, 0.75,  200,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (31828,  0,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31828,  1,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31828,  2,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31828,  3,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31828,  4,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31828,  5,  8, 85, 0.75,  300,  170,  170,  170,  200,  200,  170,  170,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31828,  6,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31828,  7,  8,  0,    0,  300,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31828,  8,  8, 85, 0.75,  300,  170,  170,  170,  200,  200,  170,  170,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (31828,   276,  2.008)  /* Magic Resistance Self III */
      , (31828,  1033,  2.008)  /* Cold Protection Self IV */
      , (31828,  1160,  2.013)  /* Heal Self V */
-     , (31828,  1237,  2.008)  /* Drain Health Other I */
+     , (31828,  1241,  2.008)  /* Drain Health Other V */
      , (31828,  1787,  2.004)  /* Halo of Frost */
      , (31828,  2074,  2.017)  /* Gossamer Flesh */
      , (31828,  2088,  2.017)  /* Senescence */
@@ -118,7 +117,3 @@ VALUES (31828,   276,  2.008)  /* Magic Resistance Self III */
      , (31828,  2168,  2.017)  /* Gelidite's Gift */
      , (31828,  2228,  2.017)  /* Broadside of a Barn */
      , (31828,  2318,  2.017)  /* Gravity Well */;
-
-INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (31828,  94) /* ATTACK_NOTIFICATION_EVENT */
-     , (31828, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/31829 Galvanic Knight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/31829 Galvanic Knight.sql
@@ -9,15 +9,15 @@ VALUES (31829,   1,         16) /* ItemType - Creature */
      , (31829,   3,         13) /* PaletteTemplate - Purple */
      , (31829,   6,         -1) /* ItemsCapacity */
      , (31829,   7,         -1) /* ContainersCapacity */
-     , (31829,  16,         32) /* ItemUseable - Remote */
-     , (31829,  25,        165) /* Level */
+     , (31829,  16,          1) /* ItemUseable - No */
+     , (31829,  25,        160) /* Level */
      , (31829,  27,          0) /* ArmorType - None */
      , (31829,  68,          5) /* TargetingTactic - Random, LastDamager */
-     , (31829,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (31829,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (31829, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (31829, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (31829, 140,          1) /* AiOptions - CanOpenDoors */
-     , (31829, 146,     450000) /* XpOverride */;
+     , (31829, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (31829,   1, True ) /* Stuck */
@@ -70,45 +70,45 @@ VALUES (31829,   1, 0x02001487) /* Setup */
      , (31829,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (31829,   1, 250, 0, 0) /* Strength */
-     , (31829,   2, 260, 0, 0) /* Endurance */
-     , (31829,   3, 250, 0, 0) /* Quickness */
-     , (31829,   4, 250, 0, 0) /* Coordination */
-     , (31829,   5, 350, 0, 0) /* Focus */
-     , (31829,   6, 350, 0, 0) /* Self */;
+VALUES (31829,   1, 170, 0, 0) /* Strength */
+     , (31829,   2, 180, 0, 0) /* Endurance */
+     , (31829,   3, 160, 0, 0) /* Quickness */
+     , (31829,   4, 160, 0, 0) /* Coordination */
+     , (31829,   5, 270, 0, 0) /* Focus */
+     , (31829,   6, 270, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (31829,   1,  6000, 0, 0, 6130) /* MaxHealth */
-     , (31829,   3,  5000, 0, 0, 5260) /* MaxStamina */
-     , (31829,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (31829,   1,  1910, 0, 0, 2000) /* MaxHealth */
+     , (31829,   3,  2500, 0, 0, 2680) /* MaxStamina */
+     , (31829,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (31829,  6, 0, 3, 0, 395, 0, 0) /* MeleeDefense        Specialized */
-     , (31829,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (31829, 14, 0, 3, 0, 170, 0, 0) /* ArcaneLore          Specialized */
-     , (31829, 15, 0, 3, 0, 205, 0, 0) /* MagicDefense        Specialized */
-     , (31829, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (31829, 31, 0, 3, 0, 115, 0, 0) /* CreatureEnchantment Specialized */
-     , (31829, 33, 0, 3, 0, 115, 0, 0) /* LifeMagic           Specialized */
-     , (31829, 34, 0, 3, 0, 115, 0, 0) /* WarMagic            Specialized */
-     , (31829, 45, 0, 3, 0, 410, 0, 0) /* LightWeapons        Specialized */;
+VALUES (31829,  6, 0, 2, 0, 393, 0, 0) /* MeleeDefense        Trained */
+     , (31829,  7, 0, 2, 0, 486, 0, 0) /* MissileDefense      Trained */
+     , (31829, 15, 0, 2, 0, 223, 0, 0) /* MagicDefense        Trained */
+     , (31829, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (31829, 24, 0, 2, 0,  40, 0, 0) /* Run                 Trained */
+     , (31829, 31, 0, 2, 0, 165, 0, 0) /* CreatureEnchantment Trained */
+     , (31829, 33, 0, 2, 0, 165, 0, 0) /* LifeMagic           Trained */
+     , (31829, 34, 0, 2, 0, 165, 0, 0) /* WarMagic            Trained */
+     , (31829, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (31829,  0, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (31829,  1, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (31829,  2, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (31829,  3, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (31829,  4, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (31829,  5, 64, 85, 0.75,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (31829,  6, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (31829,  7, 64,  0,    0,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (31829,  8, 64, 85, 0.75,  200,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (31829,  0, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31829,  1, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31829,  2, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31829,  3, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31829,  4, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31829,  5, 64, 85, 0.75,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31829,  6, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31829,  7, 64,  0,    0,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31829,  8, 64, 85, 0.75,  300,  166,  166,  166,  172,  148,  200, 20000,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (31829,   276,  2.008)  /* Magic Resistance Self III */
      , (31829,  1033,  2.008)  /* Cold Protection Self IV */
      , (31829,  1160,  2.013)  /* Heal Self V */
-     , (31829,  1237,  2.008)  /* Drain Health Other I */
+     , (31829,  1241,  2.008)  /* Drain Health Other V */
      , (31829,  1788,  2.004)  /* Eye of the Storm */
      , (31829,  2074,  2.017)  /* Gossamer Flesh */
      , (31829,  2088,  2.017)  /* Senescence */
@@ -117,7 +117,3 @@ VALUES (31829,   276,  2.008)  /* Magic Resistance Self III */
      , (31829,  2172,  2.017)  /* Astyrrian's Gift */
      , (31829,  2228,  2.017)  /* Broadside of a Barn */
      , (31829,  2318,  2.017)  /* Gravity Well */;
-
-INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (31829,  94) /* ATTACK_NOTIFICATION_EVENT */
-     , (31829, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/31830 Tenebrous Knight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/31830 Tenebrous Knight.sql
@@ -17,7 +17,7 @@ VALUES (31830,   1,         16) /* ItemType - Creature */
      , (31830, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (31830, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (31830, 140,          1) /* AiOptions - CanOpenDoors */
-     , (31830, 146,     380000) /* XpOverride */;
+     , (31830, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (31830,   1, True ) /* Stuck */
@@ -43,13 +43,13 @@ VALUES (31830,   1,       5) /* HeartbeatInterval */
      , (31830,  34,       1) /* PowerupTime */
      , (31830,  36,       1) /* ChargeSpeed */
      , (31830,  39,     1.3) /* DefaultScale */
-     , (31830,  64,   0.445) /* ResistSlash */
-     , (31830,  65,   0.556) /* ResistPierce */
-     , (31830,  66,   0.556) /* ResistBludgeon */
+     , (31830,  64,    0.45) /* ResistSlash */
+     , (31830,  65,    0.55) /* ResistPierce */
+     , (31830,  66,    0.55) /* ResistBludgeon */
      , (31830,  67,       0) /* ResistFire */
      , (31830,  68,       1) /* ResistCold */
-     , (31830,  69,   0.678) /* ResistAcid */
-     , (31830,  70,   0.668) /* ResistElectric */
+     , (31830,  69,    0.65) /* ResistAcid */
+     , (31830,  70,    0.65) /* ResistElectric */
      , (31830,  71,       1) /* ResistHealthBoost */
      , (31830,  72,       1) /* ResistStaminaDrain */
      , (31830,  73,       1) /* ResistStaminaBoost */
@@ -75,40 +75,44 @@ VALUES (31830,   1, 0x02001484) /* Setup */
      , (31830,  35,        455) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (31830,   1, 250, 0, 0) /* Strength */
-     , (31830,   2, 260, 0, 0) /* Endurance */
-     , (31830,   3, 250, 0, 0) /* Quickness */
-     , (31830,   4, 250, 0, 0) /* Coordination */
-     , (31830,   5, 350, 0, 0) /* Focus */
-     , (31830,   6, 350, 0, 0) /* Self */;
+VALUES (31830,   1, 170, 0, 0) /* Strength */
+     , (31830,   2, 180, 0, 0) /* Endurance */
+     , (31830,   3, 160, 0, 0) /* Quickness */
+     , (31830,   4, 160, 0, 0) /* Coordination */
+     , (31830,   5, 270, 0, 0) /* Focus */
+     , (31830,   6, 270, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (31830,   1,  6000, 0, 0, 6130) /* MaxHealth */
-     , (31830,   3,  5000, 0, 0, 5260) /* MaxStamina */
-     , (31830,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (31830,   1,  1910, 0, 0, 2000) /* MaxHealth */
+     , (31830,   3,  2500, 0, 0, 2680) /* MaxStamina */
+     , (31830,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (31830,  6, 0, 3, 0, 267, 0, 0) /* MeleeDefense        Specialized */
-     , (31830,  7, 0, 3, 0, 200, 0, 0) /* MissileDefense      Specialized */
-     , (31830, 14, 0, 3, 0, 170, 0, 0) /* ArcaneLore          Specialized */
-     , (31830, 15, 0, 3, 0, 230, 0, 0) /* MagicDefense        Specialized */
-     , (31830, 20, 0, 3, 0, 150, 0, 0) /* Deception           Specialized */
-     , (31830, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (31830, 31, 0, 3, 0, 275, 0, 0) /* CreatureEnchantment Specialized */
-     , (31830, 33, 0, 3, 0, 170, 0, 0) /* LifeMagic           Specialized */
-     , (31830, 34, 0, 3, 0, 275, 0, 0) /* WarMagic            Specialized */
-     , (31830, 45, 0, 3, 0, 306, 0, 0) /* LightWeapons        Specialized */;
+VALUES (31830,  6, 0, 2, 0, 393, 0, 0) /* MeleeDefense        Trained */
+     , (31830,  7, 0, 2, 0, 486, 0, 0) /* MissileDefense      Trained */
+     , (31830, 15, 0, 2, 0, 223, 0, 0) /* MagicDefense        Trained */
+     , (31830, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (31830, 24, 0, 2, 0,  40, 0, 0) /* Run                 Trained */
+     , (31830, 31, 0, 2, 0, 165, 0, 0) /* CreatureEnchantment Trained */
+     , (31830, 33, 0, 2, 0, 165, 0, 0) /* LifeMagic           Trained */
+     , (31830, 34, 0, 2, 0, 165, 0, 0) /* WarMagic            Trained */
+     , (31830, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (31830,  0, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (31830,  1, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (31830,  2, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (31830,  3, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (31830,  4, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (31830,  5, 16, 45, 0.75,  390,  390,  390,  390,  390,  780,  585,  585,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (31830,  6, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (31830,  7, 16,  0,    0,  390,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (31830,  8, 16, 45, 0.75,  390,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (31830,  0, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31830,  1, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31830,  2, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31830,  3, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31830,  4, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31830,  5, 16, 45, 0.75,  300,  390,  390,  390,  390,  780,  585,  585,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31830,  6, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31830,  7, 16,  0,    0,  300,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31830,  8, 16, 45, 0.75,  300,  390,  390,  390,  390,  780,  585,  585,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
-VALUES (31830,  2128,  2.004)  /* Ilservian's Flame */;
+VALUES (31830,  2074,   2.05)  /* Gossamer Flesh */
+     , (31830,  5393,  2.053)  /* Corrosion VII */
+     , (31830,  5401,  2.056)  /* Corruption VII */
+     , (31830,  5355,  2.118)  /* Nether Bolt VII */
+     , (31830,  5367,  2.133)  /* Nether Arc VII */
+     , (31830,  5361,  2.077)  /* Clouded Soul */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/31832 Caustic Knight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/31832 Caustic Knight.sql
@@ -9,15 +9,15 @@ VALUES (31832,   1,         16) /* ItemType - Creature */
      , (31832,   3,         21) /* PaletteTemplate - Gold */
      , (31832,   6,         -1) /* ItemsCapacity */
      , (31832,   7,         -1) /* ContainersCapacity */
-     , (31832,  16,         32) /* ItemUseable - Remote */
-     , (31832,  25,        165) /* Level */
+     , (31832,  16,          1) /* ItemUseable - No */
+     , (31832,  25,        160) /* Level */
      , (31832,  27,          0) /* ArmorType - None */
      , (31832,  68,          5) /* TargetingTactic - Random, LastDamager */
-     , (31832,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (31832,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (31832, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (31832, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (31832, 140,          1) /* AiOptions - CanOpenDoors */
-     , (31832, 146,     450000) /* XpOverride */;
+     , (31832, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (31832,   1, True ) /* Stuck */
@@ -34,8 +34,8 @@ VALUES (31832,   1,       5) /* HeartbeatInterval */
      , (31832,  15,       1) /* ArmorModVsBludgeon */
      , (31832,  16,       1) /* ArmorModVsCold */
      , (31832,  17,       1) /* ArmorModVsFire */
-     , (31832,  18,       1) /* ArmorModVsAcid */
-     , (31832,  19,     1.1) /* ArmorModVsElectric */
+     , (31832,  18,     100) /* ArmorModVsAcid */
+     , (31832,  19,       1) /* ArmorModVsElectric */
      , (31832,  31,      20) /* VisualAwarenessRange */
      , (31832,  39,     1.3) /* DefaultScale */
      , (31832,  64,    0.45) /* ResistSlash */
@@ -70,45 +70,45 @@ VALUES (31832,   1, 0x02001481) /* Setup */
      , (31832,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (31832,   1, 250, 0, 0) /* Strength */
-     , (31832,   2, 260, 0, 0) /* Endurance */
-     , (31832,   3, 250, 0, 0) /* Quickness */
-     , (31832,   4, 250, 0, 0) /* Coordination */
-     , (31832,   5, 350, 0, 0) /* Focus */
-     , (31832,   6, 350, 0, 0) /* Self */;
+VALUES (31832,   1, 170, 0, 0) /* Strength */
+     , (31832,   2, 180, 0, 0) /* Endurance */
+     , (31832,   3, 160, 0, 0) /* Quickness */
+     , (31832,   4, 160, 0, 0) /* Coordination */
+     , (31832,   5, 270, 0, 0) /* Focus */
+     , (31832,   6, 270, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (31832,   1,  6000, 0, 0, 6130) /* MaxHealth */
-     , (31832,   3,  5000, 0, 0, 5260) /* MaxStamina */
-     , (31832,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (31832,   1,  1910, 0, 0, 2000) /* MaxHealth */
+     , (31832,   3,  2500, 0, 0, 2680) /* MaxStamina */
+     , (31832,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (31832,  6, 0, 3, 0, 395, 0, 0) /* MeleeDefense        Specialized */
-     , (31832,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (31832, 14, 0, 3, 0, 170, 0, 0) /* ArcaneLore          Specialized */
-     , (31832, 15, 0, 3, 0, 205, 0, 0) /* MagicDefense        Specialized */
-     , (31832, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (31832, 31, 0, 3, 0, 115, 0, 0) /* CreatureEnchantment Specialized */
-     , (31832, 33, 0, 3, 0, 115, 0, 0) /* LifeMagic           Specialized */
-     , (31832, 34, 0, 3, 0, 115, 0, 0) /* WarMagic            Specialized */
-     , (31832, 45, 0, 3, 0, 410, 0, 0) /* LightWeapons        Specialized */;
+VALUES (31832,  6, 0, 2, 0, 393, 0, 0) /* MeleeDefense        Trained */
+     , (31832,  7, 0, 2, 0, 486, 0, 0) /* MissileDefense      Trained */
+     , (31832, 15, 0, 2, 0, 223, 0, 0) /* MagicDefense        Trained */
+     , (31832, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (31832, 24, 0, 2, 0,  40, 0, 0) /* Run                 Trained */
+     , (31832, 31, 0, 2, 0, 165, 0, 0) /* CreatureEnchantment Trained */
+     , (31832, 33, 0, 2, 0, 165, 0, 0) /* LifeMagic           Trained */
+     , (31832, 34, 0, 2, 0, 165, 0, 0) /* WarMagic            Trained */
+     , (31832, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (31832,  0, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (31832,  1, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (31832,  2, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (31832,  3, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (31832,  4, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (31832,  5, 32, 85, 0.75,  200,  200,  200,  200,  200,  200,  200,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (31832,  6, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (31832,  7, 32,  0,    0,  200,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (31832,  8, 32, 85, 0.75,  200,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (31832,  0, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (31832,  1, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (31832,  2, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (31832,  3, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (31832,  4, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (31832,  5, 32, 85, 0.75,  300,  200,  200,  200,  200,  200,  200,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (31832,  6, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (31832,  7, 32,  0,    0,  300,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (31832,  8, 32, 85, 0.75,  300,  200,  200,  200,  200,  200,  200,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (31832,   276,  2.008)  /* Magic Resistance Self III */
      , (31832,  1033,  2.008)  /* Cold Protection Self IV */
      , (31832,  1160,  2.013)  /* Heal Self V */
-     , (31832,  1237,  2.008)  /* Drain Health Other I */
+     , (31832,  1241,  2.008)  /* Drain Health Other V */
      , (31832,  1783,  2.004)  /* Searing Disc */
      , (31832,  2074,  2.017)  /* Gossamer Flesh */
      , (31832,  2088,  2.017)  /* Senescence */
@@ -117,7 +117,3 @@ VALUES (31832,   276,  2.008)  /* Magic Resistance Self III */
      , (31832,  2162,  2.017)  /* Olthoi's Gift */
      , (31832,  2228,  2.017)  /* Broadside of a Barn */
      , (31832,  2318,  2.017)  /* Gravity Well */;
-
-INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (31832,  94) /* ATTACK_NOTIFICATION_EVENT */
-     , (31832, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Elemental/70974 Luminary Knight.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Elemental/70974 Luminary Knight.sql
@@ -9,15 +9,15 @@ VALUES (70974,   1,         16) /* ItemType - Creature */
      , (70974,   3,         21) /* PaletteTemplate - Gold */
      , (70974,   6,         -1) /* ItemsCapacity */
      , (70974,   7,         -1) /* ContainersCapacity */
-     , (70974,  16,         32) /* ItemUseable - Remote */
-     , (70974,  25,        165) /* Level */
+     , (70974,  16,          1) /* ItemUseable - No */
+     , (70974,  25,        160) /* Level */
      , (70974,  27,          0) /* ArmorType - None */
      , (70974,  68,          5) /* TargetingTactic - Random, LastDamager */
-     , (70974,  93,       3080) /* PhysicsState - ReportCollisions, Gravity, LightingOn */
+     , (70974,  93,    4195336) /* PhysicsState - ReportCollisions, Gravity, EdgeSlide */
      , (70974, 101,        183) /* AiAllowedCombatStyle - Unarmed, OneHanded, OneHandedAndShield, Bow, Crossbow, ThrownWeapon */
      , (70974, 133,          2) /* ShowableOnRadar - ShowMovement */
      , (70974, 140,          1) /* AiOptions - CanOpenDoors */
-     , (70974, 146,     450000) /* XpOverride */;
+     , (70974, 146,     500000) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (70974,   1, True ) /* Stuck */
@@ -70,44 +70,44 @@ VALUES (70974,   1, 0x02001485) /* Setup */
      , (70974,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (70974,   1, 250, 0, 0) /* Strength */
-     , (70974,   2, 260, 0, 0) /* Endurance */
-     , (70974,   3, 250, 0, 0) /* Quickness */
-     , (70974,   4, 250, 0, 0) /* Coordination */
-     , (70974,   5, 350, 0, 0) /* Focus */
-     , (70974,   6, 350, 0, 0) /* Self */;
+VALUES (70974,   1, 170, 0, 0) /* Strength */
+     , (70974,   2, 180, 0, 0) /* Endurance */
+     , (70974,   3, 160, 0, 0) /* Quickness */
+     , (70974,   4, 160, 0, 0) /* Coordination */
+     , (70974,   5, 270, 0, 0) /* Focus */
+     , (70974,   6, 270, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (70974,   1,  6000, 0, 0, 6130) /* MaxHealth */
-     , (70974,   3,  5000, 0, 0, 5260) /* MaxStamina */
-     , (70974,   5,  5000, 0, 0, 5350) /* MaxMana */;
+VALUES (70974,   1,  1910, 0, 0, 2000) /* MaxHealth */
+     , (70974,   3,  2500, 0, 0, 2680) /* MaxStamina */
+     , (70974,   5,  2000, 0, 0, 2270) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (70974,  6, 0, 3, 0, 395, 0, 0) /* MeleeDefense        Specialized */
-     , (70974,  7, 0, 3, 0, 410, 0, 0) /* MissileDefense      Specialized */
-     , (70974, 14, 0, 3, 0, 170, 0, 0) /* ArcaneLore          Specialized */
-     , (70974, 15, 0, 3, 0, 205, 0, 0) /* MagicDefense        Specialized */
-     , (70974, 24, 0, 3, 0, 100, 0, 0) /* Run                 Specialized */
-     , (70974, 31, 0, 3, 0, 115, 0, 0) /* CreatureEnchantment Specialized */
-     , (70974, 33, 0, 3, 0, 115, 0, 0) /* LifeMagic           Specialized */
-     , (70974, 34, 0, 3, 0, 115, 0, 0) /* WarMagic            Specialized */
-     , (70974, 45, 0, 3, 0, 410, 0, 0) /* LightWeapons        Specialized */;
+VALUES (70974,  6, 0, 2, 0, 393, 0, 0) /* MeleeDefense        Trained */
+     , (70974,  7, 0, 2, 0, 486, 0, 0) /* MissileDefense      Trained */
+     , (70974, 15, 0, 2, 0, 223, 0, 0) /* MagicDefense        Trained */
+     , (70974, 20, 0, 2, 0,  80, 0, 0) /* Deception           Trained */
+     , (70974, 24, 0, 2, 0,  40, 0, 0) /* Run                 Trained */
+     , (70974, 31, 0, 2, 0, 165, 0, 0) /* CreatureEnchantment Trained */
+     , (70974, 33, 0, 2, 0, 165, 0, 0) /* LifeMagic           Trained */
+     , (70974, 34, 0, 2, 0, 165, 0, 0) /* WarMagic            Trained */
+     , (70974, 45, 0, 2, 0, 420, 0, 0) /* LightWeapons        Trained */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (70974,  0,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (70974,  1,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (70974,  2,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (70974,  3,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (70974,  4,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (70974,  5,  4, 85, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (70974,  6,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (70974,  7,  0,  0,    0,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (70974,  8,  4, 85, 0.75,  200,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (70974,  0,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (70974,  1,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (70974,  2,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (70974,  3,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (70974,  4,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (70974,  5,  4, 85, 0.75,  300,  200,  200,  200,  200,  200,  220,  220,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (70974,  6,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (70974,  7,  0,  0,    0,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (70974,  8,  4, 85, 0.75,  300,  200,  200,  200,  200,  200,  220,  220,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (70974,   276,  2.008)  /* Magic Resistance Self III */
      , (70974,  1160,  2.013)  /* Heal Self V */
-     , (70974,  1237,  2.008)  /* Drain Health Other I */
+     , (70974,  1241,  2.008)  /* Drain Health Other V */
      , (70974,  1786,  2.004)  /* Nuhmudira's Spines */
      , (70974,  2074,  2.017)  /* Gossamer Flesh */
      , (70974,  2088,  2.017)  /* Senescence */
@@ -116,7 +116,3 @@ VALUES (70974,   276,  2.008)  /* Magic Resistance Self III */
      , (70974,  2174,  2.017)  /* Archer's Gift */
      , (70974,  2228,  2.017)  /* Broadside of a Barn */
      , (70974,  2318,  2.017)  /* Gravity Well */;
-
-INSERT INTO `weenie_properties_event_filter` (`object_Id`, `event`)
-VALUES (70974,  94) /* ATTACK_NOTIFICATION_EVENT */
-     , (70974, 414) /* PLAYER_DEATH_EVENT */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Virindi/36860 Virindi Adjudicator.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Virindi/36860 Virindi Adjudicator.sql
@@ -1,11 +1,12 @@
 DELETE FROM `weenie` WHERE `class_Id` = 36860;
 
 INSERT INTO `weenie` (`class_Id`, `class_Name`, `type`, `last_Modified`)
-VALUES (36860, 'ace36860-virindiadjudicator', 10, '2022-12-04 19:04:52') /* Creature */;
+VALUES (36860, 'ace36860-virindiadjudicator', 10, '2026-08-22 01:03:55') /* Creature */;
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (36860,   1,         16) /* ItemType - Creature */
      , (36860,   2,         19) /* CreatureType - Virindi */
+     , (36860,   3,          3) /* PaletteTemplate - BluePurple */
      , (36860,   6,         -1) /* ItemsCapacity */
      , (36860,   7,         -1) /* ContainersCapacity */
      , (36860,  16,          1) /* ItemUseable - No */
@@ -31,27 +32,27 @@ VALUES (36860,   1, True ) /* Stuck */
 INSERT INTO `weenie_properties_float` (`object_Id`, `type`, `value`)
 VALUES (36860,   1,       5) /* HeartbeatInterval */
      , (36860,   2,       0) /* HeartbeatTimestamp */
-     , (36860,   3,       7) /* HealthRate */
-     , (36860,   4,      20) /* StaminaRate */
+     , (36860,   3,    10.6) /* HealthRate */
+     , (36860,   4,    20.5) /* StaminaRate */
      , (36860,   5,      20) /* ManaRate */
-     , (36860,  12,     0.1) /* Shade */
-     , (36860,  13,    0.88) /* ArmorModVsSlash */
-     , (36860,  14,    0.89) /* ArmorModVsPierce */
-     , (36860,  15,    0.78) /* ArmorModVsBludgeon */
-     , (36860,  16,    0.72) /* ArmorModVsCold */
-     , (36860,  17,    0.69) /* ArmorModVsFire */
-     , (36860,  18,    0.78) /* ArmorModVsAcid */
-     , (36860,  19,    0.73) /* ArmorModVsElectric */
-     , (36860,  31,      20) /* VisualAwarenessRange */
+     , (36860,  12,     0.5) /* Shade */
+     , (36860,  13,       1) /* ArmorModVsSlash */
+     , (36860,  14,       1) /* ArmorModVsPierce */
+     , (36860,  15,       1) /* ArmorModVsBludgeon */
+     , (36860,  16,       1) /* ArmorModVsCold */
+     , (36860,  17,       1) /* ArmorModVsFire */
+     , (36860,  18,       1) /* ArmorModVsAcid */
+     , (36860,  19,       1) /* ArmorModVsElectric */
+     , (36860,  31,      18) /* VisualAwarenessRange */
      , (36860,  34,       1) /* PowerupTime */
      , (36860,  36,       1) /* ChargeSpeed */
      , (36860,  43,       2) /* GeneratorRadius */
-     , (36860,  64,    0.58) /* ResistSlash */
-     , (36860,  65,    0.62) /* ResistPierce */
-     , (36860,  66,    0.71) /* ResistBludgeon */
-     , (36860,  67,    0.88) /* ResistFire */
+     , (36860,  64,       1) /* ResistSlash */
+     , (36860,  65,       1) /* ResistPierce */
+     , (36860,  66,       1) /* ResistBludgeon */
+     , (36860,  67,       1) /* ResistFire */
      , (36860,  68,     0.5) /* ResistCold */
-     , (36860,  69,    0.65) /* ResistAcid */
+     , (36860,  69,       1) /* ResistAcid */
      , (36860,  70,     0.5) /* ResistElectric */
      , (36860,  71,       1) /* ResistHealthBoost */
      , (36860,  72,       1) /* ResistStaminaDrain */
@@ -71,10 +72,11 @@ VALUES (36860,   1, 0x020009F6) /* Setup */
      , (36860,   2, 0x09000028) /* MotionTable */
      , (36860,   3, 0x20000012) /* SoundTable */
      , (36860,   4, 0x3000000D) /* CombatTable */
+     , (36860,   6, 0x040009B2) /* PaletteBase */
      , (36860,   7, 0x100000C1) /* ClothingBase */
      , (36860,   8, 0x06001227) /* Icon */
      , (36860,  22, 0x34000029) /* PhysicsEffectTable */
-     , (36860,  35,        461) /* DeathTreasureType - Loot Tier: 6 */;
+     , (36860,  35,        464) /* DeathTreasureType - Loot Tier: 5 */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
 VALUES (36860,   1, 300, 0, 0) /* Strength */
@@ -90,25 +92,24 @@ VALUES (36860,   1,   225, 0, 0, 350) /* MaxHealth */
      , (36860,   5,   100, 0, 0, 400) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (36860,  6, 0, 3, 0, 330, 0, 0) /* MeleeDefense        Specialized */
-     , (36860,  7, 0, 3, 0, 238, 0, 0) /* MissileDefense      Specialized */
-     , (36860, 14, 0, 3, 0, 300, 0, 0) /* ArcaneLore          Specialized */
-     , (36860, 15, 0, 3, 0, 186, 0, 0) /* MagicDefense        Specialized */
+VALUES (36860,  6, 0, 3, 0, 275, 0, 0) /* MeleeDefense        Specialized */
+     , (36860,  7, 0, 3, 0, 385, 0, 0) /* MissileDefense      Specialized */
+     , (36860, 15, 0, 3, 0, 265, 0, 0) /* MagicDefense        Specialized */
      , (36860, 20, 0, 3, 0, 250, 0, 0) /* Deception           Specialized */
-     , (36860, 24, 0, 3, 0, 440, 0, 0) /* Run                 Specialized */
-     , (36860, 31, 0, 3, 0, 250, 0, 0) /* CreatureEnchantment Specialized */
-     , (36860, 33, 0, 3, 0, 250, 0, 0) /* LifeMagic           Specialized */
-     , (36860, 34, 0, 3, 0, 250, 0, 0) /* WarMagic            Specialized */
-     , (36860, 45, 0, 3, 0, 335, 0, 0) /* LightWeapons        Specialized */;
+     , (36860, 24, 0, 3, 0,  90, 0, 0) /* Run                 Specialized */
+     , (36860, 31, 0, 3, 0, 200, 0, 0) /* CreatureEnchantment Specialized */
+     , (36860, 33, 0, 3, 0, 200, 0, 0) /* LifeMagic           Specialized */
+     , (36860, 34, 0, 3, 0, 200, 0, 0) /* WarMagic            Specialized */
+     , (36860, 45, 0, 3, 0, 300, 0, 0) /* LightWeapons        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (36860,  0,  1,  0,    0,  420,  370,  374,  328,  302,  290,  328,  307,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (36860,  1,  1,  0,    0,  420,  370,  374,  328,  302,  290,  328,  307,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (36860,  2,  1,  0,    0,  420,  370,  374,  328,  302,  290,  328,  307,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen */
-     , (36860,  3,  1,  0,    0,  420,  370,  374,  328,  302,  290,  328,  307,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (36860,  4,  1,  0,    0,  420,  370,  374,  328,  302,  290,  328,  307,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm */
-     , (36860,  5,  1, 50, 0.75,  420,  370,  374,  328,  302,  290,  328,  307,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (36860, 17,  1,  0,    0,  420,  370,  374,  328,  302,  290,  328,  307,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail */;
+VALUES (36860,  0,  1,  0,    0,  300,  300,  300,  300,  300,  300,  300,  300,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (36860,  1,  1,  0,    0,  300,  300,  300,  300,  300,  300,  300,  300,    0, 2, 0.44, 0.23,    0, 0.44, 0.23,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (36860,  2,  1,  0,    0,  300,  300,  300,  300,  300,  300,  300,  300,    0, 3,    0, 0.23,  0.1,    0, 0.23,  0.2,    0, 0.17, 0.45,    0, 0.17, 0.45) /* Abdomen */
+     , (36860,  3,  1,  0,    0,  300,  300,  300,  300,  300,  300,  300,  300,    0, 1, 0.23, 0.04,  0.2, 0.23, 0.04,  0.1, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (36860,  4,  1,  0,    0,  300,  300,  300,  300,  300,  300,  300,  300,    0, 2,    0,  0.3,  0.3,    0,  0.3,  0.4,    0,  0.3,  0.1,    0,  0.3,  0.1) /* LowerArm */
+     , (36860,  5,  1, 105, 0.75,  300,  300,  300,  300,  300,  300,  300,  300,    0, 2,    0,  0.2,  0.3,    0,  0.2,  0.2,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (36860, 17,  1,  0,    0,  300,  300,  300,  300,  300,  300,  300,  300,    0, 3,    0,    0,  0.1,    0,    0,  0.1,    0, 0.13, 0.45,    0, 0.13, 0.45) /* Tail */;
 
 INSERT INTO `weenie_properties_spell_book` (`object_Id`, `spell`, `probability`)
 VALUES (36860,   279,      2)  /* Magic Resistance Self VI */
@@ -137,14 +138,6 @@ SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (@parent_id,  0,  72 /* Generate */, 0, 1, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36860,  3 /* Death */,   0.03, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'As you deal the fatal blow to the Virindi Adjudicator, its limbs collapse in upon itslef folding the cloak neatly upon the ground. A chiming alien voice whispers, "Flesh Puppet! We must harvest the errant energy or your fate and ours become shared!"', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
 VALUES (36860,  5 /* HeartBeat */,   0.05, NULL, 0x8000003C /* HandCombat */, 0x41000003 /* Ready */, NULL, NULL, NULL, NULL);
@@ -195,42 +188,36 @@ INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `dela
 VALUES (@parent_id,  0,   5 /* Motion */, 0, 1, 0x10000053 /* Twitch3 */, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36860,  9 /* Generation */,   0.33, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (36860, 16 /* KillTaunt */,    0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'The rift pulses, and disgorges a creature!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'Do not meddle in our affairs, our renegades are our own to recollect. Your flesh would not survive the transfer from material to energy.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36860,  9 /* Generation */,   0.66, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (36860, 21 /* ResistSpell */,    0.5, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 SET @parent_id = LAST_INSERT_ID();
 
 INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'The rift surges with crackling energy, and a creature appears!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-INSERT INTO `weenie_properties_emote` (`object_Id`, `category`, `probability`, `weenie_Class_Id`, `style`, `substyle`, `quest`, `vendor_Type`, `min_Health`, `max_Health`)
-VALUES (36860,  9 /* Generation */,      1, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
-
-SET @parent_id = LAST_INSERT_ID();
-
-INSERT INTO `weenie_properties_emote_action` (`emote_Id`, `order`, `type`, `delay`, `extent`, `motion`, `message`, `test_String`, `min`, `max`, `min_64`, `max_64`, `min_Dbl`, `max_Dbl`, `stat`, `display`, `amount`, `amount_64`, `hero_X_P_64`, `percent`, `spell_Id`, `wealth_Rating`, `treasure_Class`, `treasure_Type`, `p_Script`, `sound`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
-VALUES (@parent_id,  0,  17 /* LocalBroadcast */, 0, 0, NULL, 'The air becomes heavy with ozone, and another creature spawns from the rift!', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+VALUES (@parent_id,  0,  10 /* Tell */, 0, 1, NULL, 'We have been dispatched for harvesting errant energy that believes itself greater than the will of the collective. We were warned of your lacking abilities but never did we believe such impotence was possible.', NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
 INSERT INTO `weenie_properties_create_list` (`object_Id`, `destination_Type`, `weenie_Class_Id`, `stack_Size`, `palette`, `shade`, `try_To_Bond`)
-VALUES (36860, 9, 20863,  0, 0, 0.04, False) /* Create Virindi Stamp (20863) for ContainTreasure */
-     , (36860, 9,     0,  0, 0, 0.96, False) /* Create nothing for ContainTreasure */
-     , (36860, 9, 27392,  0, 0, 0.03, False) /* Create Oubliette (27392) for ContainTreasure */
-     , (36860, 9,     0,  0, 0, 0.97, False) /* Create nothing for ContainTreasure */
-     , (36860, 9, 32939,  0, 0, 0.05, False) /* Create Dark Monolith Caverns (32939) for ContainTreasure */
+VALUES (36860, 9,  9292,  0, 0, 0.05, False) /* Create Virindi Singularity Key (9292) for ContainTreasure */
      , (36860, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */
+     , (36860, 9, 24477,  0, 0, 0.02, False) /* Create Sturdy Steel Key (24477) for ContainTreasure */
+     , (36860, 9,     0,  0, 0, 0.98, False) /* Create nothing for ContainTreasure */
+     , (36860, 9, 27392,  0, 0, 0.005, False) /* Create Oubliette (27392) for ContainTreasure */
+     , (36860, 9,     0,  0, 0, 0.995, False) /* Create nothing for ContainTreasure */
      , (36860, 9,  7604,  0, 0, 0.0125, False) /* Create Yellow Jewel (7604) for ContainTreasure */
      , (36860, 9,  3698,  0, 0, 0.0125, False) /* Create White Jewel (3698) for ContainTreasure */
      , (36860, 9,  3696,  0, 0, 0.0125, False) /* Create Blue Jewel (3696) for ContainTreasure */
      , (36860, 9,  3697,  0, 0, 0.0125, False) /* Create Red Jewel (3697) for ContainTreasure */
      , (36860, 9, 41470,  0, 0, 0.0125, False) /* Create Purple Jewel (41470) for ContainTreasure */
-     , (36860, 9,     0,  0, 0, 0.9375, False) /* Create nothing for ContainTreasure */;
+     , (36860, 9,     0,  0, 0, 0.9375, False) /* Create nothing for ContainTreasure */
+     , (36860, 9, 32939,  0, 0, 0.05, False) /* Create Dark Monolith Caverns (32939) for ContainTreasure */
+     , (36860, 9,     0,  0, 0, 0.95, False) /* Create nothing for ContainTreasure */;
 
 INSERT INTO `weenie_properties_generator` (`object_Id`, `probability`, `weenie_Class_Id`, `delay`, `init_Create`, `max_Create`, `when_Create`, `where_Create`, `stack_Size`, `palette_Id`, `shade`, `obj_Cell_Id`, `origin_X`, `origin_Y`, `origin_Z`, `angles_W`, `angles_X`, `angles_Y`, `angles_Z`)
 VALUES (36860, 1, 36863, 0, 1, 1, 4, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0) /* Generate Dire Champion Virindi (36863) (x1 up to max of 1) - Regenerate upon Death - Location to (re)Generate: Scatter */;

--- a/Database/Patches/9 WeenieDefaults/Creature/Virindi/36860.es
+++ b/Database/Patches/9 WeenieDefaults/Creature/Virindi/36860.es
@@ -1,0 +1,26 @@
+Death: Probability: 0.3
+    - Generate
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.05
+    - Motion: Twitch1
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.075
+    - Motion: Twitch2
+
+HeartBeat: Style: HandCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch3
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.05
+    - Motion: Twitch1
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.075
+    - Motion: Twitch2
+
+HeartBeat: Style: NonCombat, Substyle: Ready, Probability: 0.1
+    - Motion: Twitch3
+
+KillTaunt: Probability: 0.5
+    - Tell: Do not meddle in our affairs, our renegades are our own to recollect. Your flesh would not survive the transfer from material to energy.
+
+ResistSpell: Probability: 0.5
+    - Tell: We have been dispatched for harvesting errant energy that believes itself greater than the will of the collective. We were warned of your lacking abilities but never did we believe such impotence was possible.

--- a/Database/Patches/9 WeenieDefaults/Creature/Wall/35483 Watcher's Wall.sql
+++ b/Database/Patches/9 WeenieDefaults/Creature/Wall/35483 Watcher's Wall.sql
@@ -5,20 +5,25 @@ VALUES (35483, 'ace35483-watcherswall', 10, '2022-12-04 19:04:52') /* Creature *
 
 INSERT INTO `weenie_properties_int` (`object_Id`, `type`, `value`)
 VALUES (35483,   1,         16) /* ItemType - Creature */
+     , (35483,   2,         64) /* CreatureType - Wall */
      , (35483,   6,         -1) /* ItemsCapacity */
      , (35483,   7,         -1) /* ContainersCapacity */
      , (35483,  16,          1) /* ItemUseable - No */
+     , (35483,  25,        999) /* Level */
+     , (35483,  27,          0) /* ArmorType - None */
+     , (35483,  40,          1) /* CombatMode - NonCombat */
+     , (35483,  67,          1) /* Tolerance - NoAttack */
+     , (35483,  68,          5) /* TargetingTactic - Random, LastDamager */
      , (35483,  93,       1032) /* PhysicsState - ReportCollisions, Gravity */
-     , (35483, 133,          4) /* ShowableOnRadar - ShowAlways */;
+     , (35483, 101,        131) /* AiAllowedCombatStyle - Unarmed, OneHanded, ThrownWeapon */
+     , (35483, 133,          4) /* ShowableOnRadar - ShowAlways */
+     , (35483, 146,          0) /* XpOverride */;
 
 INSERT INTO `weenie_properties_bool` (`object_Id`, `type`, `value`)
 VALUES (35483,   1, True ) /* Stuck */
-     , (35483,   6, False) /* AiUsesMana */
      , (35483,  11, False) /* IgnoreCollisions */
      , (35483,  12, True ) /* ReportCollisions */
      , (35483,  13, False) /* Ethereal */
-     , (35483,  14, True ) /* GravityStatus */
-     , (35483,  19, True ) /* Attackable */
      , (35483,  29, True ) /* NoCorpse */
      , (35483,  52, True ) /* AiImmobile */
      , (35483,  82, True ) /* DontTurnOrMoveWhenGiving */
@@ -34,29 +39,28 @@ VALUES (35483,   1,       5) /* HeartbeatInterval */
      , (35483,   7,    0.25) /* StaminaUponResurrection */
      , (35483,   8,     0.3) /* ManaUponResurrection */
      , (35483,  12,     0.5) /* Shade */
-     , (35483,  13,    0.75) /* ArmorModVsSlash */
-     , (35483,  14,    0.75) /* ArmorModVsPierce */
+     , (35483,  13,       1) /* ArmorModVsSlash */
+     , (35483,  14,       1) /* ArmorModVsPierce */
      , (35483,  15,       1) /* ArmorModVsBludgeon */
-     , (35483,  16,     100) /* ArmorModVsCold */
+     , (35483,  16,       1) /* ArmorModVsCold */
      , (35483,  17,       1) /* ArmorModVsFire */
-     , (35483,  18,     0.8) /* ArmorModVsAcid */
-     , (35483,  19,    0.89) /* ArmorModVsElectric */
+     , (35483,  18,       1) /* ArmorModVsAcid */
+     , (35483,  19,       1) /* ArmorModVsElectric */
      , (35483,  31,      10) /* VisualAwarenessRange */
-     , (35483,  34,     3.3) /* PowerupTime */
+     , (35483,  34,       1) /* PowerupTime */
      , (35483,  39,     1.1) /* DefaultScale */
-     , (35483,  64,     0.5) /* ResistSlash */
-     , (35483,  65,     0.5) /* ResistPierce */
-     , (35483,  66,    0.89) /* ResistBludgeon */
-     , (35483,  67,    0.65) /* ResistFire */
-     , (35483,  68,       0) /* ResistCold */
-     , (35483,  69,     0.6) /* ResistAcid */
-     , (35483,  70,     0.6) /* ResistElectric */
+     , (35483,  64,    0.75) /* ResistSlash */
+     , (35483,  65,    0.75) /* ResistPierce */
+     , (35483,  66,    0.75) /* ResistBludgeon */
+     , (35483,  67,    0.75) /* ResistFire */
+     , (35483,  68,    0.75) /* ResistCold */
+     , (35483,  69,    0.75) /* ResistAcid */
+     , (35483,  70,    0.75) /* ResistElectric */
      , (35483,  71,       1) /* ResistHealthBoost */
      , (35483,  72,       1) /* ResistStaminaDrain */
      , (35483,  73,       1) /* ResistStaminaBoost */
      , (35483,  74,       1) /* ResistManaDrain */
      , (35483,  75,       1) /* ResistManaBoost */
-     , (35483,  80,       3) /* AiUseMagicDelay */
      , (35483, 104,      10) /* ObviousRadarRange */
      , (35483, 122,       2) /* AiAcquireHealth */
      , (35483, 125,       1) /* ResistHealthDrain */;
@@ -73,28 +77,30 @@ VALUES (35483,   1, 0x020010A8) /* Setup */
      , (35483,  22, 0x3400006B) /* PhysicsEffectTable */;
 
 INSERT INTO `weenie_properties_attribute` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`)
-VALUES (35483,   1, 500, 0, 0) /* Strength */
-     , (35483,   2, 500, 0, 0) /* Endurance */
-     , (35483,   3, 500, 0, 0) /* Quickness */
-     , (35483,   4, 500, 0, 0) /* Coordination */
-     , (35483,   5, 500, 0, 0) /* Focus */
-     , (35483,   6, 500, 0, 0) /* Self */;
+VALUES (35483,   1,   1, 0, 0) /* Strength */
+     , (35483,   2,   1, 0, 0) /* Endurance */
+     , (35483,   3,   1, 0, 0) /* Quickness */
+     , (35483,   4,   1, 0, 0) /* Coordination */
+     , (35483,   5,   1, 0, 0) /* Focus */
+     , (35483,   6,   1, 0, 0) /* Self */;
 
 INSERT INTO `weenie_properties_attribute_2nd` (`object_Id`, `type`, `init_Level`, `level_From_C_P`, `c_P_Spent`, `current_Level`)
-VALUES (35483,   1,  4750, 0, 0, 5000) /* MaxHealth */;
+VALUES (35483,   1,  5000, 0, 0, 5000) /* MaxHealth */
+     , (35483,   3,   999, 0, 0, 1000) /* MaxStamina */
+     , (35483,   5,   999, 0, 0, 1000) /* MaxMana */;
 
 INSERT INTO `weenie_properties_skill` (`object_Id`, `type`, `level_From_P_P`, `s_a_c`, `p_p`, `init_Level`, `resistance_At_Last_Check`, `last_Used_Time`)
-VALUES (35483,  6, 0, 3, 0, 433, 0, 0) /* MeleeDefense        Specialized */
-     , (35483,  7, 0, 3, 0, 373, 0, 0) /* MissileDefense      Specialized */
-     , (35483, 15, 0, 3, 0, 355, 0, 0) /* MagicDefense        Specialized */;
+VALUES (35483,  6, 0, 3, 0,   1, 0, 0) /* MeleeDefense        Specialized */
+     , (35483,  7, 0, 3, 0,   1, 0, 0) /* MissileDefense      Specialized */
+     , (35483, 15, 0, 3, 0,   1, 0, 0) /* MagicDefense        Specialized */;
 
 INSERT INTO `weenie_properties_body_part` (`object_Id`, `key`, `d_Type`, `d_Val`, `d_Var`, `base_Armor`, `armor_Vs_Slash`, `armor_Vs_Pierce`, `armor_Vs_Bludgeon`, `armor_Vs_Cold`, `armor_Vs_Fire`, `armor_Vs_Acid`, `armor_Vs_Electric`, `armor_Vs_Nether`, `b_h`, `h_l_f`, `m_l_f`, `l_l_f`, `h_r_f`, `m_r_f`, `l_r_f`, `h_l_b`, `m_l_b`, `l_l_b`, `h_r_b`, `m_r_b`, `l_r_b`)
-VALUES (35483,  0,  4,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
-     , (35483,  1,  4,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
-     , (35483,  2,  4,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
-     , (35483,  3,  3,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
-     , (35483,  4,  3,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
-     , (35483,  5,  8, 60, 0.75,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
-     , (35483,  6,  4,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
-     , (35483,  7,  4,  0,    0,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
-     , (35483,  8,  4, 60, 0.75,  500,  375,  375,  500, 50000,  500,  400,  445,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;
+VALUES (35483,  0,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0, 0.33,    0,    0) /* Head */
+     , (35483,  1,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0, 0.44, 0.17,    0) /* Chest */
+     , (35483,  2,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0,    0, 0.17,    0) /* Abdomen */
+     , (35483,  3,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 1, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0, 0.23, 0.03,    0) /* UpperArm */
+     , (35483,  4,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0,    0,  0.3,    0) /* LowerArm */
+     , (35483,  5,  4,  1, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 2,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0,    0,  0.2,    0) /* Hand */
+     , (35483,  6,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18,    0, 0.13, 0.18) /* UpperLeg */
+     , (35483,  7,  4,  0,    0,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6,    0,    0,  0.6) /* LowerLeg */
+     , (35483,  8,  4,  1, 0.75,  400,  200,  200,  200,  200,  200,  200,  200,    0, 3,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22,    0,    0, 0.22) /* Foot */;

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32020 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32020 Offering to Xik Minru.sql
@@ -25,6 +25,7 @@ VALUES (32020,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (32020,   1, 'Offering to Xik Minru') /* Name */
+     , (32020,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (32020,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (32020,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32021 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32021 Offering to Xik Minru.sql
@@ -25,6 +25,7 @@ VALUES (32021,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (32021,   1, 'Offering to Xik Minru') /* Name */
+     , (32021,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (32021,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (32021,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32022 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32022 Offering to Xik Minru.sql
@@ -25,6 +25,7 @@ VALUES (32022,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (32022,   1, 'Offering to Xik Minru') /* Name */
+     , (32022,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (32022,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (32022,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32023 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32023 Offering to Xik Minru.sql
@@ -25,6 +25,7 @@ VALUES (32023,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (32023,   1, 'Offering to Xik Minru') /* Name */
+     , (32023,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (32023,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (32023,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/32024 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/32024 Offering to Xik Minru.sql
@@ -25,6 +25,7 @@ VALUES (32024,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (32024,   1, 'Offering to Xik Minru') /* Name */
+     , (32024,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (32024,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (32024,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/70094 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/70094 Offering to Xik Minru.sql
@@ -23,6 +23,7 @@ VALUES (70094,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70094,   1, 'Offering to Xik Minru') /* Name */
+     , (70094,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (70094,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (70094,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/70095 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/70095 Offering to Xik Minru.sql
@@ -23,6 +23,7 @@ VALUES (70095,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70095,   1, 'Offering to Xik Minru') /* Name */
+     , (70095,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (70095,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (70095,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/70096 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/70096 Offering to Xik Minru.sql
@@ -23,6 +23,7 @@ VALUES (70096,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70096,   1, 'Offering to Xik Minru') /* Name */
+     , (70096,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (70096,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (70096,  33, 'offeringxikminru') /* Quest */;
 

--- a/Database/Patches/9 WeenieDefaults/Gem/Gem/70097 Offering to Xik Minru.sql
+++ b/Database/Patches/9 WeenieDefaults/Gem/Gem/70097 Offering to Xik Minru.sql
@@ -23,6 +23,7 @@ VALUES (70097,  39,     0.5) /* DefaultScale */;
 
 INSERT INTO `weenie_properties_string` (`object_Id`, `type`, `value`)
 VALUES (70097,   1, 'Offering to Xik Minru') /* Name */
+     , (70097,  14, 'Bring this to a Shrine of Xik Minru.') /* Use */
      , (70097,  16, 'An offering brought by the undead to pay tribute to High Priestess Xik Minru.') /* LongDesc */
      , (70097,  33, 'offeringxikminru') /* Quest */;
 


### PR DESCRIPTION
Elemental knight mobs - corrected level, xp, skills, physics state and item useable to match the pcap. The wiki stats listed for most of these are incorrect due to being pre Turbine monster rebalance (e.g., before hp reduction to 2000, as seen in the pcap). Also increased armor level to be closer to other 160 creatures. 

Watcher's Wall (a killable door in the Bur Recall Quest) can now be machine gunned, and has had its stats set to be in line with other walls in the game. 

Corrected art and stats of Virindi Adjudicator that spawns the Dire Champion Virindi. Based on the pcap, it is just a copy of the regular Virindi Adjudicator. Also removed incorrect portions of the emote that appeared to have been copy pasted from a rift. 

Added missing use string to Offerings to Xik Minru. 

Added missing description and use string to Scroll of Prophecy.